### PR TITLE
Oppdatert mot nye endepunkter i integrasjoner.

### DIFF
--- a/src/main/java/no/nav/familie/ks/sak/app/integrasjon/IntegrasjonTjeneste.kt
+++ b/src/main/java/no/nav/familie/ks/sak/app/integrasjon/IntegrasjonTjeneste.kt
@@ -4,6 +4,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.Tema
+import no.nav.familie.kontrakter.felles.personinfo.Ident
 import no.nav.familie.ks.sak.app.behandling.domene.typer.AktørId
 import no.nav.familie.ks.sak.app.integrasjon.infotrygd.domene.AktivKontantstøtteInfo
 import no.nav.familie.ks.sak.app.integrasjon.medlemskap.MedlemskapsInfo
@@ -221,13 +222,13 @@ class IntegrasjonTjeneste @Autowired constructor(@param:Value("\${FAMILIE_INTEGR
     fun hentHistorikkFor(personident: String, fødselsdato: LocalDate): PersonhistorikkInfo {
         val tom = LocalDate.now()
         val uri = URI.create(
-                integrasjonerServiceUri.toString() + "/personopplysning/v1/historikk?fomDato="
+                integrasjonerServiceUri.toString() + "/personopplysning/v2/historikk?fomDato="
                 + formaterDato(fødselsdato) + "&tomDato=" +
                 formaterDato(tom))
         logger.info("Henter personhistorikkInfo fra $integrasjonerServiceUri")
         return try {
             val response =
-                    requestMedPersonIdent(uri, personident, PersonhistorikkInfo::class.java)
+                    postRequest(uri, Ident(personident), PersonhistorikkInfo::class.java)
             secureLogger.info("Personhistorikk for {}: {}", personident, response.body)
             response.body
         } catch (e: RestClientException) {
@@ -239,10 +240,10 @@ class IntegrasjonTjeneste @Autowired constructor(@param:Value("\${FAMILIE_INTEGR
                maxAttempts = 3,
                backoff = Backoff(delay = 5000))
     fun hentPersoninfoFor(personIdent: String): Personinfo {
-        val uri = URI.create("$integrasjonerServiceUri/personopplysning/v1/info")
+        val uri = URI.create("$integrasjonerServiceUri/personopplysning/v2/info")
         logger.info("Henter personinfo fra $integrasjonerServiceUri")
         return try {
-            val response = requestMedPersonIdent(uri, personIdent, Personinfo::class.java)
+            val response = postRequest(uri, Ident(personIdent), Personinfo::class.java)
             secureLogger.info("Personinfo for {}: {}", personIdent, response.body)
             response.body
         } catch (e: RestClientException) {

--- a/src/test/java/no/nav/familie/ks/sak/app/grunnlag/IntegrasjonTjenesteTest.java
+++ b/src/test/java/no/nav/familie/ks/sak/app/grunnlag/IntegrasjonTjenesteTest.java
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.app.grunnlag;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import no.nav.familie.kontrakter.felles.personinfo.Ident;
 import no.nav.familie.ks.sak.app.behandling.domene.typer.AktørId;
 import no.nav.familie.ks.sak.app.integrasjon.IntegrasjonTjeneste;
 import no.nav.familie.ks.sak.app.integrasjon.infotrygd.domene.AktivKontantstøtteInfo;
@@ -99,9 +100,9 @@ public class IntegrasjonTjenesteTest {
 
     @Test
     public void hentHistorikkFor() throws Exception {
-        stubFor(get(urlEqualTo("/api/personopplysning/v1/historikk?fomDato=1980-01-31&tomDato=" + LocalDate.now().format(
+        stubFor(post(urlEqualTo("/api/personopplysning/v2/historikk?fomDato=1980-01-31&tomDato=" + LocalDate.now().format(
             DateTimeFormatter.ISO_DATE)))
-                    .withHeader(NavHttpHeaders.NAV_PERSONIDENT.asString(), equalTo(FNR))
+                    .withRequestBody(matchingJsonPath("$.[?(@.ident == '" + FNR + "')]"))
                     .willReturn(aResponse()
                                     .withHeader("Content-Type", "application/json")
                                     .withHeader("Nav-Personident", FNR)
@@ -121,8 +122,8 @@ public class IntegrasjonTjenesteTest {
 
     @Test
     public void hentPersoninfoFor() throws Exception {
-        stubFor(get(urlEqualTo("/api/personopplysning/v1/info"))
-                    .withHeader(NavHttpHeaders.NAV_PERSONIDENT.asString(), equalTo(FNR))
+        stubFor(post(urlEqualTo("/api/personopplysning/v2/info"))
+                    .withRequestBody(matchingJsonPath("$.[?(@.ident == '" + FNR + "')]"))
                     .willReturn(aResponse()
                                     .withHeader("Content-Type", "application/json")
                                     .withBody(MAPPER.writeValueAsString(Companion.success(Personinfo.builder()


### PR DESCRIPTION
Gjelder endepunkter i integrasjoner for å hente personinfo der personidenten er flyttet fra request-header til body.