### PR TITLE
Hent personinfo fra nytt endepunkt i familie-ks-oppslag

### DIFF
--- a/src/main/java/no/nav/familie/ks/sak/app/behandling/vilkår/medlemskap/regel/MinstEnErNorskStatsborger.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/behandling/vilkår/medlemskap/regel/MinstEnErNorskStatsborger.java
@@ -3,14 +3,9 @@ package no.nav.familie.ks.sak.app.behandling.vilkår.medlemskap.regel;
 import no.nav.familie.ks.sak.app.behandling.fastsetting.Faktagrunnlag;
 import no.nav.familie.ks.sak.app.behandling.resultat.årsak.VilkårIkkeOppfyltÅrsak;
 import no.nav.familie.ks.sak.app.grunnlag.Forelder;
-import no.nav.familie.ks.sak.app.integrasjon.felles.ws.Tid;
-import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.tilhørighet.Landkode;
-import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.tilhørighet.StatsborgerskapPeriode;
 import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
-
-import java.util.Optional;
 
 @RuleDocumentation(MinstEnErNorskStatsborger.ID)
 public class MinstEnErNorskStatsborger extends LeafSpecification<Faktagrunnlag> {
@@ -35,12 +30,6 @@ public class MinstEnErNorskStatsborger extends LeafSpecification<Faktagrunnlag> 
         if (forelder == null) {
             return false;
         }
-        Optional<Landkode> statsborgerskap = forelder.getPersonhistorikkInfo().getStatsborgerskaphistorikk().stream()
-                .filter(periode -> periode.getPeriode().getTom().equals(Tid.TIDENES_ENDE))
-                .filter(periode -> periode.getTilhørendeLand().erNorge())
-                .map(StatsborgerskapPeriode::getTilhørendeLand)
-                .findFirst();
-
-        return statsborgerskap.isPresent();
+        return forelder.getPersoninfo().getStatsborgerskap().erNorge();
     }
 }

--- a/src/main/java/no/nav/familie/ks/sak/app/grunnlag/Oppslag.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/grunnlag/Oppslag.java
@@ -87,7 +87,7 @@ public class Oppslag {
         return null;
     }
 
