### PR TITLE
Sørge for at UtbetalingsperiodeDetalj alltid mappes til UtbetalingsperiodeDetaljDto i respons

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.VenteÅrsak
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
-import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -95,19 +94,4 @@ data class YtelsePerioderDto(
     val stønadTom: YearMonth,
     val ytelseType: YtelseType,
     val skalUtbetales: Boolean
-)
-
-data class UtbetalingsperiodeResponsDto(
-    val periodeFom: LocalDate,
-    val periodeTom: LocalDate,
-    val antallBarn: Int,
-    val utbetaltPerMnd: Int,
-    val utbetalingsperiodeDetaljer: List<UtbetalingsperiodeDetaljDto>
-)
-
-data class UtbetalingsperiodeDetaljDto(
-    val person: PersonResponsDto,
-    val utbetaltPerMnd: Int,
-    val erPåvirketAvEndring: Boolean,
-    val prosent: BigDecimal
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/UtbetalingsperiodeResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/UtbetalingsperiodeResponsDto.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.ks.sak.api.dto
+
+import no.nav.familie.ks.sak.api.mapper.BehandlingMapper
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.tidslinje.filtrerIkkeNull
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.UtbetalingsperiodeDetalj
+import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ks.sak.kjerne.beregning.lagVertikalePerioder
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class UtbetalingsperiodeResponsDto(
+    val periodeFom: LocalDate,
+    val periodeTom: LocalDate,
+    val antallBarn: Int,
+    val utbetaltPerMnd: Int,
+    val utbetalingsperiodeDetaljer: List<UtbetalingsperiodeDetaljDto>
+)
+
+data class UtbetalingsperiodeDetaljDto(
+    val person: PersonResponsDto,
+    val utbetaltPerMnd: Int,
+    val erPåvirketAvEndring: Boolean,
+    val prosent: BigDecimal
+)
+
+fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalingsperiodeResponsDto(
+    personopplysningGrunnlag: PersonopplysningGrunnlag
+): List<UtbetalingsperiodeResponsDto> {
+    if (this.isEmpty()) return emptyList()
+    return this.lagVertikalePerioder().tilPerioder().filtrerIkkeNull().map {
+        val andelerForPeriode = it.verdi
+        val sumUtbetalingsbeløp = andelerForPeriode.sumOf { andel -> andel.kalkulertUtbetalingsbeløp }
+        UtbetalingsperiodeResponsDto(
+            periodeFom = checkNotNull(it.fom),
+            periodeTom = checkNotNull(it.tom),
+            utbetaltPerMnd = sumUtbetalingsbeløp,
+            antallBarn = andelerForPeriode.count { andel ->
+                personopplysningGrunnlag.barna.any { barn -> barn.aktør == andel.aktør }
+            },
+            utbetalingsperiodeDetaljer = andelerForPeriode.tilUtbetalingsperiodeDetaljDto(personopplysningGrunnlag)
+        )
+    }
+}
+
+private fun Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalingsperiodeDetaljDto(
+    personopplysningGrunnlag: PersonopplysningGrunnlag
+): List<UtbetalingsperiodeDetaljDto> =
+    this.map { andel ->
+        val personForAndel = personopplysningGrunnlag.personer.find { person -> andel.aktør == person.aktør }
+            ?: throw Feil("Fant ikke personopplysningsgrunnlag for andel")
+
+        UtbetalingsperiodeDetaljDto(
+            person = BehandlingMapper.lagPersonRespons(personForAndel, emptyMap()),
+            utbetaltPerMnd = andel.kalkulertUtbetalingsbeløp,
+            erPåvirketAvEndring = andel.endreteUtbetalinger.isNotEmpty(),
+            prosent = andel.prosent
+        )
+    }
+
+fun UtbetalingsperiodeDetalj.tilUtbetalingsperiodeDetaljDto() = UtbetalingsperiodeDetaljDto(
+    person = BehandlingMapper.lagPersonRespons(this.brevPerson, emptyMap()),
+    utbetaltPerMnd = this.utbetaltPerMnd,
+    erPåvirketAvEndring = this.erPåvirketAvEndring,
+    prosent = this.prosent
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/UtbetalingsperiodeResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/UtbetalingsperiodeResponsDto.kt
@@ -61,7 +61,7 @@ private fun Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalings
     }
 
 fun UtbetalingsperiodeDetalj.tilUtbetalingsperiodeDetaljDto() = UtbetalingsperiodeDetaljDto(
-    person = BehandlingMapper.lagPersonRespons(this.brevPerson, emptyMap()),
+    person = BehandlingMapper.lagPersonRespons(this.person, emptyMap()),
     utbetaltPerMnd = this.utbetaltPerMnd,
     erPåvirketAvEndring = this.erPåvirketAvEndring,
     prosent = this.prosent

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ks.sak.api.dto
 
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakBegrunnelseType
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.UtbetalingsperiodeDetalj
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.Vedtaksbegrunnelse
@@ -33,7 +32,7 @@ data class UtvidetVedtaksperiodeMedBegrunnelserDto(
     val begrunnelser: List<VedtaksbegrunnelseDto>,
     val fritekster: List<String> = emptyList(),
     val gyldigeBegrunnelser: List<String>,
-    val utbetalingsperiodeDetaljer: List<UtbetalingsperiodeDetalj> = emptyList()
+    val utbetalingsperiodeDetaljer: List<UtbetalingsperiodeDetaljDto> = emptyList()
 )
 
 fun UtvidetVedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelserDto(): UtvidetVedtaksperiodeMedBegrunnelserDto {
@@ -44,7 +43,7 @@ fun UtvidetVedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser
         type = this.type,
         begrunnelser = this.begrunnelser.map { it.tilRestVedtaksbegrunnelse() },
         fritekster = this.fritekster,
-        utbetalingsperiodeDetaljer = this.utbetalingsperiodeDetaljer,
+        utbetalingsperiodeDetaljer = this.utbetalingsperiodeDetaljer.map { it.tilUtbetalingsperiodeDetaljDto() },
         gyldigeBegrunnelser = this.gyldigeBegrunnelser.map { it.enumnavnTilString() }
     )
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
@@ -8,25 +8,18 @@ import no.nav.familie.ks.sak.api.dto.BehandlingStegTilstandResponsDto
 import no.nav.familie.ks.sak.api.dto.PersonResponsDto
 import no.nav.familie.ks.sak.api.dto.PersonerMedAndelerResponsDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
-import no.nav.familie.ks.sak.api.dto.UtbetalingsperiodeDetaljDto
 import no.nav.familie.ks.sak.api.dto.UtbetalingsperiodeResponsDto
 import no.nav.familie.ks.sak.api.dto.VedtakDto
 import no.nav.familie.ks.sak.api.dto.YtelsePerioderDto
 import no.nav.familie.ks.sak.api.mapper.RegisterHistorikkMapper.lagRegisterHistorikkResponsDto
-import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.common.tidslinje.filtrerIkkeNull
-import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
-import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.slåSammenBack2BackAndelsperioderMedSammeBeløp
-import no.nav.familie.ks.sak.kjerne.beregning.lagVertikalePerioder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
-import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -122,39 +115,4 @@ object BehandlingMapper {
                     }
                 )
             }
