### PR TITLE
Auditlogging: Logger PO-navn da det gir mer verdi for brukere enn kun applikasjonsnavn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/AuditLogger.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/AuditLogger.kt
@@ -57,7 +57,7 @@ class AuditLogger(@Value("\${NAIS_APP_NAME}") private val applicationName: Strin
     private fun createAuditLogString(data: Sporingsdata, request: HttpServletRequest): String {
         val timestamp = System.currentTimeMillis()
         val name = "Saksbehandling"
-        return "CEF:0|$applicationName|auditLog|1.0|audit:${data.event.type}|$name|INFO|end=$timestamp " +
+        return "CEF:0|Familie|$applicationName|auditLog|1.0|audit:${data.event.type}|$name|INFO|end=$timestamp " +
             "suid=${SikkerhetContext.hentSaksbehandler()} " +
             "duid=${data.personIdent} " +
             "sproc=${getCallId()} " +


### PR DESCRIPTION
Endringen er testet i preprod i familie-klage og merget: https://github.com/navikt/familie-klage/pull/336

Endringen er gjort på forespørsel fra Roger Dybdal: https://nav-it.slack.com/archives/CH4NLKAR0/p1689077799460959