### PR TITLE
Bugfix/resultat skal bli endret om beløp er endret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
@@ -121,8 +121,8 @@ object YtelsePersonUtils {
         }
 
         if (ytelsePersoner.any {
-                it.resultater.contains(OPPHØRT) && it.ytelseSlutt?.isAfter(inneværendeMåned()) == true
-            }
+            it.resultater.contains(OPPHØRT) && it.ytelseSlutt?.isAfter(inneværendeMåned()) == true
+        }
         ) {
             throw Feil(message = "Minst én ytelseperson har fått opphør som resultat og ytelseSlutt etter inneværende måned")
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
@@ -236,8 +236,7 @@ object YtelsePersonUtils {
                     perioderFjernet.any { it.verdi.kalkulertUtbetalingsbeløp > 0 }
 
                 when {
-                    erPeriodeMedEndretBeløp -> ENDRET_UTBETALING
-                    opphører -> IKKE_VURDERT
+                    opphører -> if (erPeriodeMedEndretBeløp) ENDRET_UTBETALING else IKKE_VURDERT
                     beløpRedusert || finnesReduksjonerTilbakeITidMedBeløp -> ENDRET_UTBETALING
                     finnesReduksjonerTilbakeITid -> ENDRET_UTEN_UTBETALING
                     else -> IKKE_VURDERT

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
@@ -38,7 +38,7 @@ object YtelsePersonUtils {
      */
     fun utledYtelsePersonerMedResultat(
         behandlingsresultatPersoner: List<BehandlingsresultatPerson>,
-        uregistrerteBarn: List<String> = emptyList()
+        uregistrerteBarn: List<String> = emptyList(),
     ): List<YtelsePerson> {
         val altOpphørt = behandlingsresultatPersoner.all { erYtelsenOpphørt(it.andeler) }
 
@@ -48,6 +48,11 @@ object YtelsePersonUtils {
 
             val tidslinjeForForrigeAndeler = forrigeAndeler.tilTidslinje()
             val tidslinjeForAndeler = andeler.tilTidslinje()
+
+            val erBeløpEndretTidslinje =
+                tidslinjeForAndeler.kombinerMed(tidslinjeForForrigeAndeler) { andel, andelForrigeBehandling ->
+                    andel != null && andelForrigeBehandling != null && andel.kalkulertUtbetalingsbeløp != andelForrigeBehandling.kalkulertUtbetalingsbeløp
+                }.tilPerioder().filtrerIkkeNull()
 
             val perioderLagtTil = tidslinjeForAndeler.kombinerMed(tidslinjeForForrigeAndeler) { verdi1, verdi2 ->
                 if (verdi2 == null) verdi1 else null
@@ -88,9 +93,10 @@ object YtelsePersonUtils {
 
             // 4. sjekk endring
             utledYtelsePersonResultatVedEndring(
-                behandlingsresultatPerson,
-                perioderLagtTil,
-                perioderFjernet
+                behandlingsresultatPerson = behandlingsresultatPerson,
+                perioderLagtTil = perioderLagtTil,
+                perioderFjernet = perioderFjernet,
+                erBeløpEndretTidslinje = erBeløpEndretTidslinje,
             ).let { if (it != IKKE_VURDERT) resultater.add(it) }
 
             ytelsePerson.copy(resultater = resultater, ytelseSlutt = ytelseSlutt)
@@ -100,7 +106,7 @@ object YtelsePersonUtils {
                 resultater = setOf(AVSLÅTT),
                 ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
                 ytelseSlutt = TIDENES_MORGEN.toYearMonth(),
-                kravOpprinnelse = listOf(KravOpprinnelse.INNEVÆRENDE)
+                kravOpprinnelse = listOf(KravOpprinnelse.INNEVÆRENDE),
             )
         }
     }
@@ -115,8 +121,8 @@ object YtelsePersonUtils {
         }
 
         if (ytelsePersoner.any {
-            it.resultater.contains(OPPHØRT) && it.ytelseSlutt?.isAfter(inneværendeMåned()) == true
-        }
+                it.resultater.contains(OPPHØRT) && it.ytelseSlutt?.isAfter(inneværendeMåned()) == true
+            }
         ) {
             throw Feil(message = "Minst én ytelseperson har fått opphør som resultat og ytelseSlutt etter inneværende måned")
         }
@@ -124,21 +130,22 @@ object YtelsePersonUtils {
 
     fun oppdaterYtelsePersonResultaterVedOpphør(ytelsePersoner: List<YtelsePerson>): Set<YtelsePersonResultat> {
         val resultater = ytelsePersoner.flatMap { it.resultater }.toMutableSet()
-        val erKunFremstilKravIDenneBehandling = ytelsePersoner.flatMap { it.kravOpprinnelse }.all { it == KravOpprinnelse.INNEVÆRENDE }
+        val erKunFremstilKravIDenneBehandling =
+            ytelsePersoner.flatMap { it.kravOpprinnelse }.all { it == KravOpprinnelse.INNEVÆRENDE }
 
         val kunFortsattOpphørt = resultater.all { it == FORTSATT_OPPHØRT }
         val erAvslått = resultater.all { it == AVSLÅTT }
 
-        val altOpphører = ytelsePersoner.all { it.ytelseSlutt != null && it.ytelseSlutt.erSammeEllerTidligere(inneværendeMåned()) }
+        val altOpphører =
+            ytelsePersoner.all { it.ytelseSlutt != null && it.ytelseSlutt.erSammeEllerTidligere(inneværendeMåned()) }
         val noeOpphørerPåTidligereBarn = ytelsePersoner.any {
             it.resultater.contains(OPPHØRT) && !it.kravOpprinnelse.contains(KravOpprinnelse.INNEVÆRENDE)
         }
         // alle barn har opphørt på samme dato, mao alle barn har samme ytelseSlutt og eller alle barn får avslått
-        val opphørPåSammeTid = altOpphører &&
-            (
-                ytelsePersoner.filter { it.resultater != setOf(AVSLÅTT) }
-                    .groupBy { it.ytelseSlutt }.size == 1 || erAvslått
-                )
+        val opphørPåSammeTid = altOpphører && (
+            ytelsePersoner.filter { it.resultater != setOf(AVSLÅTT) }
+                .groupBy { it.ytelseSlutt }.size == 1 || erAvslått
+            )
 
         // Hvis alt ikke er opphørt, kan ikke resultater ha Opphørt
         if (!altOpphører) resultater.remove(OPPHØRT)
@@ -157,35 +164,34 @@ object YtelsePersonUtils {
     private fun erYtelsenOpphørt(andeler: List<BehandlingsresultatAndelTilkjentYtelse>) =
         andeler.none { it.erLøpende(YearMonth.now()) }
 
-    private fun List<BehandlingsresultatAndelTilkjentYtelse>.tilTidslinje():
-        Tidslinje<BehandlingsresultatAndelTilkjentYtelse> = this.map {
-        Periode(
-            verdi = it,
-            fom = it.stønadFom.førsteDagIInneværendeMåned(),
-            tom = it.stønadTom.sisteDagIInneværendeMåned()
-        )
-    }.tilTidslinje()
+    private fun List<BehandlingsresultatAndelTilkjentYtelse>.tilTidslinje(): Tidslinje<BehandlingsresultatAndelTilkjentYtelse> =
+        this.map {
+            Periode(
+                verdi = it,
+                fom = it.stønadFom.førsteDagIInneværendeMåned(),
+                tom = it.stønadTom.sisteDagIInneværendeMåned(),
+            )
+        }.tilTidslinje()
 
     private fun avslagPåNyPerson(
         personSomSjekkes: YtelsePerson,
-        perioderLagtTil: List<Periode<BehandlingsresultatAndelTilkjentYtelse>>
-    ) = personSomSjekkes.kravOpprinnelse == listOf(KravOpprinnelse.INNEVÆRENDE) &&
-        perioderLagtTil.isEmpty()
+        perioderLagtTil: List<Periode<BehandlingsresultatAndelTilkjentYtelse>>,
+    ) = personSomSjekkes.kravOpprinnelse == listOf(KravOpprinnelse.INNEVÆRENDE) && perioderLagtTil.isEmpty()
 
     private fun finnesInnvilget(
         behandlingsresultatPerson: BehandlingsresultatPerson,
-        perioderLagtTil: List<Periode<BehandlingsresultatAndelTilkjentYtelse>>
-    ) = behandlingsresultatPerson.utledYtelsePerson().erFramstiltKravForIInneværendeBehandling() &&
-        (
-            perioderLagtTil.isNotEmpty() || andelerMedEndretBeløp(
-                behandlingsresultatPerson.forrigeAndeler,
-                behandlingsresultatPerson.andeler
-            ).any { it > 0 }
-            )
+        perioderLagtTil: List<Periode<BehandlingsresultatAndelTilkjentYtelse>>,
+    ) = behandlingsresultatPerson.utledYtelsePerson()
+        .erFramstiltKravForIInneværendeBehandling() && (
+        perioderLagtTil.isNotEmpty() || andelerMedEndretBeløp(
+            behandlingsresultatPerson.forrigeAndeler,
+            behandlingsresultatPerson.andeler,
+        ).any { it > 0 }
+        )
 
     private fun andelerMedEndretBeløp(
         forrigeAndeler: List<BehandlingsresultatAndelTilkjentYtelse>,
-        andeler: List<BehandlingsresultatAndelTilkjentYtelse>
+        andeler: List<BehandlingsresultatAndelTilkjentYtelse>,
     ): List<Int> = andeler.flatMap { andel ->
         val andelerFraForrigeBehandlingISammePeriode = forrigeAndeler.filter {
             it.periode.overlapperHeltEllerDelvisMed(andel.periode)
@@ -199,7 +205,8 @@ object YtelsePersonUtils {
     private fun utledYtelsePersonResultatVedEndring(
         behandlingsresultatPerson: BehandlingsresultatPerson,
         perioderLagtTil: List<Periode<BehandlingsresultatAndelTilkjentYtelse>>,
-        perioderFjernet: List<Periode<BehandlingsresultatAndelTilkjentYtelse>>
+        perioderFjernet: List<Periode<BehandlingsresultatAndelTilkjentYtelse>>,
+        erBeløpEndretTidslinje: List<Periode<Boolean>>,
     ): YtelsePersonResultat {
         val inneværendeMåned = YearMonth.now()
         val nesteMåned = inneværendeMåned.nesteMåned()
@@ -216,6 +223,8 @@ object YtelsePersonUtils {
 
         val opphører = stønadSlutt.isBefore(nesteMåned)
 
+        val erPeriodeMedEndretBeløp = erBeløpEndretTidslinje.any { it.verdi }
+
         return when {
             behandlingsresultatPerson.søktForPerson -> {
                 val beløpRedusert = (perioderLagtTil + perioderFjernet).isEmpty() &&
@@ -227,6 +236,7 @@ object YtelsePersonUtils {
                     perioderFjernet.any { it.verdi.kalkulertUtbetalingsbeløp > 0 }
 
                 when {
+                    erPeriodeMedEndretBeløp -> ENDRET_UTBETALING
                     opphører -> IKKE_VURDERT
                     beløpRedusert || finnesReduksjonerTilbakeITidMedBeløp -> ENDRET_UTBETALING
                     finnesReduksjonerTilbakeITid -> ENDRET_UTEN_UTBETALING
@@ -236,7 +246,7 @@ object YtelsePersonUtils {
             forrigeAndeler.isNotEmpty() -> {
                 val erAndelMedEndretBeløp = andelerMedEndretBeløp(
                     forrigeAndeler = behandlingsresultatPerson.forrigeAndeler,
-                    andeler = behandlingsresultatPerson.andeler
+                    andeler = behandlingsresultatPerson.andeler,
                 ).isNotEmpty()
 
                 val erPerioderLagtTil = erFramstiltKravForITidligereBehandling &&

--- a/src/test/resources/behandlingsresultat/RV_ENDRET_OPPHØRT_2.json
+++ b/src/test/resources/behandlingsresultat/RV_ENDRET_OPPHØRT_2.json
@@ -1,0 +1,28 @@
+{
+  "beskrivelse": "RV: SB har motatt nye opplysninger om ett barn. Vi opphører alle måneder utenom én som endres til 60% utelse.",
+  "personer": [
+    {
+      "aktør": {
+        "fødselsnummer": "20492159388",
+        "aktørId": "2045385506683"
+      },
+      "søktForPerson": true,
+      "eksplisittAvslått": false,
+      "forrigeAndeler": [
+        {
+          "stønadFom": "2022-10",
+          "stønadTom": "2023-08",
+          "kalkulertUtbetalingsbeløp": 7500
+        }
+      ],
+      "andeler": [
+        {
+          "stønadFom": "2022-10",
+          "stønadTom": "2022-10",
+          "kalkulertUtbetalingsbeløp": 4500
+        }
+      ]
+    }
+  ],
+  "forventetResultat": "ENDRET_OG_OPPHØRT"
+}


### PR DESCRIPTION
Favrokort: [NAV-13295](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13295)

Dersom kontantstøtten endrer seg en måned + opphører neste måned fikk den ikke med seg den endrede måneden på vedtakssiden. Denne PR'en fikser den bugen slik at perioden med endring også blir med. 

FØR:
![Screenshot 2023-07-20 at 14 35 58](https://github.com/navikt/familie-ks-sak/assets/8656966/13f25991-56d5-4ab4-804c-719519315ae8)


MED FIKS:
![Screenshot 2023-07-20 at 14 52 38](https://github.com/navikt/familie-ks-sak/assets/8656966/c9d1260f-7040-4363-b803-ad26fa317043)
