### PR TITLE
Vi skal bare være strenge med triggere for standard innvilgelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -135,7 +135,8 @@ class BegrunnelserForPeriodeContext(
             .filtrerPåTriggere(
                 sanityBegrunnelse.triggere,
                 sanityBegrunnelse.type,
-                erFørsteVedtaksperiodeOgBegrunnelseInneholderGjelderFørstePeriodeTrigger
+                erFørsteVedtaksperiodeOgBegrunnelseInneholderGjelderFørstePeriodeTrigger,
+                begrunnelse.begrunnelseType
             )
 
         val filtrerPåUtdypendeVilkårsvurdering = filtrerPåTriggere
@@ -293,11 +294,11 @@ class BegrunnelserForPeriodeContext(
 
     private fun finnPersonerMedVilkårResultaterSomGjelderRettFørPeriode(): Map<Person, List<VilkårResultat>> =
         personResultater.tilFørskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
-            .mapNotNull { (aktør, tidsjlinje) ->
+            .mapNotNull { (aktør, tidslinje) ->
                 val person =
                     personopplysningGrunnlag.personer.find { it.aktør.aktivFødselsnummer() == aktør.aktivFødselsnummer() }
                 val forskøvedeVilkårResultaterSlutterDagenFørVedtaksperiode =
-                    tidsjlinje.tilPerioderIkkeNull().singleOrNull {
+                    tidslinje.tilPerioderIkkeNull().singleOrNull {
                         it.tom?.plusDays(1) == vedtaksperiode.fom
                     }?.verdi
 
@@ -323,7 +324,8 @@ class BegrunnelserForPeriodeContext(
     private fun Map<Person, List<VilkårResultat>>.filtrerPåTriggere(
         triggereFraSanity: List<Trigger>,
         sanityBegrunnelseType: SanityBegrunnelseType,
-        erFørsteVedtaksperiodeOgBegrunnelseInneholderGjelderFørstePeriodeTrigger: Boolean
+        erFørsteVedtaksperiodeOgBegrunnelseInneholderGjelderFørstePeriodeTrigger: Boolean,
+        begrunnelseType: BegrunnelseType
     ) = this.filter { (person, vilkårResultaterForPerson) ->
         val oppfylteTriggereIBehandling =
             Trigger.values().filter {
@@ -335,7 +337,7 @@ class BegrunnelserForPeriodeContext(
             }
 
         // Strengere logikk for Standardbegrunnelsene for innvilgelse
-        if (sanityBegrunnelseType == SanityBegrunnelseType.STANDARD) {
+        if (sanityBegrunnelseType == SanityBegrunnelseType.STANDARD && begrunnelseType == BegrunnelseType.INNVILGET) {
             oppfylteTriggereIBehandling == triggereFraSanity
         } else {
             triggereFraSanity.all { oppfylteTriggereIBehandling.contains(it) }


### PR DESCRIPTION
Vi har denne saken i produksjon:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12808

Saksbehandler opplever at hen ikke får opp opphørstekster.
Jeg testet litt i preprod, og ser at det oppstår dersom vilkåret før vedtaksperioden er av type deltids barnehageplass.
Når det er deltidsbarnehageplass, så slår triggeren inn, og da MÅ man ha huket av for det i sanity.
Men vi ønsker jo at begrunnelsene dukker opp uansett om det er deltids barnehageplass eller ikke, så lenge det er et opphør som oppstår rett etter vilkåret.

Fant derfor ut at det ligger en kommentar i koden (// Strengere logikk for Standardbegrunnelsene for innvilgelse), men som bare sjekket for standard begrunnelse og ikke innvilgelse. Tar derfor også en sjekk på om det er innvilget før vi kjører på med streng validering av triggere.