### PR TITLE
Sørger for at Kafka listener for barnehagelistene skrus av inntil feilen fikses

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteConsumer.kt
@@ -21,6 +21,7 @@ class BarnehagelisteConsumer(val barnehageListeService: BarnehageListeService) {
         id = "familie-ks-sak-barnehageliste",
         topics = [KafkaConfig.BARNEHAGELISTE_TOPIC],
         containerFactory = "concurrentKafkaListenerContainerFactory",
+        autoStartup = "false", // TODO: Fjern denne igjen når feilen er fikset
     )
     fun listen(consumerRecord: ConsumerRecord<String, String>, ack: Acknowledgment) {
         val data: String = consumerRecord.value()


### PR DESCRIPTION
Vi får feil i KafkaListener `BarnehagelisteConsumer` som feiler med "key cannot be null". Er stuck på offset 5. Har nå lagt inn kode for å hindre at listener starter opp automatisk. Kan fjernes når feilen er håndtert.