### PR TITLE
Vi legger til validering av utbetalinger over 100% i samme periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
@@ -35,7 +36,8 @@ class BeslutteVedtakSteg(
     private val loggService: LoggService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val featureToggleService: FeatureToggleService,
-    private val genererBrevService: GenererBrevService
+    private val genererBrevService: GenererBrevService,
+    private val tilkjentYtelseValideringService: TilkjentYtelseValideringService
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.BESLUTTE_VEDTAK
 
@@ -67,6 +69,8 @@ class BeslutteVedtakSteg(
         opprettTaskFerdigstillGodkjenneVedtak(behandling = behandling)
 
         if (besluttVedtakDto.beslutning.erGodkjent()) {
+
+            tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(behandling)
 
             // Oppdater vedtaksbrev med beslutter
             val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Beslutning
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
@@ -55,6 +56,9 @@ class BeslutteVedtakStegTest {
 
     @MockK
     private lateinit var genererBrevService: GenererBrevService
+
+    @MockK
+    private lateinit var tilkjentYtelseValideringService: TilkjentYtelseValideringService
 
     @InjectMockKs
     private lateinit var beslutteVedtakSteg: BeslutteVedtakSteg
@@ -155,6 +159,7 @@ class BeslutteVedtakStegTest {
                 emptyList()
             )
         } returns mockk(relaxed = true)
+        every { tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(any()) } just runs
 
         every { vedtakService.hentAktivVedtakForBehandling(any()) } returns mockk(relaxed = true)
         every { vedtakService.oppdaterVedtak(any()) } returns mockk()
@@ -173,5 +178,6 @@ class BeslutteVedtakStegTest {
         verify(exactly = 1) { genererBrevService.genererBrevForBehandling(any()) }
         verify(exactly = 1) { vedtakService.hentAktivVedtakForBehandling(any()) }
         verify(exactly = 1) { vedtakService.oppdaterVedtak(any()) }
+        verify(exactly = 1) { tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(any()) }
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=NAV-12288

Per nå skjer valideringen ETTER at man har godkjent vedtaket, i neste steg. Da feiler det i tasken og det oppdages ikke med engang. 
Vi ønsker at det skjer litt tidligere også, når man faktisk godkjenner vedtaket. 

![Screenshot 2023-03-29 at 23 56 15](https://user-images.githubusercontent.com/110383605/228677546-54e29a08-2bc2-4d8b-8024-33c74b19b23d.png)