-
-    fun lagUtbetalingsperioder(
-        personopplysningGrunnlag: PersonopplysningGrunnlag,
-        andelerTilkjentYtelseMedEndreteUtbetalinger: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
-    ): List<UtbetalingsperiodeResponsDto> {
-        if (andelerTilkjentYtelseMedEndreteUtbetalinger.isEmpty()) return emptyList()
-        return andelerTilkjentYtelseMedEndreteUtbetalinger.lagVertikalePerioder().tilPerioder().filtrerIkkeNull().map {
-            val andelerForPeriode = it.verdi
-            val sumUtbetalingsbeløp = andelerForPeriode.sumOf { andel -> andel.kalkulertUtbetalingsbeløp }
-            UtbetalingsperiodeResponsDto(
-                periodeFom = checkNotNull(it.fom),
-                periodeTom = checkNotNull(it.tom),
-                utbetaltPerMnd = sumUtbetalingsbeløp,
-                antallBarn = andelerForPeriode.count { andel ->
-                    personopplysningGrunnlag.barna.any { barn -> barn.aktør == andel.aktør }
-                },
-                utbetalingsperiodeDetaljer = andelerForPeriode.lagUtbetalingsperiodeDetaljer(personopplysningGrunnlag)
-            )
-        }
-    }
-
-    private fun Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>.lagUtbetalingsperiodeDetaljer(
-        personopplysningGrunnlag: PersonopplysningGrunnlag
-    ): List<UtbetalingsperiodeDetaljDto> =
-        this.map { andel ->
-            val personForAndel = personopplysningGrunnlag.personer.find { person -> andel.aktør == person.aktør }
-                ?: throw Feil("Fant ikke personopplysningsgrunnlag for andel")
-
-            UtbetalingsperiodeDetaljDto(
-                person = lagPersonRespons(personForAndel, emptyMap()),
-                utbetaltPerMnd = andel.kalkulertUtbetalingsbeløp,
-                erPåvirketAvEndring = andel.endreteUtbetalinger.isNotEmpty(),
-                prosent = andel.prosent
-            )
-        }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -2,12 +2,12 @@ package no.nav.familie.ks.sak.kjerne.behandling
 
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
+import no.nav.familie.ks.sak.api.dto.tilUtbetalingsperiodeResponsDto
 import no.nav.familie.ks.sak.api.dto.tilUtvidetVedtaksperiodeMedBegrunnelserDto
 import no.nav.familie.ks.sak.api.dto.tilVedtakDto
 import no.nav.familie.ks.sak.api.mapper.BehandlingMapper
 import no.nav.familie.ks.sak.api.mapper.BehandlingMapper.lagPersonRespons
 import no.nav.familie.ks.sak.api.mapper.BehandlingMapper.lagPersonerMedAndelTilkjentYtelseRespons
