### PR TITLE
Tilgjengelig gjør avslag gjennom endret utbetalingsperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -59,6 +59,8 @@ class BehandlingsresultatService(
                 ?: emptyList()
         )
 
+        val alleAndelerHar0IUtbetaling = andelerMedEndringer.all { it.kalkulertUtbetalingsbeløp == 0 }
+
         YtelsePersonUtils.validerYtelsePersoner(ytelsePersonerMedResultat)
 
         secureLogger.info("Utledet YtelsePersonResultat på behandling $behandling: $ytelsePersonerMedResultat")
@@ -72,7 +74,10 @@ class BehandlingsresultatService(
         val ytelsePersonResultater =
             YtelsePersonUtils.oppdaterYtelsePersonResultaterVedOpphør(ytelsePersonerMedResultat)
         val behandlingsresultat =
-            BehandlingsresultatUtils.utledBehandlingsresuiltatBasertPåYtelsePersonResulater(ytelsePersonResultater)
+            BehandlingsresultatUtils.utledBehandlingsresuiltatBasertPåYtelsePersonResulater(
+                ytelsePersonResultater,
+                alleAndelerHar0IUtbetaling
+            )
 
         logger.info("Utledet behandlingsresulat på behandling er $behandling: $behandlingsresultat")
         secureLogger.info("Utledet behandlingsresulat på behandling er $behandling: $behandlingsresultat")

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -74,7 +74,7 @@ class BehandlingsresultatService(
         val ytelsePersonResultater =
             YtelsePersonUtils.oppdaterYtelsePersonResultaterVedOpphør(ytelsePersonerMedResultat)
         val behandlingsresultat =
-            BehandlingsresultatUtils.utledBehandlingsresuiltatBasertPåYtelsePersonResulater(
+            BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersonResulater(
                 ytelsePersonResultater,
                 alleAndelerHar0IUtbetaling
             )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -177,7 +177,7 @@ object BehandlingsresultatUtils {
 
             else -> throw Feil(
                 frontendFeilmelding = "Behandlingsresultatet du har fått på behandlingen er ikke støttet i løsningen enda. " +
-                        "Ta kontakt med Team familie om du er uenig i resultatet.",
+                    "Ta kontakt med Team familie om du er uenig i resultatet.",
                 message = "Kombiansjonen av behandlingsresultatene $ytelsePersonResultater er ikke støttet i løsningen."
             )
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -95,7 +95,10 @@ object BehandlingsresultatUtils {
         )
     }
 
-    fun utledBehandlingsresuiltatBasertPåYtelsePersonResulater(ytelsePersonResultater: Set<YtelsePersonResultat>): Behandlingsresultat {
+    fun utledBehandlingsresuiltatBasertPåYtelsePersonResulater(
+        ytelsePersonResultater: Set<YtelsePersonResultat>,
+        alleAndelerHar0IUtbetaling: Boolean
+    ): Behandlingsresultat {
         // Alle Behandlinsresultatene er importert. Så trenger ikke å bruke Behandlingsresulat.FORTSATT_INNVILGET
         return when {
             // Innvilget
@@ -145,7 +148,10 @@ object BehandlingsresultatUtils {
             ytelsePersonResultater.matcherAltOgHarBådeEndretOgOpphørtResultat() -> ENDRET_OG_OPPHØRT
 
             // Avslått og Opphørt, Her trenger å matchhe OPPHØRT spesifikt fordi det kun kan ha FORTSATT_OPPHØRT også. Da får vi AVSLÅTT
-            ytelsePersonResultater.matcherAltOgHarOpphørtResultat(YtelsePersonResultat.AVSLÅTT, YtelsePersonResultat.OPPHØRT) -> AVSLÅTT_OG_OPPHØRT
+            ytelsePersonResultater.matcherAltOgHarOpphørtResultat(
+                YtelsePersonResultat.AVSLÅTT,
+                YtelsePersonResultat.OPPHØRT
+            ) -> AVSLÅTT_OG_OPPHØRT
 
             // Avslått og Endret
             ytelsePersonResultater.matcherAltOgHarEndretResultat(YtelsePersonResultat.AVSLÅTT) -> AVSLÅTT_OG_ENDRET
@@ -153,9 +159,25 @@ object BehandlingsresultatUtils {
             // Avslått, Endret og Opphørt
             ytelsePersonResultater.matcherAltOgHarBådeEndretOgOpphørtResultat(YtelsePersonResultat.AVSLÅTT) -> AVSLÅTT_ENDRET_OG_OPPHØRT
 
+            // Disse to kombinasjonene er bare mulig å få dersom man har fått YtelsePersonResultat.Avslått gjennom av å avslå gjennom endret utbetalingsperioder.
+            // Dette må på plass siden uten den nye behandlingsresultat logikken, så vil man få INNVILGET,AVSLÅTT,OPPHØRT selvom man ikke har noe andeler som skal utbetales (burde vært bare avslått)
+            // Dette legges inn bare midlertidig inntil vi får på plass den nye behandlingsresultat logikken som finnes i familie-ba-sak.
+            // TODO: Overfør ny behandlingsresultat logikk til ks-sak
+            ytelsePersonResultater.eq(
+                YtelsePersonResultat.INNVILGET,
+                YtelsePersonResultat.AVSLÅTT,
+                YtelsePersonResultat.OPPHØRT
+            ) && alleAndelerHar0IUtbetaling -> AVSLÅTT
+
+            ytelsePersonResultater.eq(
+                YtelsePersonResultat.INNVILGET,
+                YtelsePersonResultat.AVSLÅTT,
+                YtelsePersonResultat.OPPHØRT
+            ) && !alleAndelerHar0IUtbetaling -> DELVIS_INNVILGET
+
             else -> throw Feil(
                 frontendFeilmelding = "Behandlingsresultatet du har fått på behandlingen er ikke støttet i løsningen enda. " +
-                    "Ta kontakt med Team familie om du er uenig i resultatet.",
+                        "Ta kontakt med Team familie om du er uenig i resultatet.",
                 message = "Kombiansjonen av behandlingsresultatene $ytelsePersonResultater er ikke støttet i løsningen."
             )
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -95,7 +95,7 @@ object BehandlingsresultatUtils {
         )
     }
 
-    fun utledBehandlingsresuiltatBasertPåYtelsePersonResulater(
+    fun utledBehandlingsresultatBasertPåYtelsePersonResulater(
         ytelsePersonResultater: Set<YtelsePersonResultat>,
         alleAndelerHar0IUtbetaling: Boolean
     ): Behandlingsresultat {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -496,7 +496,7 @@ private fun Begrunnelse.hentRelevanteEndringsperioderForBegrunnelse(
         endretUtbetalingAndeler.filter {
             it.periode.tom.sisteDagIInneværendeMåned()
                 ?.erDagenFør(vedtaksperiode.fom?.førsteDagIInneværendeMåned()) == true &&
-                    sanityBegrunnelse.endringsårsaker.contains(it.årsak)
+                sanityBegrunnelse.endringsårsaker.contains(it.årsak)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
 import no.nav.familie.ks.sak.common.util.tilYearMonth
+import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.Trigger
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.inneholderGjelderFørstePeriodeTrigger
@@ -237,7 +238,8 @@ class BrevPeriodeContext(
     ) {
         if (!gjelderSøker && barnasFødselsdatoer.isEmpty() &&
             !sanityBegrunnelse.triggere.contains(Trigger.SATSENDRING) &&
-            begrunnelse != Begrunnelse.AVSLAG_UREGISTRERT_BARN
+            begrunnelse != Begrunnelse.AVSLAG_UREGISTRERT_BARN &&
+            begrunnelse != Begrunnelse.AVSLAG_SØKT_FOR_SENT_ENDRINGSPERIODE
         ) {
             throw IllegalStateException("Ingen personer på brevbegrunnelse $begrunnelse")
         }
@@ -494,7 +496,13 @@ private fun Begrunnelse.hentRelevanteEndringsperioderForBegrunnelse(
         endretUtbetalingAndeler.filter {
             it.periode.tom.sisteDagIInneværendeMåned()
                 ?.erDagenFør(vedtaksperiode.fom?.førsteDagIInneværendeMåned()) == true &&
-                sanityBegrunnelse.endringsårsaker.contains(it.årsak)
+                    sanityBegrunnelse.endringsårsaker.contains(it.årsak)
+        }
+    }
+
+    BegrunnelseType.AVSLAG -> {
+        endretUtbetalingAndeler.filter {
+            it.periode.fom == vedtaksperiode.fom?.toYearMonth()
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/Begrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/Begrunnelse.kt
@@ -299,6 +299,10 @@ enum class Begrunnelse : IBegrunnelse {
         override val begrunnelseType = BegrunnelseType.AVSLAG
         override val sanityApiNavn = "avslagOppholdsrettEOSBorger"
     },
+    AVSLAG_SØKT_FOR_SENT_ENDRINGSPERIODE {
+        override val begrunnelseType = BegrunnelseType.AVSLAG
+        override val sanityApiNavn = "avslagSokerForSentEndringsperiode"
+    },
     ETTER_ENDRET_UTBETALING_ETTERBETALING {
         override val begrunnelseType = BegrunnelseType.ETTER_ENDRET_UTBETALING
         override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreMaanedTilbakeITid"

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -144,10 +144,7 @@ fun EndretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(
     this.begrunnelse = endretUtbetalingAndelRequestDto.begrunnelse
     this.person = person
     this.erEksplisittAvslagPåSøknad = endretUtbetalingAndelRequestDto.erEksplisittAvslagPåSøknad
-
-    // Vi skal bare ha 1 mulig avslagebegrunnelse for endret utbetalingandel.
-    // TODO: Endre til riktig avslagtekst når vi får dem inn.
-    this.begrunnelser = listOf(Begrunnelse.AVSLAG_UREGISTRERT_BARN)
+    this.begrunnelser = listOf(Begrunnelse.AVSLAG_SØKT_FOR_SENT_ENDRINGSPERIODE)
 
     return this
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -47,7 +47,7 @@ internal class BehandlingsresultatUtilsTest {
     }
 
     @Test
-    fun `utledBehandlingsresuiltatBasertPåYtelsePersonResulater skal utlede behandlingsresultat og sjekke at det matcher forventet resulat`() {
+    fun `utledBehandlingsresultatBasertPåYtelsePersonResulater skal utlede behandlingsresultat og sjekke at det matcher forventet resulat`() {
         val testmappe = File("./src/test/resources/behandlingsresultat/")
         testmappe.listFiles()?.forEach { fil ->
             val testData = objectMapper.readValue(fil.readText(), BehandlingsresulatTestData::class.java)
@@ -60,7 +60,7 @@ internal class BehandlingsresultatUtilsTest {
             val ytelsePersonResultater =
                 YtelsePersonUtils.oppdaterYtelsePersonResultaterVedOpphør(ytelsePersonerMedResulater)
             val behandlingsresultat =
-                BehandlingsresultatUtils.utledBehandlingsresuiltatBasertPåYtelsePersonResulater(
+                BehandlingsresultatUtils.utledBehandlingsresultatBasertPåYtelsePersonResulater(
                     ytelsePersonResultater,
                     false
                 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -60,7 +60,10 @@ internal class BehandlingsresultatUtilsTest {
             val ytelsePersonResultater =
                 YtelsePersonUtils.oppdaterYtelsePersonResultaterVedOpphør(ytelsePersonerMedResulater)
             val behandlingsresultat =
-                BehandlingsresultatUtils.utledBehandlingsresuiltatBasertPåYtelsePersonResulater(ytelsePersonResultater)
+                BehandlingsresultatUtils.utledBehandlingsresuiltatBasertPåYtelsePersonResulater(
+                    ytelsePersonResultater,
+                    false
+                )
             assertEquals(forventetResultat, behandlingsresultat)
         }
     }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=NAV-12479

I kontantstøtte så er det ønskelig å kunne gi et avslag på behandlingen (enten avslag eller delvis innvilget) gjennom endret utbetalingsperioder. Dette gir oss utfordringen at vi noen ganger kan få kombinasjonen INNVILGET, AVSLAG og OPPHØRT i tilfeller man bare har andeler med 0 i utbetaling. I ba-sak så hadde man fått avslag, men i kontantstøtte får man enten innvilget og opphørt, eller innvilget, opphørt og avslått. 

Jeg har derfor utvidet logikken i ks-sak bare for å støtte dette formålet, men på sikt bør vi få over behandlingsresultat logikken fra ba-sak