### PR TITLE
Fiks annen forelder vilkår

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.allopen") version kotlinVersion
+    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
 }
 
 group = "no.nav"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.allopen") version kotlinVersion
-    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
 }
 
 group = "no.nav"

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -67,6 +67,7 @@ class VilkårsvurderingSteg(
         validerAtDetIkkeErOverlappMellomGradertBarnehageplassOgDeltBosted(vilkårsvurdering)
         validerAtPerioderIBarnehageplassSamsvarerMedPeriodeIBarnetsAlderVilkår(vilkårsvurdering)
         validerAtDetIkkeFinnesMerEnn2EndringerISammeMånedIBarnehageplassVilkår(vilkårsvurdering)
+        validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, personopplysningGrunnlag.barna)
     }
 
     private fun validerAtDetFinnesBarnIPersonopplysningsgrunnlaget(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -260,7 +260,7 @@ fun finnTilOgMedDato(tilOgMed: LocalDate?, vilkårResultater: List<VilkårResult
     return if (skalVidereføresEnMndEkstra) tilOgMed.plusMonths(1).sisteDagIMåned() else tilOgMed.sisteDagIMåned()
 }
 
-fun validerBarnasVilkår(vilkårsvurdering: Vilkårsvurdering, barna: List<Person>) {
+fun validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering: Vilkårsvurdering, barna: List<Person>) {
     val feil = mutableListOf<String>()
 
     barna.map { barn ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -274,6 +274,7 @@ fun validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering: Vilkårsvurdering, b
                     feil.add("Vilkår $vilkårType for barn med fødselsdato $fødselsdato mangler fom dato.")
                 }
                 if (vilkårResultat.periodeFom != null &&
+                    vilkårType != Vilkår.MEDLEMSKAP_ANNEN_FORELDER &&
                     vilkårResultat.lagOgValiderPeriodeFraVilkår().fom.isBefore(barn.fødselsdato)
                 ) {
                     feil.add(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
@@ -101,7 +101,8 @@ private fun alleVilkårOppfyltEllerNull(
 }
 
 private fun erAlleVilkårForPersonOppfylt(
-    vilkårForPerson: Set<Vilkår>,
-    vilkårResultater: Iterable<VilkårResultat?>
-) =
-    vilkårForPerson.all { vilkår -> vilkårResultater.any { it?.resultat == Resultat.OPPFYLT && it.vilkårType == vilkår } }
+    vilkårForPerson: Set<Vilkår>, vilkårResultater: Iterable<VilkårResultat?>
+) = vilkårForPerson.all { vilkår ->
+    vilkårResultater.filter { it?.resultat != Resultat.IKKE_AKTUELT }
+        .any { it?.resultat == Resultat.OPPFYLT && it.vilkårType == vilkår }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
@@ -103,6 +103,8 @@ private fun alleVilkårOppfyltEllerNull(
 private fun erAlleVilkårForPersonOppfylt(
     vilkårForPerson: Set<Vilkår>, vilkårResultater: Iterable<VilkårResultat?>
 ) = vilkårForPerson.all { vilkår ->
-    vilkårResultater.filter { it?.resultat != Resultat.IKKE_AKTUELT }
-        .any { it?.resultat == Resultat.OPPFYLT && it.vilkårType == vilkår }
+    vilkårResultater.any {
+        it?.resultat == Resultat.OPPFYLT || it?.resultat == Resultat.IKKE_AKTUELT
+                && it.vilkårType == vilkår
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
@@ -95,13 +95,14 @@ private fun alleVilkårOppfyltEllerNull(
 ): List<VilkårResultat>? {
     val vilkårForPerson = Vilkår.hentVilkårFor(personType)
 
-    return if (erAlleVilkårForPersonOppfylt(vilkårForPerson, vilkårResultater)) {
+    return if (erAlleVilkårForPersonEntenOppfyltEllerIkkeAktuelt(vilkårForPerson, vilkårResultater)) {
         vilkårResultater.filterNotNull()
     } else null
 }
 
-private fun erAlleVilkårForPersonOppfylt(
-    vilkårForPerson: Set<Vilkår>, vilkårResultater: Iterable<VilkårResultat?>
+private fun erAlleVilkårForPersonEntenOppfyltEllerIkkeAktuelt(
+    vilkårForPerson: Set<Vilkår>,
+    vilkårResultater: Iterable<VilkårResultat?>
 ) = vilkårForPerson.all { vilkår ->
     vilkårResultater.any {
         val erOppfyltEllerIkkeAktuelt = it?.resultat == Resultat.OPPFYLT || it?.resultat == Resultat.IKKE_AKTUELT

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvVilkår.kt
@@ -104,7 +104,8 @@ private fun erAlleVilkårForPersonOppfylt(
     vilkårForPerson: Set<Vilkår>, vilkårResultater: Iterable<VilkårResultat?>
 ) = vilkårForPerson.all { vilkår ->
     vilkårResultater.any {
-        it?.resultat == Resultat.OPPFYLT || it?.resultat == Resultat.IKKE_AKTUELT
-                && it.vilkårType == vilkår
+        val erOppfyltEllerIkkeAktuelt = it?.resultat == Resultat.OPPFYLT || it?.resultat == Resultat.IKKE_AKTUELT
+
+        erOppfyltEllerIkkeAktuelt && it?.vilkårType == vilkår
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -272,7 +272,7 @@ class VilkårsvurderingStegTest {
     }
 
     @Test
-    fun `utførSteg - skal kaste feil hvis barnehageplass perioder ikke dekker perioder i mellom 1 og 2 år vilkår`() {
+    fun `utførSteg - skal kaste feil hvis barnehageplass perioder ikke dekker perioder i barnets alder vilkår`() {
         val vilkårsvurdering = lagVilkårsvurderingMedSøkersVilkår(
             søkerAktør = søker,
             behandling = behandling,
@@ -307,7 +307,7 @@ class VilkårsvurderingStegTest {
     }
 
     @Test
-    fun `utførSteg - skal kaste feil hvis barnehageplass perioder starter etter siste dato i mellom 1 og 2 år vilkår`() {
+    fun `utførSteg - skal kaste feil hvis barnehageplass perioder starter etter siste dato i barnets alder vilkår`() {
         val vilkårsvurdering = lagVilkårsvurderingMedSøkersVilkår(
             søkerAktør = søker,
             behandling = behandling,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -486,4 +486,26 @@ class VilkårsvurderingUtilsTest {
 
         assertDoesNotThrow { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
     }
+
+    @Test
+    fun `validerAtDatoErKorrektIBarnasVilkår skal ikke kaste feil når MEDLEMSKAP_ANNEN_FORELDER har fom før barnets fødselsdato`() {
+        val fom = barnPerson.fødselsdato.minusYears(10)
+        val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
+        val vilkårResultaterForBarn = setOf(
+            VilkårResultat(
+                id = 0,
+                personResultat = personResultatForBarn,
+                vilkårType = Vilkår.MEDLEMSKAP_ANNEN_FORELDER,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = fom,
+                begrunnelse = "begrunnelse",
+                behandlingId = behandling.id,
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON)
+            )
+        )
+        personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
+        vilkårsvurdering.personResultater = setOf(personResultatForBarn)
+
+        assertDoesNotThrow { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -288,7 +288,7 @@ class VilkårsvurderingUtilsTest {
     }
 
     @Test
-    fun `validerBarnasVilkår skal kaste feil når vilkår resulat er oppfylt men mangler fom`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal kaste feil når vilkår resulat er oppfylt men mangler fom`() {
         val fom = null
         val tom = LocalDate.now().plusMonths(7)
 
@@ -308,7 +308,8 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        val exception = assertThrows<Feil> { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        val exception =
+            assertThrows<Feil> { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
         assertEquals(
             "Vilkår ${Vilkår.BOR_MED_SØKER} " +
                 "for barn med fødselsdato ${barnPerson.fødselsdato.tilDagMånedÅr()} mangler fom dato.",
@@ -317,7 +318,7 @@ class VilkårsvurderingUtilsTest {
     }
 
     @Test
-    fun `validerBarnasVilkår skal kaste feil når vilkår resulat fom er før barnets fødselsdato`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal kaste feil når vilkår resulat fom er før barnets fødselsdato`() {
         val fom = barnPerson.fødselsdato.minusMonths(2)
         val tom = fom.plusMonths(5)
 
@@ -337,7 +338,8 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        val exception = assertThrows<Feil> { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        val exception =
+            assertThrows<Feil> { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
         assertEquals(
             "Vilkår ${Vilkår.BOR_MED_SØKER} for barn med fødselsdato ${barnPerson.fødselsdato.tilDagMånedÅr()}" +
                 " har fom dato før barnets fødselsdato.",
@@ -346,7 +348,7 @@ class VilkårsvurderingUtilsTest {
     }
 
     @Test
-    fun `validerBarnasVilkår skal ikke kaste feil når vilkår resulat mangler fom, tom med eksplisitt avslag`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal ikke kaste feil når vilkår resulat mangler fom, tom med eksplisitt avslag`() {
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn = setOf(
             VilkårResultat(
@@ -364,11 +366,11 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        assertDoesNotThrow { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        assertDoesNotThrow { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
     }
 
     @Test
-    fun `validerBarnasVilkår skal kaste feil når MELLOM_1_OG_2_ELLER_ADOPTERT vilkår resulat har fom etter barnets 1 år`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal kaste feil når BARNETS_ALDER vilkår resulat har fom etter barnets 1 år`() {
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn = setOf(
             VilkårResultat(
@@ -385,12 +387,13 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        val exception = assertThrows<Feil> { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        val exception =
+            assertThrows<Feil> { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
         assertEquals("F.o.m datoen må være lik barnets 1 års dag.", exception.message)
     }
 
     @Test
-    fun `validerBarnasVilkår skal kaste feil når MELLOM_1_OG_2_ELLER_ADOPTERT vilkår resulat har tom etter barnets 2 år`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal kaste feil når BARNETS_ALDER vilkår resulat har tom etter barnets 2 år`() {
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn = setOf(
             VilkårResultat(
@@ -407,12 +410,13 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        val exception = assertThrows<Feil> { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        val exception =
+            assertThrows<Feil> { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
         assertEquals("T.o.m datoen må være lik barnets 2 års dag.", exception.message)
     }
 
     @Test
-    fun `validerBarnasVilkår skal kaste feil når MELLOM_1_OG_2_ELLER_ADOPTERT med adopsjon vilkår resulat har tom etter barnets 6 år`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal kaste feil når BARNETS_ALDER med adopsjon vilkår resulat har tom etter barnets 6 år`() {
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn = setOf(
             VilkårResultat(
@@ -430,12 +434,13 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        val exception = assertThrows<Feil> { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        val exception =
+            assertThrows<Feil> { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
         assertEquals("Du kan ikke sette en t.o.m dato som er etter august året barnet fyller 6 år.", exception.message)
     }
 
     @Test
-    fun `validerBarnasVilkår skal kaste feil når MELLOM_1_OG_2_ELLER_ADOPTERT med adopsjon vilkår resulat har diff mellom fom,tom mer enn 1 år`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal kaste feil når BARNETS_ALDER med adopsjon vilkår resulat har diff mellom fom,tom mer enn 1 år`() {
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn = setOf(
             VilkårResultat(
@@ -453,12 +458,13 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        val exception = assertThrows<Feil> { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        val exception =
+            assertThrows<Feil> { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
         assertEquals("Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 1 år.", exception.message)
     }
 
     @Test
-    fun `validerBarnasVilkår skal ikke kaste feil når MELLOM_1_OG_2_ELLER_ADOPTERT med adopsjon vilkår resulat har tom etter August barnet fyller 6 år`() {
+    fun `validerAtDatoErKorrektIBarnasVilkår skal ikke kaste feil når BARNETS_ALDER med adopsjon vilkår resulat har tom etter August barnet fyller 6 år`() {
         val tom = barnPerson.fødselsdato.plusYears(6).withMonth(Month.AUGUST.value)
         val fom = tom.minusMonths(5)
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
@@ -478,6 +484,6 @@ class VilkårsvurderingUtilsTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
-        assertDoesNotThrow { validerBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
+        assertDoesNotThrow { validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, barna = listOf(barnPerson)) }
     }
 }


### PR DESCRIPTION
Denne pullrequesten fikser 3 ting:

1. Vi validerer vilkårsvurderingen når bruker trykke neste i vilkårssteget. Noe av denne valideringen ble tidligere gjort i behandlingsresultat steget.
2. Dersom bruker valgte IKKE_AKTUELT for MEDLEMSKAP_ANNEN_FORELDER så ga det ingen tilkjent ytelser.
3. Vi tillot ikke at SB satt fom dato på MEDLEMSKAP_ANNEN_FORELDER lengre bak enn barnets fødselsdato.