### PR TITLE
Chore/tester for tidslinjer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/Periode.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/Periode.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.ks.sak.common.tidslinje
+
+import java.time.LocalDate
+
+data class Periode<T>(
+    val verdi: T?,
+    val fom: LocalDate?,
+    val tom: LocalDate?
+) {
+
+    fun tilTidslinjePeriodeMedDato() = TidslinjePeriodeMedDato(verdi, fom, tom)
+}
+
+fun <T> List<Periode<T>>.tilTidslinje(): Tidslinje<T> = this.map { it.tilTidslinjePeriodeMedDato() }.tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/TidslinjePeriodeMedDato.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/TidslinjePeriodeMedDato.kt
@@ -3,15 +3,6 @@ package no.nav.familie.ks.sak.common.tidslinje
 import no.nav.familie.ks.sak.common.exception.Feil
 import java.time.LocalDate
 
-data class Periode<T>(
-    val verdi: T?,
-    val fom: LocalDate?,
-    val tom: LocalDate?
-) {
-
-    fun tilTidslinjePeriodeMedDato() = TidslinjePeriodeMedDato(verdi, fom, tom)
-}
-
 data class TidslinjePeriodeMedDato<T>(
     val periodeVerdi: PeriodeVerdi<T>,
     val fom: Dato,
@@ -45,9 +36,6 @@ data class TidslinjePeriodeMedDato<T>(
 
     fun tilPeriode() = Periode(periodeVerdi.verdi, fom.tilLocalDateEllerNull(), tom.tilLocalDateEllerNull())
 }
-
-@JvmName("perioderTilTidslinje")
-fun <T> List<Periode<T>>.tilTidslinje(): Tidslinje<T> = this.map { it.tilTidslinjePeriodeMedDato() }.tilTidslinje()
 
 fun <T> List<TidslinjePeriodeMedDato<T>>.tilTidslinje(): Tidslinje<T> {
     val perioder = this.tilTidslinjePerioder()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/PeriodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/PeriodeTest.kt
@@ -38,86 +38,86 @@ class PeriodeTest {
 
     @Test
     fun `tilPerioder - Skal kunne håndtere splitt i tidslinje`() {
-        val periode = listOf(
+        val perioder = listOf(
             Periode("a", førsteJanuar, sisteDagIJanuar),
             Periode("c", førsteMars, sisteDagIMars)
         ).tilTidslinje().tilPerioder()
 
-        Assertions.assertEquals(3, periode.size)
+        Assertions.assertEquals(3, perioder.size)
 
-        Assertions.assertEquals(førsteJanuar, periode[0].fom)
-        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
-        Assertions.assertEquals("a", periode[0].verdi)
+        Assertions.assertEquals(førsteJanuar, perioder[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, perioder[0].tom)
+        Assertions.assertEquals("a", perioder[0].verdi)
 
-        Assertions.assertEquals(førsteFebruar, periode[1].fom)
-        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
-        Assertions.assertEquals(null, periode[1].verdi)
+        Assertions.assertEquals(førsteFebruar, perioder[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, perioder[1].tom)
+        Assertions.assertEquals(null, perioder[1].verdi)
 
-        Assertions.assertEquals(førsteMars, periode[2].fom)
-        Assertions.assertEquals(sisteDagIMars, periode[2].tom)
-        Assertions.assertEquals("c", periode[2].verdi)
+        Assertions.assertEquals(førsteMars, perioder[2].fom)
+        Assertions.assertEquals(sisteDagIMars, perioder[2].tom)
+        Assertions.assertEquals("c", perioder[2].verdi)
     }
 
     @Test
     fun `tilPerioder - Skal kunne håndtere nullverdier i starten og slutten av tidslinje`() {
-        val periode = listOf(
+        val perioder = listOf(
             Periode("a", null, sisteDagIJanuar),
             Periode("b", førsteFebruar, sisteDagIFebruar),
             Periode("c", førsteMars, null)
         ).tilTidslinje().tilPerioder()
 
-        Assertions.assertEquals(3, periode.size)
+        Assertions.assertEquals(3, perioder.size)
 
-        Assertions.assertEquals(null, periode[0].fom)
-        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
-        Assertions.assertEquals("a", periode[0].verdi)
+        Assertions.assertEquals(null, perioder[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, perioder[0].tom)
+        Assertions.assertEquals("a", perioder[0].verdi)
 
-        Assertions.assertEquals(førsteFebruar, periode[1].fom)
-        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
-        Assertions.assertEquals("b", periode[1].verdi)
+        Assertions.assertEquals(førsteFebruar, perioder[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, perioder[1].tom)
+        Assertions.assertEquals("b", perioder[1].verdi)
 
-        Assertions.assertEquals(førsteMars, periode[2].fom)
-        Assertions.assertEquals(null, periode[2].tom)
-        Assertions.assertEquals("c", periode[2].verdi)
+        Assertions.assertEquals(førsteMars, perioder[2].fom)
+        Assertions.assertEquals(null, perioder[2].tom)
+        Assertions.assertEquals("c", perioder[2].verdi)
     }
 
     @Test
     fun `tilTidslinje - Skal kaste feil dersom det er flere tom-datoer med nullverdi`() {
-        val periode = listOf(
+        val perioder = listOf(
             Periode("a", null, sisteDagIJanuar),
             Periode("b", førsteFebruar, null),
             Periode("c", førsteMars, null)
         )
 
-        Assertions.assertThrows(Exception::class.java) { periode.tilTidslinje() }
+        Assertions.assertThrows(Exception::class.java) { perioder.tilTidslinje() }
     }
 
     @Test
     fun `tilTidslinje - Skal kaste feil dersom det er flere fom-datoer med nullverdi`() {
-        val periode = listOf(
+        val perioder = listOf(
             Periode("a", null, sisteDagIJanuar),
             Periode("b", null, sisteDagIFebruar),
             Periode("c", førsteMars, null)
         )
 
-        Assertions.assertThrows(Exception::class.java) { periode.tilTidslinje() }
+        Assertions.assertThrows(Exception::class.java) { perioder.tilTidslinje() }
     }
 
     @Test
     fun `tilTidslinje - Skal kaste feil om det er overlapp i periodene`() {
-        val periode = listOf(
+        val perioder = listOf(
             Periode("a", null, sisteDagIJanuar),
             Periode("b", førsteFebruar, sisteDagIMars),
             Periode("c", førsteMars, null)
         )
 
-        Assertions.assertThrows(Exception::class.java) { periode.tilTidslinje() }
+        Assertions.assertThrows(Exception::class.java) { perioder.tilTidslinje() }
     }
 
     @Test
     fun `tilTidslinje og tilPerioder - Skal håndtere tom liste`() {
-        val periode = emptyList<Periode<Any>>()
+        val perioder = emptyList<Periode<Any>>()
 
-        Assertions.assertEquals(0, periode.tilTidslinje().tilPerioder().size)
+        Assertions.assertEquals(0, perioder.tilTidslinje().tilPerioder().size)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/PeriodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/PeriodeTest.kt
@@ -1,0 +1,123 @@
+package no.nav.familie.ks.sak.common.tidslinje
+
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PeriodeTest {
+
+    private val førsteJanuar = LocalDate.of(2022, 1, 1)
+    private val sisteDagIJanuar = LocalDate.of(2022, 1, 31)
+    private val førsteFebruar = LocalDate.of(2022, 2, 1)
+    private val sisteDagIFebruar = LocalDate.of(2022, 2, 28)
+    private val førsteMars = LocalDate.of(2022, 3, 1)
+    private val sisteDagIMars = LocalDate.of(2022, 3, 31)
+
+    @Test
+    fun `tilPerioder - Skal beholde datoer ved manipulering på tidslinje`() {
+        val tidslinjeA = listOf(Periode("a", førsteJanuar, sisteDagIMars)).tilTidslinje()
+        val tidslinjeB = listOf(Periode("b", førsteFebruar, sisteDagIFebruar)).tilTidslinje()
+
+        val periode = tidslinjeA.kombinerMed(tidslinjeB) { a, b ->
+            b ?: a
+        }.tilPerioder()
+
+        Assertions.assertEquals(3, periode.size)
+
+        Assertions.assertEquals(førsteJanuar, periode[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
+
+        Assertions.assertEquals(førsteFebruar, periode[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
+
+        Assertions.assertEquals(førsteMars, periode[2].fom)
+        Assertions.assertEquals(sisteDagIMars, periode[2].tom)
+    }
+
+    @Test
+    fun `tilPerioder - Skal kunne håndtere splitt i tidslinje`() {
+        val periode = listOf(
+            Periode("a", førsteJanuar, sisteDagIJanuar),
+            Periode("c", førsteMars, sisteDagIMars)
+        ).tilTidslinje().tilPerioder()
+
+        Assertions.assertEquals(3, periode.size)
+
+        Assertions.assertEquals(førsteJanuar, periode[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
+        Assertions.assertEquals("a", periode[0].verdi)
+
+        Assertions.assertEquals(førsteFebruar, periode[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
+        Assertions.assertEquals(null, periode[1].verdi)
+
+        Assertions.assertEquals(førsteMars, periode[2].fom)
+        Assertions.assertEquals(sisteDagIMars, periode[2].tom)
+        Assertions.assertEquals("c", periode[2].verdi)
+    }
+
+    @Test
+    fun `tilPerioder - Skal kunne håndtere nullverdier i starten og slutten av tidslinje`() {
+        val periode = listOf(
+            Periode("a", null, sisteDagIJanuar),
+            Periode("b", førsteFebruar, sisteDagIFebruar),
+            Periode("c", førsteMars, null)
+        ).tilTidslinje().tilPerioder()
+
+        Assertions.assertEquals(3, periode.size)
+
+        Assertions.assertEquals(null, periode[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
+        Assertions.assertEquals("a", periode[0].verdi)
+
+        Assertions.assertEquals(førsteFebruar, periode[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
+        Assertions.assertEquals("b", periode[1].verdi)
+
+        Assertions.assertEquals(førsteMars, periode[2].fom)
+        Assertions.assertEquals(null, periode[2].tom)
+        Assertions.assertEquals("c", periode[2].verdi)
+    }
+
+    @Test
+    fun `tilTidslinje - Skal kaste feil dersom det er flere tom-datoer med nullverdi`() {
+        val periode = listOf(
+            Periode("a", null, sisteDagIJanuar),
+            Periode("b", førsteFebruar, null),
+            Periode("c", førsteMars, null)
+        )
+
+        Assertions.assertThrows(Exception::class.java) { periode.tilTidslinje() }
+    }
+
+    @Test
+    fun `tilTidslinje - Skal kaste feil dersom det er flere fom-datoer med nullverdi`() {
+        val periode = listOf(
+            Periode("a", null, sisteDagIJanuar),
+            Periode("b", null, sisteDagIFebruar),
+            Periode("c", førsteMars, null)
+        )
+
+        Assertions.assertThrows(Exception::class.java) { periode.tilTidslinje() }
+    }
+
+    @Test
+    fun `tilTidslinje - Skal kaste feil om det er overlapp i periodene`() {
+        val periode = listOf(
+            Periode("a", null, sisteDagIJanuar),
+            Periode("b", førsteFebruar, sisteDagIMars),
+            Periode("c", førsteMars, null)
+        )
+
+        Assertions.assertThrows(Exception::class.java) { periode.tilTidslinje() }
+    }
+
+    @Test
+    fun `tilTidslinje og tilPerioder - Skal håndtere tom liste`() {
+        val periode = emptyList<Periode<Any>>()
+
+        Assertions.assertEquals(0, periode.tilTidslinje().tilPerioder().size)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerMedTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerMedTest.kt
@@ -1,0 +1,75 @@
+import no.nav.familie.ks.sak.common.tidslinje.Periode
+import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class kombinerMedTest {
+
+    private val førsteJanuar = LocalDate.of(2022, 1, 1)
+    private val sisteDagIJanuar = LocalDate.of(2022, 1, 31)
+    private val førsteFebruar = LocalDate.of(2022, 2, 1)
+    private val sisteDagIFebruar = LocalDate.of(2022, 2, 28)
+    private val førsteMars = LocalDate.of(2022, 3, 1)
+    private val sisteDagIMars = LocalDate.of(2022, 3, 31)
+
+    /**
+     * a = |111|
+     * b = |-2-|
+     * (a ?: 0) + (b ?: 0) = |131|
+     **/
+    @Test
+    fun `kombinerMed - Skal kombinere overlappende verdier på tidslinjene`() {
+        val tidslinjeA = listOf(Periode(1, førsteJanuar, sisteDagIMars)).tilTidslinje()
+        val tidslinjeB = listOf(Periode(2, førsteFebruar, sisteDagIFebruar)).tilTidslinje()
+
+        val periode = tidslinjeA.kombinerMed(tidslinjeB) { verdiFraTidslinjeA, verdiFraTidslinjeB ->
+            (verdiFraTidslinjeA ?: 0) + (verdiFraTidslinjeB ?: 0)
+        }.tilPerioder()
+
+        Assertions.assertEquals(3, periode.size)
+
+        Assertions.assertEquals(førsteJanuar, periode[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
+        Assertions.assertEquals(1, periode[0].verdi)
+
+        Assertions.assertEquals(førsteFebruar, periode[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
+        Assertions.assertEquals(3, periode[1].verdi)
+
+        Assertions.assertEquals(førsteMars, periode[2].fom)
+        Assertions.assertEquals(sisteDagIMars, periode[2].tom)
+        Assertions.assertEquals(1, periode[2].verdi)
+    }
+
+    /**
+     * a = |1--|
+     * b = |--2|
+     * (a ?: 0) + (b ?: 0) = |102|
+     **/
+    @Test
+    fun `kombinerMed - Skal ikke kombinere verdier som ikke overlapper`() {
+        val tidslinjeA = listOf(Periode(1, førsteJanuar, sisteDagIJanuar)).tilTidslinje()
+        val tidslinjeB = listOf(Periode(2, førsteMars, sisteDagIMars)).tilTidslinje()
+
+        val periode = tidslinjeA.kombinerMed(tidslinjeB) { verdiFraTidslinjeA, verdiFraTidslinjeB ->
+            (verdiFraTidslinjeA ?: 0) + (verdiFraTidslinjeB ?: 0)
+        }.tilPerioder()
+
+        Assertions.assertEquals(3, periode.size)
+
+        Assertions.assertEquals(førsteJanuar, periode[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
+        Assertions.assertEquals(1, periode[0].verdi)
+
+        Assertions.assertEquals(førsteFebruar, periode[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
+        Assertions.assertEquals(0, periode[1].verdi)
+
+        Assertions.assertEquals(førsteMars, periode[2].fom)
+        Assertions.assertEquals(sisteDagIMars, periode[2].tom)
+        Assertions.assertEquals(2, periode[2].verdi)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerMedTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerMedTest.kt
@@ -28,27 +28,27 @@ class kombinerMedTest {
         val tidslinjeB =
             listOf(Periode(2, førsteFebruar, sisteDagIFebruar), Periode(2, førsteApril, sisteDagIApril)).tilTidslinje()
 
-        val periode = tidslinjeA.kombinerMed(tidslinjeB) { verdiFraTidslinjeA, verdiFraTidslinjeB ->
+        val perioder = tidslinjeA.kombinerMed(tidslinjeB) { verdiFraTidslinjeA, verdiFraTidslinjeB ->
             (verdiFraTidslinjeA ?: 0) + (verdiFraTidslinjeB ?: 0)
         }.tilPerioder()
 
-        Assertions.assertEquals(4, periode.size)
+        Assertions.assertEquals(4, perioder.size)
 
-        Assertions.assertEquals(førsteJanuar, periode[0].fom)
-        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
-        Assertions.assertEquals(1, periode[0].verdi)
+        Assertions.assertEquals(førsteJanuar, perioder[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, perioder[0].tom)
+        Assertions.assertEquals(1, perioder[0].verdi)
 
-        Assertions.assertEquals(førsteFebruar, periode[1].fom)
-        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
-        Assertions.assertEquals(3, periode[1].verdi)
+        Assertions.assertEquals(førsteFebruar, perioder[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, perioder[1].tom)
+        Assertions.assertEquals(3, perioder[1].verdi)
 
-        Assertions.assertEquals(førsteMars, periode[2].fom)
-        Assertions.assertEquals(sisteDagIMars, periode[2].tom)
-        Assertions.assertEquals(1, periode[2].verdi)
+        Assertions.assertEquals(førsteMars, perioder[2].fom)
+        Assertions.assertEquals(sisteDagIMars, perioder[2].tom)
+        Assertions.assertEquals(1, perioder[2].verdi)
 
-        Assertions.assertEquals(førsteApril, periode[3].fom)
-        Assertions.assertEquals(sisteDagIApril, periode[3].tom)
-        Assertions.assertEquals(2, periode[3].verdi)
+        Assertions.assertEquals(førsteApril, perioder[3].fom)
+        Assertions.assertEquals(sisteDagIApril, perioder[3].tom)
+        Assertions.assertEquals(2, perioder[3].verdi)
     }
 
     /**
@@ -61,22 +61,22 @@ class kombinerMedTest {
         val tidslinjeA = listOf(Periode(1, førsteJanuar, sisteDagIJanuar)).tilTidslinje()
         val tidslinjeB = listOf(Periode(2, førsteMars, sisteDagIMars)).tilTidslinje()
 
-        val periode = tidslinjeA.kombinerMed(tidslinjeB) { verdiFraTidslinjeA, verdiFraTidslinjeB ->
+        val perioder = tidslinjeA.kombinerMed(tidslinjeB) { verdiFraTidslinjeA, verdiFraTidslinjeB ->
             (verdiFraTidslinjeA ?: 0) + (verdiFraTidslinjeB ?: 0)
         }.tilPerioder()
 
-        Assertions.assertEquals(3, periode.size)
+        Assertions.assertEquals(3, perioder.size)
 
-        Assertions.assertEquals(førsteJanuar, periode[0].fom)
-        Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
-        Assertions.assertEquals(1, periode[0].verdi)
+        Assertions.assertEquals(førsteJanuar, perioder[0].fom)
+        Assertions.assertEquals(sisteDagIJanuar, perioder[0].tom)
+        Assertions.assertEquals(1, perioder[0].verdi)
 
-        Assertions.assertEquals(førsteFebruar, periode[1].fom)
-        Assertions.assertEquals(sisteDagIFebruar, periode[1].tom)
-        Assertions.assertEquals(0, periode[1].verdi)
+        Assertions.assertEquals(førsteFebruar, perioder[1].fom)
+        Assertions.assertEquals(sisteDagIFebruar, perioder[1].tom)
+        Assertions.assertEquals(0, perioder[1].verdi)
 
-        Assertions.assertEquals(førsteMars, periode[2].fom)
-        Assertions.assertEquals(sisteDagIMars, periode[2].tom)
-        Assertions.assertEquals(2, periode[2].verdi)
+        Assertions.assertEquals(førsteMars, perioder[2].fom)
+        Assertions.assertEquals(sisteDagIMars, perioder[2].tom)
+        Assertions.assertEquals(2, perioder[2].verdi)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerMedTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerMedTest.kt
@@ -14,22 +14,25 @@ class kombinerMedTest {
     private val sisteDagIFebruar = LocalDate.of(2022, 2, 28)
     private val førsteMars = LocalDate.of(2022, 3, 1)
     private val sisteDagIMars = LocalDate.of(2022, 3, 31)
+    private val førsteApril = LocalDate.of(2022, 4, 1)
+    private val sisteDagIApril = LocalDate.of(2022, 4, 30)
 
     /**
-     * a = |111|
-     * b = |-2-|
-     * (a ?: 0) + (b ?: 0) = |131|
+     * a = |111-|
+     * b = |-2-2|
+     * (a ?: 0) + (b ?: 0) = |1312|
      **/
     @Test
     fun `kombinerMed - Skal kombinere overlappende verdier på tidslinjene`() {
         val tidslinjeA = listOf(Periode(1, førsteJanuar, sisteDagIMars)).tilTidslinje()
-        val tidslinjeB = listOf(Periode(2, førsteFebruar, sisteDagIFebruar)).tilTidslinje()
+        val tidslinjeB =
+            listOf(Periode(2, førsteFebruar, sisteDagIFebruar), Periode(2, førsteApril, sisteDagIApril)).tilTidslinje()
 
         val periode = tidslinjeA.kombinerMed(tidslinjeB) { verdiFraTidslinjeA, verdiFraTidslinjeB ->
             (verdiFraTidslinjeA ?: 0) + (verdiFraTidslinjeB ?: 0)
         }.tilPerioder()
 
-        Assertions.assertEquals(3, periode.size)
+        Assertions.assertEquals(4, periode.size)
 
         Assertions.assertEquals(førsteJanuar, periode[0].fom)
         Assertions.assertEquals(sisteDagIJanuar, periode[0].tom)
@@ -42,6 +45,10 @@ class kombinerMedTest {
         Assertions.assertEquals(førsteMars, periode[2].fom)
         Assertions.assertEquals(sisteDagIMars, periode[2].tom)
         Assertions.assertEquals(1, periode[2].verdi)
+
+        Assertions.assertEquals(førsteApril, periode[3].fom)
+        Assertions.assertEquals(sisteDagIApril, periode[3].tom)
+        Assertions.assertEquals(2, periode[3].verdi)
     }
 
     /**


### PR DESCRIPTION
* Flytter `Periode`-klassen for seg selv
* Oppretter tester for `Periode`-klassen
* Oppretter tester for `kombinerMed`-funksjonen