### PR TITLE
Split andeler basert på aktør før man sjekker på 11månedsvarighet på ks

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -34,14 +34,16 @@ object TilkjentYtelseValidator {
         val søker = personopplysningGrunnlag.søker
         val barna = personopplysningGrunnlag.barna
 
-        if (tilkjentYtelse.andelerTilkjentYtelse.isNotEmpty()) {
-            val stønadFom = tilkjentYtelse.andelerTilkjentYtelse.minOf { it.stønadFom }
-            val stønadTom = tilkjentYtelse.andelerTilkjentYtelse.maxOf { it.stønadTom }
+        val andelerPerAktør = tilkjentYtelse.andelerTilkjentYtelse.groupBy { it.aktør }
+
+        andelerPerAktør.filter { it.value.isNotEmpty() }.forEach { (aktør, andeler) ->
+            val stønadFom = andeler.minOf { it.stønadFom }
+            val stønadTom = andeler.maxOf { it.stønadTom }
 
             val diff = Period.between(stønadFom.toLocalDate(), stønadTom.toLocalDate())
             if (diff.toTotalMonths() > 11) {
                 val feilmelding =
-                    "Kontantstøtte kan maks utbetales for 11 måneder. Du er i ferd med å utbetale mer enn dette. " +
+                    "Kontantstøtte kan maks utbetales for 11 måneder. Du er i ferd med å utbetale mer enn dette for barn med fnr ${aktør.aktivFødselsnummer()}. " +
                         "Kontroller datoene på vilkårene eller ta kontakt med team familie"
                 throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
             }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14054

Eksisterende bug på andel valideringen.
Andel valideringen sjekker på total ATY om perioden er lengre enn 11 måneder, men det må grupperes basert på aktør først (da man kan ha flere barn, og da skal det være lov å ha utbetaling lengre enn 11 måneder)