-import no.nav.familie.ks.sak.api.mapper.BehandlingMapper.lagUtbetalingsperioder
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -81,7 +81,7 @@ class BehandlingService(
             .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId)
 
         val utbetalingsperioder =
-            personopplysningGrunnlag?.let { lagUtbetalingsperioder(it, andelTilkjentYtelseMedEndreteUtbetalinger) }
+            personopplysningGrunnlag?.let { andelTilkjentYtelseMedEndreteUtbetalinger.tilUtbetalingsperiodeResponsDto(it) }
                 ?: emptyList()
 
         val vedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandlingId)?.let {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Utbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Utbetalingsperiode.kt
@@ -10,8 +10,7 @@ import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.tilKombinertTidslinjePerAktør
-import no.nav.familie.ks.sak.kjerne.brev.domene.BrevPerson
-import no.nav.familie.ks.sak.kjerne.brev.domene.tilBrevPerson
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -31,7 +30,7 @@ data class Utbetalingsperiode(
 ) : Vedtaksperiode
 
 data class UtbetalingsperiodeDetalj(
-    val brevPerson: BrevPerson,
+    val brevPerson: Person,
     val ytelseType: YtelseType,
     val utbetaltPerMnd: Int,
     val erPåvirketAvEndring: Boolean,
@@ -42,7 +41,6 @@ fun mapTilUtbetalingsperioder(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>
 ): List<Utbetalingsperiode> {
-
     val kombinertTidslinjePerAktør = andelerTilkjentYtelse.tilKombinertTidslinjePerAktør()
 
     val utbetalingsPerioder = kombinertTidslinjePerAktør.tilPerioderIkkeNull().map {
@@ -61,7 +59,9 @@ fun mapTilUtbetalingsperioder(
 
 private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilTidslinje() = map {
     Periode(
-        it, it.stønadFom.førsteDagIInneværendeMåned(), it.stønadTom.sisteDagIInneværendeMåned()
+        it,
+        it.stønadFom.førsteDagIInneværendeMåned(),
+        it.stønadTom.sisteDagIInneværendeMåned()
     )
 }.tilTidslinje()
 
@@ -74,7 +74,7 @@ internal fun Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>.lagUtbetaling
         )
 
     UtbetalingsperiodeDetalj(
-        brevPerson = personForAndel.tilBrevPerson(),
+        brevPerson = personForAndel,
         ytelseType = andel.type,
         utbetaltPerMnd = andel.kalkulertUtbetalingsbeløp,
         erPåvirketAvEndring = andel.endreteUtbetalinger.isNotEmpty(),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Utbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Utbetalingsperiode.kt
@@ -30,7 +30,7 @@ data class Utbetalingsperiode(
 ) : Vedtaksperiode
 
 data class UtbetalingsperiodeDetalj(
-    val brevPerson: Person,
+    val person: Person,
     val ytelseType: YtelseType,
     val utbetaltPerMnd: Int,
     val erPåvirketAvEndring: Boolean,
@@ -74,7 +74,7 @@ internal fun Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>.lagUtbetaling
         )
 
     UtbetalingsperiodeDetalj(
-        brevPerson = personForAndel,
+        person = personForAndel,
         ytelseType = andel.type,
         utbetaltPerMnd = andel.kalkulertUtbetalingsbeløp,
         erPåvirketAvEndring = andel.endreteUtbetalinger.isNotEmpty(),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeService.kt
@@ -333,7 +333,7 @@ class VedtaksperiodeService(
     ): List<Aktør> = utvidetVedtaksperiodeMedBegrunnelser
         .utbetalingsperiodeDetaljer
         .map { utbetalingsperiodeDetalj ->
-            val ident = utbetalingsperiodeDetalj.brevPerson.aktør.aktivFødselsnummer()
+            val ident = utbetalingsperiodeDetalj.person.aktør.aktivFødselsnummer()
             persongrunnlag.personer.find { it.aktør.aktivFødselsnummer() == ident }?.aktør
                 ?: personidentService.hentAktør(ident)
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeService.kt
@@ -333,7 +333,7 @@ class VedtaksperiodeService(
     ): List<Aktør> = utvidetVedtaksperiodeMedBegrunnelser
         .utbetalingsperiodeDetaljer
         .map { utbetalingsperiodeDetalj ->
-            val ident = utbetalingsperiodeDetalj.brevPerson.aktivPersonIdent
+            val ident = utbetalingsperiodeDetalj.brevPerson.aktør.aktivFødselsnummer()
             persongrunnlag.personer.find { it.aktør.aktivFødselsnummer() == ident }?.aktør
                 ?: personidentService.hentAktør(ident)
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/StandardbegrunnelseUtilsKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/StandardbegrunnelseUtilsKtTest.kt
@@ -48,7 +48,8 @@ internal class StandardbegrunnelseUtilsKtTest {
                     lagAndelTilkjentYtelse(
                         behandling = behandling,
                         stønadFom = YearMonth.of(
-                            dødsfallDatoBarn1.minusMonths(1).year, dødsfallDatoBarn1.minusMonths(1).month
+                            dødsfallDatoBarn1.minusMonths(1).year,
+                            dødsfallDatoBarn1.minusMonths(1).month
                         ),
                         stønadTom = YearMonth.of(dødsfallDatoBarn1.year, dødsfallDatoBarn1.month),
                         aktør = Aktør(barn1Fnr + "00").also { it.personidenter.add(Personident(barn1Fnr, it)) }
@@ -67,7 +68,8 @@ internal class StandardbegrunnelseUtilsKtTest {
                     lagAndelTilkjentYtelse(
                         behandling = behandling,
                         stønadFom = YearMonth.of(
-                            dødsfallDatoBarn1.minusMonths(1).year, dødsfallDatoBarn1.minusMonths(1).month
+                            dødsfallDatoBarn1.minusMonths(1).year,
+                            dødsfallDatoBarn1.minusMonths(1).month
                         ),
                         stønadTom = YearMonth.of(dødsfallDatoBarn2.year, dødsfallDatoBarn2.month),
                         aktør = Aktør(barn2Fnr + "00").also { it.personidenter.add(Personident(barn2Fnr, it)) }


### PR DESCRIPTION
Frontend har kun 1 representasjon av `UtbetalingsperiodeDetalj` som brukes både i `Utbetalingsperiode` og i `UtvidetVedtaksperiodeMedBegrunnelser`. Når backend returnerte 2 forskjellige objekter for `UtbetalingsperiodeDetalj` ble det feil i frontend. 

Har oppdatert typen til feltet `brevPerson` til `Person`, og mapper nå `UtbetalingsperiodeDetalj` til `UtebetalingsperiodeDetaljDto` også i `UtvidetVedtaksperiodeMedBegrunnelserDto`.

Hvor Dto-dataklasser er definert og hvordan vi gjør mapping til disse er ikke veldig konsekvent, så det er noe vi burde legge i backloggen og se på når vi får tid!

Kommer nå inn på vedtakssiden: 
<img width="622" alt="image" src="https://user-images.githubusercontent.com/70642183/202195529-cdeb5732-3acc-47ae-913c-6ce879f2de0d.png">
