### PR TITLE
Fjern gjelder felt i opphørsbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/vedtaksbrev/Opphørt.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/vedtaksbrev/Opphørt.kt
@@ -40,7 +40,6 @@ data class Opphørt(
                     override val navn = flettefelt(fellesdataForVedtaksbrev.søkerNavn)
                     override val fodselsnummer = flettefelt(fellesdataForVedtaksbrev.søkerFødselsnummer)
                     override val brevOpprettetDato = flettefelt(LocalDate.now().tilDagMånedÅr())
-                    override val gjelder = flettefelt(fellesdataForVedtaksbrev.gjelder)
                 },
                 perioder = fellesdataForVedtaksbrev.perioder
             )


### PR DESCRIPTION
Gjelder feltet skal ikke brukes i opphørsbrev for KS.