### PR TITLE
Byttet ut ba-sak Sentry-dns med ks-sak sin

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ spring:
 
 logging:
   config: "classpath:logback-spring.xml"
-sentry.dsn: https://dd9a6107bdda4edeb51ece7283f37af4@sentry.gc.nav.no/112
+sentry.dsn: https://6f38c5d7dad244f786b493944b3087d4@sentry.gc.nav.no/3
 sentry.logging.enabled: true
 
 retry.backoff.delay: 5000

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -48,7 +48,7 @@
     <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
         <options>
             <!-- NOTE: Trenger dsn her også for å kunne logge feil som oppstår før spring er satt opp -->
-            <dsn>https://dd9a6107bdda4edeb51ece7283f37af4@sentry.gc.nav.no/112</dsn>
+            <dsn>https://6f38c5d7dad244f786b493944b3087d4@sentry.gc.nav.no/3</dsn>
         </options>
     </appender>
 


### PR DESCRIPTION
Vi har frem til nå brukt samme Sentry-project DNS som ba-sak. Dette har ført til at feil som oppstår i ks-sak dukker opp i dashboardet til ba-sak i Sentry. 

Har nå endret denne DNS-url'en til ks-sak sin egen Sentry-project DNS.