### PR TITLE
Returner ressurs slik at vi vet at alt har gått bra ved opprettelse av klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageController.kt
@@ -24,14 +24,14 @@ class KlageController(
 ) {
 
     @PostMapping("/{fagsakId}/opprett-klagebehandling")
-    fun opprettKlage(@PathVariable fagsakId: Long, @RequestBody opprettKlageDto: OpprettKlageDto) {
+    fun opprettKlage(@PathVariable fagsakId: Long, @RequestBody opprettKlageDto: OpprettKlageDto): Ressurs<Unit> {
         tilgangService.validerTilgangTilHandlingOgFagsak(
             fagsakId = fagsakId,
             event = AuditLoggerEvent.CREATE,
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
             handling = "Vis og lagre vedtaksbrev"
         )
-        return klageService.opprettKlage(fagsakId, opprettKlageDto)
+        return Ressurs.success(klageService.opprettKlage(fagsakId, opprettKlageDto))
     }
 
     @GetMapping("/{fagsakId}/hent-klagebehandlinger")


### PR DESCRIPTION
Nå ser det ut som noe går galt frontend selv om klagen er opprettet som den skal: 
![image](https://user-images.githubusercontent.com/17828446/210224305-addfe81c-f5d6-4c64-9190-f5d0b350e9d7.png)

Fikser så vi returnerer en ressurs, slik at frontend forstår at alt er ok