### PR TITLE
Oppretter journalfør vedtaksbrev task for behandlinger som ikke skal opp mot oppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -161,7 +161,7 @@ class StegService(
             BESLUTTE_VEDTAK -> {
                 val beslutteVedtakDto = behandlingStegDto as BesluttVedtakDto
                 when (beslutteVedtakDto.beslutning) {
-                    Beslutning.GODKJENT -> hentNesteStegEtterBeslutteVedtak(behandling)
+                    Beslutning.GODKJENT -> hentNesteStegOgOpprettTaskEtterBeslutteVedtak(behandling)
                     Beslutning.UNDERKJENT -> BehandlingSteg.VEDTAK
                 }
             }
@@ -169,10 +169,14 @@ class StegService(
         }
     }
 
-    private fun hentNesteStegEtterBeslutteVedtak(behandling: Behandling): BehandlingSteg {
+    private fun hentNesteStegOgOpprettTaskEtterBeslutteVedtak(behandling: Behandling): BehandlingSteg {
         return when {
             behandling.erTekniskEndring() -> if (behandling.resultat.kanIkkeSendesTilOppdrag()) AVSLUTT_BEHANDLING else IVERKSETT_MOT_OPPDRAG
-            behandling.resultat.kanIkkeSendesTilOppdrag() -> JOURNALFØR_VEDTAKSBREV
+            behandling.resultat.kanIkkeSendesTilOppdrag() -> {
+                opprettJournalførVedtaksbrevTaskPåBehandling(behandling)
+                JOURNALFØR_VEDTAKSBREV
+            }
+
             else -> IVERKSETT_MOT_OPPDRAG
         }
     }
@@ -207,13 +211,17 @@ class StegService(
         when (behandling.steg) {
             JOURNALFØR_VEDTAKSBREV -> {
                 // JournalførVedtaksbrevTask -> DistribuerBrevTask -> AvsluttBehandlingTask for å avslutte behandling automatisk
-                val vedtakId = vedtakRepository.findByBehandlingAndAktiv(behandling.id).id
-                taskService.save(JournalførVedtaksbrevTask.opprettTask(behandling, vedtakId))
+                opprettJournalførVedtaksbrevTaskPåBehandling(behandling)
             }
             // Behandling med årsak SATSENDRING eller TEKNISK_ENDRING sender ikke vedtaksbrev. Da avslutter behandling her
             AVSLUTT_BEHANDLING -> utførSteg(behandlingId = behandling.id, AVSLUTT_BEHANDLING)
             else -> {} // Gjør ingenting
         }
+    }
+
+    private fun opprettJournalførVedtaksbrevTaskPåBehandling(behandling: Behandling) {
+        val vedtakId = vedtakRepository.findByBehandlingAndAktiv(behandling.id).id
+        taskService.save(JournalførVedtaksbrevTask.opprettTask(behandling, vedtakId))
     }
 
     fun settBehandlingstegPåVent(


### PR DESCRIPTION
Oppdaget en ganske kritisk bug i steghåndteringen i KS.

Ved behandlinger som ikke skal opp mot oppdrag settes steg til JOURNALFØR_VEDTAKSBREV.
Problemet er at man samtidig ikke oppretter en JOURNALFØR_VEDTAKSBREV task, som er det som sparker i gang prosessen med å journalføre og deretter avsluttet behandlingen. Konsekvensen av dette er derfor at behandlinger blir stuck på iverksetter vedtak.