### PR TITLE
Fix kompilator warnings + typo

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/TidslinjePeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/tidslinje/TidslinjePeriode.kt
@@ -62,7 +62,7 @@ data class TidslinjePeriode<T>(val periodeVerdi: PeriodeVerdi<T>, var lengde: In
             lengde = inf
         }
         if (lengde <= 0) {
-            throw java.lang.IllegalArgumentException("lengde må være strørre enn null.")
+            throw java.lang.IllegalArgumentException("lengde må være større enn null.")
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/bisys/BisysServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/bisys/BisysServiceTest.kt
@@ -118,7 +118,7 @@ internal class BisysServiceTest {
 
         val utbetalingerFraKsSak = utbetalinger.ksSakPerioder
         assertEquals(2, utbetalingerFraKsSak.size)
-        utbetalingerFraKsSak!!.assertUtbetaling(
+        utbetalingerFraKsSak.assertUtbetaling(
             beløp = 7500,
             fomMåned = YearMonth.now().minusMonths(5),
             tomMåned = YearMonth.now().minusMonths(3)
@@ -130,8 +130,8 @@ internal class BisysServiceTest {
         )
 
         val utbetalingerFraInfotrygd = utbetalinger.infotrygdPerioder
-        assertEquals(2, utbetalingerFraInfotrygd?.size)
-        utbetalingerFraInfotrygd!!.assertInfotrygdUtbetaling(
+        assertEquals(2, utbetalingerFraInfotrygd.size)
+        utbetalingerFraInfotrygd.assertInfotrygdUtbetaling(
             beløp = 7500,
             fomMåned = YearMonth.now().minusMonths(5),
             tomMåned = YearMonth.now().plusMonths(3)
@@ -196,7 +196,7 @@ internal class BisysServiceTest {
 
         val utbetalingerFraKsSak = utbetalinger.ksSakPerioder
         assertEquals(2, utbetalingerFraKsSak.size)
-        utbetalingerFraKsSak!!.assertUtbetaling(
+        utbetalingerFraKsSak.assertUtbetaling(
             beløp = 7500,
             fomMåned = YearMonth.now().minusMonths(5),
             tomMåned = YearMonth.now().minusMonths(3)
@@ -208,8 +208,8 @@ internal class BisysServiceTest {
         )
 
         val utbetalingerFraInfotrygd = utbetalinger.infotrygdPerioder
-        assertEquals(1, utbetalingerFraInfotrygd?.size)
-        utbetalingerFraInfotrygd!!.assertInfotrygdUtbetaling(
+        assertEquals(1, utbetalingerFraInfotrygd.size)
+        utbetalingerFraInfotrygd.assertInfotrygdUtbetaling(
             beløp = 7500,
             fomMåned = YearMonth.now().minusMonths(5),
             tomMåned = YearMonth.now().plusMonths(3)


### PR DESCRIPTION
Fjerner unødvendige null checks og fikser typo.
![compilatorw](https://user-images.githubusercontent.com/110383605/234700438-ab267b94-3260-4c25-bb36-7555d0dfb275.png)
