### PR TITLE
Barn mellom 10 og 14 måneder mvp regel

### DIFF
--- a/src/main/java/no/nav/familie/ks/sak/app/behandling/domene/kodeverk/VilkårType.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/behandling/domene/kodeverk/VilkårType.java
@@ -6,7 +6,8 @@ public enum VilkårType {
     BARNEHAGE(Constants.BARNEHAGE_KODE, "Retten til basert på plass i barnehage", "§1"),
     BOSTED(Constants.BOSTED_KODE, "Kontantstøtte ytes til den som barnet bor fast hos.", "§3"),
     BARN(Constants.BARN_KODE, "Barn er norsk statsborger", "§2"),
-    UTLAND(Constants.UTLAND_KODE, "Søker har ikke oppgitt noen tilknytning til utland (MVP)", "lovreferanse");
+    UTLAND(Constants.UTLAND_KODE, "Søker har ikke oppgitt noen tilknytning til utland (MVP)", "lovreferanse"),
+    BARN_MELLOM_10_OG_14_MÅNEDER(Constants.BARN_MELLOM_10_OG_14_MÅNEDER, "Barn er mellom 10 og 14 måneder", "MVP: Se regel 1.7 i Confluence");
 
     private final String kode;
     private final String beskrivelse;
@@ -17,7 +18,7 @@ public enum VilkårType {
         this.beskrivelse = beskrivelse;
         this.lovreferanse = lovreferanse;
     }
-
+    
     /**
      * Benyttes i skriv til brukeren etc.
      *
@@ -50,5 +51,6 @@ public enum VilkårType {
         public static final String BOSTED_KODE = "BOST";
         public static final String BARN_KODE = "BARN";
         public static final String UTLAND_KODE = "UTL";
+        public static final String BARN_MELLOM_10_OG_14_MÅNEDER = "BARN_MELLOM_10_OG_14_MÅNEDER";
     }
 }

--- a/src/main/java/no/nav/familie/ks/sak/app/behandling/domene/kodeverk/årsak/VilkårIkkeOppfyltÅrsak.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/behandling/domene/kodeverk/årsak/VilkårIkkeOppfyltÅrsak.java
@@ -21,7 +21,8 @@ public enum VilkårIkkeOppfyltÅrsak implements VilkårUtfallÅrsak {
     IKKE_BOSATT_SAMMEN(8306, "Barn er ikke bosatt sammen med begge foreldre", VilkårType.BOSTED),
 
     // MVP
-    OPPGITT_TILKNYTNING_UTLAND(8309, "Søker har svart ja på spørsmål som indikerer tilknytning til utland", VilkårType.UTLAND);
+    OPPGITT_TILKNYTNING_UTLAND(8309, "Søker har svart ja på spørsmål som indikerer tilknytning til utland", VilkårType.UTLAND),
+    BARN_IKKE_MELLOM_10_OG_14_MÅNEDER(8310, "Barnet det søkes for er ikke mellom 10 og 14 måneder", VilkårType.BARN_MELLOM_10_OG_14_MÅNEDER);
 
     private final int årsakKode;
     private final String beskrivelse;

--- a/src/main/java/no/nav/familie/ks/sak/app/behandling/regel/mvp/BarnMellom10Og14Måneder.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/behandling/regel/mvp/BarnMellom10Og14Måneder.java
@@ -1,0 +1,60 @@
+package no.nav.familie.ks.sak.app.behandling.regel.mvp;
+
+import no.nav.familie.ks.sak.app.behandling.domene.kodeverk.VilkårType;
+import no.nav.familie.ks.sak.app.behandling.fastsetting.Faktagrunnlag;
+import no.nav.familie.ks.sak.app.behandling.domene.kodeverk.årsak.VilkårIkkeOppfyltÅrsak;
+import no.nav.familie.ks.sak.app.behandling.domene.kodeverk.årsak.VilkårOppfyltÅrsak;
+import no.nav.familie.ks.sak.app.behandling.vilkår.InngangsvilkårRegel;
+import no.nav.fpsak.nare.Ruleset;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+import no.nav.fpsak.nare.specification.Specification;
+import org.springframework.stereotype.Component;
+
+@Component
+@RuleDocumentation(VilkårType.Constants.BARN_MELLOM_10_OG_14_MÅNEDER)
+public class BarnMellom10Og14Måneder implements InngangsvilkårRegel<Faktagrunnlag> {
+    
+    class Regel extends LeafSpecification<Faktagrunnlag> {
+        public Regel() {
+            super(VilkårType.BARN_MELLOM_10_OG_14_MÅNEDER.toString());
+        }
+
+        public Evaluation evaluate(Faktagrunnlag faktagrunnlag) {
+            var behandlingsdato = faktagrunnlag.getBehandlingstidspunkt();
+            var fødselsdato = faktagrunnlag.getTpsFakta().getBarna().get(0).getPersoninfo().getFødselsdato();
+            var tiMånedersDato = fødselsdato.plusMonths(10);
+            var fjortenMånedersDato = fødselsdato.plusMonths(14);
+            if ((behandlingsdato.isEqual(tiMånedersDato) || behandlingsdato.isAfter(tiMånedersDato)) && 
+                behandlingsdato.isBefore(fjortenMånedersDato)) {
+                return ja(VilkårOppfyltÅrsak.VILKÅR_OPPFYLT);
+            } else {
+                return nei(VilkårIkkeOppfyltÅrsak.BARN_IKKE_MELLOM_10_OG_14_MÅNEDER);
+            }
+        }
+    }
+    
+    @Override
+    public VilkårType getVilkårType() {
+        return VilkårType.BARN_MELLOM_10_OG_14_MÅNEDER;
+    }
+
+    @Override
+    public Faktagrunnlag konverterInput(Faktagrunnlag faktagrunnlag) {
+        return faktagrunnlag;
+    }
+    
+    @Override
+    public Evaluation evaluer(Faktagrunnlag input) {
+        return getSpecification().evaluate(input);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Specification<Faktagrunnlag> getSpecification() {
+        var rs = new Ruleset<Faktagrunnlag>();
+        
+        return rs.regel(VilkårType.BARN_MELLOM_10_OG_14_MÅNEDER.toString(), new Regel());
+    }
+}

--- a/src/test/java/no/nav/familie/ks/sak/app/behandling/vilkår/BarnMellom10Og14MånederVilkårTest.java
+++ b/src/test/java/no/nav/familie/ks/sak/app/behandling/vilkår/BarnMellom10Og14MånederVilkårTest.java
@@ -1,0 +1,47 @@
+package no.nav.familie.ks.sak.app.behandling.vilkår;
+
+import java.time.LocalDate;
+
+import no.nav.familie.ks.sak.FaktagrunnlagBuilder;
+import no.nav.familie.ks.sak.app.behandling.fastsetting.Faktagrunnlag;
+import no.nav.familie.ks.sak.app.behandling.regel.mvp.BarnMellom10Og14Måneder;
+import no.nav.fpsak.nare.evaluation.Resultat;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class BarnMellom10Og14MånederVilkårTest {
+    Faktagrunnlag faktagrunnlag = spy(FaktagrunnlagBuilder.beggeForeldreBorINorgeOgErNorskeStatsborgere());
+    LocalDate fødselsdato = faktagrunnlag.getTpsFakta().getBarna().get(0).getPersoninfo().getFødselsdato();
+    BarnMellom10Og14Måneder vilkår = new BarnMellom10Og14Måneder();
+
+    @Test
+    public void ikke_oppfylt_hvis_barn_er_under_10_måneder() {
+        when(faktagrunnlag.getBehandlingstidspunkt()).thenReturn(fødselsdato.plusMonths(10).minusDays(1));
+        final var evaluering = vilkår.evaluer(faktagrunnlag);
+        assertThat(evaluering.result()).isEqualByComparingTo(Resultat.NEI);
+    }
+
+    @Test
+    public void oppfylt_hvis_barn_er_akkurat_10_måneder() {
+        when(faktagrunnlag.getBehandlingstidspunkt()).thenReturn(fødselsdato.plusMonths(10));
+        final var evaluering = vilkår.evaluer(faktagrunnlag);
+        assertThat(evaluering.result()).isEqualByComparingTo(Resultat.JA);
+    }
+
+    @Test
+    public void oppfylt_hvis_barn_er_nesten_14_måneder() {
+        when(faktagrunnlag.getBehandlingstidspunkt()).thenReturn(fødselsdato.plusMonths(14).minusDays(1));
+        final var evaluering = vilkår.evaluer(faktagrunnlag);
+        assertThat(evaluering.result()).isEqualByComparingTo(Resultat.JA);
+    }
+
+    @Test
+    public void ikke_oppfylt_hvis_barn_er_akkurat_14_måneder() {
+        when(faktagrunnlag.getBehandlingstidspunkt()).thenReturn(fødselsdato.plusMonths(14));
+        final var evaluering = vilkår.evaluer(faktagrunnlag);
+        assertThat(evaluering.result()).isEqualByComparingTo(Resultat.NEI);
+    }
+}


### PR DESCRIPTION
Dette er en frittstående regel. Litt modifikasjon i RegelResultat må til for å definere en regel uten å gå veien gjennom en "hvis"-regel (som lager en ConditionalOrSpecification).

Ellers skal den være etter boka (se regel 1.7 i confluence), dvs. barnet må være mellom 10 og 14 måneder.

En konsekvens av dette er at "Lur Blyant" med sitt barn "Tøffeldyr Sedat" ikke kan automatisk behandles, da dette barnet nå er 18 måneder gammelt. (og kanskje noen andre testbrukere også, men dette er den eneste jeg har...)