### PR TITLE
Bruk målform fra søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -84,7 +84,7 @@ class PersonopplysningGrunnlagService(
             aktør = eksisterendePersonopplysningGrunnlag.søker.aktør,
             barnasAktør = barnAktører,
             behandling = behandling,
-            målform = eksisterendePersonopplysningGrunnlag.søker.målform
+            målform = søknadDto.søkerMedOpplysninger.målform
         )
     }
 


### PR DESCRIPTION
Vi må bruke målform som er sendt inn fra frontend, og ikke basere oss på eksisterende personopplysninggrunnlag da den ble opprettet ved oppretting av fagsak eller tidligere i løpet som ikke tok imot input for målform.