### PR TITLE
Lagt til RegistrerSøknadSteg og tilhørende dataklasser og tjenester

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -27,7 +28,8 @@ import org.springframework.web.bind.annotation.RestController
 @Validated
 class BehandlingController(
     private val behandlingService: BehandlingService,
-    private val tilgangService: TilgangService
+    private val tilgangService: TilgangService,
+    private val stegService: StegService
 ) {
 
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -39,7 +41,7 @@ class BehandlingController(
             handling = "Opprett behandling"
         )
 
-        val behandling = behandlingService.opprettBehandling(opprettBehandlingDto)
+        val behandling = stegService.håndterNyBehandling(opprettBehandlingDto)
         return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = behandling.id)))
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
@@ -40,7 +40,6 @@ class BehandlingController(
             event = AuditLoggerEvent.CREATE,
             handling = "Opprett behandling"
         )
-
         val behandling = stegService.håndterNyBehandling(opprettBehandlingDto)
         return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = behandling.id)))
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ks.sak.api
 
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
-import no.nav.familie.ks.sak.api.dto.RegisterSøknadDto
+import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
@@ -29,7 +29,7 @@ class BehandlingStegController(
     @PostMapping(path = ["registrer-søknad"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun registrereSøknadOgHentPersongrunnlag(
         @PathVariable behandlingId: Long,
-        @RequestBody registerSøknadDto: RegisterSøknadDto
+        @RequestBody registerSøknadDto: RegistrerSøknadDto
     ): ResponseEntity<Ressurs<BehandlingResponsDto>> {
         tilgangService.validerTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
@@ -27,7 +27,7 @@ class BehandlingStegController(
 ) {
 
     @PostMapping(path = ["registrer-søknad"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun registrereSøknadOgHentPersongrunnlag(
+    fun registrereSøknadOgOppdaterPersongrunnlag(
         @PathVariable behandlingId: Long,
         @RequestBody registerSøknadDto: RegistrerSøknadDto
     ): ResponseEntity<Ressurs<BehandlingResponsDto>> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ks.sak.api
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
+import no.nav.familie.ks.sak.api.dto.RegisterSøknadDto
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
+import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
+import no.nav.familie.ks.sak.sikkerhet.TilgangService
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/behandlinger/{behandlingId}/steg")
+@ProtectedWithClaims(issuer = "azuread")
+class BehandlingStegController(
+    private val tilgangService: TilgangService,
+    private val stegService: StegService,
+    private val behandlingService: BehandlingService
+) {
+
+    @PostMapping(path = ["registrer-søknad"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun registrereSøknadOgHentPersongrunnlag(
+        @PathVariable behandlingId: Long,
+        @RequestBody registerSøknadDto: RegisterSøknadDto
+    ): ResponseEntity<Ressurs<BehandlingResponsDto>> {
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "registrere søknad"
+        )
+
+        stegService.utførSteg(behandlingId, BehandlingSteg.REGISTRERE_SØKNAD, registerSøknadDto)
+        return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = behandlingId)))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingStegController.kt
@@ -26,7 +26,7 @@ class BehandlingStegController(
     private val behandlingService: BehandlingService
 ) {
 
-    @PostMapping(path = ["registrer-søknad"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping(path = ["/registrer-søknad"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun registrereSøknadOgOppdaterPersongrunnlag(
         @PathVariable behandlingId: Long,
         @RequestBody registerSøknadDto: RegistrerSøknadDto

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
@@ -16,12 +16,11 @@ data class SøknadDto(
     val endringAvOpplysningerBegrunnelse: String
 )
 
-fun SøknadDto.tilSøknadGrunnlag(behandlingId: Long): SøknadGrunnlag {
-    return SøknadGrunnlag(
+fun SøknadDto.tilSøknadGrunnlag(behandlingId: Long): SøknadGrunnlag =
+    SøknadGrunnlag(
         behandlingId = behandlingId,
         søknad = objectMapper.writeValueAsString(this)
     )
-}
 
 data class SøkerMedOpplysningerDto(
     val ident: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
@@ -2,20 +2,26 @@ package no.nav.familie.ks.sak.api.dto
 
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlag
 import java.time.LocalDate
 
 abstract class BehandlingStegDto
 
 // TODO bør sjekke om vi trenger bekreftEndringerViaFrontend felt
-data class RegisterSøknadDto(val søknad: SøknadDTO, val bekreftEndringerViaFrontend: Boolean) : BehandlingStegDto()
+data class RegistrerSøknadDto(val søknad: SøknadDto, val bekreftEndringerViaFrontend: Boolean) : BehandlingStegDto()
 
-data class SøknadDTO(
+data class SøknadDto(
     val søkerMedOpplysninger: SøkerMedOpplysningerDto,
     val barnaMedOpplysninger: List<BarnMedOpplysningerDto>,
     val endringAvOpplysningerBegrunnelse: String
 )
 
-fun SøknadDTO.writeValueAsString(): String = objectMapper.writeValueAsString(this)
+fun SøknadDto.tilSøknadGrunnlag(behandlingId: Long): SøknadGrunnlag {
+    return SøknadGrunnlag(
+        behandlingId = behandlingId,
+        søknad = objectMapper.writeValueAsString(this)
+    )
+}
 
 data class SøkerMedOpplysningerDto(
     val ident: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/SøknadGrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/SøknadGrunnlagMapper.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ks.sak.api.mapper
+
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlag
+
+object SøknadGrunnlagMapper {
+
+    fun SøknadGrunnlag.tilSøknadDto(): SøknadDto = objectMapper.readValue(this.søknad, SøknadDto::class.java)
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -12,8 +12,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
-import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
-import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -33,7 +31,6 @@ class BehandlingService(
     private val arbeidsfordelingService: ArbeidsfordelingService,
     private val vedtakService: VedtakService,
     private val loggService: LoggService,
-    private val stegService: StegService,
     private val fagsakRepository: FagsakRepository,
     private val behandlingRepository: BehandlingRepository,
     private val taskRepository: TaskRepository,
@@ -91,8 +88,6 @@ class BehandlingService(
                 )
             )
         }
-        // utfør Registrer Persongrunnlag steg
-        stegService.utførSteg(lagretBehandling.id, BehandlingSteg.REGISTRERE_PERSONGRUNNLAG)
         return lagretBehandling
     }
 
@@ -121,12 +116,13 @@ class BehandlingService(
             .maxByOrNull { it.opprettetTidspunkt }
     }
 
-    fun hentBehandling(behandlingId: Long) = behandlingRepository.hentBehandling(behandlingId)
+    fun hentBehandling(behandlingId: Long): Behandling = behandlingRepository.hentBehandling(behandlingId)
 
     fun lagBehandlingRespons(behandlingId: Long): BehandlingResponsDto {
         val behandling = hentBehandling(behandlingId)
         val arbeidsfordelingPåBehandling = arbeidsfordelingService.finnArbeidsfordelingPåBehandling(behandlingId)
-        val personer = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlag(behandlingId)?.personer?.toList()
+        val personer =
+            personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlag(behandlingId)?.personer?.toList()
         return BehandlingMapper.lagBehandlingRespons(behandling, arbeidsfordelingPåBehandling, personer)
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadSteg.kt
@@ -1,20 +1,44 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
 import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
-import no.nav.familie.ks.sak.api.dto.RegisterSøknadDto
-import no.nav.familie.ks.sak.api.dto.writeValueAsString
+import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
+import no.nav.familie.ks.sak.api.dto.tilSøknadGrunnlag
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.logg.LoggService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.søknad.SøknadGrunnlagService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
-class RegistrerSøknadSteg : IBehandlingSteg {
+class RegistrerSøknadSteg(
+    private val søknadGrunnlagService: SøknadGrunnlagService,
+    private val loggService: LoggService,
+    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
+    private val behandlingService: BehandlingService
+) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.REGISTRERE_SØKNAD
 
     override fun utførSteg(behandlingId: Long, behandlingStegDto: BehandlingStegDto) {
         logger.info("Utfører steg ${getBehandlingssteg().name} for behandling $behandlingId")
-        val registerSøknadDto = behandlingStegDto as RegisterSøknadDto
-        secureLogger.info("Data mottatt ${registerSøknadDto.søknad.writeValueAsString()}")
+        val registrerSøknadDto = behandlingStegDto as RegistrerSøknadDto
+
+        // Sjekk om det allerede finnes en registrert søknad tilknyttet behandlingen
+        val aktivSøknadGrunnlagFinnes = søknadGrunnlagService.hentAktiv(behandlingId) != null
+
+        // Logg at vi registrerer ny søknad med info om det fantes en søknad fra før
+        loggService.opprettRegistrertSøknadLogg(behandlingId, aktivSøknadGrunnlagFinnes)
+
+        // Lagre ny søknad og deaktiver gammel
+        val søknadGrunnlag =
+            søknadGrunnlagService.lagreOgDeaktiverGammel(registrerSøknadDto.søknad.tilSøknadGrunnlag(behandlingId))
+
+        // Oppdatere personopplysningsgrunnlag dersom det er lagt til barn som ikke fantes fra før
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        personopplysningGrunnlagService.oppdaterPersonopplysningGrunnlag(behandling, søknadGrunnlag.hentSøknadDto())
+
+        secureLogger.info("Data mottatt ${søknadGrunnlag.søknad}")
     }
 
     override fun gjenopptaSteg(behandlingId: Long) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadSteg.kt
@@ -38,6 +38,8 @@ class RegistrerSøknadSteg(
         val behandling = behandlingService.hentBehandling(behandlingId)
         personopplysningGrunnlagService.oppdaterPersonopplysningGrunnlag(behandling, søknadGrunnlag.hentSøknadDto())
 
+        // TODO opprett initiell vilkårsvurdering
+
         secureLogger.info("Data mottatt ${søknadGrunnlag.søknad}")
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadSteg.kt
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
-class RegisterSøknadSteg : IBehandlingSteg {
+class RegistrerSøknadSteg : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.REGISTRERE_SØKNAD
 
     override fun utførSteg(behandlingId: Long, behandlingStegDto: BehandlingStegDto) {
@@ -22,7 +22,7 @@ class RegisterSøknadSteg : IBehandlingSteg {
     }
 
     companion object {
-        private val logger: Logger = LoggerFactory.getLogger(RegisterSøknadSteg::class.java)
+        private val logger: Logger = LoggerFactory.getLogger(RegistrerSøknadSteg::class.java)
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadSteg.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg
 import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
 import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
 import no.nav.familie.ks.sak.api.dto.tilSøknadGrunnlag
+import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
@@ -12,7 +13,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
-class RegistrerSøknadSteg(
+class RegistrereSøknadSteg(
     private val søknadGrunnlagService: SøknadGrunnlagService,
     private val loggService: LoggService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
@@ -25,7 +26,7 @@ class RegistrerSøknadSteg(
         val registrerSøknadDto = behandlingStegDto as RegistrerSøknadDto
 
         // Sjekk om det allerede finnes en registrert søknad tilknyttet behandlingen
-        val aktivSøknadGrunnlagFinnes = søknadGrunnlagService.hentAktiv(behandlingId) != null
+        val aktivSøknadGrunnlagFinnes = søknadGrunnlagService.finnAktiv(behandlingId) != null
 
         // Logg at vi registrerer ny søknad med info om det fantes en søknad fra før
         loggService.opprettRegistrertSøknadLogg(behandlingId, aktivSøknadGrunnlagFinnes)
@@ -36,7 +37,7 @@ class RegistrerSøknadSteg(
 
         // Oppdatere personopplysningsgrunnlag dersom det er lagt til barn som ikke fantes fra før
         val behandling = behandlingService.hentBehandling(behandlingId)
-        personopplysningGrunnlagService.oppdaterPersonopplysningGrunnlag(behandling, søknadGrunnlag.hentSøknadDto())
+        personopplysningGrunnlagService.oppdaterPersonopplysningGrunnlag(behandling, søknadGrunnlag.tilSøknadDto())
 
         // TODO opprett initiell vilkårsvurdering
 
@@ -48,7 +49,7 @@ class RegistrerSøknadSteg(
     }
 
     companion object {
-        private val logger: Logger = LoggerFactory.getLogger(RegistrerSøknadSteg::class.java)
+        private val logger: Logger = LoggerFactory.getLogger(RegistrereSøknadSteg::class.java)
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -1,7 +1,9 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
 import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
+import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
@@ -12,7 +14,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class StegService(
     private val steg: List<IBehandlingSteg>,
-    private val behandlingRepository: BehandlingRepository
+    private val behandlingRepository: BehandlingRepository,
+    private val behandlingService: BehandlingService
 ) {
 
     @Transactional
@@ -67,6 +70,13 @@ class StegService(
                         "med steg $behandledeSteg med status ${BehandlingStegStatus.AVBRUTT}"
                 )
         }
+    }
+
+    @Transactional
+    fun håndterNyBehandling(opprettBehandlingDto: OpprettBehandlingDto): Behandling {
+        val behandling = behandlingService.opprettBehandling(opprettBehandlingDto)
+        utførSteg(behandling.id, BehandlingSteg.REGISTRERE_PERSONGRUNNLAG)
+        return behandling
     }
 
     private fun valider(behandling: Behandling, behandledeSteg: BehandlingSteg) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
@@ -82,4 +82,19 @@ class LoggService(
             )
         )
     }
+
+    fun opprettRegistrertSøknadLogg(behandlingId: Long, søknadGrunnlagFinnesFraFør: Boolean) {
+        lagreLogg(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.SØKNAD_REGISTRERT,
+                tittel = if (!søknadGrunnlagFinnesFraFør) "Søknaden ble registrert" else "Søknaden ble endret",
+                rolle = SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
+                    rolleConfig,
+                    BehandlerRolle.SAKSBEHANDLER
+                ),
+                tekst = ""
+            )
+        )
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
@@ -83,12 +83,12 @@ class LoggService(
         )
     }
 
-    fun opprettRegistrertSøknadLogg(behandlingId: Long, søknadGrunnlagFinnesFraFør: Boolean) {
+    fun opprettRegistrertSøknadLogg(behandlingId: Long, aktivSøknadGrunnlagFinnesFraFør: Boolean) {
         lagreLogg(
             Logg(
                 behandlingId = behandlingId,
                 type = LoggType.SØKNAD_REGISTRERT,
-                tittel = if (!søknadGrunnlagFinnesFraFør) "Søknaden ble registrert" else "Søknaden ble endret",
+                tittel = if (!aktivSøknadGrunnlagFinnesFraFør) "Søknaden ble registrert" else "Søknaden ble endret",
                 rolle = SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
                     rolleConfig,
                     BehandlerRolle.SAKSBEHANDLER

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
@@ -92,8 +92,7 @@ class LoggService(
                 rolle = SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
                     rolleConfig,
                     BehandlerRolle.SAKSBEHANDLER
-                ),
-                tekst = ""
+                )
             )
         )
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -52,7 +52,7 @@ class PersonopplysningGrunnlagService(
     fun oppdaterPersonopplysningGrunnlag(behandling: Behandling, søknadDto: SøknadDto) {
         val eksisterendePersonopplysningGrunnlag =
             personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id)
-                ?: throw Feil("Der finnes ikke noe aktivt personopplysningsgrunnlag for ${behandling.id}")
+                ?: throw Feil("Det finnes ikke noe aktivt personopplysningsgrunnlag for ${behandling.id}")
 
         val eksisterendeBarnAktører = eksisterendePersonopplysningGrunnlag.barna.map { it.aktør }
         val valgteBarnAktører = søknadDto.barnaMedOpplysninger.filter { it.inkludertISøknaden }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Personopplys
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class PersonopplysningGrunnlagService(
@@ -49,9 +50,10 @@ class PersonopplysningGrunnlagService(
         )
     }
 
+    @Transactional
     fun oppdaterPersonopplysningGrunnlag(behandling: Behandling, søknadDto: SøknadDto) {
         val eksisterendePersonopplysningGrunnlag =
-            personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id)
+            hentAktivPersonopplysningGrunnlag(behandling.id)
                 ?: throw Feil("Det finnes ikke noe aktivt personopplysningsgrunnlag for ${behandling.id}")
 
         val eksisterendeBarnAktører = eksisterendePersonopplysningGrunnlag.barna.map { it.aktør }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -74,7 +74,7 @@ class PersonopplysningGrunnlagService(
 
     fun lagreOgDeaktiverGammel(personopplysningGrunnlag: PersonopplysningGrunnlag): PersonopplysningGrunnlag {
         hentAktivPersonopplysningGrunnlag(personopplysningGrunnlag.behandlingId)?.let {
-            personopplysningGrunnlagRepository.saveAndFlush(it.copy(aktiv = false))
+            personopplysningGrunnlagRepository.saveAndFlush(it.also { it.aktiv = false })
         }
 
         logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} oppretter persongrunnlag $personopplysningGrunnlag")

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagService.kt
@@ -11,13 +11,13 @@ class SøknadGrunnlagService(
 ) {
     @Transactional
     fun lagreOgDeaktiverGammel(søknadGrunnlag: SøknadGrunnlag): SøknadGrunnlag {
-        søknadGrunnlagRepository.hentAktiv(søknadGrunnlag.behandlingId)
+        søknadGrunnlagRepository.finnAktiv(søknadGrunnlag.behandlingId)
             ?.let { søknadGrunnlagRepository.saveAndFlush(it.also { it.aktiv = false }) }
 
         return søknadGrunnlagRepository.save(søknadGrunnlag)
     }
 
-    fun hentAktiv(behandlingId: Long): SøknadGrunnlag? {
-        return søknadGrunnlagRepository.hentAktiv(behandlingId)
+    fun finnAktiv(behandlingId: Long): SøknadGrunnlag? {
+        return søknadGrunnlagRepository.finnAktiv(behandlingId)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagService.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ks.sak.kjerne.søknad
+
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlag
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlagRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SøknadGrunnlagService(
+    private val søknadGrunnlagRepository: SøknadGrunnlagRepository
+) {
+    @Transactional
+    fun lagreOgDeaktiverGammel(søknadGrunnlag: SøknadGrunnlag): SøknadGrunnlag {
+        val aktivSøknadGrunnlag = søknadGrunnlagRepository.hentAktiv(søknadGrunnlag.behandlingId)
+
+        if (aktivSøknadGrunnlag != null) {
+            søknadGrunnlagRepository.saveAndFlush(aktivSøknadGrunnlag.also { it.aktiv = false })
+        }
+
+        return søknadGrunnlagRepository.save(søknadGrunnlag)
+    }
+
+    fun hentAlle(behandlingId: Long): List<SøknadGrunnlag> {
+        return søknadGrunnlagRepository.hentAlle(behandlingId)
+    }
+
+    fun hentAktiv(behandlingId: Long): SøknadGrunnlag? {
+        return søknadGrunnlagRepository.hentAktiv(behandlingId)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagService.kt
@@ -11,17 +11,10 @@ class SøknadGrunnlagService(
 ) {
     @Transactional
     fun lagreOgDeaktiverGammel(søknadGrunnlag: SøknadGrunnlag): SøknadGrunnlag {
-        val aktivSøknadGrunnlag = søknadGrunnlagRepository.hentAktiv(søknadGrunnlag.behandlingId)
-
-        if (aktivSøknadGrunnlag != null) {
-            søknadGrunnlagRepository.saveAndFlush(aktivSøknadGrunnlag.also { it.aktiv = false })
-        }
+        søknadGrunnlagRepository.hentAktiv(søknadGrunnlag.behandlingId)
+            ?.let { søknadGrunnlagRepository.saveAndFlush(it.also { it.aktiv = false }) }
 
         return søknadGrunnlagRepository.save(søknadGrunnlag)
-    }
-
-    fun hentAlle(behandlingId: Long): List<SøknadGrunnlag> {
-        return søknadGrunnlagRepository.hentAlle(behandlingId)
     }
 
     fun hentAktiv(behandlingId: Long): SøknadGrunnlag? {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlag.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.søknad.domene
 
-import no.nav.familie.kontrakter.felles.objectMapper
-import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import java.time.LocalDateTime
 import javax.persistence.Column
@@ -34,9 +32,4 @@ data class SøknadGrunnlag(
 
     @Column(name = "aktiv", nullable = false)
     var aktiv: Boolean = true
-) {
-
-    fun hentSøknadDto(): SøknadDto {
-        return objectMapper.readValue(this.søknad, SøknadDto::class.java)
-    }
-}
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlag.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlag.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ks.sak.kjerne.søknad.domene
+
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.SequenceGenerator
+import javax.persistence.Table
+
+@Entity
+@Table(name = "gr_soknad")
+data class SøknadGrunnlag(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gr_soknad_seq_generator")
+    @SequenceGenerator(name = "gr_soknad_seq_generator", sequenceName = "gr_soknad_seq", allocationSize = 50)
+    val id: Long = 0,
+
+    @Column(name = "opprettet_av", nullable = false, updatable = false)
+    val opprettetAv: String = SikkerhetContext.hentSaksbehandler(),
+
+    @Column(name = "opprettet_tid", nullable = false, updatable = false)
+    val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "fk_behandling_id", updatable = false, nullable = false)
+    val behandlingId: Long,
+
+    @Column(name = "soknad", nullable = false, columnDefinition = "text")
+    var søknad: String,
+
+    @Column(name = "aktiv", nullable = false)
+    var aktiv: Boolean = true
+) {
+
+    fun hentSøknadDto(): SøknadDto {
+        return objectMapper.readValue(this.søknad, SøknadDto::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
@@ -1,0 +1,4 @@
+package no.nav.familie.ks.sak.kjerne.søknad.domene
+
+class SøknadGrunnlagRepository {
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
@@ -9,8 +9,5 @@ interface SøknadGrunnlagRepository : JpaRepository<SøknadGrunnlag, Long> {
     fun hentAktiv(behandlingId: Long): SøknadGrunnlag?
 
     @Query("SELECT gr FROM SøknadGrunnlag gr WHERE gr.behandlingId = :behandlingId")
-    fun hent(behandlingId: Long): SøknadGrunnlag
-
-    @Query("SELECT gr FROM SøknadGrunnlag gr WHERE gr.behandlingId = :behandlingId")
     fun hentAlle(behandlingId: Long): List<SøknadGrunnlag>
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query
 interface SøknadGrunnlagRepository : JpaRepository<SøknadGrunnlag, Long> {
 
     @Query("SELECT gr FROM SøknadGrunnlag gr WHERE gr.behandlingId = :behandlingId AND gr.aktiv = true")
-    fun hentAktiv(behandlingId: Long): SøknadGrunnlag?
+    fun finnAktiv(behandlingId: Long): SøknadGrunnlag?
 
     @Query("SELECT gr FROM SøknadGrunnlag gr WHERE gr.behandlingId = :behandlingId")
     fun hentAlle(behandlingId: Long): List<SøknadGrunnlag>

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepository.kt
@@ -1,4 +1,16 @@
 package no.nav.familie.ks.sak.kjerne.søknad.domene
 
-class SøknadGrunnlagRepository {
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface SøknadGrunnlagRepository : JpaRepository<SøknadGrunnlag, Long> {
+
+    @Query("SELECT gr FROM SøknadGrunnlag gr WHERE gr.behandlingId = :behandlingId AND gr.aktiv = true")
+    fun hentAktiv(behandlingId: Long): SøknadGrunnlag?
+
+    @Query("SELECT gr FROM SøknadGrunnlag gr WHERE gr.behandlingId = :behandlingId")
+    fun hent(behandlingId: Long): SøknadGrunnlag
+
+    @Query("SELECT gr FROM SøknadGrunnlag gr WHERE gr.behandlingId = :behandlingId")
+    fun hentAlle(behandlingId: Long): List<SøknadGrunnlag>
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -9,9 +9,9 @@ import no.nav.familie.kontrakter.felles.personopplysning.Sivilstand
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
 import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
-import no.nav.familie.ks.sak.api.dto.RegisterSøknadDto
+import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
 import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
-import no.nav.familie.ks.sak.api.dto.SøknadDTO
+import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -134,8 +134,8 @@ fun lagBehandling(
     kategori = kategori
 ).initBehandlingStegTilstand()
 
-fun lagRegisterSøknadDto() = RegisterSøknadDto(
-    søknad = SøknadDTO(
+fun lagRegistrerSøknadDto() = RegistrerSøknadDto(
+    søknad = SøknadDto(
         søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = randomFnr()),
         barnaMedOpplysninger = listOf(BarnMedOpplysningerDto(ident = randomFnr())),
         endringAvOpplysningerBegrunnelse = ""
@@ -212,7 +212,8 @@ fun lagPerson(personopplysningGrunnlag: PersonopplysningGrunnlag, aktør: Aktør
         aktør = aktør
     )
     person.bostedsadresser = mutableListOf(GrBostedsadresse.fraBostedsadresse(lagBostedsadresse(), person))
-    person.statsborgerskap = mutableListOf(GrStatsborgerskap.fraStatsborgerskap(lagStatsborgerskap(), Medlemskap.NORDEN, person))
+    person.statsborgerskap =
+        mutableListOf(GrStatsborgerskap.fraStatsborgerskap(lagStatsborgerskap(), Medlemskap.NORDEN, person))
     person.sivilstander = mutableListOf(GrSivilstand.fraSivilstand(lagSivilstand(), person))
 
     return person

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -203,9 +203,13 @@ fun lagAndelTilkjentYtelse(
     nasjonaltPeriodebeløp = 1054
 )
 
-fun lagPerson(personopplysningGrunnlag: PersonopplysningGrunnlag, aktør: Aktør): Person {
+fun lagPerson(
+    personopplysningGrunnlag: PersonopplysningGrunnlag,
+    aktør: Aktør,
+    personType: PersonType = PersonType.SØKER
+): Person {
     val person = Person(
-        type = PersonType.SØKER,
+        type = personType,
         fødselsdato = LocalDate.now().minusYears(30),
         kjønn = Kjønn.KVINNE,
         personopplysningGrunnlag = personopplysningGrunnlag,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
@@ -37,6 +38,9 @@ internal class PersonopplysningGrunnlagServiceTest {
 
     @MockK
     private lateinit var arbeidsfordelingService: ArbeidsfordelingService
+
+    @MockK
+    private lateinit var personidentService: PersonidentService
 
     @InjectMockKs
     private lateinit var personopplysningGrunnlagService: PersonopplysningGrunnlagService
@@ -72,7 +76,11 @@ internal class PersonopplysningGrunnlagServiceTest {
     @Test
     fun `opprettPersonopplysningGrunnlag skal opprette personopplysninggrunnlag for revurdering`() {
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
-        val revurdering = lagBehandling(fagsak = behandling.fagsak, type = BehandlingType.REVURDERING, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
+        val revurdering = lagBehandling(
+            fagsak = behandling.fagsak,
+            type = BehandlingType.REVURDERING,
+            opprettetÅrsak = BehandlingÅrsak.SØKNAD
+        )
         val barnAktør = randomAktør()
 
         every { beregningService.finnBarnFraBehandlingMedTilkjentYtelse(behandling.id) } returns listOf(barnAktør)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagServiceTest.kt
@@ -5,9 +5,16 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
+import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
+import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
@@ -17,12 +24,16 @@ import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.hamcrest.CoreMatchers.`is` as Is
 
 @ExtendWith(MockKExtension::class)
 internal class PersonopplysningGrunnlagServiceTest {
@@ -122,5 +133,82 @@ internal class PersonopplysningGrunnlagServiceTest {
         verify(atMost = 1) { arbeidsfordelingService.fastsettBehandledeEnhet(any(), any()) }
 
         assertEquals(2, personopplysningGrunnlag.personer.size)
+    }
+
+    @Test
+    fun `oppdaterPersonopplysningGrunnlag - skal deaktivere eksisterende aktivt personopplysningsgrunnlag og opprette et nytt`() {
+        val lagredePersonopplysningsGrunnlag = mutableListOf<PersonopplysningGrunnlag>()
+        val søker = randomAktør()
+        val barn1 = randomAktør()
+        val barn2 = randomAktør()
+        val fagsak = lagFagsak(søker)
+        val behandling = lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
+        val eksisterendePersonopplysningGrunnlag = lagPersonopplysningGrunnlag(
+            behandlingId = behandling.id,
+            søkerPersonIdent = søker.aktivFødselsnummer(),
+            barnasIdenter = listOf(barn1.aktivFødselsnummer())
+        )
+
+        val nyttPersonopplysningGrunnlag = lagPersonopplysningGrunnlag(
+            behandlingId = behandling.id,
+            søkerPersonIdent = søker.aktivFødselsnummer()
+        ).also { it.personer.clear() }
+
+        val nyttPersonopplysningGrunnlagMedBarna = lagPersonopplysningGrunnlag(
+            behandlingId = behandling.id,
+            søkerPersonIdent = søker.aktivFødselsnummer(),
+            barnasIdenter = listOf(barn1.aktivFødselsnummer(), barn2.aktivFødselsnummer())
+        )
+
+        every { personopplysningGrunnlagRepository.findByBehandlingAndAktiv(any()) } returns eksisterendePersonopplysningGrunnlag
+        every { personidentService.hentOgLagreAktør(any(), any()) } returns barn2
+        every { personService.lagPerson(any(), any(), any(), any(), any()) } returns lagPerson(
+            personopplysningGrunnlag = nyttPersonopplysningGrunnlag,
+            aktør = søker
+        ) andThen lagPerson(
+            personopplysningGrunnlag = nyttPersonopplysningGrunnlag,
+            aktør = barn1,
+            personType = PersonType.BARN
+        ) andThen lagPerson(
+            personopplysningGrunnlag = nyttPersonopplysningGrunnlag,
+            aktør = barn2,
+            personType = PersonType.BARN
+        )
+        every { personopplysningGrunnlagRepository.saveAndFlush(capture(lagredePersonopplysningsGrunnlag)) } returns mockk()
+        every { personopplysningGrunnlagRepository.save(capture(lagredePersonopplysningsGrunnlag)) } returns nyttPersonopplysningGrunnlag andThen nyttPersonopplysningGrunnlagMedBarna
+        personopplysningGrunnlagService.oppdaterPersonopplysningGrunnlag(
+            behandling,
+            SøknadDto(
+                søkerMedOpplysninger = SøkerMedOpplysningerDto(søker.aktivFødselsnummer()),
+                barnaMedOpplysninger = listOf(
+                    BarnMedOpplysningerDto(barn2.aktivFødselsnummer())
+                ),
+                endringAvOpplysningerBegrunnelse = ""
+            )
+        )
+
+        assertThat(lagredePersonopplysningsGrunnlag.first().aktiv, Is(false))
+        assertThat(lagredePersonopplysningsGrunnlag[1].aktiv, Is(true))
+        assertThat(lagredePersonopplysningsGrunnlag[2].personer.size, Is(3))
+        assertThat(lagredePersonopplysningsGrunnlag[2].barna.size, Is(2))
+    }
+
+    @Test
+    fun `oppdaterPersonopplysningGrunnlag - skal kaste feil dersom det ikke eksisterer noe aktivt persongrunnlag for behandling`() {
+        val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
+
+        every { personopplysningGrunnlagRepository.findByBehandlingAndAktiv(any()) } returns null
+
+        val feil = assertThrows<Feil> {
+            personopplysningGrunnlagService.oppdaterPersonopplysningGrunnlag(
+                behandling,
+                SøknadDto(
+                    søkerMedOpplysninger = SøkerMedOpplysningerDto(""),
+                    barnaMedOpplysninger = emptyList(),
+                    endringAvOpplysningerBegrunnelse = ""
+                )
+            )
+        }
+        assertEquals("Det finnes ikke noe aktivt personopplysningsgrunnlag for ${behandling.id}", feil.message)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagServiceTest.kt
@@ -41,7 +41,7 @@ class SøknadGrunnlagServiceTest {
             søknad = ""
         )
 
-        every { søknadGrunnlagRepository.hentAktiv(any()) } returns gammelSøknadGrunnlag
+        every { søknadGrunnlagRepository.finnAktiv(any()) } returns gammelSøknadGrunnlag
         every { søknadGrunnlagRepository.saveAndFlush(capture(deaktivertSøknadSlot)) } returns mockk()
         every { søknadGrunnlagRepository.save(capture(nySøknadSlot)) } returns nySøknadGrunnlag
 
@@ -58,23 +58,18 @@ class SøknadGrunnlagServiceTest {
             aktiv = true,
             søknad = ""
         )
-        every { søknadGrunnlagRepository.hentAktiv(any()) } returns søknadGrunnlag
+        every { søknadGrunnlagRepository.finnAktiv(any()) } returns søknadGrunnlag
 
-        val aktivSøknad = søknadGrunnlagService.hentAktiv(0L)
+        val aktivSøknad = søknadGrunnlagService.finnAktiv(0L)
 
         assertNotNull(aktivSøknad)
     }
 
     @Test
     fun `hentAktiv - skal returnere null dersom søknad tilknyttet behandlingId ikke finnes`() {
-        val søknadGrunnlag = SøknadGrunnlag(
-            behandlingId = 0,
-            aktiv = true,
-            søknad = ""
-        )
-        every { søknadGrunnlagRepository.hentAktiv(any()) } returns null
+        every { søknadGrunnlagRepository.finnAktiv(any()) } returns null
 
-        val aktivSøknad = søknadGrunnlagService.hentAktiv(404L)
+        val aktivSøknad = søknadGrunnlagService.finnAktiv(404L)
 
         assertNull(aktivSøknad)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/SøknadGrunnlagServiceTest.kt
@@ -1,0 +1,81 @@
+package no.nav.familie.ks.sak.kjerne.søknad
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlag
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlagRepository
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class SøknadGrunnlagServiceTest {
+
+    @MockK
+    private lateinit var søknadGrunnlagRepository: SøknadGrunnlagRepository
+
+    @InjectMockKs
+    private lateinit var søknadGrunnlagService: SøknadGrunnlagService
+
+    @Test
+    fun `lagreOgDeaktiverGammel - skal hente eksisterende aktiv søknad tilknyttet behandlingId og sette den til inaktiv og deretter lagre ny`() {
+        val deaktivertSøknadSlot = slot<SøknadGrunnlag>()
+        val nySøknadSlot = slot<SøknadGrunnlag>()
+
+        val nySøknadGrunnlag = SøknadGrunnlag(
+            behandlingId = 0,
+            aktiv = true,
+            søknad = ""
+        )
+
+        val gammelSøknadGrunnlag = SøknadGrunnlag(
+            behandlingId = 0,
+            aktiv = true,
+            søknad = ""
+        )
+
+        every { søknadGrunnlagRepository.hentAktiv(any()) } returns gammelSøknadGrunnlag
+        every { søknadGrunnlagRepository.saveAndFlush(capture(deaktivertSøknadSlot)) } returns mockk()
+        every { søknadGrunnlagRepository.save(capture(nySøknadSlot)) } returns nySøknadGrunnlag
+
+        søknadGrunnlagService.lagreOgDeaktiverGammel(nySøknadGrunnlag)
+
+        assertFalse(deaktivertSøknadSlot.captured.aktiv)
+        assertTrue(nySøknadSlot.captured.aktiv)
+    }
+
+    @Test
+    fun `hentAktiv - skal hente aktiv søknad tilknyttet behandlingId når den finnes`() {
+        val søknadGrunnlag = SøknadGrunnlag(
+            behandlingId = 0,
+            aktiv = true,
+            søknad = ""
+        )
+        every { søknadGrunnlagRepository.hentAktiv(any()) } returns søknadGrunnlag
+
+        val aktivSøknad = søknadGrunnlagService.hentAktiv(0L)
+
+        assertNotNull(aktivSøknad)
+    }
+
+    @Test
+    fun `hentAktiv - skal returnere null dersom søknad tilknyttet behandlingId ikke finnes`() {
+        val søknadGrunnlag = SøknadGrunnlag(
+            behandlingId = 0,
+            aktiv = true,
+            søknad = ""
+        )
+        every { søknadGrunnlagRepository.hentAktiv(any()) } returns null
+
+        val aktivSøknad = søknadGrunnlagService.hentAktiv(404L)
+
+        assertNull(aktivSøknad)
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadStegTest.kt
@@ -111,8 +111,9 @@ class RegistrerSøknadStegTest : OppslagSpringRunnerTest() {
         )
 
         // Valider at lagret søknad stemmer med innsendt søknad
-        val søknadGrunnlag = søknadGrunnlagRepository.hent(behandling.id)
-        assertEquals(behandling.id, søknadGrunnlag.behandlingId)
+        val søknadGrunnlag = søknadGrunnlagRepository.hentAktiv(behandling.id)
+        assertNotNull(søknadGrunnlag)
+        assertEquals(behandling.id, søknadGrunnlag!!.behandlingId)
         val lagretSøknad = søknadGrunnlag.hentSøknadDto()
         assertTrue(
             lagretSøknad.barnaMedOpplysninger.all {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerSøknadStegTest.kt
@@ -1,0 +1,164 @@
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.behandling.steg
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
+import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
+import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
+import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.lagPdlPersonInfo
+import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.integrasjon.pdl.PersonOpplysningerService
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerSøknadSteg
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlagRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class RegistrerSøknadStegTest : OppslagSpringRunnerTest() {
+
+    @Autowired
+    private lateinit var registrerSøknadSteg: RegistrerSøknadSteg
+
+    @Autowired
+    private lateinit var aktørRepository: AktørRepository
+
+    @Autowired
+    private lateinit var fagsakRepository: FagsakRepository
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var søknadGrunnlagRepository: SøknadGrunnlagRepository
+
+    @Autowired
+    private lateinit var personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository
+
+    @MockkBean(relaxed = true)
+    private lateinit var personOpplysningerService: PersonOpplysningerService
+
+    @MockkBean
+    private lateinit var arbeidsfordelingService: ArbeidsfordelingService
+
+    private lateinit var behandling: Behandling
+
+    private lateinit var søker: Aktør
+
+    private lateinit var barn1: Aktør
+
+    private lateinit var barn2: Aktør
+
+    @BeforeEach
+    fun init() {
+        søker = aktørRepository.saveAndFlush(randomAktør())
+        barn1 = aktørRepository.saveAndFlush(randomAktør())
+        barn2 = aktørRepository.saveAndFlush(randomAktør())
+        val fagsak = fagsakRepository.saveAndFlush(lagFagsak(søker))
+        behandling = behandlingRepository.saveAndFlush(
+            lagBehandling(
+                fagsak = fagsak,
+                opprettetÅrsak = BehandlingÅrsak.SØKNAD
+            )
+        )
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(behandling.id, søker.aktivFødselsnummer(), søkerAktør = søker)
+        personopplysningGrunnlagRepository.saveAndFlush(personopplysningGrunnlag)
+
+        // Mocker ut tjenester som kjører eksterne kall
+        every { personOpplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns lagPdlPersonInfo()
+        every { arbeidsfordelingService.fastsettBehandledeEnhet(any()) } just runs
+    }
+
+    @Test
+    fun `utførSteg - skal opprette SøknadGrunnlag og oppdatere personopplysningsgrunnlag for FGB`() {
+        val søknadDto = SøknadDto(
+            søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
+            barnaMedOpplysninger = listOf(
+                BarnMedOpplysningerDto(ident = barn1.aktivFødselsnummer()),
+                BarnMedOpplysningerDto(ident = barn2.aktivFødselsnummer())
+            ),
+            endringAvOpplysningerBegrunnelse = ""
+        )
+
+        // Valider at aktivt personopplysningsgrunnlag kun inneholder søker
+        val personopplysningGrunnlagFørSteg = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandling.id)
+        assertEquals(1, personopplysningGrunnlagFørSteg.personer.size)
+
+        registrerSøknadSteg.utførSteg(
+            behandling.id,
+            RegistrerSøknadDto(
+                søknadDto,
+                bekreftEndringerViaFrontend = true
+            )
+        )
+
+        // Valider at lagret søknad stemmer med innsendt søknad
+        val søknadGrunnlag = søknadGrunnlagRepository.hent(behandling.id)
+        assertEquals(behandling.id, søknadGrunnlag.behandlingId)
+        val lagretSøknad = søknadGrunnlag.hentSøknadDto()
+        assertTrue(
+            lagretSøknad.barnaMedOpplysninger.all {
+                it.ident in listOf(
+                    barn1.aktivFødselsnummer(),
+                    barn2.aktivFødselsnummer()
+                )
+            }
+        )
+        assertEquals(2, lagretSøknad.barnaMedOpplysninger.size)
+        assertEquals(søker.aktivFødselsnummer(), lagretSøknad.søkerMedOpplysninger.ident)
+
+        // Valider at aktivt personopplysningsgrunnlag er oppdatert med barna
+        val personopplysningGrunnlag = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandling.id)
+        assertEquals(3, personopplysningGrunnlag.personer.size)
+        assertEquals(2, personopplysningGrunnlag.barna.size)
+    }
+
+    @Test
+    fun `utførSteg - skal deaktivere eksisterende SøknadGrunnlag dersom det finnes fra før av og deretter opprette et nytt`() {
+        val søknadDto = SøknadDto(
+            søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
+            barnaMedOpplysninger = listOf(
+                BarnMedOpplysningerDto(ident = barn1.aktivFødselsnummer())
+            ),
+            endringAvOpplysningerBegrunnelse = ""
+        )
+
+        registrerSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto, true))
+
+        val søknadDto2 = SøknadDto(
+            søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
+            barnaMedOpplysninger = listOf(
+                BarnMedOpplysningerDto(ident = barn1.aktivFødselsnummer()),
+                BarnMedOpplysningerDto(ident = barn2.aktivFødselsnummer())
+            ),
+            endringAvOpplysningerBegrunnelse = ""
+        )
+
+        registrerSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto2, true))
+
+        val søknadsGrunnlag = søknadGrunnlagRepository.hentAlle(behandling.id)
+        val aktivtSøknadsGrunnlag = søknadsGrunnlag.singleOrNull { it.aktiv }
+
+        assertEquals(2, søknadsGrunnlag.size)
+        assertNotNull { aktivtSøknadsGrunnlag }
+        assertEquals(2, aktivtSøknadsGrunnlag?.hentSøknadDto()?.barnaMedOpplysninger?.size)
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
 import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPdlPersonInfo
@@ -19,7 +20,7 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerSøknadSteg
+import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrereSøknadSteg
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
@@ -32,10 +33,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
-class RegistrerSøknadStegTest : OppslagSpringRunnerTest() {
+class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
     @Autowired
-    private lateinit var registrerSøknadSteg: RegistrerSøknadSteg
+    private lateinit var registrereSøknadSteg: RegistrereSøknadSteg
 
     @Autowired
     private lateinit var aktørRepository: AktørRepository
@@ -102,7 +103,7 @@ class RegistrerSøknadStegTest : OppslagSpringRunnerTest() {
         val personopplysningGrunnlagFørSteg = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandling.id)
         assertEquals(1, personopplysningGrunnlagFørSteg.personer.size)
 
-        registrerSøknadSteg.utførSteg(
+        registrereSøknadSteg.utførSteg(
             behandling.id,
             RegistrerSøknadDto(
                 søknadDto,
@@ -111,10 +112,10 @@ class RegistrerSøknadStegTest : OppslagSpringRunnerTest() {
         )
 
         // Valider at lagret søknad stemmer med innsendt søknad
-        val søknadGrunnlag = søknadGrunnlagRepository.hentAktiv(behandling.id)
+        val søknadGrunnlag = søknadGrunnlagRepository.finnAktiv(behandling.id)
         assertNotNull(søknadGrunnlag)
         assertEquals(behandling.id, søknadGrunnlag!!.behandlingId)
-        val lagretSøknad = søknadGrunnlag.hentSøknadDto()
+        val lagretSøknad = søknadGrunnlag.tilSøknadDto()
         assertTrue(
             lagretSøknad.barnaMedOpplysninger.all {
                 it.ident in listOf(
@@ -142,7 +143,7 @@ class RegistrerSøknadStegTest : OppslagSpringRunnerTest() {
             endringAvOpplysningerBegrunnelse = ""
         )
 
-        registrerSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto, true))
+        registrereSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto, true))
 
         val søknadDto2 = SøknadDto(
             søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
@@ -153,13 +154,13 @@ class RegistrerSøknadStegTest : OppslagSpringRunnerTest() {
             endringAvOpplysningerBegrunnelse = ""
         )
 
-        registrerSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto2, true))
+        registrereSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto2, true))
 
         val søknadsGrunnlag = søknadGrunnlagRepository.hentAlle(behandling.id)
         val aktivtSøknadsGrunnlag = søknadsGrunnlag.singleOrNull { it.aktiv }
 
         assertEquals(2, søknadsGrunnlag.size)
         assertNotNull { aktivtSøknadsGrunnlag }
-        assertEquals(2, aktivtSøknadsGrunnlag?.hentSøknadDto()?.barnaMedOpplysninger?.size)
+        assertEquals(2, aktivtSøknadsGrunnlag?.tilSøknadDto()?.barnaMedOpplysninger?.size)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -205,7 +205,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         }
         assertEquals(
             "Steget ${REGISTRERE_SØKNAD.name} er ikke gyldig for behandling ${behandling.id} " +
-                    "med opprettetÅrsak ${behandling.opprettetÅrsak}",
+                "med opprettetÅrsak ${behandling.opprettetÅrsak}",
             exception.message
         )
     }
@@ -230,8 +230,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         }
         assertEquals(
             "Behandling ${behandling.id} har allerede et steg " +
-                    "${REGISTRERE_PERSONGRUNNLAG.name}} som er klar for behandling. " +
-                    "Kan ikke behandle ${REGISTRERE_SØKNAD.name}",
+                "${REGISTRERE_PERSONGRUNNLAG.name}} som er klar for behandling. " +
+                "Kan ikke behandle ${REGISTRERE_SØKNAD.name}",
             exception.message
         )
     }
@@ -244,7 +244,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         assertTrue(
             behandling.behandlingStegTilstand.any {
                 it.behandlingSteg == behandlingSteg &&
-                        it.behandlingStegStatus == behandlingStegStatus
+                    it.behandlingStegStatus == behandlingStegStatus
             }
         )
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -25,6 +25,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus.TILBAKE
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus.UTFØRT
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus.VENTER
 import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerPersonGrunnlagSteg
+import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerSøknadSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
@@ -45,6 +46,9 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @MockkBean(relaxed = true)
     private lateinit var registerPersonGrunnlagSteg: RegistrerPersonGrunnlagSteg
 
+    @MockkBean(relaxed = true)
+    private lateinit var registrerSøknadSteg: RegistrerSøknadSteg
+
     @Autowired
     private lateinit var aktørRepository: AktørRepository
 
@@ -60,6 +64,9 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     fun setup() {
         every { registerPersonGrunnlagSteg.utførSteg(any()) } just runs
         every { registerPersonGrunnlagSteg.getBehandlingssteg() } answers { callOriginal() }
+
+        every { registrerSøknadSteg.utførSteg(any()) } just runs
+        every { registrerSøknadSteg.getBehandlingssteg() } answers { callOriginal() }
 
         val aktør = aktørRepository.saveAndFlush(randomAktør())
         fagsak = fagsakRepository.saveAndFlush(lagFagsak(aktør))
@@ -198,7 +205,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         }
         assertEquals(
             "Steget ${REGISTRERE_SØKNAD.name} er ikke gyldig for behandling ${behandling.id} " +
-                "med opprettetÅrsak ${behandling.opprettetÅrsak}",
+                    "med opprettetÅrsak ${behandling.opprettetÅrsak}",
             exception.message
         )
     }
@@ -223,8 +230,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         }
         assertEquals(
             "Behandling ${behandling.id} har allerede et steg " +
-                "${REGISTRERE_PERSONGRUNNLAG.name}} som er klar for behandling. " +
-                "Kan ikke behandle ${REGISTRERE_SØKNAD.name}",
+                    "${REGISTRERE_PERSONGRUNNLAG.name}} som er klar for behandling. " +
+                    "Kan ikke behandle ${REGISTRERE_SØKNAD.name}",
             exception.message
         )
     }
@@ -237,7 +244,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         assertTrue(
             behandling.behandlingStegTilstand.any {
                 it.behandlingSteg == behandlingSteg &&
-                    it.behandlingStegStatus == behandlingStegStatus
+                        it.behandlingStegStatus == behandlingStegStatus
             }
         )
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -25,7 +25,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus.TILBAKE
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus.UTFØRT
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus.VENTER
 import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerPersonGrunnlagSteg
-import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerSøknadSteg
+import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrereSøknadSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
@@ -47,7 +47,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     private lateinit var registerPersonGrunnlagSteg: RegistrerPersonGrunnlagSteg
 
     @MockkBean(relaxed = true)
-    private lateinit var registrerSøknadSteg: RegistrerSøknadSteg
+    private lateinit var registrerSøknadSteg: RegistrereSøknadSteg
 
     @Autowired
     private lateinit var aktørRepository: AktørRepository

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -7,7 +7,7 @@ import io.mockk.runs
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
-import no.nav.familie.ks.sak.data.lagRegisterSøknadDto
+import no.nav.familie.ks.sak.data.lagRegistrerSøknadDto
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
@@ -110,7 +110,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         )
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
-        assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegisterSøknadDto()) }
+        assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegistrerSøknadDto()) }
         assertDoesNotThrow { stegService.utførSteg(behandling.id, VILKÅRSVURDERING) }
 
         behandling = behandlingRepository.hentBehandling(behandling.id)
@@ -120,7 +120,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         assertBehandlingHarSteg(behandling, VILKÅRSVURDERING, UTFØRT)
         assertBehandlingHarSteg(behandling, BEHANDLINGSRESULTAT, KLAR)
 
-        assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegisterSøknadDto()) }
+        assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegistrerSøknadDto()) }
         behandling = behandlingRepository.hentBehandling(behandling.id)
         assertEquals(4, behandling.behandlingStegTilstand.size)
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, UTFØRT)
@@ -151,7 +151,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, UTFØRT)
         assertBehandlingHarSteg(behandling, REGISTRERE_SØKNAD, VENTER)
 
-        assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegisterSøknadDto()) }
+        assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegistrerSøknadDto()) }
         behandling = behandlingRepository.hentBehandling(behandling.id)
         assertEquals(2, behandling.behandlingStegTilstand.size)
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, UTFØRT)
@@ -189,7 +189,13 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         behandling.leggTilNesteSteg(REGISTRERE_SØKNAD)
         behandlingRepository.saveAndFlush(behandling)
 
-        val exception = assertThrows<RuntimeException> { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegisterSøknadDto()) }
+        val exception = assertThrows<RuntimeException> {
+            stegService.utførSteg(
+                behandling.id,
+                REGISTRERE_SØKNAD,
+                lagRegistrerSøknadDto()
+            )
+        }
         assertEquals(
             "Steget ${REGISTRERE_SØKNAD.name} er ikke gyldig for behandling ${behandling.id} " +
                 "med opprettetÅrsak ${behandling.opprettetÅrsak}",
@@ -208,7 +214,13 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         behandling.leggTilNesteSteg(REGISTRERE_SØKNAD)
         behandlingRepository.saveAndFlush(behandling)
 
-        val exception = assertThrows<RuntimeException> { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegisterSøknadDto()) }
+        val exception = assertThrows<RuntimeException> {
+            stegService.utførSteg(
+                behandling.id,
+                REGISTRERE_SØKNAD,
+                lagRegistrerSøknadDto()
+            )
+        }
         assertEquals(
             "Behandling ${behandling.id} har allerede et steg " +
                 "${REGISTRERE_PERSONGRUNNLAG.name}} som er klar for behandling. " +

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/AktørRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/AktørRepositoryTest.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.personident
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.personident.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.data.randomAktør

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.personident
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.personident.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.data.randomAktør

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
@@ -57,7 +57,7 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
         val barn = lagreAktør(randomAktør())
         val søknadDto = lagreSøknadGrunnlag(behandling.id, listOf(barn), true)
 
-        val søknadGrunnlag = søknadGrunnlagRepository.hentAktiv(behandling.id)
+        val søknadGrunnlag = søknadGrunnlagRepository.finnAktiv(behandling.id)
 
         assertNotNull(søknadGrunnlag)
         assertThat(søknadGrunnlag!!.behandlingId, Is(behandling.id))
@@ -66,7 +66,7 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentAktiv - skal returnere null dersom det ikke finnes et SøknadsGrunnlag tilknyttet behandlingId`() {
-        val søknadGrunnlag = søknadGrunnlagRepository.hentAktiv(404L)
+        val søknadGrunnlag = søknadGrunnlagRepository.finnAktiv(404L)
 
         assertNull(søknadGrunnlag)
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
@@ -1,0 +1,106 @@
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.søknad.domene
+
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
+import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
+import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.api.dto.tilSøknadGrunnlag
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
+import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlagRepository
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.hamcrest.CoreMatchers.`is` as Is
+
+class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
+
+    @Autowired
+    private lateinit var søknadGrunnlagRepository: SøknadGrunnlagRepository
+
+    @Autowired
+    private lateinit var aktørRepository: AktørRepository
+
+    @Autowired
+    private lateinit var fagsakRepository: FagsakRepository
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    private lateinit var søker: Aktør
+
+    private lateinit var fagsak: Fagsak
+
+    private lateinit var behandling: Behandling
+
+    @BeforeEach
+    fun beforeEach() {
+        søker = lagreAktør(randomAktør())
+        fagsak = lagreFagsak(søker)
+        behandling = lagreBehandling(fagsak)
+    }
+
+    @Test
+    fun `hentAktiv - skal hente aktiv SøknadGrunnlag tilknyttet behandlingId`() {
+        val barn = lagreAktør(randomAktør())
+        val søknadDto = lagreSøknadGrunnlag(behandling.id, listOf(barn), true)
+
+        val søknadGrunnlag = søknadGrunnlagRepository.hentAktiv(behandling.id)
+
+        assertNotNull(søknadGrunnlag)
+        assertThat(søknadGrunnlag!!.behandlingId, Is(behandling.id))
+        assertThat(søknadGrunnlag.søknad, Is(søknadDto.tilSøknadGrunnlag(behandling.id).søknad))
+    }
+
+    @Test
+    fun `hentAktiv - skal returnere null dersom det ikke finnes et SøknadsGrunnlag tilknyttet behandlingId`() {
+        val søknadGrunnlag = søknadGrunnlagRepository.hentAktiv(404L)
+
+        assertNull(søknadGrunnlag)
+    }
+
+    @Test
+    fun `hentAlle - skal returnere alle SøknadsGrunnlag tilknyttet behandlingId`() {
+        lagreSøknadGrunnlag(behandling.id, listOf(randomAktør()))
+        lagreSøknadGrunnlag(behandling.id, listOf(randomAktør()))
+        lagreSøknadGrunnlag(behandling.id, listOf(randomAktør()), true)
+
+        val søknadsGrunnlag = søknadGrunnlagRepository.hentAlle(behandling.id)
+        assertEquals(3, søknadsGrunnlag.size)
+    }
+
+    fun lagreAktør(aktør: Aktør): Aktør {
+        return aktørRepository.saveAndFlush(aktør)
+    }
+
+    fun lagreFagsak(søker: Aktør): Fagsak {
+        return fagsakRepository.saveAndFlush(lagFagsak(aktør = søker))
+    }
+
+    fun lagreBehandling(fagsak: Fagsak): Behandling {
+        return behandlingRepository.saveAndFlush(lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
+    }
+
+    fun lagreSøknadGrunnlag(behandlingId: Long, barna: List<Aktør>, aktiv: Boolean = false): SøknadDto {
+        val søknadDto = SøknadDto(
+            SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
+            barna.map { BarnMedOpplysningerDto(ident = it.aktivFødselsnummer()) },
+            endringAvOpplysningerBegrunnelse = ""
+        )
+        søknadGrunnlagRepository.saveAndFlush(søknadDto.tilSøknadGrunnlag(behandlingId).also { it.aktiv = aktiv })
+
+        return søknadDto
+    }
+}


### PR DESCRIPTION
Logikk for å trigge og utføre steget `REGISTRERE_SØKNAD` er lagt inn.

* BehandlingStegController
* RegistrerSøknadSteg
* SøknadGrunnlag
* SøknadGrunnlagRepository
* SøknadGrunnlagService

Lagt til integrasjonstester for `RegistrerSøknadSteg` og `SøknadGrunnlagRepository` og enhetstester for `SøknadGrunnlagService`. Har også lagt til test for ny metode i `LoggService`.

Har ikke laget test for `BehandlingStegController`. Kan tas i en senere PR etter at ControllerTest-PR til @UyQuangNguyen er merget.