### PR TITLE
Lagt til opprettOppgave endepunkt i ForvaltningController

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -76,21 +76,23 @@ class ForvaltningController(
 
     @PostMapping("/opprett-oppgave")
     fun opprettOppgave(@RequestBody opprettOppgaveDto: OpprettOppgaveDto): ResponseEntity<Ressurs<String>> {
-        // hent aktørId fra fnr
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "teste opprettelse av oppgave"
+        )
         val aktørId = personidentService.hentAktør(opprettOppgaveDto.fnr).aktørId
         val opprettOppgaveRequest = OpprettOppgaveRequest(
             ident = OppgaveIdentV2(ident = aktørId, gruppe = IdentGruppe.AKTOERID),
             saksId = null,
+            journalpostId = opprettOppgaveDto.journalpostId,
             tema = Tema.KON,
             oppgavetype = opprettOppgaveDto.oppgavetype,
             fristFerdigstillelse = LocalDate.now().plusDays(1),
-            beskrivelse = "Test",
+            beskrivelse = opprettOppgaveDto.beskrivelse,
             enhetsnummer = opprettOppgaveDto.enhet,
-            // behandlingstema brukes ikke i kombinasjon med behandlingstype for kontantstøtte
-            behandlingstema = null,
-            // TODO - må diskuteres hva det kan være for KS-EØS
-            behandlingstype = null,
-            tilordnetRessurs = null
+            behandlingstema = opprettOppgaveDto.behandlingstema,
+            behandlingstype = opprettOppgaveDto.behandlingstype,
+            tilordnetRessurs = opprettOppgaveDto.tilordnetRessurs
         )
         integrasjonClient.opprettOppgave(opprettOppgaveRequest)
         return ResponseEntity.ok(Ressurs.success("Oppgave opprettet"))

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -25,7 +25,7 @@ import no.nav.familie.ks.sak.statistikk.saksstatistikk.SakStatistikkService
 import no.nav.familie.ks.sak.statistikk.stønadsstatistikk.PubliserVedtakTask
 import no.nav.familie.ks.sak.statistikk.stønadsstatistikk.StønadsstatistikkService
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.security.token.support.core.api.Unprotected
+import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -39,8 +39,7 @@ import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/forvaltning/")
-// @ProtectedWithClaims(issuer = "azuread")
-@Unprotected
+@ProtectedWithClaims(issuer = "azuread")
 @Validated
 class ForvaltningController(
     private val tilgangService: TilgangService,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/OpprettOppgaveDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/OpprettOppgaveDto.kt
@@ -1,0 +1,9 @@
+package no.nav.familie.ks.sak.api.dto
+
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+
+data class OpprettOppgaveDto(
+    val fnr: String,
+    val oppgavetype: Oppgavetype,
+    val enhet: String
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/OpprettOppgaveDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/OpprettOppgaveDto.kt
@@ -5,5 +5,10 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 data class OpprettOppgaveDto(
     val fnr: String,
     val oppgavetype: Oppgavetype,
-    val enhet: String
+    val enhet: String,
+    val beskrivelse: String,
+    val journalpostId: String?,
+    val behandlingstema: String?,
+    val behandlingstype: String?,
+    val tilordnetRessurs: String?
 )


### PR DESCRIPTION
Etter forespørsel fra Eivind har jeg lagt til et endepunkt for manuell opprettelse av oppgaver. I utgangspunktet lagt til for å kunne opprette `BehandleSed` oppgaver, men kan brukes for alle oppgavetyper.