### PR TITLE
Fikset sirkular avhengighet i forbindelse med StegService og BehandlingService på en annen måte.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
-import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -28,8 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @Validated
 class BehandlingController(
     private val behandlingService: BehandlingService,
-    private val tilgangService: TilgangService,
-    private val stegService: StegService
+    private val tilgangService: TilgangService
 ) {
 
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -40,7 +38,7 @@ class BehandlingController(
             event = AuditLoggerEvent.CREATE,
             handling = "Opprett behandling"
         )
-        val behandling = stegService.håndterNyBehandling(opprettBehandlingDto)
+        val behandling = behandlingService.opprettBehandling(opprettBehandlingDto)
         return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = behandling.id)))
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/journalføring/InnkommendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/journalføring/InnkommendeJournalføringService.kt
@@ -20,12 +20,12 @@ import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.journalføring.domene.DbJournalpost
 import no.nav.familie.ks.sak.integrasjon.journalføring.domene.DbJournalpostType
 import no.nav.familie.ks.sak.integrasjon.journalføring.domene.JournalføringRepository
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingHentService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import org.springframework.stereotype.Service
@@ -36,8 +36,8 @@ import javax.transaction.Transactional
 class InnkommendeJournalføringService(
     private val integrasjonClient: IntegrasjonClient,
     private val fagsakService: FagsakService,
-    private val stegService: StegService,
     private val behandlingService: BehandlingService,
+    private val behandlingHentService: BehandlingHentService,
     private val journalføringRepository: JournalføringRepository,
     private val loggService: LoggService
 ) {
@@ -116,14 +116,14 @@ class InnkommendeJournalføringService(
             søknadMottattDato = søknadMottattDato
         )
 
-        return stegService.håndterNyBehandling(nyBehandlingDto)
+        return behandlingService.opprettBehandling(nyBehandlingDto)
     }
 
     private fun lagreJournalpostOgKnyttFagsakTilJournalpost(
         tilknyttedeBehandlingIder: List<String>,
         journalpostId: String
     ): Pair<Sak, List<Behandling>> {
-        val behandlinger = tilknyttedeBehandlingIder.map { behandlingService.hentBehandling(it.toLong()) }
+        val behandlinger = tilknyttedeBehandlingIder.map { behandlingHentService.hentBehandling(it.toLong()) }
         val journalpost = hentJournalpost(journalpostId)
 
         behandlinger.forEach {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingHentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingHentService.kt
@@ -8,11 +8,9 @@ import org.springframework.stereotype.Service
 @Service
 class BehandlingHentService(private val behandlingRepository: BehandlingRepository) {
 
-    fun hentSisteBehandlingSomErVedtatt(fagsakId: Long): Behandling? {
-        return behandlingRepository.finnBehandlinger(fagsakId)
+    fun hentSisteBehandlingSomErVedtatt(fagsakId: Long): Behandling? = behandlingRepository.finnBehandlinger(fagsakId)
             .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
             .maxByOrNull { it.opprettetTidspunkt }
-    }
 
     fun hentBehandling(behandlingId: Long): Behandling = behandlingRepository.hentBehandling(behandlingId)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingHentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingHentService.kt
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service
 class BehandlingHentService(private val behandlingRepository: BehandlingRepository) {
 
     fun hentSisteBehandlingSomErVedtatt(fagsakId: Long): Behandling? = behandlingRepository.finnBehandlinger(fagsakId)
-            .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
-            .maxByOrNull { it.opprettetTidspunkt }
+        .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
+        .maxByOrNull { it.opprettetTidspunkt }
 
     fun hentBehandling(behandlingId: Long): Behandling = behandlingRepository.hentBehandling(behandlingId)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingHentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingHentService.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.ks.sak.kjerne.behandling
+
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import org.springframework.stereotype.Service
+
+@Service
+class BehandlingHentService(private val behandlingRepository: BehandlingRepository) {
+
+    fun hentSisteBehandlingSomErVedtatt(fagsakId: Long): Behandling? {
+        return behandlingRepository.finnBehandlinger(fagsakId)
+            .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
+            .maxByOrNull { it.opprettetTidspunkt }
+    }
+
+    fun hentBehandling(behandlingId: Long): Behandling = behandlingRepository.hentBehandling(behandlingId)
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -13,6 +13,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
+import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -39,7 +41,8 @@ class BehandlingService(
     private val taskRepository: TaskRepository,
     private val søknadGrunnlagService: SøknadGrunnlagService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
-    private val vilkårsvurderingService: VilkårsvurderingService
+    private val vilkårsvurderingService: VilkårsvurderingService,
+    private val stegService: StegService
 ) {
 
     @Transactional
@@ -93,6 +96,8 @@ class BehandlingService(
                 )
             )
         }
+        // Utfør Registrer Persongrunnlag steg
+        stegService.utførSteg(lagretBehandling.id, BehandlingSteg.REGISTRERE_PERSONGRUNNLAG)
         return lagretBehandling
     }
 
@@ -115,12 +120,16 @@ class BehandlingService(
         return behandlingRepository.save(behandling)
     }
 
+    // kan kalles fra BehandlingController eller BehandlingServicetest metoder,
+    // andre tjenester bruker eventuelt BehandlingHentService istedet
     fun hentSisteBehandlingSomErVedtatt(fagsakId: Long): Behandling? {
         return behandlingRepository.finnBehandlinger(fagsakId)
             .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
             .maxByOrNull { it.opprettetTidspunkt }
     }
 
+    // kan kalles fra BehandlingController eller BehandlingServicetest metoder,
+    // andre tjenester bruker eventuelt BehandlingHentService istedet
     fun hentBehandling(behandlingId: Long): Behandling = behandlingRepository.hentBehandling(behandlingId)
 
     fun lagBehandlingRespons(behandlingId: Long): BehandlingResponsDto {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadSteg.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
 import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
 import no.nav.familie.ks.sak.api.dto.tilSøknadGrunnlag
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
-import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingHentService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.søknad.SøknadGrunnlagService
@@ -18,7 +18,7 @@ class RegistrereSøknadSteg(
     private val søknadGrunnlagService: SøknadGrunnlagService,
     private val loggService: LoggService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
-    private val behandlingService: BehandlingService,
+    private val behandlingHentService: BehandlingHentService,
     private val vilkårsvurderingService: VilkårsvurderingService
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.REGISTRERE_SØKNAD
@@ -38,10 +38,10 @@ class RegistrereSøknadSteg(
             søknadGrunnlagService.lagreOgDeaktiverGammel(registrerSøknadDto.søknad.tilSøknadGrunnlag(behandlingId))
 
         // Oppdatere personopplysningsgrunnlag dersom det er lagt til barn som ikke fantes fra før
-        val behandling = behandlingService.hentBehandling(behandlingId)
+        val behandling = behandlingHentService.hentBehandling(behandlingId)
         personopplysningGrunnlagService.oppdaterPersonopplysningGrunnlag(behandling, søknadGrunnlag.tilSøknadDto())
 
-        val forrigeBehandlingSomErVedtatt = behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+        val forrigeBehandlingSomErVedtatt = behandlingHentService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
 
         vilkårsvurderingService.opprettVilkårsvurdering(behandling, forrigeBehandlingSomErVedtatt)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -1,9 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
 import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
-import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
@@ -14,8 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class StegService(
     private val steg: List<IBehandlingSteg>,
-    private val behandlingRepository: BehandlingRepository,
-    private val behandlingService: BehandlingService
+    private val behandlingRepository: BehandlingRepository
 ) {
 
     @Transactional
@@ -70,13 +67,6 @@ class StegService(
                         "med steg $behandledeSteg med status ${BehandlingStegStatus.AVBRUTT}"
                 )
         }
-    }
-
-    @Transactional
-    fun håndterNyBehandling(opprettBehandlingDto: OpprettBehandlingDto): Behandling {
-        val behandling = behandlingService.opprettBehandling(opprettBehandlingDto)
-        utførSteg(behandling.id, BehandlingSteg.REGISTRERE_PERSONGRUNNLAG)
-        return behandling
     }
 
     private fun valider(behandling: Behandling, behandledeSteg: BehandlingSteg) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper
-import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.data.lagBehandling
@@ -95,10 +94,7 @@ class BehandlingServiceTest {
     private val søker = randomAktør()
     private val søkersIdent = søker.personidenter.first { personIdent -> personIdent.aktiv }.fødselsnummer
     private val fagsak = lagFagsak(aktør = søker)
-    private val behandling = lagBehandling(
-        fagsak,
-        opprettetÅrsak = BehandlingÅrsak.SØKNAD
-    )
+    private val behandling = lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
     private val søknadsgrunnlagMockK = mockk<SøknadGrunnlag>()
 
     @BeforeEach


### PR DESCRIPTION
Jeg mener StegService kun bør inneholde logikken til stegflytting. Vi bør ikke blande opprettelse kall innenfor StegService. Derfor fikset jeg sirkular avhengighet mellom stegene og BehandlingService på en annen måte. Jeg opprettet hjelper tjeneste BehandlingHentService som kan brukes av andre tjenester, eventuelt alle steg klassene. Da er StegService ikke avhengig av BehandlingService lenger og BehandlingController kan benytte BehandlingService.kt for opprettelse