### PR TITLE
Lagt til `TestController` med endepunkt for å journalføre innkommende søknad om kontantstøtte

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -50,6 +50,7 @@ spec:
           - id: "52fe1bef-224f-49df-a40a-29f92d4520f8"  # BESLUTTER_ROLLE
       replyURLs:
         - "https://familie-kontantstotte-sak.dev.intern.nav.no/swagger-ui/oauth2-redirect.html"
+        - "http://localhost:8083/swagger-ui/oauth2-redirect.html"
       singlePageApplication: true
   accessPolicy:
     inbound:

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/TestController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/TestController.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ks.sak.api
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+import no.nav.familie.ks.sak.sikkerhet.TilgangService
+import no.nav.security.token.support.core.api.Unprotected
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/test")
+@Unprotected
+class TestController(private val tilgangService: TilgangService, private val integrasjonClient: IntegrasjonClient) {
+    @PostMapping("/journalfør-søknad/{fnr}")
+    fun opprettJournalføringOppgave(@PathVariable fnr: String): ResponseEntity<Ressurs<String>> {
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "journalføring av innkommende søknad"
+        )
+        val arkiverDokumentRequest = ArkiverDokumentRequest(
+            fnr = fnr,
+            forsøkFerdigstill = false,
+            hoveddokumentvarianter = listOf(
+                Dokument(
+                    dokument = ByteArray(10),
+                    dokumenttype = Dokumenttype.KONTANTSTØTTE_SØKNAD,
+                    filtype = Filtype.PDFA
+                )
+            )
+        )
+        val journalførDokumentResponse = integrasjonClient.journalførDokument(arkiverDokumentRequest)
+        return ResponseEntity.ok(Ressurs.success(journalførDokumentResponse.journalpostId, "Dokument er Journalført"))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/TestController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/TestController.kt
@@ -8,8 +8,10 @@ import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
-import no.nav.security.token.support.core.api.Unprotected
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.context.annotation.Profile
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,13 +19,16 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/test")
-@Unprotected
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+@Profile("dev", "postgres", "preprod")
 class TestController(private val tilgangService: TilgangService, private val integrasjonClient: IntegrasjonClient) {
+
     @PostMapping("/journalfør-søknad/{fnr}")
     fun opprettJournalføringOppgave(@PathVariable fnr: String): ResponseEntity<Ressurs<String>> {
         tilgangService.validerTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
-            handling = "journalføring av innkommende søknad"
+            handling = "teste journalføring av innkommende søknad for opprettelse av journalføring oppgave"
         )
         val arkiverDokumentRequest = ArkiverDokumentRequest(
             fnr = fnr,


### PR DESCRIPTION
Litt usikker på om `TestController` er det beste navnet, men tanken er ihvertfall at vi kan legge inn endepunkter her for ting vi ønsker å manuelt teste utenom "vanlig" applikasjonsflyt.

Endepunktet jeg har lagt inn journalfører en Søknad om kontantstøtte for bestemt `fnr` noe som vil føre til at det opprettes en `Journalføringsoppgave` vi kan plukke fra oppgavebenken.

Har lagt til ekstra reply-url i `app-preprod.yaml` slik at innlogging i swagger fungerer når man kjører `DevLauncherPostgresPreprod`