### PR TITLE
Legg til behandlingsnummer som header ved kall mot pdl

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     val sentryVersion = "6.8.0"
     val navFellesVersion = "1.20220901103347_4819e55"
     val eksterneKontrakterBisysVersion = "2.0_20220609214258_f30c3ce"
-    val fellesKontrakterVersion = "2.0_20230110150447_4edded8"
+    val fellesKontrakterVersion = "3.0_20230509152247_36d24db"
     val familieKontrakterSaksstatistikkVersion = "2.0_20220216121145_5a268ac"
     val familieKontrakterStønadsstatistikkKsVersion = "2.0_20230330120047_dfdd4f2"
     val familieKontrakterSkatteetatenVersion = "2.0_20210920094114_9c74239"

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/PdlConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/PdlConfig.kt
@@ -39,6 +39,7 @@ class PdlConfig(@Value("\${PDL_URL}") pdlUrl: URI) {
                 contentType = MediaType.APPLICATION_JSON
                 accept = listOf(MediaType.APPLICATION_JSON)
                 add("Tema", Tema.KON.name)
+                add("behandlingsnummer", Tema.KON.behandlingsnummer)
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlUtil.kt
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
+val logger: Logger = LoggerFactory.getLogger("PdlUtil")
 
 inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
     ident: String?,
@@ -28,6 +29,11 @@ inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
         }
         secureLogger.error("Feil ved henting av ${T::class} fra PDL: ${pdlRespons.errorMessages()}")
         throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
+    }
+
+    if (pdlRespons.harAdvarsel()) {
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
+        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlRespons.extensions?.warnings}")
     }
 
     val data = dataMapper.invoke(pdlRespons.data)

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlResponser.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlResponser.kt
@@ -12,11 +12,16 @@ import no.nav.familie.ks.sak.common.exception.PdlPersonKanIkkeBehandlesIFagsyste
 
 data class PdlBaseRespons<T>(
     val data: T,
-    val errors: List<PdlError>?
+    val errors: List<PdlError>?,
+    val extensions: PdlExtensions?
 ) {
 
     fun harFeil(): Boolean {
         return !errors.isNullOrEmpty()
+    }
+
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
     }
 
     fun errorMessages(): String {
@@ -27,14 +32,16 @@ data class PdlBaseRespons<T>(
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?
+    val extensions: PdlErrorExtensions?
 )
 
-data class PdlExtensions(val code: String?) {
-
+data class PdlErrorExtensions(val code: String?) {
     fun notFound() = code == "not_found"
 }
 
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)
 class PdlHentIdenterResponse(val pdlIdenter: PdlIdenter?)
 
 data class PdlIdenter(val identer: List<PdlIdent>)


### PR DESCRIPTION
https://github.com/navikt/familie-ba-sak/pull/3582

Kopiert inn fra PR i BA
Favrokort: [NAV-12403](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12403)

Dersom man henter ut noe fra pdl sendes det med en warning i extensions-objektet i responsen fordi behandlingsnummer ikke blir sendt med i header. Denne PR'en legger til denne headeren. 