### PR TITLE
Legg til metrikker for totalt antall saker, antall saker behandlet per enhet, antall saker per resultat og antall saker per type

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ks.sak.integrasjon.oppgave.OpprettOppgaveTask
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingMetrikker
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
@@ -41,7 +42,8 @@ class OpprettBehandlingService(
     private val fagsakRepository: FagsakRepository,
     private val behandlingRepository: BehandlingRepository,
     private val taskService: TaskService,
-    private val stegService: StegService
+    private val stegService: StegService,
+    private val behandlingMetrikker: BehandlingMetrikker
 ) {
 
     @Transactional
@@ -116,6 +118,10 @@ class OpprettBehandlingService(
                 it,
                 sisteVedtattBehandling
             )
+
+            if (it.versjon == 0L) {
+                behandlingMetrikker.tellNøkkelTallVedOpprettelseAvBehandling(it)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingMetrikker.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingMetrikker.kt
@@ -100,7 +100,7 @@ class BehandlingMetrikker(
             )
         }
 
-    @Scheduled(initialDelay = FEM_MINUTTER_VENTETID_FØR_OPPDATERING_FØRSTE_GANG, fixedRate = OPPDATERING_HVER_DAG)
+    @Scheduled(initialDelay = FEM_MINUTTER_VENTETID_FØR_OPPDATERING_FØRSTE_GANG, cron = "@daily")
     fun tellAlleBehandlinger() {
         if (!erLeader()) return
 
@@ -124,7 +124,6 @@ class BehandlingMetrikker(
     }
 
     companion object {
-        const val OPPDATERING_HVER_DAG: Long = 1000 * 60 * 60 * 24
         const val FEM_MINUTTER_VENTETID_FØR_OPPDATERING_FØRSTE_GANG: Long = 1000 * 60 * 5
         const val ÅR_MÅNED_TAG = "aar-maaned"
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingMetrikker.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingMetrikker.kt
@@ -1,0 +1,131 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.core.instrument.MultiGauge
+import io.micrometer.core.instrument.Tags
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.leader.LeaderClient
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.time.temporal.ChronoUnit
+
+@Component
+class BehandlingMetrikker(
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val behandlingRepository: BehandlingRepository
+) {
+    private val enheter = listOf("2103", "4806", "4820", "4833", "4842", "4817", "4812")
+
+    private val antallBehandlingerTotalt = MultiGauge.builder("behandlinger.totalt").register(Metrics.globalRegistry)
+
+    private val antallBehandlingerOpprettet = Metrics.counter("behandlinger.opprettet")
+
+    private val antallBehandlingerPerType = initBehandlingTypeMetrikker()
+
+    private val antallBehandlingerPerÅrsak = initBehandlingÅrsakMetrikker()
+
+    private val antallBehandlingerBehandletPerEnhet = initBehandlingerBehandletPerEnhetMetrikker()
+
+    private val antallBehandlingsresultat =
+        Behandlingsresultat.values().associateWith {
+            Metrics.counter(
+                "behandlinger.resultat",
+                "type",
+                it.name,
+                "beskrivelse",
+                it.displayName
+            )
+        }
+
+    private val behandlingstid: DistributionSummary = Metrics.summary("behandlinger.tid")
+
+    fun tellNøkkelTallVedOpprettelseAvBehandling(behandling: Behandling) {
+        antallBehandlingerOpprettet.increment()
+        antallBehandlingerPerType[behandling.type]?.increment()
+        antallBehandlingerPerÅrsak[behandling.opprettetÅrsak]?.increment()
+    }
+
+    fun oppdaterBehandlingMetrikker(behandling: Behandling) {
+        tellBehandlingstidMetrikk(behandling)
+        tellBehandlingerBehandletPerEnhetMetrikk(behandling)
+        tellBehandlingsresultatTypeMetrikk(behandling)
+    }
+
+    private fun tellBehandlingerBehandletPerEnhetMetrikk(behandling: Behandling) {
+        val behandlendeEnhet = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandling.id)
+
+        antallBehandlingerBehandletPerEnhet[behandlendeEnhet.behandlendeEnhetId]?.increment()
+    }
+
+    private fun tellBehandlingstidMetrikk(behandling: Behandling) {
+        val dagerSidenOpprettet = ChronoUnit.DAYS.between(behandling.opprettetTidspunkt, LocalDateTime.now())
+        behandlingstid.record(dagerSidenOpprettet.toDouble())
+    }
+
+    private fun tellBehandlingsresultatTypeMetrikk(behandling: Behandling) =
+        antallBehandlingsresultat[behandling.resultat]?.increment()
+
+    private fun initBehandlingTypeMetrikker(): Map<BehandlingType, Counter> =
+        BehandlingType.values().associateWith {
+            Metrics.counter(
+                "behandlinger.opprettet",
+                "type",
+                it.name,
+                "beskrivelse",
+                it.visningsnavn,
+            )
+        }
+
+    private fun initBehandlingÅrsakMetrikker(): Map<BehandlingÅrsak, Counter> =
+        BehandlingÅrsak.values().associateWith {
+            Metrics.counter(
+                "behandlinger.aarsak",
+                "aarsak",
+                it.name,
+                "beskrivelse",
+                it.visningsnavn
+            )
+        }
+
+    private fun initBehandlingerBehandletPerEnhetMetrikker(): Map<String, Counter> =
+        enheter.associateWith {
+            Metrics.counter(
+                "behandlinger.ferdigstilt",
+                "enhet",
+                it
+            )
+        }
+
+    @Scheduled(initialDelay = FEM_MINUTTER_VENTETID_FØR_OPPDATERING_FØRSTE_GANG, fixedRate = OPPDATERING_HVER_DAG)
+    fun tellAlleBehandlinger() {
+        if (!erLeader()) return
+
+        val behandlinger = behandlingRepository.count()
+
+        val rows = listOf(
+            MultiGauge.Row.of(
+                Tags.of(
+                    ÅR_MÅNED_TAG,
+                    "${YearMonth.now().year}-${YearMonth.now().month}"
+                ),
+                behandlinger
+            )
+        )
+
+        antallBehandlingerTotalt.register(rows)
+    }
+
+    private fun erLeader(): Boolean {
+        return LeaderClient.isLeader() == true
+    }
+
+    companion object {
+        const val OPPDATERING_HVER_DAG: Long = 1000 * 60 * 60 * 24
+        const val FEM_MINUTTER_VENTETID_FØR_OPPDATERING_FØRSTE_GANG: Long = 1000 * 60 * 5
+        const val ÅR_MÅNED_TAG = "aar-maaned"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingMetrikker.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingMetrikker.kt
@@ -100,7 +100,7 @@ class BehandlingMetrikker(
             )
         }
 
-    @Scheduled(initialDelay = FEM_MINUTTER_VENTETID_FØR_OPPDATERING_FØRSTE_GANG, cron = "@daily")
+    @Scheduled(cron = "@daily")
     fun tellAlleBehandlinger() {
         if (!erLeader()) return
 
@@ -124,7 +124,6 @@ class BehandlingMetrikker(
     }
 
     companion object {
-        const val FEM_MINUTTER_VENTETID_FØR_OPPDATERING_FØRSTE_GANG: Long = 1000 * 60 * 5
         const val ÅR_MÅNED_TAG = "aar-maaned"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/avsluttbehandling/AvsluttBehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/avsluttbehandling/AvsluttBehandlingSteg.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.inneværendeMåned
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingMetrikker
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
@@ -22,7 +23,8 @@ class AvsluttBehandlingSteg(
     private val behandlingService: BehandlingService,
     private val loggService: LoggService,
     private val beregningService: BeregningService,
-    private val fagsakService: FagsakService
+    private val fagsakService: FagsakService,
+    private val behandlingMetrikker: BehandlingMetrikker
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING
 
@@ -36,6 +38,9 @@ class AvsluttBehandlingSteg(
 
         // opprett historikk innslag
         loggService.opprettAvsluttBehandlingLogg(behandling)
+
+        // oppdaterer behandling metrikker
+        behandlingMetrikker.oppdaterBehandlingMetrikker(behandling)
 
         // oppdater fagsak status
         if (behandling.resultat != Behandlingsresultat.AVSLÅTT) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.oppgave.OpprettOppgaveTask
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingMetrikker
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
@@ -66,6 +67,9 @@ class OpprettBehandlingServiceTest {
     @MockK
     private lateinit var taskService: TaskService
 
+    @MockK
+    private lateinit var behandlingMetrikker: BehandlingMetrikker
+
     @InjectMockKs
     private lateinit var opprettBehandlingService: OpprettBehandlingService
 
@@ -96,6 +100,7 @@ class OpprettBehandlingServiceTest {
             LocalDate.now()
         )
         every { stegService.utførSteg(any(), any()) } returns Unit
+        every { behandlingMetrikker.tellNøkkelTallVedOpprettelseAvBehandling(behandling) } just runs
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/avsluttbehandling/AvsluttBehandlingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/avsluttbehandling/AvsluttBehandlingStegTest.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagInitieltTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingMetrikker
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -45,6 +46,9 @@ internal class AvsluttBehandlingStegTest {
     @MockK
     private lateinit var fagsakService: FagsakService
 
+    @MockK
+    private lateinit var behandlingMetrikker: BehandlingMetrikker
+
     @InjectMockKs
     private lateinit var avsluttBehandlingSteg: AvsluttBehandlingSteg
 
@@ -57,6 +61,7 @@ internal class AvsluttBehandlingStegTest {
 
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { loggService.opprettAvsluttBehandlingLogg(behandling) } just runs
+        every { behandlingMetrikker.oppdaterBehandlingMetrikker(behandling) } just runs
     }
 
     @Test


### PR DESCRIPTION
Favrokort:  https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=NAV-11495
Legger til metrikker for å komme fram til

- Totalt antall saker i KS-sak
- Antall saker behandlet av NFP Vadsø
- Antall saker behandlet av NFP Bergen
- Antall saker per behandlingsresultat

