### PR TITLE
Vi fikser forskyving av barnehageplass ved fulltidsbarnehageplass til ingen plass

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvBarnehageplass.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvBarnehageplass.kt
@@ -64,12 +64,14 @@ private fun VilkårResultat?.hentGraderingsforskjellMellomDenneOgForrigePeriode(
         vilkårResultatForrigePeriode?.vilkårResultat?.let { hentProsentForAntallTimer(vilkårResultatForrigePeriode.vilkårResultat.antallTimer) }
             ?: BigDecimal.ZERO
     val graderingDennePerioden = this?.let { hentProsentForAntallTimer(this.antallTimer) } ?: BigDecimal.ZERO
+    val førstePeriode = vilkårResultatForrigePeriode == null
 
     return when {
         graderingForrigePeriode > graderingDennePerioden && graderingDennePerioden == BigDecimal.ZERO -> Graderingsforskjell.ReduksjonGårTilIngenUtbetaling
         graderingForrigePeriode > graderingDennePerioden -> Graderingsforskjell.Reduksjon
 
-        graderingForrigePeriode < graderingDennePerioden && graderingForrigePeriode == BigDecimal.ZERO -> Graderingsforskjell.ØkingGårFraIngenUtbetaling
+        graderingForrigePeriode < graderingDennePerioden && graderingForrigePeriode == BigDecimal.ZERO -> if (førstePeriode) Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder else Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass
+
         graderingForrigePeriode < graderingDennePerioden -> Graderingsforskjell.Øking
 
         else -> Graderingsforskjell.Lik
@@ -77,11 +79,12 @@ private fun VilkårResultat?.hentGraderingsforskjellMellomDenneOgForrigePeriode(
 }
 
 enum class Graderingsforskjell {
-    ØkingGårFraIngenUtbetaling,
+    ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass,
     Øking,
     ReduksjonGårTilIngenUtbetaling,
     Reduksjon,
-    Lik
+    Lik,
+    ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder
 }
 
 data class BarnehageplassVilkårMedGraderingsforskjellMellomPerioder<NullableVilkårResultat : VilkårResultat?>(
@@ -97,28 +100,40 @@ private fun List<BarnehageplassVilkårMedGraderingsforskjellMellomPerioder<Vilk�
 
 private fun List<Periode<VilkårResultat>>.filtrerBortOverlappendePerioderMedMinstGradering() =
     map { listOf(it).tilTidslinje() }
-        .kombiner { vilkårResultater -> vilkårResultater.maxByOrNull { it.antallTimer ?: BigDecimal.ZERO } }.tilPerioderIkkeNull()
+        .kombiner { vilkårResultater -> vilkårResultater.maxByOrNull { it.antallTimer ?: BigDecimal.ZERO } }
+        .tilPerioderIkkeNull()
 
 private fun LocalDate?.tilForskøvetTomBasertPåGraderingsforskjell(
     graderingsforskjellMellomDenneOgNestePeriode: Graderingsforskjell
-) = when (graderingsforskjellMellomDenneOgNestePeriode) {
-    Graderingsforskjell.Lik,
-    Graderingsforskjell.Øking -> this?.sisteDagIMåned()
+) = this?.let { tomDato ->
+    when (graderingsforskjellMellomDenneOgNestePeriode) {
+        Graderingsforskjell.Lik,
+        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass,
+        Graderingsforskjell.Øking -> tomDato.sisteDagIMåned()
 
-    Graderingsforskjell.ØkingGårFraIngenUtbetaling -> this?.plusDays(1)?.sisteDagIMåned()
+        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder -> tomDato.plusDays(1)
+            .sisteDagIMåned()
 
-    Graderingsforskjell.ReduksjonGårTilIngenUtbetaling,
-    Graderingsforskjell.Reduksjon -> this?.plusDays(1)?.minusMonths(1)?.sisteDagIMåned()
+        Graderingsforskjell.ReduksjonGårTilIngenUtbetaling,
+        Graderingsforskjell.Reduksjon -> tomDato.plusDays(1).minusMonths(1).sisteDagIMåned()
+    }
 }
 
 private fun LocalDate?.tilForskøvetFomBasertPåGraderingsforskjell(
     graderingsforskjellMellomDenneOgForrigePeriode: Graderingsforskjell
-) = when (graderingsforskjellMellomDenneOgForrigePeriode) {
-    Graderingsforskjell.Lik,
-    Graderingsforskjell.Øking -> this?.minusDays(1)?.plusMonths(1)?.førsteDagIInneværendeMåned()
+) = this?.let { fomDato ->
+    when (graderingsforskjellMellomDenneOgForrigePeriode) {
+        Graderingsforskjell.Lik,
+        Graderingsforskjell.Øking -> fomDato.minusDays(1).plusMonths(1)?.førsteDagIInneværendeMåned()
 
-    Graderingsforskjell.ØkingGårFraIngenUtbetaling -> this?.plusMonths(1)?.førsteDagIInneværendeMåned()
+        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder -> fomDato.plusMonths(1)
+            .førsteDagIInneværendeMåned()
 
-    Graderingsforskjell.ReduksjonGårTilIngenUtbetaling,
-    Graderingsforskjell.Reduksjon -> this?.førsteDagIInneværendeMåned()
+        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass -> if (fomDato == fomDato.førsteDagIInneværendeMåned()) fomDato else fomDato.plusMonths(
+            1
+        ).førsteDagIInneværendeMåned()
+
+        Graderingsforskjell.ReduksjonGårTilIngenUtbetaling,
+        Graderingsforskjell.Reduksjon -> fomDato.førsteDagIInneværendeMåned()
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvBarnehageplass.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvBarnehageplass.kt
@@ -64,13 +64,13 @@ private fun VilkårResultat?.hentGraderingsforskjellMellomDenneOgForrigePeriode(
         vilkårResultatForrigePeriode?.vilkårResultat?.let { hentProsentForAntallTimer(vilkårResultatForrigePeriode.vilkårResultat.antallTimer) }
             ?: BigDecimal.ZERO
     val graderingDennePerioden = this?.let { hentProsentForAntallTimer(this.antallTimer) } ?: BigDecimal.ZERO
-    val førstePeriode = vilkårResultatForrigePeriode == null
+    val erFørstePeriode = vilkårResultatForrigePeriode == null
 
     return when {
         graderingForrigePeriode > graderingDennePerioden && graderingDennePerioden == BigDecimal.ZERO -> Graderingsforskjell.ReduksjonGårTilIngenUtbetaling
         graderingForrigePeriode > graderingDennePerioden -> Graderingsforskjell.Reduksjon
 
-        graderingForrigePeriode < graderingDennePerioden && graderingForrigePeriode == BigDecimal.ZERO -> if (førstePeriode) Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder else Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass
+        graderingForrigePeriode < graderingDennePerioden && graderingForrigePeriode == BigDecimal.ZERO -> if (erFørstePeriode) Graderingsforskjell.IngenUtbetalingGrunnetFørsteperiodeTilØking else Graderingsforskjell.IngenUtbetalingGrunnetFullBarnehageplassTilØking
 
         graderingForrigePeriode < graderingDennePerioden -> Graderingsforskjell.Øking
 
@@ -79,12 +79,12 @@ private fun VilkårResultat?.hentGraderingsforskjellMellomDenneOgForrigePeriode(
 }
 
 enum class Graderingsforskjell {
-    ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass,
+    IngenUtbetalingGrunnetFullBarnehageplassTilØking,
     Øking,
     ReduksjonGårTilIngenUtbetaling,
     Reduksjon,
     Lik,
-    ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder
+    IngenUtbetalingGrunnetFørsteperiodeTilØking
 }
 
 data class BarnehageplassVilkårMedGraderingsforskjellMellomPerioder<NullableVilkårResultat : VilkårResultat?>(
@@ -108,11 +108,10 @@ private fun LocalDate?.tilForskøvetTomBasertPåGraderingsforskjell(
 ) = this?.let { tomDato ->
     when (graderingsforskjellMellomDenneOgNestePeriode) {
         Graderingsforskjell.Lik,
-        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass,
+        Graderingsforskjell.IngenUtbetalingGrunnetFullBarnehageplassTilØking,
         Graderingsforskjell.Øking -> tomDato.sisteDagIMåned()
 
-        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder -> tomDato.plusDays(1)
-            .sisteDagIMåned()
+        Graderingsforskjell.IngenUtbetalingGrunnetFørsteperiodeTilØking -> tomDato.plusDays(1).sisteDagIMåned()
 
         Graderingsforskjell.ReduksjonGårTilIngenUtbetaling,
         Graderingsforskjell.Reduksjon -> tomDato.plusDays(1).minusMonths(1).sisteDagIMåned()
@@ -126,10 +125,10 @@ private fun LocalDate?.tilForskøvetFomBasertPåGraderingsforskjell(
         Graderingsforskjell.Lik,
         Graderingsforskjell.Øking -> fomDato.minusDays(1).plusMonths(1)?.førsteDagIInneværendeMåned()
 
-        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetIngenTidligerePerioder -> fomDato.plusMonths(1)
+        Graderingsforskjell.IngenUtbetalingGrunnetFørsteperiodeTilØking -> fomDato.plusMonths(1)
             .førsteDagIInneværendeMåned()
 
-        Graderingsforskjell.ØkingGårFraIngenUtbetalingGrunnetFullBarnehageplass -> if (fomDato == fomDato.førsteDagIInneværendeMåned()) fomDato else fomDato.plusMonths(
+        Graderingsforskjell.IngenUtbetalingGrunnetFullBarnehageplassTilØking -> if (fomDato == fomDato.førsteDagIInneværendeMåned()) fomDato else fomDato.plusMonths(
             1
         ).førsteDagIInneværendeMåned()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvBarnehageplassVilkårTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvBarnehageplassVilkårTest.kt
@@ -307,7 +307,7 @@ class forskyvBarnehageplassVilkårTest {
     }
 
     @Test
-    fun `forskyvBarnehageplassVilkår skal skyves en måned framover ved overgang fra periode med 33 timer eller mer`() {
+    fun `forskyvBarnehageplassVilkår skal ikke forskyves en måned framover ved overgang fra periode med 33 timer`() {
         val vilkårResultat1 = lagVilkårResultat(
             vilkårType = Vilkår.BARNEHAGEPLASS,
             periodeFom = august.atDay(14),
@@ -326,10 +326,10 @@ class forskyvBarnehageplassVilkårTest {
         Assertions.assertEquals(2, forskjøvedeVilkårResultater.size)
 
         Assertions.assertEquals(september.atDay(1), forskjøvedeVilkårResultater.first().fom)
-        Assertions.assertEquals(oktober.atEndOfMonth(), forskjøvedeVilkårResultater.first().tom)
+        Assertions.assertEquals(september.atEndOfMonth(), forskjøvedeVilkårResultater.first().tom)
         Assertions.assertEquals(BigDecimal.valueOf(33), forskjøvedeVilkårResultater.first().verdi.antallTimer)
 
-        Assertions.assertEquals(november.atDay(1), forskjøvedeVilkårResultater[1].fom)
+        Assertions.assertEquals(oktober.atDay(1), forskjøvedeVilkårResultater[1].fom)
         Assertions.assertEquals(november.atEndOfMonth(), forskjøvedeVilkårResultater[1].tom)
         Assertions.assertEquals(BigDecimal.valueOf(8), forskjøvedeVilkårResultater[1].verdi.antallTimer)
     }


### PR DESCRIPTION
Vi må skille på hvorfor man gikk fra ingen utbetaling til noe utbetaling.

Et scenario:

* Om man gikk fra 100% barnehageplass (ingen utbetaling) til 0% barnehageplass, så skal man få utbetalt for inneværende måneden dersom man ikke hadde barnehage plass f.o.m den første dagen i måned.
* Om man gikk fra å ikke ha kontantstøtte (ingen utbetaling) til å ha kontantstøtte, så skal man få utbetalt neste måned.

Testet OK i preprod av Birgitte.