### PR TITLE
Rettelser tilknyttet hentMinimalFagsak og journalføring av innkommende dokumenter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakController.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ks.sak.sikkerhet.TilgangService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -77,7 +78,10 @@ class FagsakController(private val fagsakService: FagsakService, private val til
             event = AuditLoggerEvent.ACCESS,
             handling = "Hent fagsak for person"
         )
+        val minimalFagsakForPerson = fagsakService.hentMinimalFagsakForPerson(personIdent)
 
-        return ResponseEntity.ok().body(Ressurs.success(fagsakService.hentMinimalFagsakForPerson(personIdent)))
+        return minimalFagsakForPerson?.let { ResponseEntity.ok().body(Ressurs.success(it)) }
+            ?: ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Ressurs.failure(errorMessage = "Fant ikke fagsak på person"))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakController.kt
@@ -78,7 +78,7 @@ class FagsakController(private val fagsakService: FagsakService, private val til
             event = AuditLoggerEvent.ACCESS,
             handling = "Hent fagsak for person"
         )
-        val minimalFagsakForPerson = fagsakService.hentMinimalFagsakForPerson(personIdent)
+        val minimalFagsakForPerson = fagsakService.finnMinimalFagsakForPerson(personIdent)
 
         return minimalFagsakForPerson?.let { ResponseEntity.ok().body(Ressurs.success(it)) }
             ?: ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/JournalføringController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/JournalføringController.kt
@@ -37,7 +37,14 @@ class JournalføringController(
         @PathVariable journalpostId: String,
         @PathVariable dokumentId: String
     ): ResponseEntity<Ressurs<ByteArray>> =
