### PR TITLE
Oppettelse av opplysningspliktvilkåret skal være mulig overalt.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
@@ -46,6 +47,11 @@ class VilkårsvurderingService(
             initiellVilkårsvurdering.kopierOverOppfylteOgIkkeAktuelleResultaterFraForrigeBehandling(
                 vilkårsvurderingForrigeBehandling = hentAktivVilkårsvurderingForBehandling(forrigeBehandlingSomErVedtatt.id)
             )
+        }
+
+        aktivVilkårsvurdering?.finnOpplysningspliktVilkår()?.let {
+            initiellVilkårsvurdering.personResultater.single { it.erSøkersResultater() }
+                .leggTilBlankAnnenVurdering(AnnenVurderingType.OPPLYSNINGSPLIKT)
         }
 
         initiellVilkårsvurdering.oppdaterMedDødsdatoer(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
@@ -120,6 +120,12 @@ class BrevServiceTest {
             behandlendeEnhetId = "1234"
         )
 
+        every { vilkårsvurderingService.finnAktivVilkårsvurdering(any()) } returns lagVilkårsvurderingMedSøkersVilkår(
+            søkerAktør = søker,
+            behandling = behandling,
+            resultat = Resultat.IKKE_VURDERT
+        )
+
         every { taskService.save(any()) } returns mockk()
 
         every { behandlingRepository.hentBehandling(behandlingId = behandling.id) } returns behandling
@@ -250,6 +256,12 @@ class BrevServiceTest {
             behandlendeEnhetId = "1234"
         )
 
+        every { vilkårsvurderingService.finnAktivVilkårsvurdering(any()) } returns lagVilkårsvurderingMedSøkersVilkår(
+            søkerAktør = søker,
+            behandling = behandling,
+            resultat = Resultat.IKKE_VURDERT
+        )
+
         every { taskService.save(any()) } returns mockk()
 
         every { behandlingRepository.hentBehandling(behandlingId = behandling.id) } returns behandling
@@ -293,7 +305,7 @@ class BrevServiceTest {
             )
         )
 
-        verify(exactly = 1) { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(any()) }
+        verify(exactly = 1) { vilkårsvurderingService.finnAktivVilkårsvurdering(any()) }
     }
 
     @ParameterizedTest

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
@@ -349,6 +349,12 @@ class BrevServiceTest {
             resultat = Resultat.IKKE_VURDERT
         )
 
+        every { vilkårsvurderingService.finnAktivVilkårsvurdering(any()) } returns lagVilkårsvurderingMedSøkersVilkår(
+            søkerAktør = søker,
+            behandling = behandling,
+            resultat = Resultat.IKKE_VURDERT
+        )
+
         every {
             settBehandlingPåVentService.settBehandlingPåVent(
                 any(),


### PR DESCRIPTION
Per nå så feiler det å sende innhentingsbrev dersom man står i registrer søknads delen av behandlingen.
Dette er fordi at funksjonaliteten krever at villkårene er opprettet, men dette skjer bare i neste steg.

Jeg har derfor
- Endret litt logikk slik at vi oppretter vilkårene tidligere hvis man sender innhentingsbrev.
- Når opplysningsvilkåret er satt så skal den ikke kunne fjernes i nåværende behandling. Vi oppretter derfor da alltid en blank opplysningsplikt når vi oppretter nye blanke vilkår.