### PR TITLE
Lagt til nødvendige miljøvariabler i lokal config og oppdatert readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ CREATE DATABASE "familie-ks-sak";
 
 ### Autentisering
 
-For å kalle applikasjonen fra fontend må du sette miljøvariablene KS_SAK_CLIENT_ID og CLIENT_SECRET. Dette kan gjøres
+For å kalle applikasjonen fra fontend må du sette miljøvariablene AZURE_APP_CLIENT_ID og AZURE_APP_CLIENT_SECRET. Dette kan gjøres
 under `Edit Configurations -> Environment Variables`. Miljøvariablene kan hentes fra `azuread-familie-ks-sak-lokal` i
 dev-gcp-clusteret ved å gjøre følgende:
 
 1. Logg på `gcloud`, typisk med kommandoen: `gcloud auth login`
 2. Koble deg til dev-gcp-cluster'et: `kubectl config use-context dev-gcp`
 3. Hent info:  
-   `kubectl -n teamfamilie get secret azuread-familie-ks-sak-lokal -o json | jq '.data | map_values(@base64d)'`.
+   `kubectl -n teamfamilie get secret azuread-familie-ks-sak-lokal -o json | jq '.data | map_values(@base64d)'`. Dersom du er på windows: `kubectl -n teamfamilie get secret azuread-familie-ks-sak-lokal -o json` og base64 decode verdiene "manuelt".
 
-KS_SAK_CLIENT_ID må settes til `AZURE_APP_CLIENT_ID` og CLIENT_SECRET til`AZURE_APP_CLIENT_SECRET`
+Kopier og sett verdiene til de lokale miljøvariablene `AZURE_APP_CLIENT_ID` og `AZURE_APP_CLIENT_SECRET`.
 
 Se `.deploy/nais/azure-ad-app-lokal.yaml` dersom du ønsker å deploye `azuread-familie-ks-sak-lokal`
 
@@ -67,15 +67,15 @@ Til slutt skal miljøvariablene se slik ut:
 
 DevLauncher/DevLauncherPostgres
 
-* BA_SAK_CLIENT_ID=`AZURE_APP_CLIENT_ID` (fra `azuread-familie-ks-sak-lokal`)
-* CLIENT_SECRET=`AZURE_APP_CLIENT_SECRET` (fra `azuread-familie-ks-sak-lokal`)
+* AZURE_APP_CLIENT_ID=(verdi fra `azuread-familie-ks-sak-lokal`)
+* AZURE_APP_CLIENT_SECRET=(verdi fra `azuread-familie-ks-sak-lokal`)
 
 DevLauncherPostgresPreprod:
 krever at man henter azuread fra en pod til familie-ks-sak. Som rulleres oftere enn azuread-familie-ks-sak-lokal
 `kubectl -n teamfamilie exec -c familie-ks-sak -it familie-ks-sak-byttmegmedpodid -- env | grep AZURE_APP_CLIENT`
 
