### PR TITLE
Lagt til OppdragKlient

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -25,7 +25,7 @@ class OppdragKlient(
     @Value("\${FAMILIE_OPPDRAG_API_URL}")
     private val familieOppdragUri: String,
     @Qualifier("azure") restOperations: RestOperations
-) : AbstractRestClient(restOperations, "økonomi_barnetrygd") {
+) : AbstractRestClient(restOperations, "økonomi_kontantstøtte") {
 
     fun iverksettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag): String {
         val uri = URI.create("$familieOppdragUri/oppdrag")

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -1,0 +1,165 @@
+package no.nav.familie.ks.sak.integrasjon.oppdrag
+
+import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.felles.oppdrag.GrensesnittavstemmingRequest
+import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingRequestV2
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
+import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient.Companion.RETRY_BACKOFF_5000MS
+import no.nav.familie.ks.sak.integrasjon.kallEksternTjenesteRessurs
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestOperations
+import java.net.URI
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+class OppdragKlient(
+    @Value("\${FAMILIE_OPPDRAG_API_URL}")
+    private val familieOppdragUri: String,
+    @Qualifier("azure") restOperations: RestOperations
+) : AbstractRestClient(restOperations, "økonomi_barnetrygd") {
+
+    fun iverksettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag): String {
+        val uri = URI.create("$familieOppdragUri/oppdrag")
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Iverksetter mot oppdrag"
+        ) {
+            postForEntity(uri = uri, utbetalingsoppdrag)
+        }
+    }
+
+    @Retryable(
+        value = [Exception::class],
+        maxAttempts = 3,
+        backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS)
+    )
+    fun hentSimulering(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat {
+        val uri = URI.create("$familieOppdragUri/simulering/v1")
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Henter simulering fra Økonomi"
+        ) {
+            postForEntity(uri = uri, utbetalingsoppdrag)
+        }
+    }
+
+    fun hentStatus(oppdragId: OppdragId): OppdragStatus {
+        val uri = URI.create("$familieOppdragUri/status")
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Henter oppdragstatus fra Økonomi"
+        ) {
+            postForEntity(uri = uri, oppdragId)
+        }
+    }
+
+    fun grensesnittavstemOppdrag(fraDato: LocalDateTime, tilDato: LocalDateTime): String {
+        val uri = URI.create("$familieOppdragUri/grensesnittavstemming")
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Gjør grensesnittavstemming mot oppdrag"
+        ) {
+            postForEntity(
+                uri = uri,
+                GrensesnittavstemmingRequest(
+                    fagsystem = FAGSYSTEM,
+                    fra = fraDato,
+                    til = tilDato
+                )
+            )
+        }
+    }
+
+    fun konsistensavstemOppdragStart(
+        avstemmingsdato: LocalDateTime,
+        transaksjonsId: UUID
+    ): String {
+        val uri = URI.create(
+            "$familieOppdragUri/v2/konsistensavstemming" +
+                "?sendStartmelding=true&sendAvsluttmelding=false&transaksjonsId=$transaksjonsId"
+        )
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Start konsistensavstemming mot oppdrag i batch"
+        ) {
+            postForEntity(
+                uri = uri,
+                KonsistensavstemmingRequestV2(
+                    fagsystem = FAGSYSTEM,
+                    avstemmingstidspunkt = avstemmingsdato,
+                    perioderForBehandlinger = emptyList()
+                )
+            )
+        }
+    }
+
+    fun konsistensavstemOppdragData(
+        avstemmingsdato: LocalDateTime,
+        perioderTilAvstemming: List<PerioderForBehandling>,
+        transaksjonsId: UUID
+    ): String {
+        val uri = URI.create(
+            "$familieOppdragUri/v2/konsistensavstemming" +
+                "?sendStartmelding=false&sendAvsluttmelding=false&transaksjonsId=$transaksjonsId"
+        )
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Konsistenstavstemmer chunk mot oppdrag"
+        ) {
+            postForEntity(
+                uri = uri,
+                KonsistensavstemmingRequestV2(
+                    fagsystem = FAGSYSTEM,
+                    avstemmingstidspunkt = avstemmingsdato,
+                    perioderForBehandlinger = perioderTilAvstemming
+                )
+            )
+        }
+    }
+
+    fun konsistensavstemOppdragAvslutt(
+        avstemmingsdato: LocalDateTime,
+        transaksjonsId: UUID
+    ): String {
+        val uri = URI.create(
+            "$familieOppdragUri/v2/konsistensavstemming" +
+                "?sendStartmelding=false&sendAvsluttmelding=true&transaksjonsId=$transaksjonsId"
+        )
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Avslutt konsistensavstemming mot oppdrag"
+        ) {
+            postForEntity(
+                uri = uri,
+                KonsistensavstemmingRequestV2(
+                    fagsystem = FAGSYSTEM,
+                    avstemmingstidspunkt = avstemmingsdato,
+                    perioderForBehandlinger = emptyList()
+                )
+            )
+        }
+    }
+
+    companion object {
+        private val FAGSYSTEM = "KS"
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlientTest.kt
@@ -1,0 +1,82 @@
+package no.nav.familie.ks.sak.integrasjon.oppdrag
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.web.client.RestOperations
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import org.hamcrest.CoreMatchers.`is` as Is
+
+internal class OppdragKlientTest {
+    private val restOperations: RestOperations = RestTemplateBuilder().build()
+    private lateinit var oppdragKlient: OppdragKlient
+    private lateinit var wiremockServerItem: WireMockServer
+
+    @BeforeEach
+    fun beforeEach() {
+        wiremockServerItem = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
+        wiremockServerItem.start()
+        oppdragKlient = OppdragKlient(wiremockServerItem.baseUrl(), restOperations)
+    }
+
+    @Test
+    fun `hentSimulering - skal hente simulering for utbetalingsoppdrag`() {
+        wiremockServerItem.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/simulering/v1"))
+                .willReturn(WireMock.okJson(readFile("hentSimulering.json")))
+        )
+
+        val simulering = oppdragKlient.hentSimulering(
+            Utbetalingsoppdrag(
+                kodeEndring = Utbetalingsoppdrag.KodeEndring.NY,
+                fagSystem = "KS",
+                saksnummer = "1234",
+                aktoer = "12345678910",
+                saksbehandlerId = "Z12345",
+                avstemmingTidspunkt = LocalDateTime.now(),
+                utbetalingsperiode = listOf(
+                    Utbetalingsperiode(
+                        erEndringPåEksisterendePeriode = false,
+                        periodeId = 1,
+                        datoForVedtak = LocalDate.now(),
+                        klassifisering = "klassifisering",
+                        vedtakdatoFom = LocalDate.of(2021, 1, 1),
+                        vedtakdatoTom = LocalDate.of(2021, 5, 31),
+                        sats = BigDecimal.valueOf(7500),
+                        satsType = Utbetalingsperiode.SatsType.MND,
+                        utbetalesTil = "12345678910",
+                        behandlingId = 1
+                    )
+                )
+            )
+        )
+
+        assertThat(simulering.simuleringMottaker.size, Is(1))
+    }
+
+    @Test
+    fun `hentStatus - skal hente status for oppdragId`() {
+        wiremockServerItem.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/status"))
+                .willReturn(WireMock.okJson(readFile("hentStatus.json")))
+        )
+
+        val oppdragStatus = oppdragKlient.hentStatus(OppdragId("KS", "12345678910", "1"))
+
+        assertThat(oppdragStatus, Is(OppdragStatus.KVITTERT_OK))
+    }
+
+    private fun readFile(filnavn: String): String {
+        return this::class.java.getResource("/oppdrag/json/$filnavn").readText()
+    }
+}

