### PR TITLE
Satt opp integrasjon mot Sanity og lagt til endepunkt for å hente vilkårsbegrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingController.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.ks.sak.api
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårDto
+import no.nav.familie.ks.sak.kjerne.vedtak.VedtakBegrunnelseType
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/vilkaarsvurdering")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class VilkårsvurderingController(
+    private val vilkårsvurderingService: VilkårsvurderingService
+) {
+    @GetMapping(path = ["/vilkaarsbegrunnelser"])
+    fun hentVilkårsbegrunnelser(): ResponseEntity<Ressurs<Map<VedtakBegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårDto>>>> {
+        return ResponseEntity.ok(Ressurs.success(vilkårsvurderingService.hentVilkårsbegrunnelser()))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingController.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ks.sak.api
 
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårDto
+import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.kjerne.vedtak.VedtakBegrunnelseType
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.VilkårsvurderingService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -19,7 +19,7 @@ class VilkårsvurderingController(
     private val vilkårsvurderingService: VilkårsvurderingService
 ) {
     @GetMapping(path = ["/vilkaarsbegrunnelser"])
-    fun hentVilkårsbegrunnelser(): ResponseEntity<Ressurs<Map<VedtakBegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårDto>>>> {
+    fun hentVilkårsbegrunnelser(): ResponseEntity<Ressurs<Map<VedtakBegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårResponseDto>>>> {
         return ResponseEntity.ok(Ressurs.success(vilkårsvurderingService.hentVilkårsbegrunnelser()))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VilkårsvurderingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VilkårsvurderingDto.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.api.dto
 
+import no.nav.familie.ks.sak.kjerne.vedtak.IVedtakBegrunnelse
 import no.nav.familie.ks.sak.kjerne.vedtak.Standardbegrunnelse
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Regelverk
@@ -38,4 +39,10 @@ data class AnnenVurderingDto(
     val resultat: Resultat,
     val type: AnnenVurderingType,
     val begrunnelse: String?
+)
+
+data class VedtakBegrunnelseTilknyttetVilkårDto(
+    val id: IVedtakBegrunnelse,
+    val navn: String,
+    val vilkår: Vilkår?
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VilkårsvurderingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VilkårsvurderingDto.kt
@@ -41,7 +41,7 @@ data class AnnenVurderingDto(
     val begrunnelse: String?
 )
 
-data class VedtakBegrunnelseTilknyttetVilkårDto(
+data class VedtakBegrunnelseTilknyttetVilkårResponseDto(
     val id: IVedtakBegrunnelse,
     val navn: String,
     val vilkår: Vilkår?

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.familie.http.client.RetryOAuth2HttpClient
 import no.nav.familie.http.config.RestTemplateAzure
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.filter.LogFilter
 import no.nav.security.token.support.client.core.http.OAuth2HttpClient
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
@@ -18,10 +19,14 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
+import org.springframework.http.converter.ByteArrayHttpMessageConverter
+import org.springframework.http.converter.StringHttpMessageConverter
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.retry.annotation.EnableRetry
 import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.web.client.RestOperations
 import org.springframework.web.client.RestTemplate
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
@@ -72,6 +77,17 @@ class ApplicationConfig {
                 .setConnectTimeout(Duration.of(2, ChronoUnit.SECONDS))
                 .setReadTimeout(Duration.of(4, ChronoUnit.SECONDS))
         )
+
+    @Bean
+    fun restOperations(): RestOperations {
+        return RestTemplate(
+            listOf(
+                StringHttpMessageConverter(StandardCharsets.UTF_8),
+                ByteArrayHttpMessageConverter(),
+                MappingJackson2HttpMessageConverter(objectMapper)
+            )
+        )
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(ApplicationConfig::class.java)

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/CachedSanityKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/CachedSanityKlient.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ks.sak.integrasjon.sanity
+
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Component
+
+@Component
+class CachedSanityKlient(
+    private val sanityKlient: SanityKlient,
+    @Value("\${SANITY_DATASET}") private val sanityDatasett: String
+) {
+
+    @Cacheable("sanityBegrunnelser", cacheManager = "shortCache")
+    fun hentSanityBegrunnelserCached(): List<SanityBegrunnelse> {
+        return sanityKlient.hentBegrunnelser(datasett = sanityDatasett)
+    }
+
+    @Cacheable("sanityEØSBegrunnelser", cacheManager = "shortCache")
+    fun hentEØSBegrunnelserCached(): List<SanityEØSBegrunnelse> {
+        return sanityKlient.hentEØSBegrunnelser(datasett = sanityDatasett)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/CachedSanityKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/CachedSanityKlient.kt
@@ -13,12 +13,10 @@ class CachedSanityKlient(
 ) {
 
     @Cacheable("sanityBegrunnelser", cacheManager = "shortCache")
-    fun hentSanityBegrunnelserCached(): List<SanityBegrunnelse> {
-        return sanityKlient.hentBegrunnelser(datasett = sanityDatasett)
-    }
+    fun hentSanityBegrunnelserCached(): List<SanityBegrunnelse> =
+        sanityKlient.hentBegrunnelser(datasett = sanityDatasett)
 
     @Cacheable("sanityEØSBegrunnelser", cacheManager = "shortCache")
-    fun hentEØSBegrunnelserCached(): List<SanityEØSBegrunnelse> {
-        return sanityKlient.hentEØSBegrunnelser(datasett = sanityDatasett)
-    }
+    fun hentEØSBegrunnelserCached(): List<SanityEØSBegrunnelse> =
+        sanityKlient.hentEØSBegrunnelser(datasett = sanityDatasett)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityKlient.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ks.sak.integrasjon.sanity
+
+import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.ks.sak.common.kallEksternTjeneste
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelserResponsDto
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelserResponsDto
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestOperations
+import java.net.URI
+import java.net.URLEncoder
+
+@Service
+class SanityKlient(@Value("\${SANITY_BASE_URL}") private val sanityBaseUrl: String, restOperations: RestOperations) :
+    AbstractRestClient(restOperations, "sanity") {
+    fun hentBegrunnelser(datasett: String = "ba-brev"): List<SanityBegrunnelse> {
+        val uri = lagHentUri(datasett, hentBegrunnelser)
+
+        // TODO: Fjern try/catch og default dummy-respons ved feil når vi får satt opp sanity dokument og struktur på respons.
+        return try {
+            val restSanityBegrunnelser =
+                kallEksternTjeneste<SanityBegrunnelserResponsDto>(
+                    tjeneste = "Sanity",
+                    uri = uri,
+                    formål = "Henter begrunnelser fra sanity"
+                ) {
+                    getForEntity(uri)
+                }
+
+            restSanityBegrunnelser.result.map { it.tilSanityBegrunnelse() }
+        } catch (e: Exception) {
+            listOf(SanityBegrunnelse("dummyApiNavn", "dummyNavnISystem", Vilkår.values().toList()))
+        }
+    }
+
+    fun hentEØSBegrunnelser(datasett: String = "ba-brev"): List<SanityEØSBegrunnelse> {
+        val uri = lagHentUri(datasett, hentEØSBegrunnelser)
+
+        // TODO: Fjern try/catch og default dummy-respons ved feil når vi får satt opp sanity dokument og struktur på respons.
+        return try {
+            val restSanityEØSBegrunnelser = kallEksternTjeneste<SanityEØSBegrunnelserResponsDto>(
+                tjeneste = "Sanity",
+                uri = uri,
+                formål = "Henter EØS-begrunnelser fra sanity"
+            ) {
+                getForEntity(uri)
+            }
+
+            restSanityEØSBegrunnelser.result.map { it.tilSanityEØSBegrunnelse() }
+        } catch (e: Exception) {
+            listOf(SanityEØSBegrunnelse("dummyApiNavn", "dummyNavnISystem"))
+        }
+    }
+
+    private fun lagHentUri(datasett: String, query: String): URI {
+        val hentQuery = URLEncoder.encode(query, "utf-8")
+        return URI.create("$sanityBaseUrl/$datasett?query=$hentQuery")
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityQueries.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityQueries.kt
@@ -1,0 +1,36 @@
+package no.nav.familie.ks.sak.integrasjon.sanity
+
+// TODO: Tilpass query for KS
+const val hentBegrunnelser =
+    "*[_type == \"begrunnelse\" && behandlingstema != \"EØS\" && apiNavn != null && navnISystem != null]{" +
+        "apiNavn," +
+        "navnISystem," +
+        "hjemler," +
+        "hjemlerFolketrygdloven," +
+        "vilkaar," +
+        "rolle," +
+        "lovligOppholdTriggere," +
+        "bosattIRiketTriggere," +
+        "giftPartnerskapTriggere," +
+        "borMedSokerTriggere," +
+        "ovrigeTriggere," +
+        "endretUtbetalingsperiodeTriggere," +
+        "endretUtbetalingsperiodeDeltBostedUtbetalingTrigger," +
+        "endringsaarsaker," +
+        "utvidetBarnetrygdTriggere" +
+        "}"
+
+// TODO: Tilpass query for KS
+const val hentEØSBegrunnelser =
+    "*[_type == \"begrunnelse\" && behandlingstema == \"EØS\" && apiNavn != null && navnISystem != null]{" +
+        "apiNavn," +
+        "navnISystem," +
+        "hjemler," +
+        "hjemlerFolketrygdloven," +
+        "hjemlerEOSForordningen883," +
+        "hjemlerEOSForordningen987," +
+        "hjemlerSeperasjonsavtalenStorbritannina," +
+        "annenForeldersAktivitet," +
+        "barnetsBostedsland," +
+        "kompetanseResultat" +
+        "}"

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityService.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.ks.sak.integrasjon.sanity
+
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient.Companion.RETRY_BACKOFF_5000MS
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+
+@Service
+class SanityService(
+    private val cachedSanityKlient: CachedSanityKlient
+) {
+
+    @Retryable(
+        value = [Exception::class],
+        maxAttempts = 3,
+        backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS)
+    )
+    fun hentSanityBegrunnelser(): List<SanityBegrunnelse> = cachedSanityKlient.hentSanityBegrunnelserCached()
+
+    @Retryable(
+        value = [Exception::class],
+        maxAttempts = 3,
+        backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS)
+    )
+    fun hentSanityEØSBegrunnelser(): List<SanityEØSBegrunnelse> =
+        cachedSanityKlient.hentEØSBegrunnelserCached()
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
@@ -1,0 +1,78 @@
+package no.nav.familie.ks.sak.integrasjon.sanity.domene
+
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.ks.sak.kjerne.vedtak.TriggesAv
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkår
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+data class SanityBegrunnelse(
+    val apiNavn: String?,
+    val navnISystem: String,
+    val vilkaar: List<Vilkår>? = null,
+    val rolle: List<PersonType> = emptyList()
+)
+
+data class SanityBegrunnelserResponsDto(
+    val ms: Int,
+    val query: String,
+    val result: List<SanityBegrunnelseDto>
+)
+
+// TODO: Har fjernet de fleste av feltene som brukes i ba-sak, så her må vi finne ut hvilke felter vi skal ha for KS
+data class SanityBegrunnelseDto(
+    val apiNavn: String?,
+    val navnISystem: String,
+    val vilkaar: List<String>? = emptyList(),
+    val rolle: List<String>? = emptyList()
+) {
+    fun tilSanityBegrunnelse(): SanityBegrunnelse {
+        return SanityBegrunnelse(
+            apiNavn = apiNavn,
+            navnISystem = navnISystem,
+            vilkaar = vilkaar?.mapNotNull {
+                finnEnumverdi(it, Vilkår.values(), apiNavn)
+            },
+            rolle = rolle?.mapNotNull { finnEnumverdi(it, PersonType.values(), apiNavn) } ?: emptyList()
+        )
+    }
+}
+
+private val logger: Logger = LoggerFactory.getLogger(SanityBegrunnelseDto::class.java)
+
+fun <T : Enum<T>> finnEnumverdi(verdi: String, enumverdier: Array<T>, apiNavn: String?): T? {
+    val enumverdi = enumverdier.firstOrNull { verdi == it.name }
+    if (enumverdi == null) {
+        logger.error(
+            "$verdi på begrunnelsen $apiNavn er ikke blant verdiene til enumen ${enumverdier.javaClass.simpleName}"
+        )
+    }
+    return enumverdi
+}
+
+enum class VilkårRolle {
+    SOKER,
+    BARN
+}
+
+fun SanityBegrunnelse.tilTriggesAv(): TriggesAv {
+    return TriggesAv(
+        vilkår = this.vilkaar?.toSet() ?: emptySet(),
+        personTyper = if (this.rolle.isEmpty()) {
+            when {
+                this.inneholderVilkår(Vilkår.BOSATT_I_RIKET) -> Vilkår.BOSATT_I_RIKET.parterDetteGjelderFor.toSet()
+                this.inneholderVilkår(Vilkår.MEDLEMSKAP) -> Vilkår.MEDLEMSKAP.parterDetteGjelderFor.toSet()
+                this.inneholderVilkår(Vilkår.BARNEHAGEPLASS) -> Vilkår.BARNEHAGEPLASS.parterDetteGjelderFor.toSet()
+                this.inneholderVilkår(Vilkår.MEDLEMSKAP_ANNEN_FORELDER) -> Vilkår.MEDLEMSKAP_ANNEN_FORELDER.parterDetteGjelderFor.toSet()
+                this.inneholderVilkår(Vilkår.BOR_MED_SØKER) -> Vilkår.BOR_MED_SØKER.parterDetteGjelderFor.toSet()
+                this.inneholderVilkår(Vilkår.MELLOM_1_OG_2_ELLER_ADOPTERT) -> Vilkår.MELLOM_1_OG_2_ELLER_ADOPTERT.parterDetteGjelderFor.toSet()
+                else -> setOf(PersonType.BARN, PersonType.SØKER)
+            }
+        } else {
+            this.rolle.toSet()
+        }
+    )
+}
+
+fun SanityBegrunnelse.inneholderVilkår(vilkår: Vilkår) =
+    this.vilkaar?.contains(vilkår) ?: false

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityEØSBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityEØSBegrunnelse.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.ks.sak.integrasjon.sanity.domene
+
+data class SanityEØSBegrunnelse(
+    val apiNavn: String,
+    val navnISystem: String
+)
+
+data class SanityEØSBegrunnelserResponsDto(
+    val ms: Int,
+    val query: String,
+    val result: List<SanityEØSBegrunnelseDto>
+)
+
+// TODO: Har fjernet de fleste av feltene som brukes i ba-sak, så her må vi finne ut hvilke felter vi skal ha for KS
+data class SanityEØSBegrunnelseDto(
+    val apiNavn: String,
+    val navnISystem: String
+) {
+    fun tilSanityEØSBegrunnelse(): SanityEØSBegrunnelse {
+        return SanityEØSBegrunnelse(
+            apiNavn = apiNavn,
+            navnISystem = navnISystem
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/EØSStandardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/EØSStandardbegrunnelse.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.ks.sak.kjerne.vedtak
+
+// TODO: Må legge inn faktiske begrunnelser vi skal ha her
+enum class EØSStandardbegrunnelse : IVedtakBegrunnelse {
+    DUMMY {
+        override val sanityApiNavn = "dummyApiNavn"
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.EØS_OPPHØR
+    };
+
+    override val kanDelesOpp = false
+    override fun enumnavnTilString() = this.name
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/Standardbegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/Standardbegrunnelse.kt
@@ -14,7 +14,16 @@ interface IVedtakBegrunnelse {
     fun enumnavnTilString(): String
 }
 
-enum class Standardbegrunnelse : IVedtakBegrunnelse
+// TODO: Må legge inn faktiske begrunnelser vi skal ha her
+enum class Standardbegrunnelse : IVedtakBegrunnelse {
+    DUMMY {
+        override val sanityApiNavn = "dummyApiNavn"
+        override val vedtakBegrunnelseType = VedtakBegrunnelseType.AVSLAG
+    };
+
+    override val kanDelesOpp = false
+    override fun enumnavnTilString() = this.name
+}
 
 @Converter
 class StandardbegrunnelseListConverter :

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/StandardbegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/StandardbegrunnelseUtils.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.ks.sak.kjerne.vedtak
+
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(Standardbegrunnelse::class.java)
+
+fun Standardbegrunnelse.tilSanityBegrunnelse(
+    sanityBegrunnelser: List<SanityBegrunnelse>
+): SanityBegrunnelse? {
+    val sanityBegrunnelse = sanityBegrunnelser.find { it.apiNavn == this.sanityApiNavn }
+    if (sanityBegrunnelse == null) {
+        logger.warn("Finner ikke begrunnelse med apinavn '${this.sanityApiNavn}' på '${this.name}' i Sanity")
+    }
+    return sanityBegrunnelse
+}
+
+fun EØSStandardbegrunnelse.tilSanityEØSBegrunnelse(
+    eøsSanityBegrunnelser: List<SanityEØSBegrunnelse>
+): SanityEØSBegrunnelse? {
+    val sanityBegrunnelse = eøsSanityBegrunnelser.find { it.apiNavn == this.sanityApiNavn }
+    if (sanityBegrunnelse == null) {
+        logger.warn("Finner ikke begrunnelse med apinavn '${this.sanityApiNavn}' på '${this.name}' i Sanity")
+    }
+    return sanityBegrunnelse
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/TriggesAv.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/TriggesAv.kt
@@ -1,0 +1,9 @@
+package no.nav.familie.ks.sak.kjerne.vedtak
+
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkår
+
+data class TriggesAv(
+    val vilkår: Set<Vilkår>,
+    val personTyper: Set<PersonType>
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.vilkårsvurdering
 
-import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårDto
+import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
@@ -87,7 +87,7 @@ class VilkårsvurderingService(
         }
     }
 
-    fun hentVilkårsbegrunnelser(): Map<VedtakBegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårDto>> =
+    fun hentVilkårsbegrunnelser(): Map<VedtakBegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårResponseDto>> =
         standardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityBegrunnelser()) + eøsStandardbegrunnelserTilNedtrekksmenytekster(
             sanityService.hentSanityEØSBegrunnelser()
         )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingService.kt
@@ -1,8 +1,11 @@
 package no.nav.familie.ks.sak.kjerne.vilkårsvurdering
 
+import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårDto
+import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import no.nav.familie.ks.sak.kjerne.vedtak.VedtakBegrunnelseType
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkår
@@ -16,7 +19,8 @@ import org.springframework.stereotype.Service
 @Service
 class VilkårsvurderingService(
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
-    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService
+    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
+    private val sanityService: SanityService
 ) {
 
     fun opprettVilkårsvurdering(behandling: Behandling, forrigeBehandlingSomErVedtatt: Behandling?): Vilkårsvurdering {
@@ -82,6 +86,11 @@ class VilkårsvurderingService(
             }.toSet()
         }
     }
+
+    fun hentVilkårsbegrunnelser(): Map<VedtakBegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårDto>> =
+        standardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityBegrunnelser()) + eøsStandardbegrunnelserTilNedtrekksmenytekster(
+            sanityService.hentSanityEØSBegrunnelser()
+        )
 
     companion object {
         val logger = LoggerFactory.getLogger(VilkårsvurderingService::class.java)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.vilkårsvurdering
 
-import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårDto
+import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.tilTriggesAv
@@ -40,7 +40,7 @@ fun eøsStandardbegrunnelserTilNedtrekksmenytekster(
 fun vedtakBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
     sanityBegrunnelser: List<SanityBegrunnelse>,
     vedtakBegrunnelse: Standardbegrunnelse
-): List<VedtakBegrunnelseTilknyttetVilkårDto> {
+): List<VedtakBegrunnelseTilknyttetVilkårResponseDto> {
     val sanityBegrunnelse = vedtakBegrunnelse.tilSanityBegrunnelse(sanityBegrunnelser) ?: return emptyList()
 
     val triggesAv = sanityBegrunnelse.tilTriggesAv()
@@ -48,7 +48,7 @@ fun vedtakBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
 
     return if (triggesAv.vilkår.isEmpty()) {
         listOf(
-            VedtakBegrunnelseTilknyttetVilkårDto(
+            VedtakBegrunnelseTilknyttetVilkårResponseDto(
                 id = vedtakBegrunnelse,
                 navn = visningsnavn,
                 vilkår = null
@@ -56,7 +56,7 @@ fun vedtakBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
         )
     } else {
         triggesAv.vilkår.map {
-            VedtakBegrunnelseTilknyttetVilkårDto(
+            VedtakBegrunnelseTilknyttetVilkårResponseDto(
                 id = vedtakBegrunnelse,
                 navn = visningsnavn,
                 vilkår = it
@@ -68,11 +68,11 @@ fun vedtakBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
 fun eøsBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
     sanityEØSBegrunnelser: List<SanityEØSBegrunnelse>,
     vedtakBegrunnelse: EØSStandardbegrunnelse
-): List<VedtakBegrunnelseTilknyttetVilkårDto> {
+): List<VedtakBegrunnelseTilknyttetVilkårResponseDto> {
     val eøsSanityBegrunnelse = vedtakBegrunnelse.tilSanityEØSBegrunnelse(sanityEØSBegrunnelser) ?: return emptyList()
 
     return listOf(
-        VedtakBegrunnelseTilknyttetVilkårDto(
+        VedtakBegrunnelseTilknyttetVilkårResponseDto(
             id = vedtakBegrunnelse,
             navn = eøsSanityBegrunnelse.navnISystem,
             vilkår = null

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -1,0 +1,81 @@
+package no.nav.familie.ks.sak.kjerne.vilkårsvurdering
+
+import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårDto
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.tilTriggesAv
+import no.nav.familie.ks.sak.kjerne.vedtak.EØSStandardbegrunnelse
+import no.nav.familie.ks.sak.kjerne.vedtak.Standardbegrunnelse
+import no.nav.familie.ks.sak.kjerne.vedtak.tilSanityBegrunnelse
+import no.nav.familie.ks.sak.kjerne.vedtak.tilSanityEØSBegrunnelse
+
+fun standardbegrunnelserTilNedtrekksmenytekster(
+    sanityBegrunnelser: List<SanityBegrunnelse>
+) =
+    Standardbegrunnelse
+        .values()
+        .groupBy { it.vedtakBegrunnelseType }
+        .mapValues { begrunnelseGruppe ->
+            begrunnelseGruppe.value
+                .flatMap { vedtakBegrunnelse ->
+                    vedtakBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
+                        sanityBegrunnelser,
+                        vedtakBegrunnelse
+                    )
+                }
+        }
+
+fun eøsStandardbegrunnelserTilNedtrekksmenytekster(
+    sanityEØSBegrunnelser: List<SanityEØSBegrunnelse>
+) = EØSStandardbegrunnelse.values().groupBy { it.vedtakBegrunnelseType }
+    .mapValues { begrunnelseGruppe ->
+        begrunnelseGruppe.value.flatMap { vedtakBegrunnelse ->
+            eøsBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
+                sanityEØSBegrunnelser,
+                vedtakBegrunnelse
+            )
+        }
+    }
+
+fun vedtakBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    vedtakBegrunnelse: Standardbegrunnelse
+): List<VedtakBegrunnelseTilknyttetVilkårDto> {
+    val sanityBegrunnelse = vedtakBegrunnelse.tilSanityBegrunnelse(sanityBegrunnelser) ?: return emptyList()
+
+    val triggesAv = sanityBegrunnelse.tilTriggesAv()
+    val visningsnavn = sanityBegrunnelse.navnISystem
+
+    return if (triggesAv.vilkår.isEmpty()) {
+        listOf(
+            VedtakBegrunnelseTilknyttetVilkårDto(
+                id = vedtakBegrunnelse,
+                navn = visningsnavn,
+                vilkår = null
+            )
+        )
+    } else {
+        triggesAv.vilkår.map {
+            VedtakBegrunnelseTilknyttetVilkårDto(
+                id = vedtakBegrunnelse,
+                navn = visningsnavn,
+                vilkår = it
+            )
+        }
+    }
+}
+
+fun eøsBegrunnelseTilRestVedtakBegrunnelseTilknyttetVilkår(
+    sanityEØSBegrunnelser: List<SanityEØSBegrunnelse>,
+    vedtakBegrunnelse: EØSStandardbegrunnelse
+): List<VedtakBegrunnelseTilknyttetVilkårDto> {
+    val eøsSanityBegrunnelse = vedtakBegrunnelse.tilSanityEØSBegrunnelse(sanityEØSBegrunnelser) ?: return emptyList()
+
+    return listOf(
+        VedtakBegrunnelseTilknyttetVilkårDto(
+            id = vedtakBegrunnelse,
+            navn = eøsSanityBegrunnelse.navnISystem,
+            vilkår = null
+        )
+    )
+}

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -150,7 +150,7 @@ logging:
     root: INFO
 sentry.environment: preprod
 
-SANITY_DATASET: "ba-brev"
+SANITY_DATASET: "ks-brev"
 
 PDL_URL: https://pdl-api-q1.dev-fss-pub.nais.io
 PDL_SCOPE: api://dev-fss.pdl.pdl-api-q1/.default

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -152,7 +152,7 @@ spring:
 
 sentry.environment: prod
 
-SANITY_DATASET: "ba-brev"
+SANITY_DATASET: "ks-brev"
 
 PDL_URL: https://pdl-api.prod-fss-pub.nais.io
 PDL_SCOPE: api://prod-fss.pdl.pdl-api/.default

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -114,7 +114,8 @@ FAMILIE_EF_SAK_API_URL_SCOPE: api://dev-gcp.teamfamilie.familie-ef-sak/.default
 FAMILIE_EF_SAK_API_URL: http://familie-ef-sak/api
 
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
-SANITY_DATASET: "ba-brev"
+SANITY_DATASET: "ks-brev"
+SANITY_BASE_URL: "https://xsrv1mh6.api.sanity.io/v2021-06-07/data/query"
 
 BA_SAK_FRONTEND_CLIENT_ID: "dummy"
 BA_MOTTAK_CLIENT_ID: "dummy"

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -3,13 +3,22 @@ package no.nav.familie.ks.sak.kjerne.vilkårsvurdering
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
-import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårsvurdering
 import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.vedtak.EØSStandardbegrunnelse
+import no.nav.familie.ks.sak.kjerne.vedtak.Standardbegrunnelse
+import no.nav.familie.ks.sak.kjerne.vedtak.VedtakBegrunnelseType
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.vilkårsvurdering.domene.Vilkårsvurdering
@@ -18,10 +27,11 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
-class VilkårsvurderingServiceTest : OppslagSpringRunnerTest() {
+@ExtendWith(MockKExtension::class)
+class VilkårsvurderingServiceTest {
 
     @MockK
     private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
@@ -29,18 +39,23 @@ class VilkårsvurderingServiceTest : OppslagSpringRunnerTest() {
     @MockK
     private lateinit var personopplysningGrunnlagService: PersonopplysningGrunnlagService
 
+    @MockK
+    private lateinit var sanityService: SanityService
+
     @InjectMockKs
     private lateinit var vilkårsvurderingService: VilkårsvurderingService
 
-    @BeforeEach
-    fun beforeEach() {
-        opprettSøkerFagsakOgBehandling()
-    }
+    private val søker = randomAktør()
+
+    private val fagsak = lagFagsak(søker)
+
+    private val behandling = lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
     @Test
     fun `opprettVilkårsvurdering - skal opprette tom vilkårsvurdering dersom det ikke finnes tidligere vedtatte behandlinger på fagsak`() {
-        val barn1 = lagreAktør(randomAktør())
-        val barn2 = lagreAktør(randomAktør())
+        val barn1 = randomAktør()
+        val barn2 = randomAktør()
+
         val lagretVilkårsvurderingSlot = slot<Vilkårsvurdering>()
         every { vilkårsvurderingRepository.finnAktiv(any()) } returns null
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns lagPersonopplysningGrunnlag(
@@ -73,8 +88,8 @@ class VilkårsvurderingServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettVilkårsvurdering - skal opprette tom vilkårsvurdering og deaktivere eksisterende dersom det ikke finnes tidligere vedtatte behandlinger på fagsak`() {
-        val barn1 = lagreAktør(randomAktør())
-        val barn2 = lagreAktør(randomAktør())
+        val barn1 = randomAktør()
+        val barn2 = randomAktør()
         val lagretDeaktivertVilkårsvurderingSlot = slot<Vilkårsvurdering>()
         val lagretVilkårsvurderingSlot = slot<Vilkårsvurdering>()
         every { vilkårsvurderingRepository.finnAktiv(any()) } returns lagVilkårsvurdering(
@@ -97,5 +112,30 @@ class VilkårsvurderingServiceTest : OppslagSpringRunnerTest() {
 
         assertEquals(3, lagretVilkårsvurdering.personResultater.size)
         assertFalse(lagretDeaktivertVilkårsvurdering.aktiv)
+    }
+
+    @Test
+    fun `hentVilkårsbegrunnelser - skal returnere et map med begrunnelsestyper mappet mot liste av begrunnelser`() {
+        every { sanityService.hentSanityBegrunnelser() } returns listOf(
+            SanityBegrunnelse(
+                Standardbegrunnelse.DUMMY.sanityApiNavn,
+                "navnISystem",
+                Vilkår.values().toList()
+            )
+        )
+
+        every { sanityService.hentSanityEØSBegrunnelser() } returns listOf(
+            SanityEØSBegrunnelse(
+                EØSStandardbegrunnelse.DUMMY.sanityApiNavn,
+                "navnISystem"
+            )
+        )
+
+        val vilkårsbegrunnelser = vilkårsvurderingService.hentVilkårsbegrunnelser()
+
+        // TODO: Endre denne testen når vi får lagt inn riktige Standardbegrunnelser og EØSStandardbegrunnelser
+        assertEquals(2, vilkårsbegrunnelser.size)
+        assertEquals(Vilkår.values().size, vilkårsbegrunnelser[VedtakBegrunnelseType.AVSLAG]?.size)
+        assertEquals(1, vilkårsbegrunnelser[VedtakBegrunnelseType.EØS_OPPHØR]?.size)
     }
 }

--- a/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
+++ b/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
@@ -38,7 +38,7 @@ import org.springframework.transaction.annotation.Transactional
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(initializers = [DbContainerInitializer::class])
 @SpringBootTest(classes = [DevLauncherLocal::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("postgres")
+@ActiveProfiles("postgres", "integrasjonstest")
 @EnableMockOAuth2Server
 @Tag("integrationTest")
 abstract class OppslagSpringRunnerTest {

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -1,0 +1,6 @@
+no.nav.security.jwt:
+  issuer:
+    azuread:
+      discoveryurl: http://localhost:${mock-oauth2-server.port}/azuread/.well-known/openid-configuration
+      acceptedaudience: familie-ks-sak-test
+      cookiename: localhost-idtoken

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -1,9 +1,9 @@
 no.nav.security.jwt:
-  issuer:
-    azuread:
-      discoveryurl: http://localhost:${mock-oauth2-server.port}/azuread/.well-known/openid-configuration
-      acceptedaudience: familie-ks-sak-test
-      cookiename: localhost-idtoken
+  #  issuer:
+  #    azuread:
+  #      discoveryurl: http://localhost:${mock-oauth2-server.port}/azuread/.well-known/openid-configuration
+  #      acceptedaudience: familie-ks-sak-test
+  #      cookiename: localhost-idtoken
   client:
     registration:
       familie-integrasjoner-onbehalfof:

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -1,9 +1,4 @@
 no.nav.security.jwt:
-  #  issuer:
-  #    azuread:
-  #      discoveryurl: http://localhost:${mock-oauth2-server.port}/azuread/.well-known/openid-configuration
-  #      acceptedaudience: familie-ks-sak-test
-  #      cookiename: localhost-idtoken
   client:
     registration:
       familie-integrasjoner-onbehalfof:


### PR DESCRIPTION
Lagt til:
* SanityKlient og CachedSanityKlient med `hentBegrunnelser()` og `hentEØSBegrunnelser()`
* SanityService som wrapper `CachedSanityKlient`
* Utvidet `VilkårsvurderingService` med `hentVilkårsbegrunnelser`
* Lagt til endepunkt `/vilkaarsbegrunnelser` som kaller på `hentVilkårsbegrunnelser` fra `VilkårsvurderingService`

Foreløpig har jeg fjernet mye av feltene som ble brukt i respons fra Sanity-datasettet `ba-brev` da de var veldig spesifikke for barnetrygd. Her må vi også få definert responsen vi skal ha for `ks-brev`!.

I og med at datasettet `ks-brev` ikke eksisterer, har jeg mocket ut en "dummy"-respons fra `SanityKlient` slik at vi får noe data som kan vises i frontend inntil videre.