### PR TITLE
Splitter ut endret utbetaling andel dto til request og response m/ fo…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelController.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ks.sak.api
 
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
-import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelDto
+import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.TilbakestillBehandlingService
@@ -35,7 +35,7 @@ class EndretUtbetalingAndelController(
     fun oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
         @PathVariable behandlingId: Long,
         @PathVariable endretUtbetalingAndelId: Long,
-        @RequestBody endretUtbetalingAndelDto: EndretUtbetalingAndelDto
+        @RequestBody endretUtbetalingAndelRequestDto: EndretUtbetalingAndelRequestDto
     ): ResponseEntity<Ressurs<BehandlingResponsDto>> {
         tilgangService.validerTilgangTilHandlingOgFagsakForBehandling(
             behandlingId = behandlingId,
@@ -49,7 +49,7 @@ class EndretUtbetalingAndelController(
         endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
             behandling,
             endretUtbetalingAndelId,
-            endretUtbetalingAndelDto
+            endretUtbetalingAndelRequestDto
         )
 
         tilbakestillBehandlingService

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
@@ -36,7 +36,7 @@ data class BehandlingResponsDto(
     val utbetalingsperioder: List<UtbetalingsperiodeResponsDto>,
     val personerMedAndelerTilkjentYtelse: List<PersonerMedAndelerResponsDto>,
     val vedtak: VedtakDto?,
-    val endretUtbetalingAndeler: List<EndretUtbetalingAndelDto>,
+    val endretUtbetalingAndeler: List<EndretUtbetalingAndelResponsDto>,
     val totrinnskontroll: TotrinnskontrollDto?,
     val endringstidspunkt: LocalDate?,
     val sisteVedtaksperiodeVisningDato: LocalDate?,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
@@ -5,7 +5,7 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 
-data class EndretUtbetalingAndelDto(
+data class EndretUtbetalingAndelRequestDto(
     val id: Long?,
     val personIdent: String?,
     val prosent: BigDecimal?,
@@ -16,4 +16,18 @@ data class EndretUtbetalingAndelDto(
     val søknadstidspunkt: LocalDate?,
     val begrunnelse: String?,
     val erEksplisittAvslagPåSøknad: Boolean?
+)
+
+data class EndretUtbetalingAndelResponsDto(
+    val id: Long?,
+    val personIdent: String?,
+    val prosent: BigDecimal?,
+    val fom: YearMonth?,
+    val tom: YearMonth?,
+    val årsak: Årsak?,
+    val avtaletidspunktDeltBosted: LocalDate?,
+    val søknadstidspunkt: LocalDate?,
+    val begrunnelse: String?,
+    val erEksplisittAvslagPåSøknad: Boolean?,
+    val erTilknyttetAndeler: Boolean
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ks.sak.api.dto.ArbeidsfordelingResponsDto
 import no.nav.familie.ks.sak.api.dto.BehandlingPåVentResponsDto
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.BehandlingStegTilstandResponsDto
-import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelDto
+import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelResponsDto
 import no.nav.familie.ks.sak.api.dto.FeilutbetaltValutaDto
 import no.nav.familie.ks.sak.api.dto.PersonResponsDto
 import no.nav.familie.ks.sak.api.dto.PersonerMedAndelerResponsDto
@@ -42,7 +42,7 @@ object BehandlingMapper {
         utbetalingsperioder: List<UtbetalingsperiodeResponsDto>,
         vedtak: VedtakDto?,
         totrinnskontroll: TotrinnskontrollDto?,
-        endretUtbetalingAndeler: List<EndretUtbetalingAndelDto>,
+        endretUtbetalingAndeler: List<EndretUtbetalingAndelResponsDto>,
         endringstidspunkt: LocalDate,
         tilbakekreving: Tilbakekreving?,
         sisteVedtaksperiodeVisningDato: LocalDate?,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -25,7 +25,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
-import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.tilEndretUtbetalingAndelDto
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.tilEndretUtbetalingAndelResponsDto
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
@@ -124,7 +124,7 @@ class BehandlingService(
 
         val endreteUtbetalingerMedAndeler = andelerTilkjentYtelseOgEndreteUtbetalingerService
             .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandlingId)
-            .map { it.tilEndretUtbetalingAndelDto() }
+            .map { it.tilEndretUtbetalingAndelResponsDto() }
 
         val totrinnskontroll =
             totrinnskontrollRepository.findByBehandlingAndAktiv(behandlingId = behandling.id)?.tilTotrinnskontrollDto()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.endretutbetaling
 
-import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelDto
+import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
@@ -34,17 +34,17 @@ class EndretUtbetalingAndelService(
     fun oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
         behandling: Behandling,
         endretUtbetalingAndelId: Long,
-        endretUtbetalingAndelDto: EndretUtbetalingAndelDto
+        endretUtbetalingAndelRequestDto: EndretUtbetalingAndelRequestDto
     ) {
         val endretUtbetalingAndel = endretUtbetalingAndelRepository.getReferenceById(endretUtbetalingAndelId)
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id)
         val personopplysningGrunnlag =
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
         val person =
-            personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == endretUtbetalingAndelDto.personIdent }
+            personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == endretUtbetalingAndelRequestDto.personIdent }
         val andelTilkjentYtelser = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
 
-        endretUtbetalingAndel.fraEndretUtbetalingAndelDto(endretUtbetalingAndelDto, person)
+        endretUtbetalingAndel.fraEndretUtbetalingAndelDto(endretUtbetalingAndelRequestDto, person)
 
         val andreEndredeAndelerPåBehandling = hentEndredeUtbetalingAndeler(behandling.id)
             .filter { it.id != endretUtbetalingAndelId }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -12,7 +12,7 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValida
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerÅrsak
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
-import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.fraEndretUtbetalingAndelDto
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.fraEndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -44,7 +44,7 @@ class EndretUtbetalingAndelService(
             personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == endretUtbetalingAndelRequestDto.personIdent }
         val andelTilkjentYtelser = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
 
-        endretUtbetalingAndel.fraEndretUtbetalingAndelDto(endretUtbetalingAndelRequestDto, person)
+        endretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(endretUtbetalingAndelRequestDto, person)
 
         val andreEndredeAndelerPåBehandling = hentEndredeUtbetalingAndeler(behandling.id)
             .filter { it.id != endretUtbetalingAndelId }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -131,7 +131,7 @@ fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilEndretUtbetalingAndelRespon
         erTilknyttetAndeler = this.andelerTilkjentYtelse.isNotEmpty()
     )
 
-fun EndretUtbetalingAndel.fraEndretUtbetalingAndelDto(
+fun EndretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(
     endretUtbetalingAndelRequestDto: EndretUtbetalingAndelRequestDto,
     person: Person
 ): EndretUtbetalingAndel {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.endretutbetaling.domene
 
-import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelDto
+import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
+import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelResponsDto
 import no.nav.familie.ks.sak.common.entitet.BaseEntitet
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.MånedPeriode
@@ -115,8 +116,8 @@ data class EndretUtbetalingAndel(
     fun erÅrsakDeltBosted() = this.årsak == Årsak.DELT_BOSTED
 }
 
-fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilEndretUtbetalingAndelDto() =
-    EndretUtbetalingAndelDto(
+fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilEndretUtbetalingAndelResponsDto() =
+    EndretUtbetalingAndelResponsDto(
         id = this.id,
         personIdent = this.aktivtFødselsnummer,
         prosent = this.prosent,
@@ -126,22 +127,23 @@ fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilEndretUtbetalingAndelDto() 
         avtaletidspunktDeltBosted = this.avtaletidspunktDeltBosted,
         søknadstidspunkt = this.søknadstidspunkt,
         begrunnelse = this.begrunnelse,
-        erEksplisittAvslagPåSøknad = this.erEksplisittAvslagPåSøknad
+        erEksplisittAvslagPåSøknad = this.erEksplisittAvslagPåSøknad,
+        erTilknyttetAndeler = this.andelerTilkjentYtelse.isNotEmpty()
     )
 
 fun EndretUtbetalingAndel.fraEndretUtbetalingAndelDto(
-    endretUtbetalingAndelDto: EndretUtbetalingAndelDto,
+    endretUtbetalingAndelRequestDto: EndretUtbetalingAndelRequestDto,
     person: Person
 ): EndretUtbetalingAndel {
-    this.fom = endretUtbetalingAndelDto.fom
-    this.tom = endretUtbetalingAndelDto.tom
-    this.prosent = endretUtbetalingAndelDto.prosent ?: BigDecimal(0)
-    this.årsak = endretUtbetalingAndelDto.årsak
-    this.avtaletidspunktDeltBosted = endretUtbetalingAndelDto.avtaletidspunktDeltBosted
-    this.søknadstidspunkt = endretUtbetalingAndelDto.søknadstidspunkt
-    this.begrunnelse = endretUtbetalingAndelDto.begrunnelse
+    this.fom = endretUtbetalingAndelRequestDto.fom
+    this.tom = endretUtbetalingAndelRequestDto.tom
+    this.prosent = endretUtbetalingAndelRequestDto.prosent ?: BigDecimal(0)
+    this.årsak = endretUtbetalingAndelRequestDto.årsak
+    this.avtaletidspunktDeltBosted = endretUtbetalingAndelRequestDto.avtaletidspunktDeltBosted
+    this.søknadstidspunkt = endretUtbetalingAndelRequestDto.søknadstidspunkt
+    this.begrunnelse = endretUtbetalingAndelRequestDto.begrunnelse
     this.person = person
-    this.erEksplisittAvslagPåSøknad = endretUtbetalingAndelDto.erEksplisittAvslagPåSøknad
+    this.erEksplisittAvslagPåSøknad = endretUtbetalingAndelRequestDto.erEksplisittAvslagPåSøknad
 
     // Vi skal bare ha 1 mulig avslagebegrunnelse for endret utbetalingandel.
     // TODO: Endre til riktig avslagtekst når vi får dem inn.


### PR DESCRIPTION
Jeg har splittet ut endret utbetaling andel dto til egen request og response (istedenfor å slenge inn en nullable verdi i eneste dto klasse vi hadde)
I tillegg har jeg lagt til ekstra felt erTilknyttetAndeler til response siden frontend trenger dette for å vite om en endret utbetalt andel er OK. Se før og etter.

Før:
<img width="1207" alt="Screenshot 2023-01-22 at 01 08 12" src="https://user-images.githubusercontent.com/110383605/213894884-239b219d-8651-47cf-8cbd-448e7c982977.png">

Etter:
<img width="909" alt="Screenshot 2023-01-22 at 01 07 46" src="https://user-images.githubusercontent.com/110383605/213894888-edc6992b-43b6-4ea3-8a35-2998ff10bc3b.png">