--- a/src/test/resources/oppdrag/json/hentSimulering.json
+++ b/src/test/resources/oppdrag/json/hentSimulering.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "simuleringMottaker": [
+      {
+        "simulertPostering": [
+          {
+            "fagOmrådeKode": "KONTANTSTØTTE",
+            "fom": "2021-01-01",
+            "tom": "2021-05-31",
+            "betalingType": "DEBIT",
+            "beløp": 7500,
+            "posteringType": "YTELSE",
+            "forfallsdato": "2021-01-01",
+            "utenInntrekk": false
+          }
+        ],
+        "mottakerNummer": "12345678910",
+        "mottakerType": "BRUKER"
+      }
+    ]
+  },
+  "status": "SUKSESS",
+  "melding": "string",
+  "frontendFeilmelding": "string",
+  "stacktrace": "string"
+}

--- a/src/test/resources/oppdrag/json/hentStatus.json
+++ b/src/test/resources/oppdrag/json/hentStatus.json
@@ -1,0 +1,7 @@
+{
+  "data": "KVITTERT_OK",
+  "status": "SUKSESS",
+  "melding": "string",
+  "frontendFeilmelding": "string",
+  "stacktrace": "string"
+}


### PR DESCRIPTION
Har lagt til `OppdragKlient` (`ØkonomiKlient` i BA). Den er mer eller mindre uendret med unntak av at vi bruker "KS" som fagsystem i kall tilknyttet grensesnittavstemming. Døpte den om da det blir tydelig hvilket system vi kommuniserer med.

Har også lagt inn et par enkle tester av klienten for å validere deserialisering der det returneres noe annet enn en string.