### PR TITLE
Bruk Temurin JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/java:17
+FROM ghcr.io/navikt/baseimages/temurin:17
 
 ENV APPD_ENABLED=true
 ENV APP_NAME=familie-ks-sak


### PR DESCRIPTION
`navikt/java:17` imaget er deprecated. Bytter til `ghcr.io/navikt/baseimages/temurin:17`

Se slacktråd for mer info: 
https://nav-it.slack.com/archives/C60FFACN5/p1667402819577079


