### PR TITLE
Utvidet OppslagSpringRunnerTest med initialisering av søker, fagsak og behandling

### DIFF
--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -32,13 +32,6 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Personopplys
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.sivilstand.GrSivilstand
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.statsborgerskap.GrStatsborgerskap
-import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.AnnenVurdering
-import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
-import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.PersonResultat
-import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Resultat
-import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkår
-import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
-import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
@@ -238,53 +231,4 @@ fun lagPerson(
     person.sivilstander = mutableListOf(GrSivilstand.fraSivilstand(lagSivilstand(), person))
 
     return person
-}
-
-fun lagVilkårsvurdering(
-    søkerAktør: Aktør,
-    behandling: Behandling,
-    resultat: Resultat,
-    søkerPeriodeFom: LocalDate? = LocalDate.now().minusMonths(1),
-    søkerPeriodeTom: LocalDate? = LocalDate.now().plusYears(2)
-): Vilkårsvurdering {
-    val vilkårsvurdering = Vilkårsvurdering(
-        behandling = behandling
-    )
-    val personResultat = PersonResultat(
-        vilkårsvurdering = vilkårsvurdering,
-        aktør = søkerAktør
-    )
-    personResultat.setSortedVilkårResultater(
-        setOf(
-            VilkårResultat(
-                personResultat = personResultat,
-                vilkårType = Vilkår.BOSATT_I_RIKET,
-                resultat = resultat,
-                periodeFom = søkerPeriodeFom,
-                periodeTom = søkerPeriodeTom,
-                begrunnelse = "",
-                behandlingId = behandling.id
-            ),
-            VilkårResultat(
-                personResultat = personResultat,
-                vilkårType = Vilkår.MEDLEMSSKAP,
-                resultat = resultat,
-                periodeFom = søkerPeriodeFom,
-                periodeTom = søkerPeriodeTom,
-                begrunnelse = "",
-                behandlingId = behandling.id
-            )
-        )
-    )
-    personResultat.andreVurderinger.add(
-        AnnenVurdering(
-            personResultat = personResultat,
-            resultat = resultat,
-            type = AnnenVurderingType.OPPLYSNINGSPLIKT,
-            begrunnelse = null
-        )
-    )
-
-    vilkårsvurdering.personResultater = setOf(personResultat)
-    return vilkårsvurdering
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -32,6 +32,13 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Personopplys
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.sivilstand.GrSivilstand
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.statsborgerskap.GrStatsborgerskap
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.AnnenVurdering
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
@@ -221,4 +228,53 @@ fun lagPerson(
     person.sivilstander = mutableListOf(GrSivilstand.fraSivilstand(lagSivilstand(), person))
 
     return person
+}
+
+fun lagVilkårsvurdering(
+    søkerAktør: Aktør,
+    behandling: Behandling,
+    resultat: Resultat,
+    søkerPeriodeFom: LocalDate? = LocalDate.now().minusMonths(1),
+    søkerPeriodeTom: LocalDate? = LocalDate.now().plusYears(2)
+): Vilkårsvurdering {
+    val vilkårsvurdering = Vilkårsvurdering(
+        behandling = behandling
+    )
+    val personResultat = PersonResultat(
+        vilkårsvurdering = vilkårsvurdering,
+        aktør = søkerAktør
+    )
+    personResultat.setSortedVilkårResultater(
+        setOf(
+            VilkårResultat(
+                personResultat = personResultat,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = resultat,
+                periodeFom = søkerPeriodeFom,
+                periodeTom = søkerPeriodeTom,
+                begrunnelse = "",
+                behandlingId = behandling.id
+            ),
+            VilkårResultat(
+                personResultat = personResultat,
+                vilkårType = Vilkår.MEDLEMSSKAP,
+                resultat = resultat,
+                periodeFom = søkerPeriodeFom,
+                periodeTom = søkerPeriodeTom,
+                begrunnelse = "",
+                behandlingId = behandling.id
+            )
+        )
+    )
+    personResultat.andreVurderinger.add(
+        AnnenVurdering(
+            personResultat = personResultat,
+            resultat = resultat,
+            type = AnnenVurderingType.OPPLYSNINGSPLIKT,
+            begrunnelse = null
+        )
+    )
+
+    vilkårsvurdering.personResultater = setOf(personResultat)
+    return vilkårsvurdering
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -42,6 +42,7 @@ import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+import kotlin.math.abs
 import kotlin.random.Random
 
 val fødselsnummerGenerator = FoedselsnummerGenerator()
@@ -129,12 +130,21 @@ fun lagPersonopplysningGrunnlag(
 
 fun lagFagsak(aktør: Aktør = randomAktør(randomFnr())) = Fagsak(aktør = aktør)
 
+private var gjeldendeBehandlingId: Long = abs(Random.nextLong(10000000))
+
+private const val ID_INKREMENT = 50
+fun nesteBehandlingId(): Long {
+    gjeldendeBehandlingId += ID_INKREMENT
+    return gjeldendeBehandlingId
+}
+
 fun lagBehandling(
     fagsak: Fagsak = lagFagsak(),
     type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     opprettetÅrsak: BehandlingÅrsak,
     kategori: BehandlingKategori = BehandlingKategori.NASJONAL
 ): Behandling = Behandling(
+    id = nesteBehandlingId(),
     fagsak = fagsak,
     type = type,
     opprettetÅrsak = opprettetÅrsak,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -72,12 +72,17 @@ internal class ArbeidsfordelingServiceTest {
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
         val endreBehandlendeEnhetDto = EndreBehandlendeEnhetDto("testId", "testBegrunnelse")
 
-        every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(0) } returns null
+        every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) } returns null
 
         val feil =
-            assertThrows<IllegalStateException> { arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(behandling, endreBehandlendeEnhetDto) }
+            assertThrows<IllegalStateException> {
+                arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(
+                    behandling,
+                    endreBehandlendeEnhetDto
+                )
+            }
 
-        assertThat(feil.message, Is("Finner ikke tilknyttet arbeidsfordeling på behandling med id 0"))
+        assertThat(feil.message, Is("Finner ikke tilknyttet arbeidsfordeling på behandling med id ${behandling.id}"))
     }
 
     @Test
@@ -87,14 +92,27 @@ internal class ArbeidsfordelingServiceTest {
         val mockedArbeidsfordelingPåBehandling = mockk<ArbeidsfordelingPåBehandling>(relaxed = true)
         val mockedArbeidsfordelingPåBehandlingEtterEndring = mockk<ArbeidsfordelingPåBehandling>(relaxed = true)
 
-        every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(0) } returns mockedArbeidsfordelingPåBehandling
-        every { integrasjonClient.hentNavKontorEnhet("testId") } returns NavKontorEnhet(0, "testNavn", "testEnhet", "testStatus")
-        every { mockedArbeidsfordelingPåBehandling.copy(0, 0, "testId", "testNavn", true) } returns mockedArbeidsfordelingPåBehandlingEtterEndring
+        every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) } returns mockedArbeidsfordelingPåBehandling
+        every { integrasjonClient.hentNavKontorEnhet("testId") } returns NavKontorEnhet(
+            0,
+            "testNavn",
+            "testEnhet",
+            "testStatus"
+        )
+        every {
+            mockedArbeidsfordelingPåBehandling.copy(
+                0,
+                0,
+                "testId",
+                "testNavn",
+                true
+            )
+        } returns mockedArbeidsfordelingPåBehandlingEtterEndring
         every { arbeidsfordelingPåBehandlingRepository.save(mockedArbeidsfordelingPåBehandlingEtterEndring) } returns mockedArbeidsfordelingPåBehandlingEtterEndring
 
         arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(behandling, endreBehandlendeEnhetDto)
 