-    private Personinfo finnBarnSøktFor(Søknad søknad, Personinfo personinfo) {
+    private Personinfo finnBarnSøktFor(Søknad søknad, Personinfo forelder) {
         return hentPersonFor("123");
         // TODO: Fnr for valgt barn bør sendes med søknad.
         // TODO: Sjekk om barn er i familierelasjon og returner personinfo for barn
@@ -121,6 +121,23 @@ public class Oppslag {
                 throw new OppslagException(response.body());
             } else {
                 return mapper.readValue(response.body(), PersonhistorikkInfo.class);
+            }
+        } catch (IOException | InterruptedException e) {
+            logger.warn("Ukjent feil ved oppslag mot '" + uri + "'. " + e.getMessage());
+            throw new OppslagException("Ukjent feil ved oppslag mot '" + uri + "'. " + e.getMessage());
+        }
+    }
+
+    private Personinfo hentPersoninfoFor(String aktørId) {
+        URI uri = URI.create(oppslagServiceUri + "/personopplysning/info?id=" + aktørId );
+        logger.info("Henter personinfo fra " + oppslagServiceUri);
+        try {
+            HttpResponse<String> response = client.send(request(uri), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != HttpStatus.OK.value()) {
+                logger.warn("Kall mot oppslag feilet ved uthenting av personinfo: " + response.body());
+                throw new OppslagException(response.body());
+            } else {
+                return mapper.readValue(response.body(), Personinfo.class);
             }
         } catch (IOException | InterruptedException e) {
             logger.warn("Ukjent feil ved oppslag mot '" + uri + "'. " + e.getMessage());

--- a/src/main/java/no/nav/familie/ks/sak/app/grunnlag/Oppslag.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/grunnlag/Oppslag.java
@@ -2,8 +2,6 @@ package no.nav.familie.ks.sak.app.grunnlag;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import no.nav.familie.ks.sak.app.integrasjon.personopplysning.OppslagException;
-import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.AktørId;
-import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.PersonIdent;
 import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.PersonhistorikkInfo;
 import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.Personinfo;
 import no.nav.familie.ks.sak.app.integrasjon.sts.StsRestClient;
@@ -62,8 +60,8 @@ public class Oppslag {
 
     public TpsFakta hentTpsFakta(Søknad søknad, String personident) {
         Forelder forelder = genererForelder(hentAktørId(personident));
-        Forelder annenForelder = finnAnnenForelder(søknad);
-        Personinfo barn = finnBarnSøktFor(søknad, forelder.getPersoninfo());
+        Forelder annenForelder = hentAnnenForelder(søknad);
+        Personinfo barn = hentBarnSøktFor(søknad);
         return new TpsFakta.Builder()
                 .medForelder(forelder)
                 .medBarn(barn)
@@ -74,12 +72,12 @@ public class Oppslag {
     private Forelder genererForelder(String aktørId) {
         return new Forelder.Builder()
                 .medPersonhistorikkInfo(hentHistorikkFor(aktørId))
-                .medPersoninfo(hentPersonFor(aktørId))
+                .medPersoninfo(hentPersoninfoFor(aktørId))
                 .build();
     }
 
-    private Forelder finnAnnenForelder(Søknad søknad) {
-        String personident = søknad.familieforhold.annenForelderFodselsnummer;
+    private Forelder hentAnnenForelder(Søknad søknad) {
+        String personident = søknad.familieforhold.annenForelderFødselsnummer;
         if (!personident.isEmpty()) {
             String aktørId = hentAktørId(personident);
             return genererForelder(aktørId);
@@ -87,10 +85,10 @@ public class Oppslag {
         return null;
     }
 
-    private Personinfo finnBarnSøktFor(Søknad søknad, Personinfo forelder) {
-        return hentPersonFor("123");
-        // TODO: Fnr for valgt barn bør sendes med søknad.
-        // TODO: Sjekk om barn er i familierelasjon og returner personinfo for barn
+    private Personinfo hentBarnSøktFor(Søknad søknad) {
+        String fødselsnummer = søknad.getMineBarn().getFødselsnummer();
+        String aktørId = hentAktørId(fødselsnummer);
+        return hentPersoninfoFor(aktørId);
     }
 
     private String hentAktørId(String personident) {
@@ -147,15 +145,5 @@ public class Oppslag {
 
     private String formaterDato(LocalDate date) {
         return date.format(DateTimeFormatter.ISO_DATE);
-    }
-
-    private Personinfo hentPersonFor(String aktørId) {
-        //TODO: Hent når implementert i oppslag. Personinfo brukes foreløpig ikke i noen regler.
-        return Personinfo.builder()
-                .medAktørId(new AktørId("1111111111111"))
-                .medPersonIdent(new PersonIdent("11111111111"))
-                .medNavn("Navn Navnesen")
-                .medFødselsdato(LocalDate.now())
-                .build();
     }
 }

--- a/src/main/java/no/nav/familie/ks/sak/app/grunnlag/søknad/Barn.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/grunnlag/søknad/Barn.java
@@ -6,22 +6,27 @@ import java.time.format.DateTimeParseException;
 
 public class Barn {
     private String navn;
-    private String fodselsdato;
+    private String fødselsdato;
+    private String fødselsnummer;
     private String erFlerling;
 
     public String getNavn() {
         return navn;
     }
 
-    public LocalDate getFodselsdato() {
-        if (fodselsdato == null) {
+    public LocalDate getFødselsdato() {
+        if (fødselsdato == null) {
             return null;
         }
         try {
-            return LocalDate.parse(fodselsdato, DateTimeFormatter.ISO_DATE);
+            return LocalDate.parse(fødselsdato, DateTimeFormatter.ISO_DATE);
         } catch (DateTimeParseException e) {
             return null;
         }
+    }
+
+    public String getFødselsnummer() {
+        return fødselsnummer;
     }
 
     public String getErFlerling() {

--- a/src/main/java/no/nav/familie/ks/sak/app/grunnlag/søknad/Familieforhold.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/grunnlag/søknad/Familieforhold.java
@@ -3,5 +3,5 @@ package no.nav.familie.ks.sak.app.grunnlag.søknad;
 public class Familieforhold {
     public String borForeldreneSammenMedBarnet;
     public String annenForelderNavn;
-    public String annenForelderFodselsnummer;
+    public String annenForelderFødselsnummer;
 }

--- a/src/main/java/no/nav/familie/ks/sak/app/integrasjon/personopplysning/domene/relasjon/Familierelasjon.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/integrasjon/personopplysning/domene/relasjon/Familierelasjon.java
@@ -2,7 +2,11 @@ package no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.relasjon;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.Periode;
 import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.PersonIdent;
+import no.nav.familie.ks.sak.app.integrasjon.personopplysning.domene.status.PersonstatusType;
 
 public class Familierelasjon {
     private PersonIdent personIdent;
@@ -15,8 +19,12 @@ public class Familierelasjon {
      * @deprecated bruk ctor med PersonIdent
      */
     @Deprecated
-    public Familierelasjon(String fnr, RelasjonsRolleType relasjonsrolle, LocalDate fødselsdato,
-                           String adresse, Boolean harSammeBosted) {
+    @JsonCreator
+    public Familierelasjon(@JsonProperty("fnr") String fnr,
+                           @JsonProperty("relasjonsrolle") RelasjonsRolleType relasjonsrolle,
+                           @JsonProperty("fødselsdato") LocalDate fødselsdato,
+                           @JsonProperty("adresse") String adresse,
+                           @JsonProperty("harSammeBosted") Boolean harSammeBosted) {
 
         this(PersonIdent.fra(fnr), relasjonsrolle, fødselsdato, adresse, harSammeBosted);
     }

--- a/src/test/java/no/nav/familie/ks/sak/app/behandling/SamletVilkårsVurderingTest.java
+++ b/src/test/java/no/nav/familie/ks/sak/app/behandling/SamletVilkårsVurderingTest.java
@@ -39,8 +39,7 @@ public class SamletVilkårsVurderingTest {
 
         final var alleUtfall = vurder.getResultater().stream().map(Regelresultat::getUtfallType).collect(Collectors.toList());
         assertThat(alleUtfall).hasSize(inngangsvilkår.size());
-        assertThat(alleUtfall).containsExactly(UtfallType.IKKE_OPPFYLT, UtfallType.OPPFYLT);
+        assertThat(alleUtfall).containsExactlyInAnyOrder(UtfallType.IKKE_OPPFYLT, UtfallType.OPPFYLT);
         assertThat(vurder.getUtfallType()).isEqualTo(UtfallType.IKKE_OPPFYLT);
-
     }
 }

--- a/src/test/java/no/nav/familie/ks/sak/app/behandling/SamletVilkårsVurderingTest.java
+++ b/src/test/java/no/nav/familie/ks/sak/app/behandling/SamletVilkårsVurderingTest.java
@@ -39,7 +39,8 @@ public class SamletVilkårsVurderingTest {
 
         final var alleUtfall = vurder.getResultater().stream().map(Regelresultat::getUtfallType).collect(Collectors.toList());
         assertThat(alleUtfall).hasSize(inngangsvilkår.size());
-        assertThat(alleUtfall).containsExactlyInAnyOrder(UtfallType.IKKE_OPPFYLT, UtfallType.OPPFYLT);
+        assertThat(alleUtfall).containsExactly(UtfallType.IKKE_OPPFYLT, UtfallType.OPPFYLT);
         assertThat(vurder.getUtfallType()).isEqualTo(UtfallType.IKKE_OPPFYLT);
+
     }
 }

--- a/src/test/resources/soknadFullBarnehageplass.json
+++ b/src/test/resources/soknadFullBarnehageplass.json
@@ -19,7 +19,7 @@
     "skalSlutteIBarnehageKommune": ""
   },
   "familieforhold": {
-    "annenForelderFodselsnummer": "",
+    "annenForelderFødselsnummer": "",
     "annenForelderNavn": "",
     "borForeldreneSammenMedBarnet": "JA"
   },
@@ -30,7 +30,8 @@
     "skalBoMedBarnetINorgeNesteTolvMaaneder": "JA"
   },
   "mineBarn": {
-    "fodselsdato": "2018-12-12",
+    "fødselsdato": "2018-12-12",
+    "fødselsnummer": "11111111111",
     "navn": "Jakob",
     "erFlerling": "NEI"
   },

--- a/src/test/resources/soknadGradertBarnehageplass.json
+++ b/src/test/resources/soknadGradertBarnehageplass.json
@@ -19,7 +19,7 @@
     "skalSlutteIBarnehageKommune": "Trondheim"
   },
   "familieforhold": {
-    "annenForelderFodselsnummer": "",
+    "annenForelderFødselsnummer": "",
     "annenForelderNavn": "",
     "borForeldreneSammenMedBarnet": "JA"
   },
@@ -30,7 +30,8 @@
     "skalBoMedBarnetINorgeNesteTolvMaaneder": "JA"
   },
   "mineBarn": {
-    "fodselsdato": "2018-12-12",
+    "fødselsdato": "2018-12-12",
+    "fødselsnummer": "11111111111",
     "navn": "Jakob",
     "erFlerling": "NEI"
   },

--- a/src/test/resources/soknadUtenBarnehageplass.json
+++ b/src/test/resources/soknadUtenBarnehageplass.json
@@ -19,7 +19,7 @@
     "skalSlutteIBarnehageKommune": ""
   },
   "familieforhold": {
-    "annenForelderFodselsnummer": "",
+    "annenForelderFødselsnummer": "",
     "annenForelderNavn": "",
     "borForeldreneSammenMedBarnet": "JA"
   },
@@ -30,7 +30,8 @@
     "skalBoMedBarnetINorgeNesteTolvMaaneder": "JA"
   },
   "mineBarn": {
-    "fodselsdato": "2018-12-12",
+    "fødselsdato": "2018-12-12",
+    "fødselsnummer": "11111111111",
     "navn": "Jakob",
     "erFlerling": "NEI"
   },


### PR DESCRIPTION
- `barn` og `annenForelder` hentes nå fra personinfo-endepunkt i familie-ks-oppslag i stedet for å bruke mock
- Forenkler statsborgerskap-sjekk ved å bruke personinfo i stedet for personhistorikkinfo
- Litt refaktorering siden vi går for æ,ø,å videre:  
   - fodselsnummer -> fødselsnummer
   - fodselsdato -> fødselsdato