### PR TITLE
Bugfiks på kopiering av endret andeler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -134,7 +134,7 @@ class EndretUtbetalingAndelService(
     @Transactional
     fun kopierEndretUtbetalingAndelFraForrigeBehandling(behandling: Behandling, forrigeBehandling: Behandling) =
         hentEndredeUtbetalingAndeler(forrigeBehandling.id).forEach {
-            val kopiertOverEndretUtbetalingAndel = it.copy(behandlingId = behandling.id)
+            val kopiertOverEndretUtbetalingAndel = it.copy(id = 0, behandlingId = behandling.id)
             endretUtbetalingAndelRepository.save(kopiertOverEndretUtbetalingAndel)
         }
 }


### PR DESCRIPTION
Under testing av endret utbetaling i develop så merket jeg at ks-sak kræsjet hver gang man prøvde å lage en revurdering på saker som hadde behandlinger m/ endret utbetalinger.
Dette skjedde fordi man prøver å kopiere endret utbetaling fra forrige behandling, men siden man ikke tilbakestiller id, så feiler id (det eksisterer da to objekter med samme id, og feiler med "Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect)")