### PR TITLE
Fjern etterbetaling 3 måned begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/Begrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/Begrunnelse.kt
@@ -275,10 +275,6 @@ enum class Begrunnelse : IBegrunnelse {
         override val begrunnelseType = BegrunnelseType.AVSLAG
         override val sanityApiNavn = "avslagSokerForSentEndringsperiode"
     },
-    ETTER_ENDRET_UTBETALING_ETTERBETALING {
-        override val begrunnelseType = BegrunnelseType.ETTER_ENDRET_UTBETALING
-        override val sanityApiNavn = "etterEndretUtbetalingEtterbetalingTreMaanedTilbakeITid"
-    },
     OPPHØR_FULLTIDSPLASS_I_BARNEHAGE {
         override val begrunnelseType = BegrunnelseType.OPPHØR
         override val sanityApiNavn = "opphorFulltidsplassIBarnehage"

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -194,7 +194,7 @@ class VilkårsvurderingServiceTest {
         val vilkårsbegrunnelser = vilkårsvurderingService.hentVilkårsbegrunnelser()
 
         // TODO: Endre denne testen når vi får lagt inn riktige Begrunnelser og EØSBegrunnelser
-        assertEquals(6, vilkårsbegrunnelser.size)
+        assertEquals(5, vilkårsbegrunnelser.size)
         assertEquals(0, vilkårsbegrunnelser[BegrunnelseType.AVSLAG]?.size)
         assertEquals(1, vilkårsbegrunnelser[BegrunnelseType.EØS_OPPHØR]?.size)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -268,56 +268,6 @@ class BrevPeriodeContextTest {
     }
 
     @Test
-    fun `genererBrevPeriodeDto skal gi riktig output for etterEndretUtbetalingEtterbetalingTreMaanedTilbakeITid dersom person har endretutbetalingandeler som matcher vedtaksperiode`() {
-        val barnFødselsdato = LocalDate.of(2021, 3, 15)
-
-        val personerIbehandling = listOf(
-            PersonIBehandling(
-                personType = PersonType.SØKER,
-                fødselsDato = LocalDate.now().minusYears(20),
-                overstyrendeVilkårResultater = emptyList()
-            ),
-            PersonIBehandling(
-                personType = PersonType.BARN,
-                fødselsDato = barnFødselsdato,
-                overstyrendeVilkårResultater = listOf(
-                    lagVilkårResultat(
-                        vilkårType = Vilkår.BARNETS_ALDER,
-                        periodeFom = barnFødselsdato.plusYears(1),
-                        periodeTom = barnFødselsdato.plusYears(2),
-                        utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON)
-                    )
-                )
-            )
-        )
-
-        val brevPeriodeDto = lagBrevPeriodeContext(
-            personerIBehandling = personerIbehandling,
-            begrunnelser = listOf(Begrunnelse.ETTER_ENDRET_UTBETALING_ETTERBETALING),
-            vedtaksperiodeType = Vedtaksperiodetype.UTBETALING,
-            skalOppretteEndretUtbetalingAndeler = true
-        ).genererBrevPeriodeDto()
-
-        Assertions.assertEquals(
-            BegrunnelseDataDto(
-                vedtakBegrunnelseType = BegrunnelseType.ETTER_ENDRET_UTBETALING,
-                apiNavn = "etterEndretUtbetalingEtterbetalingTreMaanedTilbakeITid",
-                sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
-                gjelderSoker = false,
-                gjelderAndreForelder = true,
-                barnasFodselsdatoer = barnFødselsdato.tilKortString(),
-                antallBarn = 1,
-                maanedOgAarBegrunnelsenGjelderFor = "april 2022",
-                maalform = "bokmaal",
-                belop = "7 500",
-                antallTimerBarnehageplass = "0",
-                soknadstidspunkt = "12.12.20"
-            ),
-            brevPeriodeDto?.begrunnelser?.single()
-        )
-    }
-
-    @Test
     fun `genererBrevPeriodeDto skal gi true for gjelderAnnenForelder feltet dersom annen forelder ikke er vurdert i MedlemskapAnnenForelder vilkåret`() {
         val barnFødselsdato = LocalDate.of(2021, 3, 15)
 
@@ -350,15 +300,15 @@ class BrevPeriodeContextTest {
 
         val brevPeriodeDto = lagBrevPeriodeContext(
             personerIBehandling = personerIbehandling,
-            begrunnelser = listOf(Begrunnelse.ETTER_ENDRET_UTBETALING_ETTERBETALING),
+            begrunnelser = listOf(Begrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON),
             vedtaksperiodeType = Vedtaksperiodetype.UTBETALING,
             skalOppretteEndretUtbetalingAndeler = true
         ).genererBrevPeriodeDto()
 
         Assertions.assertEquals(
             BegrunnelseDataDto(
-                vedtakBegrunnelseType = BegrunnelseType.ETTER_ENDRET_UTBETALING,
-                apiNavn = "etterEndretUtbetalingEtterbetalingTreMaanedTilbakeITid",
+                vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
+                apiNavn = Begrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON.sanityApiNavn,
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
                 gjelderSoker = false,
                 gjelderAndreForelder = true,
@@ -368,7 +318,7 @@ class BrevPeriodeContextTest {
                 maalform = "bokmaal",
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
-                soknadstidspunkt = "12.12.20"
+                soknadstidspunkt = ""
             ),
             brevPeriodeDto?.begrunnelser?.single()
         )
@@ -407,15 +357,15 @@ class BrevPeriodeContextTest {
 
         val brevPeriodeDto = lagBrevPeriodeContext(
             personerIBehandling = personerIbehandling,
-            begrunnelser = listOf(Begrunnelse.ETTER_ENDRET_UTBETALING_ETTERBETALING),
+            begrunnelser = listOf(Begrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON),
             vedtaksperiodeType = Vedtaksperiodetype.UTBETALING,
             skalOppretteEndretUtbetalingAndeler = true
         ).genererBrevPeriodeDto()
 
         Assertions.assertEquals(
             BegrunnelseDataDto(
-                vedtakBegrunnelseType = BegrunnelseType.ETTER_ENDRET_UTBETALING,
-                apiNavn = "etterEndretUtbetalingEtterbetalingTreMaanedTilbakeITid",
+                vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
+                apiNavn = Begrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON.sanityApiNavn,
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
                 gjelderSoker = false,
                 gjelderAndreForelder = false,
@@ -425,7 +375,7 @@ class BrevPeriodeContextTest {
                 maalform = "bokmaal",
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
-                soknadstidspunkt = "12.12.20"
+                soknadstidspunkt = ""
             ),
             brevPeriodeDto?.begrunnelser?.single()
         )


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=NAV-11030

Nå som avslagsbegrunnelsene er på plass så fjerner vi etterbetlaing 3 måneder teksten.
Dette skal nå være en avslagstekst.