### PR TITLE
Oppdaterer familie-eksterne-kontrakter avhengighet for stonadstatistikk-ks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     val eksterneKontrakterBisysVersion = "2.0_20220609214258_f30c3ce"
     val fellesKontrakterVersion = "2.0_20230110150447_4edded8"
     val familieKontrakterSaksstatistikkVersion = "2.0_20220216121145_5a268ac"
-    val familieKontrakterStønadsstatistikkKsVersion = "2.0_20221123121611_ca933bd"
+    val familieKontrakterStønadsstatistikkKsVersion = "2.0_20230330120047_dfdd4f2"
     val familieKontrakterSkatteetatenVersion = "2.0_20210920094114_9c74239"
     val tokenValidationSpringVersion = "2.1.8"
     val navFoedselsnummerVersion = "1.0-SNAPSHOT.6"


### PR DESCRIPTION
Oppdaterer avhengighet til stonadsstatistikk-ks (familie-eksterne-kontrakter) for å fikse bug relatert til BehandlingÅrsak `BARNEHAGELISTE`.

Fikser disse feilene: https://familie-prosessering.intern.nav.no/service/familie-ks-sak