### PR TITLE
Fjernet simulering-mock

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/kombinerTidslinjer.kt
@@ -35,7 +35,11 @@ fun <I, R> Collection<Tidslinje<I>>.kombiner(
     listeKombinator: (Iterable<I>) -> R
 ): Tidslinje<R> = this.slåSammen().map {
     when (it) {
-        is Verdi -> Verdi(listeKombinator(it.verdi)!!)
+        is Verdi -> {
+            val resultat = listeKombinator(it.verdi)
+            if (resultat != null) Verdi(resultat) else Null()
+        }
+
         is Null -> Null()
         is Udefinert -> Udefinert()
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -7,15 +7,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
-import no.nav.familie.kontrakter.felles.simulering.BetalingType
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
-import no.nav.familie.kontrakter.felles.simulering.FagOmrådeKode
-import no.nav.familie.kontrakter.felles.simulering.MottakerType
-import no.nav.familie.kontrakter.felles.simulering.PosteringType
-import no.nav.familie.kontrakter.felles.simulering.SimuleringMottaker
-import no.nav.familie.kontrakter.felles.simulering.SimulertPostering
-import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
-import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient.Companion.RETRY_BACKOFF_5000MS
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjenesteRessurs
 import org.springframework.beans.factory.annotation.Qualifier
@@ -25,7 +17,6 @@ import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
 import java.net.URI
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -53,7 +44,6 @@ class OppdragKlient(
         backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS)
     )
     fun hentSimulering(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat {
-        return DetaljertSimuleringResultat(simuleringMottakerMock)
         val uri = URI.create("$familieOppdragUri/simulering/v1")
 
         return kallEksternTjenesteRessurs(
@@ -173,44 +163,3 @@ class OppdragKlient(
         private const val FAGSYSTEM = "KS"
     }
 }
-
-val simulertPosteringMock = listOf(
-    SimulertPostering(
-        fagOmrådeKode = FagOmrådeKode.KONTANTSTØTTE,
-        fom = LocalDate.now().minusMonths(3).førsteDagIInneværendeMåned(),
-        tom = LocalDate.now().minusMonths(3).sisteDagIMåned(),
-        betalingType = BetalingType.DEBIT,
-        beløp = 7500.0.toBigDecimal(),
-        posteringType = PosteringType.YTELSE,
-        forfallsdato = LocalDate.now(),
-        utenInntrekk = false
-    ),
-    SimulertPostering(
-        fagOmrådeKode = FagOmrådeKode.KONTANTSTØTTE,
-        fom = LocalDate.now().minusMonths(2).førsteDagIInneværendeMåned(),
-        tom = LocalDate.now().minusMonths(2).sisteDagIMåned(),
-        betalingType = BetalingType.DEBIT,
-        beløp = 6500.0.toBigDecimal(),
-        posteringType = PosteringType.YTELSE,
-        forfallsdato = LocalDate.now().plusMonths(1),
-        utenInntrekk = false
-    ),
-    SimulertPostering(
-        fagOmrådeKode = FagOmrådeKode.KONTANTSTØTTE,
-        fom = LocalDate.now().minusMonths(1).førsteDagIInneværendeMåned(),
-        tom = LocalDate.now().minusMonths(1).sisteDagIMåned(),
-        betalingType = BetalingType.DEBIT,
-        beløp = 5000.0.toBigDecimal(),
-        posteringType = PosteringType.YTELSE,
-        forfallsdato = LocalDate.now().plusMonths(2),
-        utenInntrekk = false
-    )
-)
-
-val simuleringMottakerMock = listOf(
-    SimuleringMottaker(
-        simulertPostering = simulertPosteringMock,
-        mottakerType = MottakerType.BRUKER,
-        mottakerNummer = "12345678910"
-    )
-)


### PR DESCRIPTION
* Fjernet mock-respons for `hentSimulering()`
* Fikset liten bug som skapte null-feil ved generering av vedtaksperioder. Den samme feilen er rettet i https://github.com/navikt/familie-ks-sak/pull/158 men den er ikke merget enda, men trengs altså for å komme seg inn på simuleringssiden.