### PR TITLE
Inkluder register historikk selv uten statsborgerskap

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
@@ -95,7 +95,7 @@ object BehandlingMapper {
             manueltOverstyrt = arbeidsfordelingPåBehandling.manueltOverstyrt
         )
 
-    fun lagPersonRespons(person: Person, landKodeOgLandNavn: Map<String, String>) = PersonResponsDto(
+    fun lagPersonRespons(person: Person, landKodeOgLandNavn: Map<String, String>?) = PersonResponsDto(
         type = person.type,
         fødselsdato = person.fødselsdato,
         personIdent = person.aktør.aktivFødselsnummer(),
@@ -103,10 +103,7 @@ object BehandlingMapper {
         kjønn = KJOENN.valueOf(person.kjønn.name),
         målform = person.målform,
         dødsfallDato = person.dødsfall?.dødsfallDato,
-        registerhistorikk = if (landKodeOgLandNavn.isNotEmpty()) lagRegisterHistorikkResponsDto(
-            person,
-            landKodeOgLandNavn
-        ) else null
+        registerhistorikk = lagRegisterHistorikkResponsDto(person, landKodeOgLandNavn)
     )
 
     fun lagPersonerMedAndelTilkjentYtelseRespons(

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/RegisterHistorikkMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/RegisterHistorikkMapper.kt
@@ -12,14 +12,22 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.statsborgers
 
 object RegisterHistorikkMapper {
 
-    fun lagRegisterHistorikkResponsDto(person: Person, landKodeOgLandNavn: Map<String, String>) = RegisterHistorikkResponsDto(
-        hentetTidspunkt = person.personopplysningGrunnlag.opprettetTidspunkt,
-        oppholdstillatelse = person.opphold.map { lagRegisterOpplysningDto(it) },
-        statsborgerskap = person.statsborgerskap.map { lagRegisterOpplysningDto(it, landKodeOgLandNavn) },
-        bostedsadresse = person.bostedsadresser.map { lagRegisterOpplysningDto(it) },
-        sivilstand = person.sivilstander.map { lagRegisterOpplysningDto(it) },
-        dødsboadresse = person.dødsfall?.let { listOf(lagRegisterOpplysningDto(it)) } ?: emptyList()
-    )
+    fun lagRegisterHistorikkResponsDto(person: Person, landKodeOgLandNavn: Map<String, String>?) =
+        RegisterHistorikkResponsDto(
+            hentetTidspunkt = person.personopplysningGrunnlag.opprettetTidspunkt,
+            oppholdstillatelse = person.opphold.map { lagRegisterOpplysningDto(it) },
+            statsborgerskap = landKodeOgLandNavn?.let {
+                person.statsborgerskap.map { statsborgerskap ->
+                    lagRegisterOpplysningDto(
+                        statsborgerskap,
+                        landKodeOgLandNavn
+                    )
+                }
+            },
+            bostedsadresse = person.bostedsadresser.map { lagRegisterOpplysningDto(it) },
+            sivilstand = person.sivilstander.map { lagRegisterOpplysningDto(it) },
+            dødsboadresse = person.dødsfall?.let { listOf(lagRegisterOpplysningDto(it)) } ?: emptyList()
+        )
 
     private fun lagRegisterOpplysningDto(dødsfall: Dødsfall): RegisteropplysningResponsDto =
         RegisteropplysningResponsDto(


### PR DESCRIPTION
Per nå så inkluderer vi ikke registerhistorikk dersom vi ikke har fått noe info om statsborgerskap på søker/barn.
Dette går vi bort ifra nå.