### PR TITLE
Forhindre simulering for avslåtte behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg
 
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak.SATSENDRING
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak.SØKNAD
@@ -12,6 +13,7 @@ enum class BehandlingSteg(
     val gyldigBehandlerRolle: List<BehandlerRolle> = listOf(BehandlerRolle.SAKSBEHANDLER),
     // default verdi er at steg er gyldig for alle behandling årsaker
     val gyldigForÅrsaker: List<BehandlingÅrsak> = BehandlingÅrsak.values().toList(),
+    val gyldigForResultater: List<Behandlingsresultat> = Behandlingsresultat.values().toList(),
     val tilknyttetBehandlingStatus: BehandlingStatus = BehandlingStatus.UTREDES
 ) {
     REGISTRERE_PERSONGRUNNLAG(
@@ -24,7 +26,8 @@ enum class BehandlingSteg(
     SIMULERING(
         sekvens = 5,
         gyldigBehandlerRolle = listOf(BehandlerRolle.SYSTEM, BehandlerRolle.SAKSBEHANDLER),
-        gyldigForÅrsaker = BehandlingÅrsak.values().filterNot { it == SATSENDRING }
+        gyldigForÅrsaker = BehandlingÅrsak.values().filterNot { it == SATSENDRING },
+        gyldigForResultater = Behandlingsresultat.values().filterNot { it == Behandlingsresultat.AVSLÅTT }
     ),
     VEDTAK(
         sekvens = 6,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -154,7 +154,8 @@ class StegService(
     ): BehandlingSteg {
         val nesteGyldigeStadier = BehandlingSteg.values().filter {
             it.sekvens > behandledeSteg.sekvens &&
-                behandling.opprettetÅrsak in it.gyldigForÅrsaker
+                behandling.opprettetÅrsak in it.gyldigForÅrsaker &&
+                behandling.resultat in it.gyldigForResultater
         }.sortedBy { it.sekvens }
         return when (behandledeSteg) {
             AVSLUTT_BEHANDLING -> throw Feil("Behandling ${behandling.id} er allerede avsluttet")


### PR DESCRIPTION
Grunnet måten stegmotoren er satt opp i familie-ks-sak så feiler det å godkjenne vedtak når en behandling har fått resultat avslått. Dette skjer fordi man ønsker å hoppe over simuleringssteget i frontend, men siden backend oppretter dette steget så går det ikke an å gå videre.

Jeg har derfor gjort følgende:

- Hoppe over opprettelsen av steget simulering dersom en behandling har fått avslag.
- I frontend så kaller vi ikke på simuleringssteget dersom behandlingen har fått avslag : https://github.com/navikt/familie-ks-sak-frontend/pull/242