### PR TITLE
Legg til muligheten for å endre behandlingstema etter vilkårsvurderin…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BehandlingController.kt
@@ -4,6 +4,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingPåVentDto
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
+import no.nav.familie.ks.sak.api.dto.EndreBehandlingstemaDto
 import no.nav.familie.ks.sak.api.dto.HenleggBehandlingDto
 import no.nav.familie.ks.sak.api.dto.LeggTilBarnDto
 import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
@@ -187,5 +188,30 @@ class BehandlingController(
         )
         leggTilBarnService.leggTilBarn(behandlingId, leggTilBarnDto.barnIdent)
         return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = behandlingId)))
+    }
+
+    @PutMapping(path = ["/{behandlingId}/behandlingstema"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun endreBehandlingstema(
+        @PathVariable behandlingId: Long,
+        @RequestBody endreBehandlingstemaDto: EndreBehandlingstemaDto
+    ): ResponseEntity<Ressurs<BehandlingResponsDto>> {
+        tilgangService.validerTilgangTilHandlingOgFagsakForBehandling(
+            behandlingId = behandlingId,
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            event = AuditLoggerEvent.UPDATE,
+            handling = "Endre behandlingstema på behandling"
+        )
+
+        behandlingService.endreBehandlingstemaPåBehandling(
+            behandlingId = behandlingId,
+            overstyrtKategori = endreBehandlingstemaDto.behandlingKategori,
+        )
+
+        return ResponseEntity.ok(
+            Ressurs.success(
+                behandlingService
+                    .lagBehandlingRespons(behandlingId = behandlingId)
+            )
+        )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndreBehandlingstemaDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndreBehandlingstemaDto.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.ks.sak.api.dto
+
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
+
+data class EndreBehandlingstemaDto(val behandlingKategori: BehandlingKategori)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -248,7 +248,7 @@ enum class BehandlingKategori(val visningsnavn: String, val nivå: Int) {
     }
 }
 
-fun List<BehandlingKategori>.finnHøyesteKategori(): BehandlingKategori? = this.maxByOrNull { it.nivå }
+fun List<BehandlingKategori>.finnHøyesteKategori(): BehandlingKategori = this.maxBy { it.nivå }
 
 enum class BehandlingStatus {
     OPPRETTET,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.config.RolleConfig
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.ArbeidsfordelingsEnhet
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Beslutning
 import no.nav.familie.ks.sak.kjerne.logg.domene.Logg
@@ -321,6 +322,23 @@ class LoggService(
             )
         )
     }
+
+    fun opprettEndretBehandlingstemaLogg(
+        behandling: Behandling,
+        forrigeKategori: BehandlingKategori,
+        nyKategori: BehandlingKategori
+    ) =
+        lagreLogg(
+            Logg(
+                behandlingId = behandling.id,
+                type = LoggType.BEHANDLINGSTEMA_ENDRET,
+                rolle = SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
+                    rolleConfig,
+                    BehandlerRolle.SAKSBEHANDLER
+                ),
+                tekst = "Behandlingstema er manuelt endret fra $forrigeKategori ordinær til $nyKategori ordinær"
+            )
+        )
 
     companion object {
         private val logger = LoggerFactory.getLogger(LoggService::class.java)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggType.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggType.kt
@@ -5,7 +5,7 @@ enum class LoggType(val visningsnavn: String, val tittel: String = visningsnavn)
     LIVSHENDELSE("Livshendelse"),
     BEHANDLENDE_ENHET_ENDRET("Behandlende enhet endret", "Endret enhet på behandling"),
     BEHANDLING_OPPRETTET("Behandling opprettet"),
-    BEHANDLINGSTYPE_ENDRET("Endret behandlingstype", "Endret behandlingstema"),
+    BEHANDLINGSTEMA_ENDRET("Endret behandlingstema", "Endret behandlingstema"),
     BARN_LAGT_TIL("Barn lagt til på behandling"),
     DOKUMENT_MOTTATT("Dokument ble mottatt"),
     SØKNAD_REGISTRERT("Søknaden ble registrert"),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggServiceTest.kt
@@ -367,7 +367,7 @@ class LoggServiceTest {
     }
 
     @Test
-    fun `opprettSendTilBeslutterLogg - skal lagre logg på at behandlingstema er endret`() {
+    fun `opprettEndretBehandlingstemaLogg - skal lagre logg på at behandlingstema er endret`() {
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
         every { loggRepository.save(any()) } returnsArgument 0

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ks.sak.config.RolleConfig
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.ArbeidsfordelingsEnhet
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.logg.domene.Logg
@@ -363,5 +364,28 @@ class LoggServiceTest {
 
         assertThat(lagretLogg.behandlingId, Is(behandling.id))
         assertThat(lagretLogg.type, Is(LoggType.SEND_TIL_BESLUTTER))
+    }
+
+    @Test
+    fun `opprettSendTilBeslutterLogg - skal lagre logg på at behandlingstema er endret`() {
+        val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
+
+        every { loggRepository.save(any()) } returnsArgument 0
+
+        val forrigeKategori = BehandlingKategori.NASJONAL
+        val nyKategori = BehandlingKategori.EØS
+
+        val opprettetLogg = loggService.opprettEndretBehandlingstemaLogg(
+            behandling,
+            forrigeKategori,
+            nyKategori
+        )
+
+        assertThat(opprettetLogg.behandlingId, Is(behandling.id))
+        assertThat(opprettetLogg.type, Is(LoggType.BEHANDLINGSTEMA_ENDRET))
+        assertThat(
+            opprettetLogg.tekst,
+            Is(("Behandlingstema er manuelt endret fra $forrigeKategori ordinær til $nyKategori ordinær"))
+        )
     }
 }


### PR DESCRIPTION
Jeg har
- Lagt til nytt endepunkt som lar SB endre behandlingstema manuelt fra frontend (bytte mellom EØS og NASJONAL)
- Lagt til logikk for å støtte dette
- Lagt til logikk som endrer behandlingstema automatisk etter vilkårsvurdering steget. Det settes til EØS dersom noe av vilkårene vurderes etter EØS ordningen, eller forrige vedtatte behandling har vilkår som fortsatt er løpende og ble vurdert etter EØS ordningen. Ellers blir den satt til nasjonal.

<img width="1728" alt="eøs endring" src="https://user-images.githubusercontent.com/110383605/210279492-3af945c8-dd93-4fcb-8024-7a4638f1f0ba.png">


