### PR TITLE
Når vi skal sjekke offset må vi sjekke etter andeler i iverksatte behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
@@ -89,7 +89,7 @@ class InternKonsistensavstemmingService(
     }
 
     private fun hentFagsakTilAndelerISisteBehandlingSendtTilØkonomiMap(fagsaker: Set<Long>): Map<Long, List<AndelTilkjentYtelse>> {
-        val behandlinger = behandlingService.hentSisteBehandlingSomErSendtTilØkonomiPerFagsak(fagsaker)
+        val behandlinger = behandlingService.hentSisteBehandlingSomErAvsluttetEllerSendtTilØkonomiPerFagsak(fagsaker)
 
         return andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(behandlinger.map { it.id })
             .groupBy { it.behandlingId }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -30,17 +30,17 @@ class UtbetalingsoppdragGenerator {
      *
      * @param[vedtakMedTilkjentYtelse] tilpasset objekt som inneholder tilkjentytelse,og andre nødvendige felter som trenges for å lage utbetalingsoppdrag
      * @param[andelTilkjentYtelseForUtbetalingsoppdragFactory] type factory bestemmer om AndelTilkjentYtelse muteres eller ikke. Avhengig om det er AndelTilkjentYtelseForIverksetting eller AndelTilkjentYtelseForSimulerin
-     * @param[forrigeTilkjentYtelse] forrige tilkjentYtelse
+     * @param[forrigeTilkjentYtelseMedAndeler] forrige tilkjentYtelse
      * @return oppdatert TilkjentYtelse som inneholder generert utbetalingsoppdrag
      */
     fun lagTilkjentYtelseMedUtbetalingsoppdrag(
         vedtakMedTilkjentYtelse: VedtakMedTilkjentYtelse,
         andelTilkjentYtelseForUtbetalingsoppdragFactory: AndelTilkjentYtelseForUtbetalingsoppdragFactory,
-        forrigeTilkjentYtelse: TilkjentYtelse? = null
+        forrigeTilkjentYtelseMedAndeler: TilkjentYtelse? = null
     ): TilkjentYtelse {
         val tilkjentYtelse = vedtakMedTilkjentYtelse.tilkjentYtelse
         val vedtak = vedtakMedTilkjentYtelse.vedtak
-        val erFørsteBehandlingPåFagsak = forrigeTilkjentYtelse == null
+        val erFørsteBehandlingPåFagsakSomSkalIverksettes = forrigeTilkjentYtelseMedAndeler == null
 
         // Filtrer kun andeler som kan sendes til oppdrag
         val andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() }
@@ -51,7 +51,7 @@ class UtbetalingsoppdragGenerator {
 
         // Filtrerer og grupperer forrige andeler basert på personIdent.
         val forrigeAndeler =
-            forrigeTilkjentYtelse?.andelerTilkjentYtelse?.filter { it.erAndelSomSkalSendesTilOppdrag() }
+            forrigeTilkjentYtelseMedAndeler?.andelerTilkjentYtelse?.filter { it.erAndelSomSkalSendesTilOppdrag() }
                 ?.pakkInnForUtbetaling(andelTilkjentYtelseForUtbetalingsoppdragFactory)
                 ?: emptyList()
 
@@ -86,7 +86,7 @@ class UtbetalingsoppdragGenerator {
             // lager utbetalingsperioder og oppdaterer andelerTilkjentYtelse
             val opprettelsePeriodeMedAndeler = lagUtbetalingsperioderForOpprettelse(
                 andeler = andelerTilOpprettelse,
-                erFørsteBehandlingPåFagsak = erFørsteBehandlingPåFagsak,
+                erFørsteBehandlingPåFagsak = erFørsteBehandlingPåFagsakSomSkalIverksettes,
                 vedtak = vedtak,
                 sisteOffsetIKjedeOversikt = vedtakMedTilkjentYtelse.sisteOffsetPerIdent,
                 sisteOffsetPåFagsak = vedtakMedTilkjentYtelse.sisteOffsetPåFagsak
@@ -106,7 +106,7 @@ class UtbetalingsoppdragGenerator {
         val opphøres = lagUtbetalingsperioderForOpphør(andeler = andelerTilOpphør, vedtak = vedtak)
 
         val aksjonskodePåOppdragsnivå =
-            if (erFørsteBehandlingPåFagsak) Utbetalingsoppdrag.KodeEndring.NY else Utbetalingsoppdrag.KodeEndring.ENDR
+            if (erFørsteBehandlingPåFagsakSomSkalIverksettes) Utbetalingsoppdrag.KodeEndring.NY else Utbetalingsoppdrag.KodeEndring.ENDR
         val utbetalingsoppdrag = Utbetalingsoppdrag(
             saksbehandlerId = vedtakMedTilkjentYtelse.saksbehandlerId,
             kodeEndring = aksjonskodePåOppdragsnivå,

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -86,8 +86,9 @@ class UtbetalingsoppdragService(
         val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId)
 
         // Henter tilkjentYtelse som har utbetalingsoppdrag og var sendt til oppdrag fra forrige iverksatt behandling
-        val forrigeBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
-        val forrigeTilkjentYtelse = forrigeBehandling?.let { beregningService.hentTilkjentYtelseForBehandling(it.id) }
+        val forrigeBehandlingSomErIverksatt = behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
+        val forrigeTilkjentYtelseMedAndeler =
+            forrigeBehandlingSomErIverksatt?.let { beregningService.hentTilkjentYtelseForBehandling(it.id) }
 
         val sisteOffsetPerIdent = beregningService.hentSisteOffsetPerIdent(
             behandling.fagsak.id,
@@ -106,7 +107,7 @@ class UtbetalingsoppdragService(
 
         return utbetalingsoppdragGenerator.lagTilkjentYtelseMedUtbetalingsoppdrag(
             vedtakMedTilkjentYtelse = vedtakMedTilkjentYtelse,
-            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+            forrigeTilkjentYtelseMedAndeler = forrigeTilkjentYtelseMedAndeler,
             andelTilkjentYtelseForUtbetalingsoppdragFactory = andelTilkjentYtelseForUtbetalingsoppdragFactory
         )
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.feilutbetaltvaluta.FeilutbetaltValutaService
@@ -196,6 +197,23 @@ class BehandlingService(
     fun hentAktivtFødselsnummerForBehandlinger(behandlingIder: List<Long>): Map<Long, String> =
         behandlingRepository.finnAktivtFødselsnummerForBehandlinger(behandlingIder).associate { it.first to it.second }
 
+    fun hentIverksatteBehandlinger(fagsakId: Long): List<Behandling> =
+        behandlingRepository.finnIverksatteBehandlinger(fagsakId = fagsakId)
+
+    /**
+     * Henter siste iverksatte behandling på fagsak
+     */
+    fun hentSisteBehandlingSomErIverksatt(fagsakId: Long): Behandling? {
+        val iverksatteBehandlinger = hentIverksatteBehandlinger(fagsakId)
+        return hentSisteBehandlingSomErIverksatt(iverksatteBehandlinger)
+    }
+
+    private fun hentSisteBehandlingSomErIverksatt(iverksatteBehandlinger: List<Behandling>): Behandling? {
+        return iverksatteBehandlinger
+            .filter { it.steg == BehandlingSteg.AVSLUTT_BEHANDLING }
+            .maxByOrNull { it.opprettetTidspunkt }
+    }
+
     @Transactional
     fun endreBehandlingstemaPåBehandling(behandlingId: Long, overstyrtKategori: BehandlingKategori): Behandling {
         val behandling = hentBehandling(behandlingId)
@@ -217,15 +235,15 @@ class BehandlingService(
             .filter { it.erAvsluttet() && !it.erHenlagt() }
     }
 
-    fun hentSisteBehandlingSomErSendtTilØkonomiPerFagsak(fagsakIder: Set<Long>): List<Behandling> {
+    fun hentSisteBehandlingSomErAvsluttetEllerSendtTilØkonomiPerFagsak(fagsakIder: Set<Long>): List<Behandling> {
         val behandlingerPåFagsakene = behandlingRepository.finnBehandlinger(fagsakIder)
 
         return behandlingerPåFagsakene
             .groupBy { it.fagsak.id }
-            .mapNotNull { (_, behandling) -> behandling.hentSisteSomErSentTilØkonomi() }
+            .mapNotNull { (_, behandling) -> behandling.hentSisteBehandlingSomErAvsluttetEllerSendtTilØkonomi() }
     }
 
-    private fun List<Behandling>.hentSisteSomErSentTilØkonomi() =
+    private fun List<Behandling>.hentSisteBehandlingSomErAvsluttetEllerSendtTilØkonomi() =
         filter { !it.erHenlagt() && (it.status == BehandlingStatus.AVSLUTTET || it.status == BehandlingStatus.IVERKSETTER_VEDTAK) }
             .maxByOrNull { it.opprettetTidspunkt }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -240,10 +240,10 @@ class BehandlingService(
 
         return behandlingerPåFagsakene
             .groupBy { it.fagsak.id }
-            .mapNotNull { (_, behandling) -> behandling.hentSisteBehandlingSomErAvsluttetEllerSendtTilØkonomi() }
+            .mapNotNull { (_, behandling) -> behandling.filtrerSisteBehandlingSomErAvsluttetEllerSendtTilØkonomi() }
     }
 
-    private fun List<Behandling>.hentSisteBehandlingSomErAvsluttetEllerSendtTilØkonomi() =
+    private fun List<Behandling>.filtrerSisteBehandlingSomErAvsluttetEllerSendtTilØkonomi() =
         filter { !it.erHenlagt() && (it.status == BehandlingStatus.AVSLUTTET || it.status == BehandlingStatus.IVERKSETTER_VEDTAK) }
             .maxByOrNull { it.opprettetTidspunkt }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -145,7 +145,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 )
             ),
             AndelTilkjentYtelseForIverksetting.Factory,
-            forrigeTilkjentYtelse = forrigeTilkjentYtelse
+            forrigeTilkjentYtelseMedAndeler = forrigeTilkjentYtelse
         )
 
         val utbetalingsoppdrag = konvertTilUtbetalingsoppdrag(oppdatertTilkjentYtelse.utbetalingsoppdrag)
@@ -285,7 +285,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                     tilkjentYtelse = tilkjentYtelseIAndreBehandling
                 ),
                 AndelTilkjentYtelseForIverksetting.Factory,
-                forrigeTilkjentYtelse = oppdatertTilkjentYtelseIFørsteBehandling
+                forrigeTilkjentYtelseMedAndeler = oppdatertTilkjentYtelseIFørsteBehandling
             )
 
         val utbetalingsoppdrag =
@@ -410,7 +410,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                     tilkjentYtelse = tilkjentYtelseIAndreBehandling
                 ),
                 AndelTilkjentYtelseForIverksetting.Factory,
-                forrigeTilkjentYtelse = oppdatertTilkjentYtelseIFørsteBehandling
+                forrigeTilkjentYtelseMedAndeler = oppdatertTilkjentYtelseIFørsteBehandling
             )
 
         val utbetalingsoppdrag =
@@ -550,7 +550,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                     erSimulering = true
                 ),
                 AndelTilkjentYtelseForIverksetting.Factory,
-                forrigeTilkjentYtelse = oppdatertTilkjentYtelseIFørsteBehandling
+                forrigeTilkjentYtelseMedAndeler = oppdatertTilkjentYtelseIFørsteBehandling
             )
 
         val utbetalingsoppdrag =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -52,7 +52,7 @@ internal class UtbetalingsperiodeServiceTest {
     @BeforeEach
     fun beforeEach() {
         every { beregningService.hentTilkjentYtelseForBehandling(any()) } returns mockk()
-        every { behandlingService.hentSisteBehandlingSomErVedtatt(any()) } returns null
+        every { behandlingService.hentSisteBehandlingSomErIverksatt(any()) } returns null
         every {
             beregningService.hentSisteOffsetPerIdent(
                 any(),


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13867&referrer=slack

Vi får feil ved generering av utbetalingsoppdraget for behandlinger som tidligere bare har blitt avslått eller henlagt.
Dette oppstår fordi vi sjekker forrige behandling etter tilkjentytelse, og dermed forventer vi at andeler skal ha offset.
De har dermed ikke offset dersom de aldri ble iverksatt mot økonomi.

Vi ønsker derfor bare å sjekke forrige IVERKSATTE behandling,