### PR TITLE
Eksplitt avslag endret utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelDto.kt
@@ -14,5 +14,6 @@ data class EndretUtbetalingAndelDto(
     val årsak: Årsak?,
     val avtaletidspunktDeltBosted: LocalDate?,
     val søknadstidspunkt: LocalDate?,
-    val begrunnelse: String?
+    val begrunnelse: String?,
+    var erEksplisittAvslagPåSøknad: Boolean?
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelDto.kt
@@ -15,5 +15,5 @@ data class EndretUtbetalingAndelDto(
     val avtaletidspunktDeltBosted: LocalDate?,
     val søknadstidspunkt: LocalDate?,
     val begrunnelse: String?,
-    var erEksplisittAvslagPåSøknad: Boolean?
+    val erEksplisittAvslagPåSøknad: Boolean?
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -80,7 +80,7 @@ class BehandlingsresultatService(
         return behandlingsresultat
     }
 
-    private fun lagBehandlingsresulatPersoner(
+    fun lagBehandlingsresulatPersoner(
         behandling: Behandling,
         personerFremslitKravFor: List<Aktør>,
         andelerMedEndringer: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeService.kt
@@ -7,6 +7,8 @@ import no.nav.familie.ks.sak.common.util.NullablePeriode
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
+import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
@@ -252,7 +254,9 @@ class VedtaksperiodeService(
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandlingId)
 
         val andelerTilkjentYtelse =
-            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId = behandlingId)
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
+                behandlingId = behandlingId
+            )
 
         return vedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
             personopplysningGrunnlag,
@@ -356,11 +360,53 @@ class VedtaksperiodeService(
 
     private fun hentAvslagsperioderMedBegrunnelser(vedtak: Vedtak): List<VedtaksperiodeMedBegrunnelser> {
         val behandling = vedtak.behandling
+        val avslagsperioderFraVilkårsvurdering = hentAvslagsperioderFraVilkårsvurdering(behandling.id, vedtak)
+        val avslagsperioderFraEndretUtbetalinger = hentAvslagsperioderFraEndretUtbetalinger(behandling.id, vedtak)
+
+        val uregistrerteBarn = søknadGrunnlagService.hentAktiv(behandlingId = behandling.id).hentUregistrerteBarn()
+
+        return if (uregistrerteBarn.isNotEmpty()) {
+            leggTilAvslagsbegrunnelseForUregistrertBarn(
+                avslagsperioder = avslagsperioderFraVilkårsvurdering + avslagsperioderFraEndretUtbetalinger,
+                vedtak = vedtak,
+                uregistrerteBarn = uregistrerteBarn
+            )
+        } else {
+            avslagsperioderFraVilkårsvurdering + avslagsperioderFraEndretUtbetalinger
+        }
+    }
+
+    private fun hentAvslagsperioderFraEndretUtbetalinger(
+        behandlingId: Long,
+        vedtak: Vedtak
+    ): List<VedtaksperiodeMedBegrunnelser> {
+        val endreteUtbetalinger =
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(
+                behandlingId
+            )
+
+        val periodegrupperteAvslagEndreteUtbetalinger =
+            endreteUtbetalinger.filter { it.erEksplisittAvslagPåSøknad == true }
+                .groupBy { NullablePeriode(it.fom?.toLocalDate(), it.tom?.toLocalDate()) }
+
+        val avslagsperioder = periodegrupperteAvslagEndreteUtbetalinger.map { (fellesPeriode, endretUtbetalinger) ->
+
+            val avslagsbegrunnelser = endretUtbetalinger.map { it.begrunnelser }.flatten().toSet().toList()
+
+            lagVedtaksPeriodeMedBegrunnelser(vedtak, fellesPeriode, avslagsbegrunnelser)
+        }.toMutableList()
+
+        return avslagsperioder
+    }
+
+    private fun hentAvslagsperioderFraVilkårsvurdering(
+        behandlingId: Long,
+        vedtak: Vedtak
+    ): MutableList<VedtaksperiodeMedBegrunnelser> {
         val vilkårsvurdering =
-            vilkårsvurderingRepository.finnAktivForBehandling(behandlingId = behandling.id)
-                ?: throw Feil(
-                    "Fant ikke vilkårsvurdering for behandling ${behandling.id} ved generering av avslagsperioder"
-                )
+            vilkårsvurderingRepository.finnAktivForBehandling(behandlingId = behandlingId) ?: throw Feil(
+                "Fant ikke vilkårsvurdering for behandling $behandlingId ved generering av avslagsperioder"
+            )
 
         val periodegrupperteAvslagsvilkår: Map<NullablePeriode, List<VilkårResultat>> =
             vilkårsvurdering.personResultater.flatMap { it.vilkårResultater }
@@ -369,71 +415,55 @@ class VedtaksperiodeService(
 
         val avslagsperioder = periodegrupperteAvslagsvilkår.map { (fellesPeriode, vilkårResultater) ->
 
-            val avslagsbegrunnelser =
-                vilkårResultater.map { it.begrunnelser }.flatten().toSet().toList()
+            val avslagsbegrunnelser = vilkårResultater.map { it.begrunnelser }.flatten().toSet().toList()
 
-            VedtaksperiodeMedBegrunnelser(
-                vedtak = vedtak,
-                fom = fellesPeriode.fom,
-                tom = fellesPeriode.tom,
-                type = Vedtaksperiodetype.AVSLAG
-            )
-                .apply {
-                    begrunnelser.addAll(
-                        avslagsbegrunnelser.map { begrunnelse ->
-                            Vedtaksbegrunnelse(
-                                vedtaksperiodeMedBegrunnelser = this,
-                                begrunnelse = begrunnelse
-                            )
-                        }
-                    )
-                }
+            lagVedtaksPeriodeMedBegrunnelser(vedtak, fellesPeriode, avslagsbegrunnelser)
         }.toMutableList()
 
-        val uregistrerteBarn =
-            søknadGrunnlagService.hentAktiv(behandlingId = behandling.id).hentUregistrerteBarn()
-
-        return if (uregistrerteBarn.isNotEmpty()) {
-            leggTilAvslagsbegrunnelseForUregistrertBarn(
-                avslagsperioder = avslagsperioder,
-                vedtak = vedtak,
-                uregistrerteBarn = uregistrerteBarn
-            )
-        } else {
-            avslagsperioder
-        }
+        return avslagsperioder
     }
 
-    private fun leggTilAvslagsbegrunnelseForUregistrertBarn(
-        avslagsperioder: List<VedtaksperiodeMedBegrunnelser>,
+    private fun lagVedtaksPeriodeMedBegrunnelser(
         vedtak: Vedtak,
-        uregistrerteBarn: List<BarnMedOpplysningerDto>
-    ): List<VedtaksperiodeMedBegrunnelser> {
-        val avslagsperioderMedTomPeriode =
-            if (avslagsperioder.none { it.fom == null && it.tom == null }) {
-                avslagsperioder + VedtaksperiodeMedBegrunnelser(
-                    vedtak = vedtak,
-                    fom = null,
-                    tom = null,
-                    type = Vedtaksperiodetype.AVSLAG
+        periode: NullablePeriode,
+        avslagsbegrunnelser: List<Begrunnelse>
+    ): VedtaksperiodeMedBegrunnelser = VedtaksperiodeMedBegrunnelser(
+        vedtak = vedtak, fom = periode.fom, tom = periode.tom?.sisteDagIMåned(), type = Vedtaksperiodetype.AVSLAG
+    ).apply {
+        begrunnelser.addAll(
+            avslagsbegrunnelser.map { begrunnelse ->
+                Vedtaksbegrunnelse(
+                    vedtaksperiodeMedBegrunnelser = this, begrunnelse = begrunnelse
                 )
-            } else {
-                avslagsperioder
             }
-
-        return avslagsperioderMedTomPeriode.map {
-            if (it.fom == null && it.tom == null && uregistrerteBarn.isNotEmpty()) {
-                it.apply {
-                    begrunnelser.add(
-                        Vedtaksbegrunnelse(
-                            vedtaksperiodeMedBegrunnelser = this,
-                            begrunnelse = Begrunnelse.AVSLAG_UREGISTRERT_BARN
-                        )
-                    )
-                }
-            } else {
-                it
-            }
-        }.toList()
+        )
     }
+}
+
+private fun leggTilAvslagsbegrunnelseForUregistrertBarn(
+    avslagsperioder: List<VedtaksperiodeMedBegrunnelser>,
+    vedtak: Vedtak,
+    uregistrerteBarn: List<BarnMedOpplysningerDto>
+): List<VedtaksperiodeMedBegrunnelser> {
+    val avslagsperioderMedTomPeriode = if (avslagsperioder.none { it.fom == null && it.tom == null }) {
+        avslagsperioder + VedtaksperiodeMedBegrunnelser(
+            vedtak = vedtak, fom = null, tom = null, type = Vedtaksperiodetype.AVSLAG
+        )
+    } else {
+        avslagsperioder
+    }
+
+    return avslagsperioderMedTomPeriode.map {
+        if (it.fom == null && it.tom == null && uregistrerteBarn.isNotEmpty()) {
+            it.apply {
+                begrunnelser.add(
+                    Vedtaksbegrunnelse(
+                        vedtaksperiodeMedBegrunnelser = this, begrunnelse = Begrunnelse.AVSLAG_UREGISTRERT_BARN
+                    )
+                )
+            }
+        } else {
+            it
+        }
+    }.toList()
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -150,6 +150,7 @@ data class EndretUtbetalingAndelMedAndelerTilkjentYtelse(
     val id get() = endretUtbetalingAndel.id
     val fom get() = endretUtbetalingAndel.fom
     val tom get() = endretUtbetalingAndel.tom
+    val erEksplisittAvslagPåSøknad get() = endretUtbetalingAndel.erEksplisittAvslagPåSøknad
     val endretUtbetaling get() = endretUtbetalingAndel
     val andelerTilkjentYtelse get() = andeler
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -142,6 +142,7 @@ data class EndretUtbetalingAndelMedAndelerTilkjentYtelse(
     val periode get() = endretUtbetalingAndel.periode
     val person get() = endretUtbetalingAndel.person
     val begrunnelse get() = endretUtbetalingAndel.begrunnelse
+    val begrunnelser get() = endretUtbetalingAndel.begrunnelser
     val søknadstidspunkt get() = endretUtbetalingAndel.søknadstidspunkt
     val avtaletidspunktDeltBosted get() = endretUtbetalingAndel.avtaletidspunktDeltBosted
     val prosent get() = endretUtbetalingAndel.prosent

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -142,6 +142,11 @@ fun EndretUtbetalingAndel.fraEndretUtbetalingAndelDto(
     this.begrunnelse = endretUtbetalingAndelDto.begrunnelse
     this.person = person
     this.erEksplisittAvslagPåSøknad = endretUtbetalingAndelDto.erEksplisittAvslagPåSøknad
+
+    // Vi skal bare ha 1 mulig avslagebegrunnelse for endret utbetalingandel.
+    // TODO: Endre til riktig avslagtekst når vi får dem inn.
+    this.begrunnelser = listOf(Begrunnelse.AVSLAG_UREGISTRERT_BARN)
+
     return this
 }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -71,7 +71,10 @@ data class EndretUtbetalingAndel(
 
     @Column(name = "vedtak_begrunnelse_spesifikasjoner")
     @Convert(converter = StandardbegrunnelseListConverter::class)
-    var begrunnelser: List<Begrunnelse> = emptyList()
+    var begrunnelser: List<Begrunnelse> = emptyList(),
+
+    @Column(name = "er_eksplisitt_avslag_paa_soknad")
+    var erEksplisittAvslagPåSøknad: Boolean? = null
 ) : BaseEntitet() {
 
     fun overlapperMed(periode: MånedPeriode) = periode.overlapperHeltEllerDelvisMed(this.periode)
@@ -122,21 +125,23 @@ fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilEndretUtbetalingAndelDto() 
         årsak = this.årsak,
         avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted,
         søknadstidspunkt = this.søknadstidspunkt,
-        begrunnelse = this.begrunnelse
+        begrunnelse = this.begrunnelse,
+        erEksplisittAvslagPåSøknad = this.erEksplisittAvslagPåSøknad
     )
 
 fun EndretUtbetalingAndel.fraEndretUtbetalingAndelDto(
-    restEndretUtbetalingAndel: EndretUtbetalingAndelDto,
+    endretUtbetalingAndelDto: EndretUtbetalingAndelDto,
     person: Person
 ): EndretUtbetalingAndel {
-    this.fom = restEndretUtbetalingAndel.fom
-    this.tom = restEndretUtbetalingAndel.tom
-    this.prosent = restEndretUtbetalingAndel.prosent ?: BigDecimal(0)
-    this.årsak = restEndretUtbetalingAndel.årsak
-    this.avtaletidspunktDeltBosted = restEndretUtbetalingAndel.avtaletidspunktDeltBosted
-    this.søknadstidspunkt = restEndretUtbetalingAndel.søknadstidspunkt
-    this.begrunnelse = restEndretUtbetalingAndel.begrunnelse
+    this.fom = endretUtbetalingAndelDto.fom
+    this.tom = endretUtbetalingAndelDto.tom
+    this.prosent = endretUtbetalingAndelDto.prosent ?: BigDecimal(0)
+    this.årsak = endretUtbetalingAndelDto.årsak
+    this.avtaletidspunktDeltBosted = endretUtbetalingAndelDto.avtaletidspunktDeltBosted
+    this.søknadstidspunkt = endretUtbetalingAndelDto.søknadstidspunkt
+    this.begrunnelse = endretUtbetalingAndelDto.begrunnelse
     this.person = person
+    this.erEksplisittAvslagPåSøknad = endretUtbetalingAndelDto.erEksplisittAvslagPåSøknad
     return this
 }
 

--- a/src/main/resources/db/migration/V4__eksplitt_avslag_endretutbetalingandel.sql
+++ b/src/main/resources/db/migration/V4__eksplitt_avslag_endretutbetalingandel.sql
@@ -1,0 +1,2 @@
+ALTER TABLE endret_utbetaling_andel
+    ADD COLUMN er_eksplisitt_avslag_paa_soknad BOOLEAN;

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -715,7 +715,11 @@ fun lagDødsfall(
     dødsfallPoststed = dødsfallPoststed
 )
 
-fun lagVilkårsvurderingOppfylt(personer: Collection<Person>, behandling: Behandling = lagBehandling()): Vilkårsvurdering {
+fun lagVilkårsvurderingOppfylt(
+    personer: Collection<Person>,
+    behandling: Behandling = lagBehandling(),
+    erEksplisittAvslagPåSøknad: Boolean = false
+): Vilkårsvurdering {
     val vilkårsvurdering = Vilkårsvurdering(
         behandling = behandling
     )
@@ -730,13 +734,16 @@ fun lagVilkårsvurderingOppfylt(personer: Collection<Person>, behandling: Behand
             Vilkår.hentVilkårFor(person.type).map {
                 VilkårResultat(
                     personResultat = personResultat,
-                    periodeFom = if (person.type == PersonType.SØKER) person.fødselsdato else person.fødselsdato.plusYears(1),
+                    periodeFom = if (person.type == PersonType.SØKER) person.fødselsdato else person.fødselsdato.plusYears(
+                        1
+                    ),
                     periodeTom = if (person.type == PersonType.SØKER) null else person.fødselsdato.plusYears(2),
                     vilkårType = it,
                     resultat = Resultat.OPPFYLT,
                     begrunnelse = "",
                     behandlingId = vilkårsvurdering.behandling.id,
-                    utdypendeVilkårsvurderinger = emptyList()
+                    utdypendeVilkårsvurderinger = emptyList(),
+                    erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad
                 )
             }.toSet()
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
@@ -1,0 +1,157 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.lagVilkårsvurderingOppfylt
+import no.nav.familie.ks.sak.data.randomFnr
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ks.sak.kjerne.beregning.EndretUtbetalingAndelMedAndelerTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.hamcrest.CoreMatchers.`is` as Is
+
+@ExtendWith(MockKExtension::class)
+class BehandlingsresultatServiceTest {
+
+    @MockK
+    private lateinit var behandlingService: BehandlingService
+
+    @MockK
+    private lateinit var andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
+
+    @MockK
+    private lateinit var vilkårsvurderingService: VilkårsvurderingService
+
+    @MockK
+    private lateinit var søknadGrunnlagService: SøknadGrunnlagService
+
+    @MockK
+    private lateinit var personidentService: PersonidentService
+
+    @MockK
+    private lateinit var personopplysningGrunnlagService: PersonopplysningGrunnlagService
+
+    @InjectMockKs
+    private lateinit var behandlingsresultatService: BehandlingsresultatService
+
+    @Test
+    fun `lagBehandlingsresulatPersoner - skal returnere BehandlingsresultatPerson som ikke er eksplisittAvslag hvis det ikke er avslag i vilkårsvurdering eller endretutbetaling`() {
+        val behandling = mockk<Behandling>(relaxed = true)
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(behandlingId = behandling.id, barnasIdenter = listOf(randomFnr(), randomFnr()))
+        val vilkårsvurdering = lagVilkårsvurderingOppfylt(personopplysningGrunnlag.personer)
+
+        val andelerMedEndringer = personopplysningGrunnlag.personer.map {
+            EndretUtbetalingAndelMedAndelerTilkjentYtelse(
+                EndretUtbetalingAndel(
+                    behandlingId = behandling.id,
+                    erEksplisittAvslagPåSøknad = false,
+                    person = it
+                ),
+                emptyList()
+            )
+        }
+
+        every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) } returns personopplysningGrunnlag
+        every {
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(
+                behandlingId = behandling.id
+            )
+        } returns andelerMedEndringer
+
+        val behandlingsresulatPersoner = behandlingsresultatService.lagBehandlingsresulatPersoner(
+            behandling = behandling,
+            personerFremslitKravFor = emptyList(),
+            forrigeAndelerMedEndringer = emptyList(),
+            vilkårsvurdering = vilkårsvurdering,
+            andelerMedEndringer = emptyList()
+        )
+
+        assertThat(behandlingsresulatPersoner.all { it.eksplisittAvslag }, Is(false))
+    }
+
+    @Test
+    fun `lagBehandlingsresulatPersoner - skal returnere BehandlingsresultatPerson som er eksplisittAvslag hvis det er avslag i endretutbetaling`() {
+        val behandling = mockk<Behandling>(relaxed = true)
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(behandlingId = behandling.id, barnasIdenter = listOf(randomFnr(), randomFnr()))
+        val vilkårsvurdering = lagVilkårsvurderingOppfylt(personopplysningGrunnlag.personer)
+
+        val andelerMedEndringer = personopplysningGrunnlag.personer.map {
+            EndretUtbetalingAndelMedAndelerTilkjentYtelse(
+                EndretUtbetalingAndel(
+                    behandlingId = behandling.id,
+                    erEksplisittAvslagPåSøknad = true,
+                    person = it
+                ),
+                emptyList()
+            )
+        }
+
+        every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) } returns personopplysningGrunnlag
+        every {
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(
+                behandlingId = behandling.id
+            )
+        } returns andelerMedEndringer
+
+        val behandlingsresulatPersoner = behandlingsresultatService.lagBehandlingsresulatPersoner(
+            behandling = behandling,
+            personerFremslitKravFor = emptyList(),
+            forrigeAndelerMedEndringer = emptyList(),
+            vilkårsvurdering = vilkårsvurdering,
+            andelerMedEndringer = emptyList()
+        )
+
+        assertThat(behandlingsresulatPersoner.all { it.eksplisittAvslag }, Is(true))
+    }
+
+    @Test
+    fun `lagBehandlingsresulatPersoner - skal returnere BehandlingsresultatPerson som er eksplisittAvslag hvis det er avslag i vilkårsvurderingen`() {
+        val behandling = mockk<Behandling>(relaxed = true)
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(behandlingId = behandling.id, barnasIdenter = listOf(randomFnr(), randomFnr()))
+        val vilkårsvurdering =
+            lagVilkårsvurderingOppfylt(personer = personopplysningGrunnlag.personer, erEksplisittAvslagPåSøknad = true)
+
+        val andelerMedEndringer = personopplysningGrunnlag.personer.map {
+            EndretUtbetalingAndelMedAndelerTilkjentYtelse(
+                EndretUtbetalingAndel(
+                    behandlingId = behandling.id,
+                    erEksplisittAvslagPåSøknad = false,
+                    person = it
+                ),
+                emptyList()
+            )
+        }
+
+        every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) } returns personopplysningGrunnlag
+        every {
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(
+                behandlingId = behandling.id
+            )
+        } returns andelerMedEndringer
+
+        val behandlingsresulatPersoner = behandlingsresultatService.lagBehandlingsresulatPersoner(
+            behandling = behandling,
+            personerFremslitKravFor = emptyList(),
+            forrigeAndelerMedEndringer = emptyList(),
+            vilkårsvurdering = vilkårsvurdering,
+            andelerMedEndringer = emptyList()
+        )
+
+        assertThat(behandlingsresulatPersoner.all { it.eksplisittAvslag }, Is(true))
+    }
+}


### PR DESCRIPTION
Vi legger til mulighet for å legge til eksplisitt avslag på endret utbetaling.
Det fungerer forsåvidt helt lik som vilkårsvurdering sin, men det er 1-1 kobling mellom avslag og begrunnelse så vi bruker en fastsatt begrunnelse. Teksten er ikke klar i sanity, så vi bruker bare en random avslagtekst foreløpig.


https://user-images.githubusercontent.com/110383605/206933580-f5d03294-0f76-4626-a83f-8459556fe7c6.mov
