### PR TITLE
Vi fyller ut mottattTid feltet mot dvh med opprettettidspunkt dersom det ikke er søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkService.kt
@@ -73,10 +73,12 @@ class SakStatistikkService(
             behandling.behandlingStegTilstand.singleOrNull { it.behandlingStegStatus == BehandlingStegStatus.VENTER }
                 ?.let { BehandlingPåVentDto(it.frist!!, it.årsak!!) }
 
+        val mottattTid = behandling.søknadMottattDato ?: behandling.opprettetTidspunkt
+
         return BehandlingStatistikkDto(
             saksnummer = behandling.fagsak.id,
             behandlingID = behandling.id,
-            mottattTid = behandling.søknadMottattDato?.tilOffset(),
+            mottattTid = mottattTid.tilOffset(),
             registrertTid = behandling.opprettetTidspunkt.tilOffset(),
             behandlingType = behandling.type,
             behandlingStatus = behandling.status,


### PR DESCRIPTION
Favrokort: [NAV-12384](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12384)

Det er obligatorisk å fylle ut mottattTid feltet når vi sender saksstatistikk over til dvh.
Denne ble ikke fylt ut dersom behandlingen ikke ble opprettet av årsak søknad, så vi defaulter til opprettetTidspunkt dersom søknadMottattDato ikke finnes.