-* BA_SAK_CLIENT_ID=`AZURE_APP_CLIENT_ID` (fra `familie-ks-sak`)
-* CLIENT_SECRET=`AZURE_APP_CLIENT_SECRET` (fra `familie-ks-sak`)
+* AZURE_APP_CLIENT_ID=(verdi fra `familie-ks-sak`)
+* AZURE_APP_CLIENT_SECRET=(verdi fra `familie-ks-sak`)
 
 ### Ktlint
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,35 @@ psql -U postgres
 CREATE DATABASE "familie-ks-sak";
 ```
 
+### Autentisering
+
+For å kalle applikasjonen fra fontend må du sette miljøvariablene KS_SAK_CLIENT_ID og CLIENT_SECRET. Dette kan gjøres
+under `Edit Configurations -> Environment Variables`. Miljøvariablene kan hentes fra `azuread-familie-ks-sak-lokal` i
+dev-gcp-clusteret ved å gjøre følgende:
+
+1. Logg på `gcloud`, typisk med kommandoen: `gcloud auth login`
+2. Koble deg til dev-gcp-cluster'et: `kubectl config use-context dev-gcp`
+3. Hent info:  
+   `kubectl -n teamfamilie get secret azuread-familie-ks-sak-lokal -o json | jq '.data | map_values(@base64d)'`.
+
+KS_SAK_CLIENT_ID må settes til `AZURE_APP_CLIENT_ID` og CLIENT_SECRET til`AZURE_APP_CLIENT_SECRET`
+
+Se `.deploy/nais/azure-ad-app-lokal.yaml` dersom du ønsker å deploye `azuread-familie-ks-sak-lokal`
+
+Til slutt skal miljøvariablene se slik ut:
+
+DevLauncher/DevLauncherPostgres
+
+* BA_SAK_CLIENT_ID=`AZURE_APP_CLIENT_ID` (fra `azuread-familie-ks-sak-lokal`)
+* CLIENT_SECRET=`AZURE_APP_CLIENT_SECRET` (fra `azuread-familie-ks-sak-lokal`)
+
+DevLauncherPostgresPreprod:
+krever at man henter azuread fra en pod til familie-ks-sak. Som rulleres oftere enn azuread-familie-ks-sak-lokal
+`kubectl -n teamfamilie exec -c familie-ks-sak -it familie-ks-sak-byttmegmedpodid -- env | grep AZURE_APP_CLIENT`
+
+* BA_SAK_CLIENT_ID=`AZURE_APP_CLIENT_ID` (fra `familie-ks-sak`)
+* CLIENT_SECRET=`AZURE_APP_CLIENT_SECRET` (fra `familie-ks-sak`)
+
 ### Ktlint
 
 * Vi bruker ktlint i dette prosjektet for å formatere kode.

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -147,5 +147,6 @@ FAMILIE_STATISTIKK_URL: dummy
 PDL_URL: "dummy"
 CREDENTIAL_USERNAME: not-a-real-srvuser
 CREDENTIAL_PASSWORD: not-a-real-pw
+AZURE_APP_CLIENT_ID: ${KS_SAK_CLIENT_ID}
 
 retry.backoff.delay: 5

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -7,8 +7,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_INTEGRASJONER_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       pdl-onbehalfof:
         resource-url: ${PDL_URL}
@@ -16,8 +16,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${PDL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       pdl-clientcredentials:
         resource-url: ${PDL_URL}
@@ -25,8 +25,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${PDL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-integrasjoner-clientcredentials:
         resource-url: ${FAMILIE_INTEGRASJONER_API_URL}
@@ -34,8 +34,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_INTEGRASJONER_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-oppdrag-clientcredentials:
         resource-url: ${FAMILIE_OPPDRAG_API_URL}
@@ -43,8 +43,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_OPPDRAG_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ba-infotrygd-onbehalfof:
         resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
@@ -52,8 +52,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ba-infotrygd-feed-clientcredentials:
         resource-url: ${FAMILIE_BA_INFOTRYGD_FEED_API_URL}
@@ -61,8 +61,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_BA_INFOTRYGD_FEED_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ba-infotrygd-clientcredentials:
         resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
@@ -70,8 +70,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-oppdrag-onbehalfof:
         resource-url: ${FAMILIE_OPPDRAG_API_URL}
@@ -79,8 +79,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_OPPDRAG_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-tilbake-onbehalfof:
         resource-url: ${FAMILIE_TILBAKE_API_URL}
@@ -88,8 +88,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_TILBAKE_API_URL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-tilbake-clientcredentials:
         resource-url: ${FAMILIE_TILBAKE_API_URL}
@@ -97,8 +97,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_TILBAKE_API_URL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
 
 
@@ -147,6 +147,5 @@ FAMILIE_STATISTIKK_URL: dummy
 PDL_URL: "dummy"
 CREDENTIAL_USERNAME: not-a-real-srvuser
 CREDENTIAL_PASSWORD: not-a-real-pw
-AZURE_APP_CLIENT_ID: ${KS_SAK_CLIENT_ID}
 
 retry.backoff.delay: 5

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -7,8 +7,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_INTEGRASJONER_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-integrasjoner-clientcredentials:
         resource-url: ${FAMILIE_INTEGRASJONER_API_URL}
@@ -16,8 +16,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_INTEGRASJONER_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       pdl-onbehalfof:
         resource-url: ${PDL_URL}
@@ -25,8 +25,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${PDL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       pdl-clientcredentials:
         resource-url: ${PDL_URL}
@@ -34,8 +34,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${PDL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-oppdrag-clientcredentials:
         resource-url: ${FAMILIE_OPPDRAG_API_URL}
@@ -43,8 +43,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_OPPDRAG_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-tilbake-onbehalfof:
         resource-url: ${FAMILIE_TILBAKE_API_URL}
@@ -52,8 +52,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_TILBAKE_API_URL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-tilbake-clientcredentials:
         resource-url: ${FAMILIE_TILBAKE_API_URL}
@@ -61,8 +61,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_TILBAKE_API_URL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ba-infotrygd-onbehalfof:
         resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
@@ -70,8 +70,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ba-infotrygd-feed-clientcredentials:
         resource-url: ${FAMILIE_BA_INFOTRYGD_FEED_API_URL}
@@ -79,8 +79,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_BA_INFOTRYGD_FEED_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ba-infotrygd-clientcredentials:
         resource-url: ${FAMILIE_BA_INFOTRYGD_API_URL}
@@ -88,8 +88,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_BA_INFOTRYGD_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-oppdrag-onbehalfof:
         resource-url: ${FAMILIE_OPPDRAG_API_URL}
@@ -97,8 +97,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_OPPDRAG_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ef-sak-onbehalfof:
         resource-url: ${FAMILIE_EF_SAK_API_URL}
@@ -106,8 +106,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_EF_SAK_API_URL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
       familie-ef-sak-clientcredentials:
         resource-url: ${FAMILIE_EF_SAK_API_URL}
@@ -115,8 +115,8 @@ no.nav.security.jwt:
         grant-type: client_credentials
         scope: ${FAMILIE_EF_SAK_API_URL_SCOPE}
         authentication:
-          client-id: ${KS_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
 
 prosessering.fixedDelayString.in.milliseconds: 2000
@@ -181,5 +181,3 @@ KAFKA_BROKERS: http://localhost:9092
 retry.backoff.delay: 5
 NAIS_APP_NAME: familie-ks-sak
 CRON_FAGSAKSTATUS_SCHEDULER: "0 0/10 * ? * *"
-
-AZURE_APP_CLIENT_ID: ${KS_SAK_CLIENT_ID}

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -181,3 +181,5 @@ KAFKA_BROKERS: http://localhost:9092
 retry.backoff.delay: 5
 NAIS_APP_NAME: familie-ks-sak
 CRON_FAGSAKSTATUS_SCHEDULER: "0 0/10 * ? * *"
+
+AZURE_APP_CLIENT_ID: ${KS_SAK_CLIENT_ID}


### PR DESCRIPTION
For at vi skal kunne bruke `familie-ks-sak` som backend for `familie-ks-sak-frontend` må miljøvariablene `KS_SAK_CLIENT_ID` og `CLIENT_SECRET` settes. Har oppdatert README med denne informasjonen og justert `application-dev.yaml` og `application-postgres.yaml` slik at swaggerConfig også skal fungere lokalt