-        verify(exactly = 1) { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(0) }
+        verify(exactly = 1) { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) }
         verify(exactly = 1) { integrasjonClient.hentNavKontorEnhet("testId") }
         verify(exactly = 1) { mockedArbeidsfordelingPåBehandling.copy(0, 0, "testId", "testNavn", true) }
         verify(exactly = 1) { arbeidsfordelingPåBehandlingRepository.save(mockedArbeidsfordelingPåBehandlingEtterEndring) }

--- a/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
+++ b/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
@@ -9,6 +9,12 @@ import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.config.DatabaseCleanupService
 import no.nav.familie.ks.sak.config.DbContainerInitializer
 import no.nav.familie.ks.sak.config.RolleConfig
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
@@ -53,6 +59,15 @@ abstract class OppslagSpringRunnerTest {
 
     @Autowired
     lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var aktørRepository: AktørRepository
+
+    @Autowired
+    private lateinit var fagsakRepository: FagsakRepository
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
 
     @LocalServerPort
     var port: Int = 0
@@ -100,6 +115,13 @@ abstract class OppslagSpringRunnerTest {
             .forEach { it.clear() }
 
     private fun resetTableForAllEntityClass() = databaseCleanupService.truncate()
+
+    fun lagreAktør(aktør: Aktør): Aktør = aktørRepository.saveAndFlush(aktør)
+
+    fun lagreFagsak(fagsak: Fagsak): Fagsak = fagsakRepository.saveAndFlush(fagsak)
+
+    fun lagreBehandling(behandling: Behandling): Behandling =
+        behandlingRepository.saveAndFlush(behandling)
 
     companion object {
         protected fun initLoggingEventListAppender(): ListAppender<ILoggingEvent> =

--- a/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
+++ b/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
@@ -23,7 +23,6 @@ import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -83,13 +82,6 @@ abstract class OppslagSpringRunnerTest {
     @LocalServerPort
     var port: Int = 0
 
-    @BeforeEach
-    fun beforeEach() {
-        søker = lagreAktør(randomAktør())
-        fagsak = lagreFagsak(lagFagsak(aktør = søker))
-        behandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
-    }
-
     @AfterEach
     @Transactional
     fun reset() {
@@ -97,6 +89,12 @@ abstract class OppslagSpringRunnerTest {
         resetTableForAllEntityClass()
         clearCaches()
         resetWiremockServers()
+    }
+
+    fun opprettSøkerFagsakOgBehandling(søker: Aktør = randomAktør()) {
+        this.søker = lagreAktør(søker)
+        fagsak = lagreFagsak(lagFagsak(aktør = søker))
+        behandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
     }
 
     protected fun lokalTestToken(

--- a/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
+++ b/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
@@ -9,8 +9,12 @@ import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.config.DatabaseCleanupService
 import no.nav.familie.ks.sak.config.DbContainerInitializer
 import no.nav.familie.ks.sak.config.RolleConfig
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
@@ -19,6 +23,7 @@ import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -69,8 +74,21 @@ abstract class OppslagSpringRunnerTest {
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
 
+    lateinit var søker: Aktør
+
+    lateinit var fagsak: Fagsak
+
+    lateinit var behandling: Behandling
+
     @LocalServerPort
     var port: Int = 0
+
+    @BeforeEach
+    fun beforeEach() {
+        søker = lagreAktør(randomAktør())
+        fagsak = lagreFagsak(lagFagsak(aktør = søker))
+        behandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
+    }
 
     @AfterEach
     @Transactional

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/BehandlingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/BehandlingControllerTest.kt
@@ -37,6 +37,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun setup() {
         RestAssured.port = port
+        opprettSøkerFagsakOgBehandling()
         arbeidsfordelingPåBehandlingRepository.save(
             ArbeidsfordelingPåBehandling(
                 behandlingId = behandling.id,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -1,20 +1,12 @@
 package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.behandling.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
-import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagFagsak
-import no.nav.familie.ks.sak.data.randomAktør
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
-import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,17 +16,6 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
-
-    private lateinit var søker: Aktør
-    private lateinit var fagsak: Fagsak
-    private lateinit var behandling: Behandling
-
-    @BeforeEach
-    fun beforeEach() {
-        søker = lagreAktør(randomAktør())
-        fagsak = lagreFagsak(lagFagsak(søker))
-        behandling = lagreBehandling(lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
-    }
 
     @Test
     fun `hentBehandling - skal finne behandling med behandlingsId`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -7,15 +7,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
+
+    @BeforeEach
+    fun beforeEach() {
+        opprettSøkerFagsakOgBehandling()
+    }
 
     @Test
     fun `hentBehandling - skal finne behandling med behandlingsId`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagStegTest.kt
@@ -51,6 +51,7 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
+        opprettSøkerFagsakOgBehandling()
         every { personOpplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns lagPdlPersonInfo()
         every { arbeidsfordelingService.fastsettBehandledeEnhet(any()) } just runs
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagStegTest.kt
@@ -7,22 +7,18 @@ import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPdlPersonInfo
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.shouldNotBeNull
 import no.nav.familie.ks.sak.integrasjon.pdl.PersonOpplysningerService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerPersonGrunnlagSteg
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
-import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
@@ -39,12 +35,6 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
     private lateinit var registrerPersonGrunnlagSteg: RegistrerPersonGrunnlagSteg
 
     @Autowired
-    private lateinit var fagsakRepository: FagsakRepository
-
-    @Autowired
-    private lateinit var aktørRepository: AktørRepository
-
-    @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
 
     @Autowired
@@ -59,18 +49,8 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
     @MockkBean
     private lateinit var beregningService: BeregningService
 
-    private lateinit var behandling: Behandling
-
     @BeforeEach
     fun init() {
-        val aktør = aktørRepository.saveAndFlush(randomAktør())
-        val fagsak = fagsakRepository.saveAndFlush(lagFagsak(aktør))
-        behandling = behandlingRepository.saveAndFlush(
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD
-            )
-        )
         every { personOpplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns lagPdlPersonInfo()
         every { arbeidsfordelingService.fastsettBehandledeEnhet(any()) } just runs
     }
@@ -81,7 +61,8 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
         verify(atLeast = 1) { arbeidsfordelingService.fastsettBehandledeEnhet(behandling) }
         verify(atMost = 1) { personOpplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(behandling.fagsak.aktør) }
 
-        val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id).shouldNotBeNull()
+        val personopplysningGrunnlag =
+            personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id).shouldNotBeNull()
         assertEquals(1, personopplysningGrunnlag.personer.size)
 
         val person = personopplysningGrunnlag.personer.single()
@@ -97,9 +78,12 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre REGISTRERE_PERSONGRUNNLAG steg for Revurdering`() {
-        val barnAktør = aktørRepository.saveAndFlush(randomAktør())
+        val barnAktør = lagreAktør(randomAktør())
         every { beregningService.finnBarnFraBehandlingMedTilkjentYtelse(behandling.id) } returns listOf(barnAktør)
-        every { personOpplysningerService.hentPersoninfoEnkel(any()) } returns lagPdlPersonInfo(enkelPersonInfo = true, erBarn = true)
+        every { personOpplysningerService.hentPersoninfoEnkel(any()) } returns lagPdlPersonInfo(
+            enkelPersonInfo = true,
+            erBarn = true
+        )
 
         val gammelPersonopplysningGrunnlag = lagPersonopplysningGrunnlag(
             behandlingId = behandling.id,
@@ -109,7 +93,12 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
             barnAktør = listOf(barnAktør)
         )
         personopplysningGrunnlagRepository.save(gammelPersonopplysningGrunnlag)
-        behandlingRepository.saveAndFlush(behandling.copy(status = BehandlingStatus.AVSLUTTET, aktiv = false))
+        lagreBehandling(
+            behandling.also {
+                it.status = BehandlingStatus.AVSLUTTET
+                it.aktiv = false
+            }
+        )
 
         val revurdering = behandlingRepository.saveAndFlush(
             lagBehandling(
@@ -125,7 +114,8 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
         verify(atMost = 1) { personOpplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(revurdering.fagsak.aktør) }
         verify(atMost = 1) { personOpplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(barnAktør) }
 
-        val personopplysningGrunnlag = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(revurdering.id).shouldNotBeNull()
+        val personopplysningGrunnlag =
+            personopplysningGrunnlagRepository.findByBehandlingAndAktiv(revurdering.id).shouldNotBeNull()
         assertEquals(2, personopplysningGrunnlag.personer.size)
 
         val søker = personopplysningGrunnlag.personer.single { it.type == PersonType.SØKER }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
@@ -53,6 +53,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun init() {
+        opprettSøkerFagsakOgBehandling()
         barn1 = aktørRepository.saveAndFlush(randomAktør())
         barn2 = aktørRepository.saveAndFlush(randomAktør())
         val personopplysningGrunnlag =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
@@ -10,18 +10,12 @@ import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
 import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
-import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPdlPersonInfo
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.pdl.PersonOpplysningerService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrereSøknadSteg
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
@@ -42,12 +36,6 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
     private lateinit var aktørRepository: AktørRepository
 
     @Autowired
-    private lateinit var fagsakRepository: FagsakRepository
-
-    @Autowired
-    private lateinit var behandlingRepository: BehandlingRepository
-
-    @Autowired
     private lateinit var søknadGrunnlagRepository: SøknadGrunnlagRepository
 
     @Autowired
@@ -59,26 +47,14 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
     @MockkBean
     private lateinit var arbeidsfordelingService: ArbeidsfordelingService
 
-    private lateinit var behandling: Behandling
-
-    private lateinit var søker: Aktør
-
     private lateinit var barn1: Aktør
 
     private lateinit var barn2: Aktør
 
     @BeforeEach
     fun init() {
-        søker = aktørRepository.saveAndFlush(randomAktør())
         barn1 = aktørRepository.saveAndFlush(randomAktør())
         barn2 = aktørRepository.saveAndFlush(randomAktør())
-        val fagsak = fagsakRepository.saveAndFlush(lagFagsak(søker))
-        behandling = behandlingRepository.saveAndFlush(
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD
-            )
-        )
         val personopplysningGrunnlag =
             lagPersonopplysningGrunnlag(behandling.id, søker.aktivFødselsnummer(), søkerAktør = søker)
         personopplysningGrunnlagRepository.saveAndFlush(personopplysningGrunnlag)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -6,9 +6,7 @@ import io.mockk.just
 import io.mockk.runs
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagRegistrerSøknadDto
-import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
@@ -27,9 +25,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus.VENTER
 import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerPersonGrunnlagSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrereSøknadSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
-import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -50,15 +45,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     private lateinit var registrerSøknadSteg: RegistrereSøknadSteg
 
     @Autowired
-    private lateinit var aktørRepository: AktørRepository
-
-    @Autowired
-    private lateinit var fagsakRepository: FagsakRepository
-
-    @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
-
-    private lateinit var fagsak: Fagsak
 
     @BeforeEach
     fun setup() {
@@ -67,19 +54,10 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
         every { registrerSøknadSteg.utførSteg(any()) } just runs
         every { registrerSøknadSteg.getBehandlingssteg() } answers { callOriginal() }
-
-        val aktør = aktørRepository.saveAndFlush(randomAktør())
-        fagsak = fagsakRepository.saveAndFlush(lagFagsak(aktør))
     }
 
     @Test
     fun `utførSteg skal utføre REGISTRER_PERSONGRUNNLAG og sette neste steg til REGISTRER_SØKNAD for FGB`() {
-        var behandling = behandlingRepository.saveAndFlush(
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD
-            )
-        )
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
 
@@ -91,30 +69,25 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre REGISTRER_PERSONGRUNNLAG og sette neste steg til VILKÅRSVURDERING for revurdering`() {
-        var behandling = behandlingRepository.saveAndFlush(
+        lagreBehandling(behandling.also { it.aktiv = false })
+        var revurderingBehandling = lagreBehandling(
             lagBehandling(
                 fagsak = fagsak,
                 type = BehandlingType.REVURDERING,
                 opprettetÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER
             )
         )
-        assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
-        assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
+        assertBehandlingHarSteg(revurderingBehandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
+        assertDoesNotThrow { stegService.utførSteg(revurderingBehandling.id, REGISTRERE_PERSONGRUNNLAG) }
 
-        behandling = behandlingRepository.hentBehandling(behandling.id)
-        assertEquals(2, behandling.behandlingStegTilstand.size)
-        assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, UTFØRT)
-        assertBehandlingHarSteg(behandling, VILKÅRSVURDERING, KLAR)
+        revurderingBehandling = behandlingRepository.hentBehandling(revurderingBehandling.id)
+        assertEquals(2, revurderingBehandling.behandlingStegTilstand.size)
+        assertBehandlingHarSteg(revurderingBehandling, REGISTRERE_PERSONGRUNNLAG, UTFØRT)
+        assertBehandlingHarSteg(revurderingBehandling, VILKÅRSVURDERING, KLAR)
     }
 
     @Test
     fun `utførSteg skal tilbakeføre behandlingsresultat når REGISTRERE_SØKNAD utføres på nytt for FGB`() {
-        var behandling = behandlingRepository.saveAndFlush(
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD
-            )
-        )
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegistrerSøknadDto()) }
@@ -138,12 +111,6 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal gjenoppta REGISTRERE_SØKNAD når steget er på vent for FGB`() {
-        var behandling = behandlingRepository.saveAndFlush(
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD
-            )
-        )
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
         behandling = behandlingRepository.hentBehandling(behandling.id)
@@ -151,7 +118,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
                 it.behandlingStegTilstand
                     .maxByOrNull { tilstand -> tilstand.behandlingSteg.sekvens }?.behandlingStegStatus = VENTER
             }
-        behandlingRepository.saveAndFlush(behandling)
+        lagreBehandling(behandling)
 
         behandling = behandlingRepository.hentBehandling(behandling.id)
         assertEquals(2, behandling.behandlingStegTilstand.size)
@@ -167,14 +134,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal ikke utføre IVERKSETT_MOT_OPPDRAG steg`() {
-        val behandling = behandlingRepository.saveAndFlush(
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD
-            )
-        )
         behandling.leggTilNesteSteg(IVERKSETT_MOT_OPPDRAG)
-        behandlingRepository.saveAndFlush(behandling)
+        lagreBehandling(behandling)
 
         val exception = assertThrows<RuntimeException> { stegService.utførSteg(behandling.id, IVERKSETT_MOT_OPPDRAG) }
         assertEquals(
@@ -185,41 +146,36 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal ikke utføre REGISTRERE_SØKNAD for behandling med årsak SATSENDRING`() {
-        val behandling = behandlingRepository.saveAndFlush(
+        lagreBehandling(behandling.also { it.aktiv = false })
+        var revurderingBehandling = lagreBehandling(
             lagBehandling(
                 fagsak = fagsak,
                 type = BehandlingType.REVURDERING,
                 opprettetÅrsak = BehandlingÅrsak.SATSENDRING
             )
         )
-        assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
-        behandling.leggTilNesteSteg(REGISTRERE_SØKNAD)
-        behandlingRepository.saveAndFlush(behandling)
+        assertBehandlingHarSteg(revurderingBehandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
+        revurderingBehandling.leggTilNesteSteg(REGISTRERE_SØKNAD)
+        lagreBehandling(revurderingBehandling)
 
         val exception = assertThrows<RuntimeException> {
             stegService.utførSteg(
-                behandling.id,
+                revurderingBehandling.id,
                 REGISTRERE_SØKNAD,
                 lagRegistrerSøknadDto()
             )
         }
         assertEquals(
-            "Steget ${REGISTRERE_SØKNAD.name} er ikke gyldig for behandling ${behandling.id} " +
-                "med opprettetÅrsak ${behandling.opprettetÅrsak}",
+            "Steget ${REGISTRERE_SØKNAD.name} er ikke gyldig for behandling ${revurderingBehandling.id} " +
+                "med opprettetÅrsak ${revurderingBehandling.opprettetÅrsak}",
             exception.message
         )
     }
 
     @Test
     fun `utførSteg skal ikke utføre SATSENDRING steg før REGISTRERE_PERSONGRUNNLAG er utført`() {
-        val behandling = behandlingRepository.saveAndFlush(
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD
-            )
-        )
         behandling.leggTilNesteSteg(REGISTRERE_SØKNAD)
-        behandlingRepository.saveAndFlush(behandling)
+        lagreBehandling(behandling)
 
         val exception = assertThrows<RuntimeException> {
             stegService.utførSteg(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -49,6 +49,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun setup() {
+        opprettSøkerFagsakOgBehandling()
         every { registerPersonGrunnlagSteg.utførSteg(any()) } just runs
         every { registerPersonGrunnlagSteg.getBehandlingssteg() } answers { callOriginal() }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
@@ -1,12 +1,9 @@
 package no.nav.familie.ks.sak.kjerne.fagsak.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
-import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.randomAktør
-import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -16,17 +13,8 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    private lateinit var søker: Aktør
-
-    @BeforeEach
-    fun beforeEach() {
-        søker = lagreAktør(randomAktør())
-    }
-
     @Test
     fun `finnFagsak skal returnere fagsak dersom det eksisterer en fagsak med id`() {
-        val fagsak = lagreFagsak(lagFagsak(søker))
-
         val hentetFagsak = fagsakRepository.finnFagsak(fagsak.id)!!
 
         assertThat(hentetFagsak.id, Is(fagsak.id))
@@ -50,8 +38,6 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `finnFagsakForAktør skal returnere fagsak dersom det finnes fagsak for aktør`() {
-        val fagsak = lagreFagsak(lagFagsak(søker))
-
         val hentetFagsak = fagsakRepository.finnFagsakForAktør(søker)!!
 
         assertThat(hentetFagsak.id, Is(fagsak.id))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ks.sak.kjerne.fagsak.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.randomAktør
-import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -14,14 +16,16 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
-    @Autowired
-    private lateinit var aktørRepository: AktørRepository
+    private lateinit var søker: Aktør
 
-    val randomAktør = randomAktør()
+    @BeforeEach
+    fun beforeEach() {
+        søker = lagreAktør(randomAktør())
+    }
 
     @Test
     fun `finnFagsak skal returnere fagsak dersom det eksisterer en fagsak med id`() {
-        val fagsak = lagreFagsak()
+        val fagsak = lagreFagsak(lagFagsak(søker))
 
         val hentetFagsak = fagsakRepository.finnFagsak(fagsak.id)!!
 
@@ -46,17 +50,11 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `finnFagsakForAktør skal returnere fagsak dersom det finnes fagsak for aktør`() {
-        val fagsak = lagreFagsak()
+        val fagsak = lagreFagsak(lagFagsak(søker))
 
-        val hentetFagsak = fagsakRepository.finnFagsakForAktør(randomAktør)!!
+        val hentetFagsak = fagsakRepository.finnFagsakForAktør(søker)!!
 
         assertThat(hentetFagsak.id, Is(fagsak.id))
         assertThat(hentetFagsak.aktør, Is(fagsak.aktør))
-    }
-
-    private fun lagreFagsak(): Fagsak {
-        val aktør = aktørRepository.saveAndFlush(randomAktør)
-
-        return fagsakRepository.saveAndFlush(Fagsak(aktør = aktør))
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.data.randomAktør
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -12,6 +13,11 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
+
+    @BeforeEach
+    fun beforeEach() {
+        opprettSøkerFagsakOgBehandling()
+    }
 
     @Test
     fun `finnFagsak skal returnere fagsak dersom det eksisterer en fagsak med id`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/domene/LoggRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/domene/LoggRepositoryTest.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.logg.LoggType
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -12,6 +13,11 @@ internal class LoggRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var loggRepository: LoggRepository
+
+    @BeforeEach
+    fun beforeEach() {
+        opprettSøkerFagsakOgBehandling()
+    }
 
     @Test
     fun `hentLoggForBehandling - skal returnere logg som er lagret for behandling`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/domene/LoggRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/domene/LoggRepositoryTest.kt
@@ -2,18 +2,8 @@ package no.nav.familie.ks.sak.kjerne.logg.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.config.BehandlerRolle
-import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagFagsak
-import no.nav.familie.ks.sak.data.randomAktør
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.logg.LoggType
-import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -22,24 +12,6 @@ internal class LoggRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var loggRepository: LoggRepository
-
-    @Autowired
-    private lateinit var fagsakRepository: FagsakRepository
-
-    @Autowired
-    private lateinit var behandlingRepository: BehandlingRepository
-
-    @Autowired
-    private lateinit var aktørRepository: AktørRepository
-
-    private lateinit var fagsak: Fagsak
-    private lateinit var behandling: Behandling
-
-    @BeforeEach
-    fun beforeEach() {
-        fagsak = lagreFagsak()
-        behandling = lagreBehandling(fagsak)
-    }
 
     @Test
     fun `hentLoggForBehandling - skal returnere logg som er lagret for behandling`() {
@@ -58,11 +30,4 @@ internal class LoggRepositoryTest : OppslagSpringRunnerTest() {
         assertThat(hentetLogg.single().behandlingId, Is(behandling.id))
         assertThat(hentetLogg.single().type, Is(LoggType.BEHANDLING_OPPRETTET))
     }
-
-    private fun lagreFagsak(): Fagsak {
-        val aktør = aktørRepository.saveAndFlush(randomAktør())
-        return fagsakRepository.saveAndFlush(lagFagsak(aktør))
-    }
-
-    private fun lagreBehandling(fagsak: Fagsak): Behandling = behandlingRepository.saveAndFlush(lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/AktørRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/AktørRepositoryTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -14,6 +15,11 @@ class AktørRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var aktørRepository: AktørRepository
+
+    @BeforeEach
+    fun beforeEach() {
+        opprettSøkerFagsakOgBehandling()
+    }
 
     @Test
     fun `findByAktørId - skal returnere Aktør dersom aktør med bestemt aktørId finnes i db`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
@@ -42,8 +42,6 @@ class PersonidentRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `findByFødselsnummerOrNull - skal returnere null dersom det ikke finnes en personident med bestemt fødselsnummer i db`() {
-        val aktør = opprettAktør()
-        val aktivFødselsnummer = aktør.aktivFødselsnummer()
         val fødselsnummer = randomFnr()
 
         val personident = personidentRepository.findByFødselsnummerOrNull(fødselsnummer)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
@@ -1,14 +1,12 @@
 package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.personident.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
-import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
-import no.nav.familie.ks.sak.kjerne.personident.Aktør
-import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -17,22 +15,21 @@ class PersonidentRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var personidentRepository: PersonidentRepository
 
-    @Autowired
-    private lateinit var aktørRepository: AktørRepository
+    @BeforeEach
+    fun beforeEach() {
+        opprettSøkerFagsakOgBehandling()
+    }
 
     @Test
     fun `hentAlleIdenterForAktørid - skal hente liste over alle personidenter tilknyttet aktørId`() {
-        val aktør = opprettAktør()
-
-        val hentedePersonidenter = personidentRepository.hentAlleIdenterForAktørid(aktør.aktørId)
+        val hentedePersonidenter = personidentRepository.hentAlleIdenterForAktørid(søker.aktørId)
 
         assertEquals(1, hentedePersonidenter.size)
     }
 
     @Test
     fun `findByFødselsnummerOrNull - skal hente personident med bestemt fødselsnummer dersom det finnes i db`() {
-        val aktør = opprettAktør()
-        val aktivFødselsnummer = aktør.aktivFødselsnummer()
+        val aktivFødselsnummer = søker.aktivFødselsnummer()
 
         val personident = personidentRepository.findByFødselsnummerOrNull(aktivFødselsnummer)
 
@@ -47,9 +44,5 @@ class PersonidentRepositoryTest : OppslagSpringRunnerTest() {
         val personident = personidentRepository.findByFødselsnummerOrNull(fødselsnummer)
 
         assertNull(personident)
-    }
-
-    private fun opprettAktør(): Aktør {
-        return aktørRepository.saveAndFlush(randomAktør())
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
@@ -9,12 +9,9 @@ import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
-import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlagRepository
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -30,15 +27,6 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var søknadGrunnlagRepository: SøknadGrunnlagRepository
 
-    @Autowired
-    private lateinit var aktørRepository: AktørRepository
-
-    @Autowired
-    private lateinit var fagsakRepository: FagsakRepository
-
-    @Autowired
-    private lateinit var behandlingRepository: BehandlingRepository
-
     private lateinit var søker: Aktør
 
     private lateinit var fagsak: Fagsak
@@ -48,8 +36,8 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun beforeEach() {
         søker = lagreAktør(randomAktør())
-        fagsak = lagreFagsak(søker)
-        behandling = lagreBehandling(fagsak)
+        fagsak = lagreFagsak(lagFagsak(søker))
+        behandling = lagreBehandling(lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
     }
 
     @Test
@@ -79,18 +67,6 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
 
         val søknadsGrunnlag = søknadGrunnlagRepository.hentAlle(behandling.id)
         assertEquals(3, søknadsGrunnlag.size)
-    }
-
-    fun lagreAktør(aktør: Aktør): Aktør {
-        return aktørRepository.saveAndFlush(aktør)
-    }
-
-    fun lagreFagsak(søker: Aktør): Fagsak {
-        return fagsakRepository.saveAndFlush(lagFagsak(aktør = søker))
-    }
-
-    fun lagreBehandling(fagsak: Fagsak): Behandling {
-        return behandlingRepository.saveAndFlush(lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
     }
 
     fun lagreSøknadGrunnlag(behandlingId: Long, barna: List<Aktør>, aktiv: Boolean = false): SøknadDto {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
@@ -12,6 +12,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -20,6 +21,11 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var søknadGrunnlagRepository: SøknadGrunnlagRepository
+
+    @BeforeEach
+    fun beforeEach() {
+        opprettSøkerFagsakOgBehandling()
+    }
 
     @Test
     fun `hentAktiv - skal hente aktiv SøknadGrunnlag tilknyttet behandlingId`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/søknad/domene/SøknadGrunnlagRepositoryTest.kt
@@ -5,19 +5,13 @@ import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.api.dto.tilSøknadGrunnlag
-import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.randomAktør
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.søknad.domene.SøknadGrunnlagRepository
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.hamcrest.CoreMatchers.`is` as Is
@@ -26,19 +20,6 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var søknadGrunnlagRepository: SøknadGrunnlagRepository
-
-    private lateinit var søker: Aktør
-
-    private lateinit var fagsak: Fagsak
-
-    private lateinit var behandling: Behandling
-
-    @BeforeEach
-    fun beforeEach() {
-        søker = lagreAktør(randomAktør())
-        fagsak = lagreFagsak(lagFagsak(søker))
-        behandling = lagreBehandling(lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
-    }
 
     @Test
     fun `hentAktiv - skal hente aktiv SøknadGrunnlag tilknyttet behandlingId`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/domene/VedtakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/domene/VedtakRepositoryTest.kt
@@ -1,19 +1,11 @@
 package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.vedtak.domene
 
 import no.nav.familie.ks.sak.OppslagSpringRunnerTest
-import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagFagsak
-import no.nav.familie.ks.sak.data.randomAktør
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
-import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.vedtak.domene.VedtakRepository
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,17 +16,6 @@ internal class VedtakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var vedtakRepository: VedtakRepository
-
-    private lateinit var søker: Aktør
-    private lateinit var fagsak: Fagsak
-    private lateinit var behandling: Behandling
-
-    @BeforeEach
-    fun beforeEach() {
-        søker = lagreAktør(randomAktør())
-        fagsak = lagreFagsak(lagFagsak(søker))
-        behandling = lagreBehandling(lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD))
-    }
 
     @Test
     fun `findByBehandlingAndAktiv - skal kaste EmptyResultDataAccessException hvis det ikke finnes aktiv vedtak for behandling`() {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/domene/VedtakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/domene/VedtakRepositoryTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ks.sak.kjerne.vedtak.domene.VedtakRepository
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,6 +17,11 @@ internal class VedtakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var vedtakRepository: VedtakRepository
+
+    @BeforeEach
+    fun beforeEach() {
+        opprettSøkerFagsakOgBehandling()
+    }
 
     @Test
     fun `findByBehandlingAndAktiv - skal kaste EmptyResultDataAccessException hvis det ikke finnes aktiv vedtak for behandling`() {


### PR DESCRIPTION
Lagt til feltene `søker`, `fagsak` og `behandling` i `OppslagSpringRunnerTest` og initialiserer de i `@BeforeEach` slik at vi slipper masse duplisert kode rundt omkring i de forskjellige integrasjonstestene.

Har måttet justere noen av testene etter endringen og ellers fjernet mye duplisert kode.

Litt rotete commit-meldinger da jeg først la inn endringen i vilkårsvurdering-branchen 🙈 Tenkte det var bedre å gjøre det som en separat PR.