### PR TITLE
Nullpointer på PersoninfoResponse

### DIFF
--- a/src/main/java/no/nav/familie/ks/sak/app/integrasjon/OppslagTjeneste.java
+++ b/src/main/java/no/nav/familie/ks/sak/app/integrasjon/OppslagTjeneste.java
@@ -257,7 +257,7 @@ public class OppslagTjeneste {
         logger.info("Henter personinfo fra " + oppslagServiceUri);
         try {
             ResponseEntity<Personinfo> response = requestMedPersonIdent(uri, personIdent, Personinfo.class);
-            secureLogger.info("Personinfo for {}: {}", personIdent, Objects.requireNonNull(response.getBody()).getFamilierelasjoner());
+            secureLogger.info("Personinfo for {}: {}", personIdent, response.getBody());
 
             if (response.getStatusCode().is2xxSuccessful()) {
                 return response.getBody();


### PR DESCRIPTION
Fjerner requireNonNull på responseBody i loggmeldingen og getFamilierelasjoner, slik at vi kan komme til koden under og skrive ut en mer fornuftig feilmelding.

Hører til en nullpointer vi fikk i prod.