### PR TITLE
Hent kun løpende podder

### DIFF
--- a/hentMiljøvariabler.sh
+++ b/hentMiljøvariabler.sh
@@ -7,7 +7,7 @@ then
   exit
 fi
 
-PODNAVN=$(kubectl -n teamfamilie get pods -o name | grep familie-ks-sak | grep -v "frontend" |  sed "s/^.\{4\}//" | head -n 1);
+PODNAVN=$(kubectl -n teamfamilie get pods --field-selector=status.phase==Running -o name | grep familie-ks-sak | grep -v "frontend" |  sed "s/^.\{4\}//" | head -n 1);
 
 PODVARIABLER="$(kubectl -n teamfamilie exec -c familie-ks-sak -it "$PODNAVN" -- env)"
 AZURE_APP_CLIENT_ID="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_ID" | tr -d '\r' )"


### PR DESCRIPTION
Passer på at vi ikke henter miljøvariablene fra podder som ikke kjører. I dette tilfellet 👇 prøvde jeg å hente fra den øverste podden som ga meg feilmeldingen `error: cannot exec into a container in a completed pod;`
<img width="764" alt="image" src="https://user-images.githubusercontent.com/17828446/207002774-0a3599dc-9cd0-4813-9166-3c53241dd2f8.png">
