### PR TITLE
Fjerner bruk av miljøvariabler fra secret

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     team: teamfamilie
 spec:
-  envFrom:
-    - secret: familie-ks-sak
   image: {{image}}
   port: 8083
   leaderElection: true

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     team: teamfamilie
 spec:
-  envFrom:
-    - secret: familie-ks-sak
   image: {{image}}
   port: 8083
   leaderElection: true

--- a/src/test/resources/application-dev-postgres-preprod.yaml
+++ b/src/test/resources/application-dev-postgres-preprod.yaml
@@ -140,8 +140,6 @@ SANITY_DATASET: "ks-brev"
 FAMILIE_KS_SAK_API_URL: http://localhost:8086/api
 FAMILIE_KS_INFOTRYGD_API_URL: https://familie-ks-infotrygd.dev.intern.nav.no/api
 FAMILIE_KS_INFOTRYGD_SCOPE: api://dev-fss.teamfamilie.familie-ks-infotrygd/.default
-CREDENTIAL_USERNAME: not-a-real-srvuser
-CREDENTIAL_PASSWORD: not-a-real-pw
 
 FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.dev.intern.nav.no/api
 FAMILIE_INTEGRASJONER_SCOPE: api://dev-fss.teamfamilie.familie-integrasjoner/.default

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -173,8 +173,6 @@ FAMILIE_INTEGRASJONER_API_URL: http://localhost:28085/api
 FAMILIE_TILBAKE_API_URL: http://localhost:8030/api
 FAMILIE_KS_SAK_API_URL: http://localhost:8086/api
 FAMILIE_BA_INFOTRYGD_API_URL: http://localhost:28085
-CREDENTIAL_USERNAME: not-a-real-srvuser
-CREDENTIAL_PASSWORD: not-a-real-pw
 
 KAFKA_BROKERS: http://localhost:9092
 

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -167,8 +167,6 @@ FAMILIE_INTEGRASJONER_API_URL: http://localhost:28085/api
 FAMILIE_TILBAKE_API_URL: http://localhost:8030/api
 FAMILIE_KS_SAK_API_URL: http://localhost:8086/api
 FAMILIE_BA_INFOTRYGD_API_URL: http://localhost:28085
-CREDENTIAL_USERNAME: not-a-real-srvuser
-CREDENTIAL_PASSWORD: not-a-real-pw
 
 KAFKA_BROKERS: http://localhost:9092
 


### PR DESCRIPTION
Miljøvariabelen `CREDENTIAL_USERNAME` med verdi "srvfamilie-ba-sak" ble brukt i kall mot `familie-integrasjoner` og `familie-oppdrag` (sikkert også flere), noe som fører til at det utenifra ser ut til at det er ba-sak som utfører kallene og ikke ks-sak.

Miljøvariabelen ble hentet fra secreten `familie-ks-sak` sammen med en del andre variabler. Ingen av disse variablene er nødvendig å hente fra secret. De vi trenger ligger allerede definert i henholdsvis `application-preprod.yaml` og `application-prod.yaml`. Fjerner derfor bruken av secreten og alle referanser til variablene `CREDENTIAL_USERNAME` og `CREDENTIAL_PASSWORD`.

I kall ut av applikasjon vil nå applikasjonens navn bli brukt som identifikator.