### PR TITLE
Bugfix/fjern hardkoding av antallbarn ved avslag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -206,7 +206,6 @@ class BrevPeriodeContext(
     }
 
     fun hentAntallBarnForBegrunnelse(
-        gjelderSøker: Boolean,
         barnasFødselsdatoer: List<LocalDate>,
         begrunnelse: Begrunnelse
     ): Int {
@@ -215,7 +214,6 @@ class BrevPeriodeContext(
 
         return when {
             erAvslagUregistrerteBarn -> uregistrerteBarn.size
-            gjelderSøker && begrunnelse.begrunnelseType == BegrunnelseType.AVSLAG -> 0
             else -> barnasFødselsdatoer.size
         }
     }
@@ -350,7 +348,6 @@ class BrevPeriodeContext(
                     gjelderAndreForelder = gjelderAndreForelder,
                     barnasFodselsdatoer = barnasFødselsdatoer.tilBrevTekst(),
                     antallBarn = hentAntallBarnForBegrunnelse(
-                        gjelderSøker = gjelderSøker,
                         barnasFødselsdatoer = barnasFødselsdatoer,
                         begrunnelse = begrunnelse
                     ),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -188,10 +188,9 @@ class BrevPeriodeContext(
             begrunnelse.begrunnelseType != BegrunnelseType.ENDRET_UTBETALING &&
             begrunnelse.begrunnelseType != BegrunnelseType.ETTER_ENDRET_UTBETALING -> {
             if (begrunnelse.begrunnelseType == BegrunnelseType.AVSLAG) {
-                persongrunnlag.personer
+                personerMedVilkårSomPasserBegrunnelse
                     .filter { it.type == PersonType.BARN }
-                    .map { it.fødselsdato } +
-                    uregistrerteBarn.mapNotNull { it.fødselsdato }
+                    .map { it.fødselsdato }
             } else {
                 (personerMedUtbetaling + personerMedVilkårSomPasserBegrunnelse).toSet()
                     .filter { it.type == PersonType.BARN }


### PR DESCRIPTION
Tidligere så har det vært hardkodet at så lenge det er en avslagsbegrunnelse, så skal antallBarn være satt til 0.
Dette stemmer ikke lenger, da det skal være mulig å ha avslagsbegrunnelser og riktig antallBarn for å få fram riktige valgfelt i sanity.

Før (dette var det eneste man kunne få før denne pr):
![føøøøør](https://github.com/navikt/familie-ks-sak/assets/110383605/28a280b6-0810-4ace-9b31-b8a1a0063d9c)

Etter:
![etterr3](https://github.com/navikt/familie-ks-sak/assets/110383605/dfa2542d-1448-420f-b5ec-b6983aad9798)
![etterr2](https://github.com/navikt/familie-ks-sak/assets/110383605/5e60ef81-9ed2-493d-867d-fc08f14fd2a6)
![etterr1](https://github.com/navikt/familie-ks-sak/assets/110383605/b7b98ea8-50c1-4c9b-ab90-a45165f8bf88)
