### PR TITLE
Filtrer bort nye vilkår som ikke er initiert

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -143,7 +143,7 @@ class VedtaksperiodeService(
         return vilkårsvurdering.personResultater.mapNotNull { personResultat ->
 
             val vilkårResultaterForAktørSomAlltidSkalKunneBegrunnes =
-                personResultat.vilkårResultater.filter { listeAvVilkårSomAlltidSkalKunneBegrunnes.contains(it.vilkårType) }
+                personResultat.vilkårResultater.filter { listeAvVilkårSomAlltidSkalKunneBegrunnes.contains(it.vilkårType) && it.periodeFom != null }
 
             val vilkårResultaterForAktørMapSomAlltidSkalKunneBegrunnes =
                 vilkårResultaterForAktørSomAlltidSkalKunneBegrunnes


### PR DESCRIPTION
Oppdaget av @haldersaikat .
Man får feil dersom man prøver å legge til ny periode. 
Grunnen til dette er at man da prøver å legge den inn i en ny tidslinje (ingen fom og ingen tom), og da kræsjer det.
Vi filtrer derfor bort alle vilkår uten fom satt (vi ønsker bare de som er fylt ut)