-        ResponseEntity.ok(Ressurs.success(innkommendeJournalføringService.hentDokumentIJournalpost(journalpostId, dokumentId)))
+        ResponseEntity.ok(
+            Ressurs.success(
+                innkommendeJournalføringService.hentDokumentIJournalpost(
+                    journalpostId,
+                    dokumentId
+                )
+            )
+        )
 
     @PostMapping(path = ["/{journalpostId}/journalfør/{oppgaveId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun journalførOppgave(

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/OppgaveController.kt
@@ -113,7 +113,7 @@ class OppgaveController(
                 personOpplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(it)
                     .tilPersonInfoDto(it.aktivFødselsnummer())
             },
-            minimalFagsak = aktør?.let { fagsakService.hentMinimalFagsakForPerson(aktør.aktørId) }
+            minimalFagsak = aktør?.let { fagsakService.finnMinimalFagsakForPerson(aktør.aktørId) }
         )
 
         return ResponseEntity.ok(Ressurs.success(dataForManuellJournalføringDto))

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/journalføring/InnkommendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/journalføring/InnkommendeJournalføringService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.integrasjon.journalføring
 
 import no.nav.familie.kontrakter.felles.BrukerIdType
+import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.dokarkiv.LogiskVedleggRequest
 import no.nav.familie.kontrakter.felles.journalpost.Bruker
@@ -140,7 +141,7 @@ class InnkommendeJournalføringService(
 
         val tilknyttetFagsak = Sak(
             fagsakId = fagsak?.id?.toString(),
-            fagsaksystem = fagsak?.let { Tema.KON.name },
+            fagsaksystem = fagsak?.let { Fagsystem.KONT.name },
             sakstype = fagsak?.let { Sakstype.FAGSAK.type } ?: Sakstype.GENERELL_SAK.type
         )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
@@ -100,8 +100,11 @@ class FagsakService(
         )
     }
 
-    fun hentMinimalFagsakForPerson(personident: String): MinimalFagsakResponsDto =
-        lagMinimalFagsakResponsDto(hentFagsakForPerson(personident))
+    fun hentMinimalFagsakForPerson(personIdent: String): MinimalFagsakResponsDto? {
+        val aktør = personidentService.hentAktør(personIdent)
+        val fagsak = finnFagsakForPerson(aktør)
+        return fagsak?.let { lagMinimalFagsakResponsDto(it) }
+    }
 
     @Transactional
     fun lagre(fagsak: Fagsak): Fagsak {
@@ -194,8 +197,11 @@ class FagsakService(
         frontendFeilmelding = "Finner ikke fagsak med id $fagsakId"
     )
 
-    fun hentFagsakForPerson(personIdent: String): Fagsak {
-        val aktør = personidentService.hentOgLagreAktør(personIdent, true)
+    fun finnFagsakForPerson(aktør: Aktør): Fagsak? {
+        return fagsakRepository.finnFagsakForAktør(aktør)
+    }
+
+    fun hentFagsakForPerson(aktør: Aktør): Fagsak {
         return fagsakRepository.finnFagsakForAktør(aktør) ?: throw Feil("Fant ikke fagsak på person")
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
@@ -100,7 +100,7 @@ class FagsakService(
         )
     }
 
-    fun hentMinimalFagsakForPerson(personIdent: String): MinimalFagsakResponsDto? {
+    fun finnMinimalFagsakForPerson(personIdent: String): MinimalFagsakResponsDto? {
         val aktør = personidentService.hentAktør(personIdent)
         val fagsak = finnFagsakForPerson(aktør)
         return fagsak?.let { lagMinimalFagsakResponsDto(it) }
@@ -197,13 +197,10 @@ class FagsakService(
         frontendFeilmelding = "Finner ikke fagsak med id $fagsakId"
     )
 
-    fun finnFagsakForPerson(aktør: Aktør): Fagsak? {
-        return fagsakRepository.finnFagsakForAktør(aktør)
-    }
+    fun finnFagsakForPerson(aktør: Aktør): Fagsak? = fagsakRepository.finnFagsakForAktør(aktør)
 
-    fun hentFagsakForPerson(aktør: Aktør): Fagsak {
-        return fagsakRepository.finnFagsakForAktør(aktør) ?: throw Feil("Fant ikke fagsak på person")
-    }
+    fun hentFagsakForPerson(aktør: Aktør): Fagsak =
+        finnFagsakForPerson(aktør) ?: throw Feil("Fant ikke fagsak på person")
 
     companion object {
         private val logger = LoggerFactory.getLogger(FagsakService::class.java)

--- a/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ks.sak.config.RolleConfig
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
@@ -17,6 +18,7 @@ class TilgangService(
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val rolleConfig: RolleConfig,
     private val integrasjonService: IntegrasjonService,
+    private val personidentService: PersonidentService,
     private val cacheManager: CacheManager,
     private val auditLogger: AuditLogger
 ) {
@@ -124,7 +126,8 @@ class TilgangService(
         minimumBehandlerRolle: BehandlerRolle,
         handling: String
     ) {
-        val fagsakId = fagsakService.hentFagsakForPerson(personIdent).id
+        val aktør = personidentService.hentOgLagreAktør(personIdent, true)
+        val fagsakId = fagsakService.hentFagsakForPerson(aktør).id
         validerTilgangTilHandlingOgFagsak(fagsakId, event, minimumBehandlerRolle, handling)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -286,7 +286,7 @@ class FagsakServiceTest {
         every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
         every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
 
-        val fagsakForPerson = fagsakService.hentFagsakForPerson(aktør.aktørId)
+        val fagsakForPerson = fagsakService.hentFagsakForPerson(aktør)
 
         assertEquals(fagsak.id, fagsakForPerson.id)
         assertEquals(fagsak.aktør, fagsakForPerson.aktør)
@@ -299,7 +299,7 @@ class FagsakServiceTest {
         every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
         every { fagsakRepository.finnFagsakForAktør(any()) } returns null
 
-        val feil = assertThrows<Feil> { fagsakService.hentFagsakForPerson(aktør.aktørId) }
+        val feil = assertThrows<Feil> { fagsakService.hentFagsakForPerson(aktør) }
 
         assertEquals("Fant ikke fagsak på person", feil.message)
     }


### PR DESCRIPTION
`hentMinimalFagsak` kastet tidligere feil dersom fagsak tilknyttet aktør ikke eksisterte. Nå returnerer den null dersom det ikke eksisterer noen fagsak og null må eventuelt håndteres utenfor.

Tidligere sendte vi `KON` som fagsystem i journalføringskall. Har nå rettet dette til `KONT`. Dette gjør at vi kan journalføre innkommende dokumenter korrekt.