### PR TITLE
Overfør intern konsistensavstemming fra ba til ks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     val navFoedselsnummerVersion = "1.0-SNAPSHOT.6"
     val prosesseringVersion = "1.20221110194901_e9e0d90"
     val restAssuredVersion = "5.3.0"
+    val kotlinxVersion = "1.6.4"
 
     // ---------- Spring ---------- \\
     implementation("org.springframework.boot:spring-boot-starter")
@@ -57,6 +58,7 @@ dependencies {
     // ---------- Kotlin ---------- \\
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxVersion")
 
     // ---------- DB ---------- \\
     implementation("org.flywaydb:flyway-core")

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -66,6 +66,18 @@ class OppdragKlient(
         }
     }
 
+    fun hentSisteUtbetalingsoppdragForFagsaker(
+        fagsakIder: Set<Long>
+    ): List<UtbetalingsoppdragMedBehandlingOgFagsak> {
+        val uri = URI.create("$familieOppdragUri/$FAGSYSTEM/fagsaker/siste-utbetalingsoppdrag")
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Hent utbetalingsoppdrag for fagsaker"
+        ) { postForEntity(uri = uri, payload = fagsakIder) }
+    }
+
     fun sendGrensesnittavstemmingTilOppdrag(fom: LocalDateTime, tom: LocalDateTime): String {
         val uri = URI.create("$familieOppdragUri/grensesnittavstemming")
         return kallEksternTjenesteRessurs(
@@ -156,3 +168,9 @@ class OppdragKlient(
         private const val FAGSYSTEM = "KS"
     }
 }
+
+data class UtbetalingsoppdragMedBehandlingOgFagsak(
+    val fagsakId: Long,
+    val behandlingId: Long,
+    val utbetalingsoppdrag: Utbetalingsoppdrag
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingScheduler.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ks.sak.integrasjon.økonomi.internkonsistensavstemming
+
+import no.nav.familie.leader.LeaderClient
+import no.nav.familie.prosessering.internal.TaskService
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class InternKonsistensavstemmingScheduler(
+    val taskService: TaskService
+) {
+
+    @Scheduled(cron = "0 0 0 16 * *")
+    fun startInternKonsistensavstemming() {
+        if (LeaderClient.isLeader() == true) {
+            taskService.save(OpprettInternKonsistensavstemmingTaskerTask.opprettTask())
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
@@ -11,11 +11,10 @@ import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.ks.sak.task.overstyrTaskMedNyCallId
 import no.nav.familie.log.IdUtils
-import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -99,20 +98,5 @@ class InternKonsistensavstemmingService(
 
     companion object {
         val logger = LoggerFactory.getLogger(this::class.java)!!
-
-        fun <T> overstyrTaskMedNyCallId(callId: String, body: () -> T): T {
-            val originalCallId = MDC.get(MDCConstants.MDC_CALL_ID) ?: null
-
-            return try {
-                MDC.put(MDCConstants.MDC_CALL_ID, callId)
-                body()
-            } finally {
-                if (originalCallId == null) {
-                    MDC.remove(MDCConstants.MDC_CALL_ID)
-                } else {
-                    MDC.put(MDCConstants.MDC_CALL_ID, originalCallId)
-                }
-            }
-        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
@@ -1,0 +1,118 @@
+package no.nav.familie.ks.sak.integrasjon.økonomi.internkonsistensavstemming
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import no.nav.familie.ba.sak.integrasjoner.økonomi.internkonsistensavstemming.erForskjellMellomAndelerOgOppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.log.IdUtils
+import no.nav.familie.log.mdc.MDCConstants
+import no.nav.familie.prosessering.internal.TaskService
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class InternKonsistensavstemmingService(
+    val oppdragKlient: OppdragKlient,
+    val behandlingService: BehandlingService,
+    val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    val fagsakRepository: FagsakRepository,
+    val taskService: TaskService
+) {
+    fun validerLikUtbetalingIAndeleneOgUtbetalingsoppdragetPåAlleFagsaker(maksAntallTasker: Int = Int.MAX_VALUE) {
+        val fagsakerSomIkkeErArkivert = fagsakRepository
+            .hentFagsakerSomIkkeErArkivert()
+            .map { it.id }
+            .sortedBy { it }
+
+        val startTid = LocalDateTime.now()
+
+        fagsakerSomIkkeErArkivert
+            // Antall fagsaker per task burde være en multippel av 3000 siden vi chunker databasekallet i 3000 i familie-oppdrag
+            .chunked(3000)
+            .take(maksAntallTasker)
+            .forEachIndexed { index, fagsaker ->
+                // Venter 15 sekunder mellom hver task for å ikke overkjøre familie-oppdrag siden ba-sak har mer ressurser
+                val startTidForTask = startTid.plusSeconds(15 * index.toLong())
+                overstyrTaskMedNyCallId(IdUtils.generateId()) {
+                    val task = InternKonsistensavstemmingTask.opprettTask(fagsaker.toSet(), startTidForTask)
+                    taskService.save(task)
+                }
+            }
+    }
+
+    fun validerLikUtbetalingIAndeleneOgUtbetalingsoppdraget(fagsaker: Set<Long>) {
+        val fagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap =
+            hentFagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap(fagsaker)
+
+        val fagsakerMedFeil = fagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap.mapNotNull { entry ->
+            val fagsakId = entry.key
+            val andeler = entry.value.first
+            val utbetalingsoppdrag = entry.value.second
+
+            fagsakId.takeIf { erForskjellMellomAndelerOgOppdrag(andeler, utbetalingsoppdrag, fagsakId) }
+        }
+
+        if (fagsakerMedFeil.isNotEmpty()) {
+            logger.error(
+                "Tilkjent ytelse og utbetalingsoppdraget som er lagret i familie-oppdrag er inkonsistent" +
+                    "\nSe secure logs for mer detaljer." +
+                    "\nDette gjelder fagsakene $fagsakerMedFeil"
+            )
+        }
+    }
+
+    private fun hentFagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap(fagsakIder: Set<Long>): Map<Long, Pair<List<AndelTilkjentYtelse>, Utbetalingsoppdrag?>> {
+        val scope = CoroutineScope(SupervisorJob())
+        val utbetalingsoppdragDeferred = scope.async {
+            oppdragKlient.hentSisteUtbetalingsoppdragForFagsaker(fagsakIder)
+        }
+
+        val fagsakTilAndelerISisteBehandlingSendTilØkonomiMap =
+            hentFagsakTilAndelerISisteBehandlingSendtTilØkonomiMap(fagsakIder)
+
+        val fagsakTilSisteUtbetalingsoppdragMap = runBlocking { utbetalingsoppdragDeferred.await() }
+            .associate { it.fagsakId to it.utbetalingsoppdrag }
+
+        val fagsakTilSisteUtbetalingsoppdragOgSisteAndeler =
+            fagsakTilAndelerISisteBehandlingSendTilØkonomiMap.mapValues { (fagsakId, andel) ->
+                Pair(andel, fagsakTilSisteUtbetalingsoppdragMap[fagsakId])
+            }
+        return fagsakTilSisteUtbetalingsoppdragOgSisteAndeler
+    }
+
+    private fun hentFagsakTilAndelerISisteBehandlingSendtTilØkonomiMap(fagsaker: Set<Long>): Map<Long, List<AndelTilkjentYtelse>> {
+        val behandlinger = behandlingService.hentSisteBehandlingSomErSendtTilØkonomiPerFagsak(fagsaker)
+
+        return andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(behandlinger.map { it.id })
+            .groupBy { it.behandlingId }
+            .mapKeys { (behandlingId, _) -> behandlinger.find { it.id == behandlingId }?.fagsak?.id!! }
+    }
+
+    companion object {
+        val logger = LoggerFactory.getLogger(this::class.java)!!
+
+        fun <T> overstyrTaskMedNyCallId(callId: String, body: () -> T): T {
+            val originalCallId = MDC.get(MDCConstants.MDC_CALL_ID) ?: null
+
+            return try {
+                MDC.put(MDCConstants.MDC_CALL_ID, callId)
+                body()
+            } finally {
+                if (originalCallId == null) {
+                    MDC.remove(MDCConstants.MDC_CALL_ID)
+                } else {
+                    MDC.put(MDCConstants.MDC_CALL_ID, originalCallId)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingTask.kt
@@ -1,0 +1,60 @@
+package no.nav.familie.ks.sak.integrasjon.økonomi.internkonsistensavstemming
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.log.mdc.MDCConstants
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.PropertiesWrapper
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.Properties
+import kotlin.system.measureTimeMillis
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = InternKonsistensavstemmingTask.TASK_STEP_TYPE,
+    beskrivelse = "Kjør intern konsistensavstemming",
+    maxAntallFeil = 3,
+    triggerTidVedFeilISekunder = 600
+)
+class InternKonsistensavstemmingTask(
+    val internKonsistensavstemmingService: InternKonsistensavstemmingService
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val fagsakIder: Set<Long> = objectMapper.readValue(task.payload)
+
+        val tidBrukt = measureTimeMillis {
+            internKonsistensavstemmingService.validerLikUtbetalingIAndeleneOgUtbetalingsoppdraget(fagsakIder)
+        }
+
+        logger.info(
+            "Fullført intern konsistensavstemming på fagsak ${fagsakIder.min()} til ${fagsakIder.max()}. " +
+                "Tid brukt = $tidBrukt millisekunder"
+        )
+    }
+
+    companion object {
+        fun opprettTask(fagsakIder: Set<Long>, startTid: LocalDateTime): Task {
+            val metadata = Properties().apply {
+                this["fagsakerIder"] = "${fagsakIder.min()} til ${fagsakIder.max()}"
+                this[MDCConstants.MDC_CALL_ID] = MDC.get(MDCConstants.MDC_CALL_ID) ?: ""
+            }
+
+            return Task(
+                type = this.TASK_STEP_TYPE,
+                payload = objectMapper.writeValueAsString(fagsakIder),
+                triggerTid = startTid,
+                metadataWrapper = PropertiesWrapper(metadata)
+            )
+        }
+
+        const val TASK_STEP_TYPE = "internKonsistensavstemming"
+        val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtil.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.slåSammen
-import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -65,8 +64,8 @@ private fun Utbetalingsperiode.erIngenPersonerMedTilsvarendeAndelITidsrommet(
         .groupBy { Pair(it.aktør, it.type) }
         .map { (_, andeler) -> andeler.tilBeløpstidslinje() }
 
-    return andelsTidslinjerPerPersonOgYtelsetype.all {
-        !this.harTilsvarendeAndelerForPersonOgYtelsetype(it)
+    return andelsTidslinjerPerPersonOgYtelsetype.none {
+        this.harTilsvarendeAndelerForPersonOgYtelsetype(it)
     }
 }
 
@@ -93,8 +92,8 @@ private fun Utbetalingsperiode.tilBeløpstidslinje() =
 private fun List<AndelTilkjentYtelse>.tilBeløpstidslinje() =
     this.map {
         Periode(
-            fom = it.stønadFom.toLocalDate().førsteDagIInneværendeMåned(),
-            tom = it.stønadTom.toLocalDate().sisteDagIMåned(),
+            fom = it.stønadFom.atDay(1),
+            tom = it.stønadTom.atEndOfMonth(),
             verdi = it.kalkulertUtbetalingsbeløp.toBigDecimal()
         )
     }.tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtil.kt
@@ -1,0 +1,110 @@
+package no.nav.familie.ba.sak.integrasjoner.økonomi.internkonsistensavstemming
+
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.ks.sak.common.tidslinje.Periode
+import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
+import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
+import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.common.util.slåSammen
+import no.nav.familie.ks.sak.common.util.toLocalDate
+import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.integrasjon.secureLogger
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import java.math.BigDecimal
+
+fun erForskjellMellomAndelerOgOppdrag(
+    andeler: List<AndelTilkjentYtelse>,
+    utbetalingsoppdrag: Utbetalingsoppdrag?,
+    fagsakId: Long
+): Boolean {
+    val utbetalingsperioder =
+        utbetalingsoppdrag?.utbetalingsperiode
+            ?.filter { it.opphør == null }
+            ?: emptyList()
+
+    val forskjellMellomAndeleneOgUtbetalingsoppdraget =
+        hentForskjellIAndelerOgUtbetalingsoppdrag(utbetalingsperioder, andeler)
+
+    when (forskjellMellomAndeleneOgUtbetalingsoppdraget) {
+        is UTBETALINGSPERIODER_UTEN_TILSVARENDE_ANDEL -> secureLogger.info(
+            "Fagsak $fagsakId har sendt utbetalingsperiode(r) til økonomi som ikke har tilsvarende andel tilkjent ytelse." +
+                "\nDet er differanse i perioden(e) ${forskjellMellomAndeleneOgUtbetalingsoppdraget.utbetalingsperioder.tilTidStrenger()}." +
+                "\n\nSiste utbetalingsoppdrag som er sendt til familie-øknonomi på fagsaken er:" +
+                "\n$utbetalingsoppdrag"
+        )
+
+        is INGEN_FORSKJELL -> Unit
+    }
+
+    return forskjellMellomAndeleneOgUtbetalingsoppdraget !is INGEN_FORSKJELL
+}
+
+private fun hentForskjellIAndelerOgUtbetalingsoppdrag(
+    utbetalingsperioder: List<Utbetalingsperiode>,
+    andeler: List<AndelTilkjentYtelse>
+): AndelOgOppdragForskjell {
+    val utbetalingsperioderUtenTilsvarendeAndel = utbetalingsperioder.filter {
+        it.erIngenPersonerMedTilsvarendeAndelITidsrommet(andeler)
+    }
+
+    return if (utbetalingsperioderUtenTilsvarendeAndel.isEmpty()) {
+        INGEN_FORSKJELL
+    } else {
+        UTBETALINGSPERIODER_UTEN_TILSVARENDE_ANDEL(utbetalingsperioderUtenTilsvarendeAndel)
+    }
+}
+
+private fun Utbetalingsperiode.erIngenPersonerMedTilsvarendeAndelITidsrommet(
+    andeler: List<AndelTilkjentYtelse>
+): Boolean {
+    val andelsTidslinjerPerPersonOgYtelsetype = andeler
+        .groupBy { Pair(it.aktør, it.type) }
+        .map { (_, andeler) -> andeler.tilBeløpstidslinje() }
+
+    return andelsTidslinjerPerPersonOgYtelsetype.all {
+        !this.harTilsvarendeAndelerForPersonOgYtelsetype(it)
+    }
+}
+
+private fun Utbetalingsperiode.harTilsvarendeAndelerForPersonOgYtelsetype(
+    andelerTidslinjeForEnPersonOgYtelsetype: Tidslinje<BigDecimal>
+): Boolean {
+    val erAndelLikUtbetalingTidslinje = this.tilBeløpstidslinje()
+        .kombinerMed(andelerTidslinjeForEnPersonOgYtelsetype) { utbetalingsperiode, andel ->
+            utbetalingsperiode?.let { utbetalingsperiode == andel }
+        }
+
+    return erAndelLikUtbetalingTidslinje.tilPerioder().all { it.verdi != false }
+}
+
+private fun Utbetalingsperiode.tilBeløpstidslinje() =
+    listOf(
+        Periode(
+            fom = this.vedtakdatoFom.førsteDagIInneværendeMåned(),
+            tom = this.vedtakdatoTom.sisteDagIMåned(),
+            verdi = this.sats
+        )
+    ).tilTidslinje()
+
+private fun List<AndelTilkjentYtelse>.tilBeløpstidslinje() =
+    this.map {
+        Periode(
+            fom = it.stønadFom.toLocalDate().førsteDagIInneværendeMåned(),
+            tom = it.stønadTom.toLocalDate().sisteDagIMåned(),
+            verdi = it.kalkulertUtbetalingsbeløp.toBigDecimal()
+        )
+    }.tilTidslinje()
+
+private fun List<Utbetalingsperiode>.tilTidStrenger() =
+    slåSammen(this.map { "${it.vedtakdatoFom.toYearMonth()} til ${it.vedtakdatoTom.toYearMonth()}" })
+
+private sealed interface AndelOgOppdragForskjell
+
+private data class UTBETALINGSPERIODER_UTEN_TILSVARENDE_ANDEL(val utbetalingsperioder: List<Utbetalingsperiode>) :
+    AndelOgOppdragForskjell
+
+private object INGEN_FORSKJELL : AndelOgOppdragForskjell

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/OpprettInternKonsistensavstemmingTaskerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/OpprettInternKonsistensavstemmingTaskerTask.kt
@@ -1,0 +1,48 @@
+package no.nav.familie.ks.sak.integrasjon.økonomi.internkonsistensavstemming
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.log.IdUtils
+import no.nav.familie.log.mdc.MDCConstants
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.PropertiesWrapper
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.MDC
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.Properties
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = OpprettInternKonsistensavstemmingTaskerTask.TASK_STEP_TYPE,
+    beskrivelse = "Start intern konsistensavstemming tasker",
+    maxAntallFeil = 3
+)
+class OpprettInternKonsistensavstemmingTaskerTask(
+    val internKonsistensavstemmingService: InternKonsistensavstemmingService
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val maksAntallTasker: Int = objectMapper.readValue(task.payload)
+        internKonsistensavstemmingService
+            .validerLikUtbetalingIAndeleneOgUtbetalingsoppdragetPåAlleFagsaker(maksAntallTasker)
+    }
+
+    companion object {
+        fun opprettTask(maksAntallTasker: Int = Int.MAX_VALUE): Task {
+            val metadata = Properties().apply {
+                this[MDCConstants.MDC_CALL_ID] = MDC.get(MDCConstants.MDC_CALL_ID) ?: IdUtils.generateId()
+            }
+
+            return Task(
+                type = TASK_STEP_TYPE,
+                payload = maksAntallTasker.toString(),
+                triggerTid = LocalDateTime.now(),
+                metadataWrapper = PropertiesWrapper(metadata)
+            )
+        }
+
+        const val TASK_STEP_TYPE = "startInternKonsistensavstemmingTasker"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -217,6 +217,18 @@ class BehandlingService(
             .filter { it.erAvsluttet() && !it.erHenlagt() }
     }
 
+    fun hentSisteBehandlingSomErSendtTilØkonomiPerFagsak(fagsakIder: Set<Long>): List<Behandling> {
+        val behandlingerPåFagsakene = behandlingRepository.finnBehandlinger(fagsakIder)
+
+        return behandlingerPåFagsakene
+            .groupBy { it.fagsak.id }
+            .mapNotNull { (_, behandling) -> behandling.hentSisteSomErSentTilØkonomi() }
+    }
+
+    private fun List<Behandling>.hentSisteSomErSentTilØkonomi() =
+        filter { !it.erHenlagt() && (it.status == BehandlingStatus.AVSLUTTET || it.status == BehandlingStatus.IVERKSETTER_VEDTAK) }
+            .maxByOrNull { it.opprettetTidspunkt }
+
     companion object {
 
         private val logger: Logger = LoggerFactory.getLogger(BehandlingService::class.java)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepository.kt
@@ -19,6 +19,9 @@ interface BehandlingRepository : JpaRepository<Behandling, Long> {
     @Query(value = "SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id = :fagsakId AND f.arkivert = false")
     fun finnBehandlinger(fagsakId: Long): List<Behandling>
 
+    @Query(value = "SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id in :fagsakIder AND f.arkivert = false")
+    fun finnBehandlinger(fagsakIder: Set<Long>): List<Behandling>
+
     @Query(
         "SELECT b FROM Behandling b JOIN b.fagsak f WHERE f.id = :fagsakId AND f.arkivert = false " +
             "AND b.aktiv = true "

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepository.kt
@@ -23,6 +23,9 @@ interface FagsakRepository : JpaRepository<Fagsak, Long> {
     @Query(value = "SELECT f from Fagsak f WHERE f.status = 'LØPENDE'  AND f.arkivert = false")
     fun finnLøpendeFagsaker(): List<Fagsak>
 
+    @Query(value = "SELECT f from Fagsak f where f.arkivert = false")
+    fun hentFagsakerSomIkkeErArkivert(): List<Fagsak>
+
     @Modifying
     @Query(
         value = """

--- a/src/main/kotlin/no/nav/familie/ks/sak/task/TaskUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/task/TaskUtils.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ks.sak.task
 import no.nav.familie.ks.sak.common.util.erHverdag
 import no.nav.familie.ks.sak.common.util.erKlokkenMellom21Og06
 import no.nav.familie.ks.sak.common.util.kl06IdagEllerNesteDag
+import no.nav.familie.log.mdc.MDCConstants
+import org.slf4j.MDC
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.Month
@@ -41,4 +43,19 @@ fun nesteGyldigeTriggertidForBehandlingIHverdager(
     }
 
     return date
+}
+
+fun <T> overstyrTaskMedNyCallId(callId: String, body: () -> T): T {
+    val originalCallId = MDC.get(MDCConstants.MDC_CALL_ID) ?: null
+
+    return try {
+        MDC.put(MDCConstants.MDC_CALL_ID, callId)
+        body()
+    } finally {
+        if (originalCallId == null) {
+            MDC.remove(MDCConstants.MDC_CALL_ID)
+        } else {
+            MDC.put(MDCConstants.MDC_CALL_ID, originalCallId)
+        }
+    }
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -283,7 +283,7 @@ fun lagInitieltTilkjentYtelse(behandling: Behandling) =
 
 fun lagAndelTilkjentYtelse(
     tilkjentYtelse: TilkjentYtelse? = null,
-    behandling: Behandling,
+    behandling: Behandling = lagBehandling(),
     aktør: Aktør? = null,
     stønadFom: YearMonth = YearMonth.now().minusMonths(1),
     stønadTom: YearMonth = YearMonth.now().plusMonths(8),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtilTest.kt
@@ -1,0 +1,565 @@
+package no.nav.familie.ks.sak.integrasjon.økonomi.internkonsistensavstemming
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ba.sak.integrasjoner.økonomi.internkonsistensavstemming.erForskjellMellomAndelerOgOppdrag
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class InternKonsistensavstemmingUtilTest {
+
+    @Test
+    fun `Skal ignorere forskjeller før første utbetalingsoppdragsperiode`() {
+        val andelerSisteVedtatteBehandling = listOf(
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2021-12"),
+                stønadTom = YearMonth.parse("2021-12"),
+                sats = 1654
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2022-01"),
+                stønadTom = YearMonth.parse("2023-02"),
+                sats = 1676
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2023-03"),
+                stønadTom = YearMonth.parse("2027-10"),
+                sats = 1723
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2027-11"),
+                stønadTom = YearMonth.parse("2039-10"),
+                sats = 1083
+            )
+        )
+        val utbetalingsoppdrag = objectMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
+
+        Assertions.assertFalse(
+            erForskjellMellomAndelerOgOppdrag(
+                andelerSisteVedtatteBehandling,
+                utbetalingsoppdrag,
+                0L
+            )
+        )
+    }
+
+    @Test
+    fun `skal se at vi mangler andel for oppdragsperiode`() {
+        val andelerSisteVedtatteBehandling = listOf(
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2021-12"),
+                stønadTom = YearMonth.parse("2021-12"),
+                sats = 1654
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2022-01"),
+                stønadTom = YearMonth.parse("2023-02"),
+                sats = 1676
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2023-03"),
+                stønadTom = YearMonth.parse("2027-10"),
+                sats = 1723
+            )
+        )
+        val utbetalingsoppdrag = objectMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
+
+        Assertions.assertTrue(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
+    }
+
+    @Test
+    fun `skal se at andel og oppdragsperiode har forskjellig beløp`() {
+        val andelerSisteVedtatteBehandling = listOf(
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2021-12"),
+                stønadTom = YearMonth.parse("2021-12"),
+                sats = 1654
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2022-01"),
+                stønadTom = YearMonth.parse("2023-02"),
+                sats = 1676
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2023-03"),
+                stønadTom = YearMonth.parse("2027-10"),
+                sats = 1723
+            ),
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse("2027-11"),
+                stønadTom = YearMonth.parse("2039-10"),
+                sats = 9999
+            )
+        )
+        val utbetalingsoppdrag = objectMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
+
+        Assertions.assertTrue(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
+    }
+
+    @Test
+    fun `skal ikke si det er forskjell ved riktig utbetalingsoppdrag når det er flere kjeder`() {
+        val andelStringer = listOf(
+            "2021-05,2021-08,1354",
+            "2021-09,2021-12,1654",
+
+            "2022-01,2023-02,1676",
+            "2023-03,2024-11,1723",
+            "2024-12,2036-11,1083",
+
+            "2021-05,2023-02,1054,UTVIDET_BARNETRYGD",
+            "2023-03,2036-11,2489,UTVIDET_BARNETRYGD"
+        )
+
+        val andelerSisteVedtatteBehandling = andelStringer.map { it.split(",") }.map {
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse(it[0]),
+                stønadTom = YearMonth.parse(it[1]),
+                sats = it[2].toInt(),
+            )
+        }
+
+        val utbetalingsoppdrag = objectMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockMedUtvidet)
+
+        Assertions.assertFalse(
+            erForskjellMellomAndelerOgOppdrag(
+                andelerSisteVedtatteBehandling,
+                utbetalingsoppdrag,
+                0L
+            )
+        )
+    }
+
+    @Test
+    fun `skal ikke si det er forskjell ved riktig utbetalingsoppdrag når kun ett barn ble endret i siste behandling som iverksatte`() {
+        val andelStringer = listOf(
+            "2022-05,2022-06,1676,2554733867704", // barn 1, ble laget i siste behandling som iverksatte
+            "2022-07,2028-03,838,2554733867704", // barn 1, ble laget i siste behandling som iverksatte
+            "2028-04,2040-03,527,2554733867704", // barn 1, ble laget i siste behandling som iverksatte
+
+            "2022-07,2028-05,1676,2909658383415", // barn 2, ble laget før siste behandling som iverksatte
+            "2028-06,2040-05,1054,2909658383415" // barn 2, ble laget før siste behandling som iverksatte
+        )
+
+        val andelerSisteVedtatteBehandling = andelStringer.map { it.split(",") }.map {
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse(it[0]),
+                stønadTom = YearMonth.parse(it[1]),
+                sats = it[2].toInt(),
+                aktør = Aktør(it[3])
+            )
+        }
+
+        val utbetalingsoppdrag = objectMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockEndringKunEttBarn)
+
+        Assertions.assertFalse(
+            erForskjellMellomAndelerOgOppdrag(
+                andelerSisteVedtatteBehandling,
+                utbetalingsoppdrag,
+                0L
+            )
+        )
+    }
+
+    @Test
+    fun `skal ikke si det er forskjell ved opphør`() {
+        val andelStringer = listOf(
+            "2016-02,2019-02,970,2193974415300",
+            "2019-03,2020-08,1054,2193974415300",
+            "2020-09,2021-08,1354,2193974415300",
+            "2021-09,2021-12,1654,2193974415300",
+            "2022-01,2022-02,1054,2193974415300",
+            "2012-06,2019-02,970,2094407059820",
+            "2019-03,2022-01,1054,2094407059820"
+        )
+
+        val andelerSisteVedtatteBehandling = andelStringer.map { it.split(",") }.map {
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse(it[0]),
+                stønadTom = YearMonth.parse(it[1]),
+                sats = it[2].toInt(),
+                aktør = Aktør(it[3])
+            )
+        }
+
+        val utbetalingsoppdrag = objectMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockOpphør)
+
+        Assertions.assertFalse(
+            erForskjellMellomAndelerOgOppdrag(
+                andelerSisteVedtatteBehandling,
+                utbetalingsoppdrag,
+                0L
+            )
+        )
+    }
+
+    @Test
+    fun `skal si andelene og utbetalingene er like dersom andel blir splittet opp, men betaler ut det samme i periodene`() {
+        val andelStringer = listOf(
+            "2021-01,2022-03,1054",
+            "2022-04,2022-06,1054"
+        )
+
+        val aktør = randomAktør()
+        val behandling = lagBehandling()
+
+        val andelerSisteVedtatteBehandling = andelStringer.map { it.split(",") }.map {
+            lagAndelTilkjentYtelse(
+                stønadFom = YearMonth.parse(it[0]),
+                stønadTom = YearMonth.parse(it[1]),
+                sats = it[2].toInt(),
+                aktør = aktør,
+                behandling = behandling
+            )
+        }
+
+        val utbetalingsoppdrag = objectMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockEnPeriode)
+
+        Assertions.assertFalse(
+            erForskjellMellomAndelerOgOppdrag(
+                andelerSisteVedtatteBehandling,
+                utbetalingsoppdrag,
+                0L
+            )
+        )
+    }
+}
+
+private val mockUtbetalingsoppdrag = """
+    {
+      "kodeEndring": "ENDR",
+      "fagSystem": "KS",
+      "saksnummer": "1",
+      "aktoer": "1",
+      "saksbehandlerId": "VL",
+      "avstemmingTidspunkt": "2023-02-08T16:12:56.200284803",
+      "utbetalingsperiode": [
+        {
+          "erEndringPåEksisterendePeriode": true,
+          "opphør": {
+            "opphørDatoFom": "2022-01-01"
+          },
+          "periodeId": 2,
+          "forrigePeriodeId": 1,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2027-11-01",
+          "vedtakdatoTom": "2039-10-31",
+          "sats": 1054,
+          "satsType": "MND",
+          "utbetalesTil": "1",
+          "behandlingId": 1,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 3,
+          "forrigePeriodeId": 2,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2022-01-01",
+          "vedtakdatoTom": "2023-02-28",
+          "sats": 1676,
+          "satsType": "MND",
+          "utbetalesTil": "1",
+          "behandlingId": 1,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 4,
+          "forrigePeriodeId": 3,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2023-03-01",
+          "vedtakdatoTom": "2027-10-31",
+          "sats": 1723,
+          "satsType": "MND",
+          "utbetalesTil": "1",
+          "behandlingId": 1,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 5,
+          "forrigePeriodeId": 4,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2027-11-01",
+          "vedtakdatoTom": "2039-10-31",
+          "sats": 1083,
+          "satsType": "MND",
+          "utbetalesTil": "1",
+          "behandlingId": 1,
+          "utbetalingsgrad": null
+        }
+      ],
+      "gOmregning": false
+    }
+""".trimIndent()
+
+private val utbetalingsoppdragMockMedUtvidet = """
+    {
+      "kodeEndring": "ENDR",
+      "fagSystem": "KS",
+      "saksnummer": "200028561",
+      "aktoer": "02416938515",
+      "saksbehandlerId": "VL",
+      "avstemmingTidspunkt": "2023-02-08T15:57:38.341011606",
+      "utbetalingsperiode": [
+        {
+          "erEndringPåEksisterendePeriode": true,
+          "opphør": {
+            "opphørDatoFom": "2022-01-01"
+          },
+          "periodeId": 3,
+          "forrigePeriodeId": 2,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2024-12-01",
+          "vedtakdatoTom": "2036-11-30",
+          "sats": 1054,
+          "satsType": "MND",
+          "utbetalesTil": "02416938515",
+          "behandlingId": 100134370,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": true,
+          "opphør": {
+            "opphørDatoFom": "2021-05-01"
+          },
+          "periodeId": 4,
+          "forrigePeriodeId": null,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2021-05-01",
+          "vedtakdatoTom": "2036-11-30",
+          "sats": 1054,
+          "satsType": "MND",
+          "utbetalesTil": "02416938515",
+          "behandlingId": 100134370,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 5,
+          "forrigePeriodeId": 3,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2022-01-01",
+          "vedtakdatoTom": "2023-02-28",
+          "sats": 1676,
+          "satsType": "MND",
+          "utbetalesTil": "02416938515",
+          "behandlingId": 100134370,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 6,
+          "forrigePeriodeId": 5,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2023-03-01",
+          "vedtakdatoTom": "2024-11-30",
+          "sats": 1723,
+          "satsType": "MND",
+          "utbetalesTil": "02416938515",
+          "behandlingId": 100134370,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 7,
+          "forrigePeriodeId": 6,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2024-12-01",
+          "vedtakdatoTom": "2036-11-30",
+          "sats": 1083,
+          "satsType": "MND",
+          "utbetalesTil": "02416938515",
+          "behandlingId": 100134370,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 8,
+          "forrigePeriodeId": 4,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2021-05-01",
+          "vedtakdatoTom": "2023-02-28",
+          "sats": 1054,
+          "satsType": "MND",
+          "utbetalesTil": "02416938515",
+          "behandlingId": 100134370,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 9,
+          "forrigePeriodeId": 8,
+          "datoForVedtak": "2023-02-08",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2023-03-01",
+          "vedtakdatoTom": "2036-11-30",
+          "sats": 2489,
+          "satsType": "MND",
+          "utbetalesTil": "02416938515",
+          "behandlingId": 100134370,
+          "utbetalingsgrad": null
+        }
+      ],
+      "gOmregning": false
+    }
+""".trimIndent()
+
+val utbetalingsoppdragMockEndringKunEttBarn = """
+    {
+      "kodeEndring": "ENDR",
+      "fagSystem": "KS",
+      "saksnummer": "200002102",
+      "aktoer": "07118905215",
+      "saksbehandlerId": "Z994623",
+      "avstemmingTidspunkt": "2022-08-16T08:49:13.565620862",
+      "utbetalingsperiode": [
+        {
+          "erEndringPåEksisterendePeriode": true,
+          "opphør": {
+            "opphørDatoFom": "2022-05-01"
+          },
+          "periodeId": 3,
+          "forrigePeriodeId": 2,
+          "datoForVedtak": "2022-08-16",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2028-04-01",
+          "vedtakdatoTom": "2040-03-31",
+          "sats": 1054,
+          "satsType": "MND",
+          "utbetalesTil": "07118905215",
+          "behandlingId": 100098303,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 4,
+          "forrigePeriodeId": 3,
+          "datoForVedtak": "2022-08-16",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2022-05-01",
+          "vedtakdatoTom": "2022-06-30",
+          "sats": 1676,
+          "satsType": "MND",
+          "utbetalesTil": "07118905215",
+          "behandlingId": 100098303,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 5,
+          "forrigePeriodeId": 4,
+          "datoForVedtak": "2022-08-16",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2022-07-01",
+          "vedtakdatoTom": "2028-03-31",
+          "sats": 838,
+          "satsType": "MND",
+          "utbetalesTil": "07118905215",
+          "behandlingId": 100098303,
+          "utbetalingsgrad": null
+        },
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 6,
+          "forrigePeriodeId": 5,
+          "datoForVedtak": "2022-08-16",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2028-04-01",
+          "vedtakdatoTom": "2040-03-31",
+          "sats": 527,
+          "satsType": "MND",
+          "utbetalesTil": "07118905215",
+          "behandlingId": 100098303,
+          "utbetalingsgrad": null
+        }
+      ],
+      "gOmregning": false
+    }
+""".trimIndent()
+
+val utbetalingsoppdragMockOpphør = """
+    {
+      "kodeEndring": "ENDR",
+      "fagSystem": "KS",
+      "saksnummer": "200001701",
+      "aktoer": "25118604604",
+      "saksbehandlerId": "Z991771",
+      "avstemmingTidspunkt": "2022-08-09T14:42:14.977345689",
+      "utbetalingsperiode": [
+        {
+          "erEndringPåEksisterendePeriode": true,
+          "opphør": {
+            "opphørDatoFom": "2022-08-01"
+          },
+          "periodeId": 10,
+          "forrigePeriodeId": 9,
+          "datoForVedtak": "2022-08-09",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2025-02-01",
+          "vedtakdatoTom": "2037-01-31",
+          "sats": 1054,
+          "satsType": "MND",
+          "utbetalesTil": "25118604604",
+          "behandlingId": 100096955,
+          "utbetalingsgrad": null
+        }
+      ],
+      "gOmregning": false
+    }
+""".trimIndent()
+
+val utbetalingsoppdragMockEnPeriode = """
+    {
+      "kodeEndring": "NY",
+      "fagSystem": "KONT",
+      "saksnummer": "1",
+      "aktoer": "1",
+      "saksbehandlerId": "",
+      "avstemmingTidspunkt": "2021-12-23T08:11:33.333476714",
+      "utbetalingsperiode": [
+        {
+          "erEndringPåEksisterendePeriode": false,
+          "opphør": null,
+          "periodeId": 0,
+          "forrigePeriodeId": null,
+          "datoForVedtak": "2021-12-23",
+          "klassifisering": "KS",
+          "vedtakdatoFom": "2021-01-01",
+          "vedtakdatoTom": "2022-06-30",
+          "sats": 1054,
+          "satsType": "MND",
+          "utbetalesTil": "1",
+          "behandlingId": 1,
+          "utbetalingsgrad": null
+        }
+      ]
+    }
+""".trimIndent()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -115,7 +115,7 @@ class BehandlingServiceTest {
     @BeforeEach
     fun beforeEach() {
         every { behandlingRepository.hentBehandling(any()) } returns behandling
-        every { behandlingRepository.finnBehandlinger(any()) } returns emptyList()
+        every { behandlingRepository.finnBehandlinger(any<Long>()) } returns emptyList()
         every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(any()) } returns ArbeidsfordelingPåBehandling(
             behandlingId = behandling.id,
             behandlendeEnhetId = "enhet",


### PR DESCRIPTION
Overfører intern konsistensavstemming logikk fra ba til ks.
Litt små justeringer er gjort mtp tidslinjebruk siden vi bruker annen type tidslinje i ks.