### PR TITLE
Sørger for at alle begrunnelser med skalAlltidVises = true alltid er tilgjengelig

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
@@ -21,7 +21,8 @@ data class SanityBegrunnelse(
     val hjemler: List<String>,
     val endringsårsaker: List<Årsak>,
     val endretUtbetalingsperiode: List<EndretUtbetalingsperiodeTrigger>,
-    val støtterFritekst: Boolean
+    val støtterFritekst: Boolean,
+    val skalAlltidVises: Boolean
 )
 
 enum class SanityBegrunnelseType {
@@ -65,7 +66,8 @@ data class SanityBegrunnelseDto(
     val endretUtbetalingsperiode: List<String> = emptyList(),
     val triggere: List<String> = emptyList(),
     val hjemler: List<String> = emptyList(),
-    val stotterFritekst: Boolean?
+    val stotterFritekst: Boolean?,
+    val skalAlltidVises: Boolean?
 ) {
     fun tilSanityBegrunnelse(): SanityBegrunnelse {
         return SanityBegrunnelse(
@@ -89,7 +91,8 @@ data class SanityBegrunnelseDto(
             endretUtbetalingsperiode = endretUtbetalingsperiode.mapNotNull {
                 finnEnumverdi(it, EndretUtbetalingsperiodeTrigger.values(), apiNavn)
             },
-            støtterFritekst = stotterFritekst ?: false
+            støtterFritekst = stotterFritekst ?: false,
+            skalAlltidVises = skalAlltidVises ?: false
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -80,6 +80,8 @@ class BegrunnelserForPeriodeContext(
             sanityBegrunnelse
         )
 
+        if (sanityBegrunnelse.skalAlltidVises) return true
+
         return hentPersonerMedVilkårResultaterSomPasserMedBegrunnelseOgPeriode(this, sanityBegrunnelse).isNotEmpty()
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -76,12 +76,11 @@ class BegrunnelserForPeriodeContext(
     private fun Begrunnelse.triggesForVedtaksperiode(): Boolean {
         val sanityBegrunnelse = this.tilSanityBegrunnelse(sanityBegrunnelser) ?: return false
 
+        if (sanityBegrunnelse.skalAlltidVises) return true
+
         if (sanityBegrunnelse.endretUtbetalingsperiode.isNotEmpty()) return erEtterEndretPeriodeAvSammeÅrsak(
             sanityBegrunnelse
         )
-
-        if (sanityBegrunnelse.skalAlltidVises) return true
-
         return hentPersonerMedVilkårResultaterSomPasserMedBegrunnelseOgPeriode(this, sanityBegrunnelse).isNotEmpty()
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -179,7 +179,8 @@ class VilkårsvurderingServiceTest {
                 hjemler = emptyList(),
                 endretUtbetalingsperiode = emptyList(),
                 endringsårsaker = emptyList(),
-                støtterFritekst = false
+                støtterFritekst = false,
+                skalAlltidVises = false
             )
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -245,7 +245,8 @@ class BegrunnelserForPeriodeContextTest {
             hjemler = emptyList(),
             endretUtbetalingsperiode = emptyList(),
             endringsårsaker = emptyList(),
-            støtterFritekst = false
+            støtterFritekst = false,
+            skalAlltidVises = false
         )
         val personResultatBarn = PersonResultat(
             aktør = barnAktør,
@@ -312,7 +313,8 @@ class BegrunnelserForPeriodeContextTest {
                 hjemler = emptyList(),
                 endretUtbetalingsperiode = emptyList(),
                 endringsårsaker = emptyList(),
-                støtterFritekst = false
+                støtterFritekst = false,
+                skalAlltidVises = false
             ),
             SanityBegrunnelse(
                 apiNavn = Begrunnelse.INNVILGET_SØKER_OG_ELLER_BARN_HAR_OPPHOLDSTILLATELSE.sanityApiNavn,
@@ -325,7 +327,8 @@ class BegrunnelserForPeriodeContextTest {
                 hjemler = emptyList(),
                 endretUtbetalingsperiode = emptyList(),
                 endringsårsaker = emptyList(),
-                støtterFritekst = false
+                støtterFritekst = false,
+                skalAlltidVises = false
             ),
             SanityBegrunnelse(
                 apiNavn = Begrunnelse.INNVILGET_SØKER_OG_ELLER_BARN_BOSATT_I_RIKET.sanityApiNavn,
@@ -338,7 +341,8 @@ class BegrunnelserForPeriodeContextTest {
                 hjemler = emptyList(),
                 endretUtbetalingsperiode = emptyList(),
                 endringsårsaker = emptyList(),
-                støtterFritekst = false
+                støtterFritekst = false,
+                skalAlltidVises = false
             ),
             SanityBegrunnelse(
                 apiNavn = Begrunnelse.INNVILGET_SØKER_OG_ELLER_BARN_BOSATT_I_RIKET_OG_HAR_OPPHOLDSTILLATELSE.sanityApiNavn,
@@ -351,7 +355,8 @@ class BegrunnelserForPeriodeContextTest {
                 hjemler = emptyList(),
                 endretUtbetalingsperiode = emptyList(),
                 endringsårsaker = emptyList(),
-                støtterFritekst = false
+                støtterFritekst = false,
+                skalAlltidVises = false
             )
         )
         val personResultatBarn = PersonResultat(
@@ -421,7 +426,8 @@ class BegrunnelserForPeriodeContextTest {
                 hjemler = emptyList(),
                 endringsårsaker = emptyList(),
                 endretUtbetalingsperiode = emptyList(),
-                støtterFritekst = false
+                støtterFritekst = false,
+                skalAlltidVises = false
             )
         )
         val personResultatBarn = PersonResultat(
@@ -486,7 +492,8 @@ class BegrunnelserForPeriodeContextTest {
             hjemler = emptyList(),
             endretUtbetalingsperiode = emptyList(),
             endringsårsaker = emptyList(),
-            støtterFritekst = false
+            støtterFritekst = false,
+            skalAlltidVises = false
         ),
         SanityBegrunnelse(
             apiNavn = Begrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON.sanityApiNavn,
@@ -499,7 +506,8 @@ class BegrunnelserForPeriodeContextTest {
             hjemler = emptyList(),
             endretUtbetalingsperiode = emptyList(),
             endringsårsaker = emptyList(),
-            støtterFritekst = false
+            støtterFritekst = false,
+            skalAlltidVises = false
         ),
         SanityBegrunnelse(
             apiNavn = Begrunnelse.INNVILGET_DELTID_BARNEHAGE.sanityApiNavn,
@@ -512,7 +520,8 @@ class BegrunnelserForPeriodeContextTest {
             hjemler = emptyList(),
             endretUtbetalingsperiode = emptyList(),
             endringsårsaker = emptyList(),
-            støtterFritekst = false
+            støtterFritekst = false,
+            skalAlltidVises = false
         ),
         SanityBegrunnelse(
             apiNavn = Begrunnelse.INNVILGET_DELTID_BARNEHAGE_ADOPSJON.sanityApiNavn,
@@ -525,7 +534,8 @@ class BegrunnelserForPeriodeContextTest {
             hjemler = emptyList(),
             endretUtbetalingsperiode = emptyList(),
             endringsårsaker = emptyList(),
-            støtterFritekst = false
+            støtterFritekst = false,
+            skalAlltidVises = false
         )
     )
 


### PR DESCRIPTION
Valgt `skalAlltidVises` på begrunnelsen "Erklæring om motregning":
![image](https://user-images.githubusercontent.com/70642183/211500457-f0eff2b3-c443-4aa3-bc4e-dce3b5772b63.png)

Begrunnelsen "Erklæring om motregning" dukker opp som et valg:
![image](https://user-images.githubusercontent.com/70642183/211500605-5acb66da-09d5-45f0-b43c-6fb8d8b68e4c.png)
