### PR TITLE
Fiks validering av barnets alder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -198,7 +198,8 @@ class VilkårsvurderingSteg(
         personopplysningGrunnlag: PersonopplysningGrunnlag
     ) {
         vilkårsvurdering.personResultater.filter { !it.erSøkersResultater() }.forEach { personResultat ->
-            val person = personopplysningGrunnlag.personer.single { it.aktør == personResultat.aktør }
+            val person =
+                personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == personResultat.aktør.aktivFødselsnummer() }
 
             val barnehageplassVilkårResultater = personResultat.vilkårResultater.filter {
                 it.vilkårType == Vilkår.BARNEHAGEPLASS

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -17,7 +17,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.IBehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
@@ -119,7 +118,10 @@ class VilkårsvurderingSteg(
             )
         }
         validerAtDetIkkeErOverlappMellomGradertBarnehageplassOgDeltBosted(vilkårsvurdering)
-        validerAtPerioderIBarnehageplassSamsvarerMedPeriodeIBarnetsAlderVilkår(vilkårsvurdering)
+        validerAtPerioderIBarnehageplassSamsvarerMedPeriodeIBarnetsAlderVilkår(
+            vilkårsvurdering,
+            personopplysningGrunnlag
+        )
         validerAtDetIkkeFinnesMerEnn2EndringerISammeMånedIBarnehageplassVilkår(vilkårsvurdering)
         validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering, personopplysningGrunnlag.barna)
         validerIkkeBlandetRegelverk(personopplysningGrunnlag, vilkårsvurdering)
@@ -192,9 +194,12 @@ class VilkårsvurderingSteg(
     }
 
     private fun validerAtPerioderIBarnehageplassSamsvarerMedPeriodeIBarnetsAlderVilkår(
-        vilkårsvurdering: Vilkårsvurdering
+        vilkårsvurdering: Vilkårsvurdering,
+        personopplysningGrunnlag: PersonopplysningGrunnlag
     ) {
         vilkårsvurdering.personResultater.filter { !it.erSøkersResultater() }.forEach { personResultat ->
+            val person = personopplysningGrunnlag.personer.single { it.aktør == personResultat.aktør }
+
             val barnehageplassVilkårResultater = personResultat.vilkårResultater.filter {
                 it.vilkårType == Vilkår.BARNEHAGEPLASS
             }
@@ -206,15 +211,17 @@ class VilkårsvurderingSteg(
                 barnehageplassVilkårResultater.sortedWith(compareBy(nullsLast()) { it.periodeTom }).last().periodeTom
                     ?: TIDENES_ENDE
 
-            val barnetsAlderVilkårResultater = personResultat.vilkårResultater.filter {
-                it.vilkårType == Vilkår.BARNETS_ALDER && it.resultat == Resultat.OPPFYLT
-            }
+            val barnetsAlderVilkårResultater =
+                personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.BARNETS_ALDER }
+
             val minFraOgMedDatoIBarnetsAlderVilkårResultater =
                 barnetsAlderVilkårResultater.sortedBy { it.periodeFom }.first().periodeFom
-                    ?: error("Mangler fom dato")
+                    ?: person.fødselsdato.plusYears(1)
+
             val maksTilOmMedDatoIBarnetsAlderVilkårResultater =
                 barnetsAlderVilkårResultater.sortedBy { it.periodeTom }.last().periodeTom
-                    ?: error("Mangler tom dato")
+                    ?: person.fødselsdato.plusYears(2)
+
             if (minFraOgMedDatoIBarnehageplassVilkårResultater.isAfter(minFraOgMedDatoIBarnetsAlderVilkårResultater) ||
                 maksTilOmMedDatoIBarnehageplassVilkårResultater.isBefore(maksTilOmMedDatoIBarnetsAlderVilkårResultater)
             ) {


### PR DESCRIPTION
Vi fikser validering av barnets alder.

- Når vi validerer at det er samsvar mellom barnets alder og barnehageplass perioder så må vi sjekke perioder uavhengig av om det er oppfylt eller ikke.
- Det skal være mulig å lage uoppfylt barnets alder periode uten fom og tom fra frontend. Ved slike tilfeller defaulter man til fom som er 1 år etter barnet er født, og tom som er 2 år etter barnet er født.