### PR TITLE
Lagrer ned søknadsinfo ved journalføring for uthenting av digitaliseringsgrad mer enn 1 måned tilbake i tid

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingSøknadsinfo.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingSøknadsinfo.kt
@@ -1,0 +1,40 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import no.nav.familie.ks.sak.common.entitet.BaseEntitet
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.SequenceGenerator
+import javax.persistence.Table
+
+@Entity(name = "BehandlingSøknadsinfo")
+@Table(name = "BEHANDLING_SOKNADSINFO")
+data class BehandlingSøknadsinfo(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "behandling_søknadsinfo_seq_generator")
+    @SequenceGenerator(
+        name = "behandling_søknadsinfo_seq_generator",
+        sequenceName = "behandling_soknadsinfo_seq",
+        allocationSize = 50,
+    )
+    val id: Long = 0,
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "fk_behandling_id", nullable = false, updatable = false)
+    val behandling: Behandling,
+
+    @Column(name = "mottatt_dato")
+    val mottattDato: LocalDateTime,
+
+    @Column(name = "journalpost_id")
+    val journalpostId: String,
+
+    @Column(name = "er_digital")
+    val erDigital: Boolean,
+
+) : BaseEntitet()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingSøknadsinfoRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingSøknadsinfoRepository.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
+
+interface BehandlingSøknadsinfoRepository : JpaRepository<BehandlingSøknadsinfo, Long> {
+
+    @Query(
+        """
+            SELECT COUNT(*) AS totalt,
+                   SUM(CAST(er_digital AS INTEGER)) AS digitalt,
+                   SUM(CAST(NOT er_digital AS INTEGER)) AS papir
+            FROM (SELECT DISTINCT journalpost_id, er_digital
+                  FROM behandling_soknadsinfo
+                  WHERE mottatt_dato >= :fomDato
+                  AND mottatt_dato <= :tomDato
+                  ) AS bs
+    """,
+        nativeQuery = true,
+    )
+    fun hentAntallSøknaderIPeriode(fomDato: LocalDateTime, tomDato: LocalDateTime): AntallSøknader
+}
+
+interface AntallSøknader {
+
+    val totalt: Int
+    val digitalt: Int?
+    val papir: Int?
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingSøknadsinfoService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingSøknadsinfoService.kt
@@ -1,0 +1,48 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Service
+class BehandlingSøknadsinfoService(
+    private val behandlingSøknadsinfoRepository: BehandlingSøknadsinfoRepository,
+) {
+
+    @Transactional
+    fun lagreNedSøknadsinfo(søknadsinfo: Søknadsinfo, behandling: Behandling) {
+        val behandlingSøknadsinfo = BehandlingSøknadsinfo(
+            behandling = behandling,
+            mottattDato = søknadsinfo.mottattDato,
+            journalpostId = søknadsinfo.journalpostId,
+            erDigital = søknadsinfo.erDigital,
+        )
+        behandlingSøknadsinfoRepository.save(behandlingSøknadsinfo)
+    }
+
+    fun hentSøknadsstatistikk(fom: LocalDate, tom: LocalDate): SøknadsstatistikkForPeriode =
+        behandlingSøknadsinfoRepository.hentAntallSøknaderIPeriode(fom.atStartOfDay(), tom.atTime(LocalTime.MAX))
+            .let {
+                SøknadsstatistikkForPeriode(
+                    fom = fom,
+                    tom = tom,
+                    antallSøknader = it,
+                    digitaliseringsgrad = (it.digitalt ?: 0) / it.totalt.toFloat(),
+                )
+            }
+}
+
+class Søknadsinfo(
+    val journalpostId: String,
+    val mottattDato: LocalDateTime,
+    val erDigital: Boolean,
+)
+
+class SøknadsstatistikkForPeriode(
+    val fom: LocalDate,
+    val tom: LocalDate,
+    val antallSøknader: AntallSøknader,
+    val digitaliseringsgrad: Float,
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/internstatistikk/InternStatistikkController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/internstatistikk/InternStatistikkController.kt
@@ -1,0 +1,40 @@
+package no.nav.familie.ks.sak.statistikk.internstatistikk
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.ks.sak.common.util.RessursUtils
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.SøknadsstatistikkForPeriode
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/internstatistikk")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class InternStatistikkController(
+    private val behandlingSøknadsinfoService: BehandlingSøknadsinfoService,
+) {
+
+    @GetMapping(path = ["antallSoknader"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun hentSøknadsstatistikkForPeriode(
+        @RequestParam
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        fom: LocalDate?,
+        @RequestParam
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        tom: LocalDate?,
+    ): ResponseEntity<Ressurs<SøknadsstatistikkForPeriode>> {
+        val fomDato = fom ?: LocalDate.now().minusMonths(4).withDayOfMonth(1)
+        val tomDato = tom ?: fomDato.plusMonths(4).minusDays(1)
+
+        return RessursUtils.ok(behandlingSøknadsinfoService.hentSøknadsstatistikk(fomDato, tomDato))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/internstatistikk/InternStatistikkController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/internstatistikk/InternStatistikkController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.statistikk.internstatistikk
 
+import io.swagger.v3.oas.annotations.media.Schema
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.common.util.RessursUtils
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingSøknadsinfoService
@@ -25,9 +26,11 @@ class InternStatistikkController(
 
     @GetMapping(path = ["antallSoknader"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun hentSøknadsstatistikkForPeriode(
+        @Schema(description = "Default er første dag i forrige tertial-periode regnet fra dagens dato")
         @RequestParam
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         fom: LocalDate?,
+        @Schema(description = "Default er siste dag i tertial-perioden regnet fra fom-dato")
         @RequestParam
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         tom: LocalDate?,

--- a/src/main/resources/db/migration/V8__søknad_digitaliseringsgrad_data.sql
+++ b/src/main/resources/db/migration/V8__søknad_digitaliseringsgrad_data.sql
@@ -1,0 +1,5 @@
+ALTER TABLE behandling_soknadsinfo
+    ADD COLUMN IF NOT EXISTS er_digital BOOLEAN NOT NULL,
+    ADD COLUMN IF NOT EXISTS journalpost_id VARCHAR NOT NULL;
+
+CREATE INDEX journalpost_id_idx ON behandling_soknadsinfo (journalpost_id);


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-14320)
Lagrer ned søknadsinfo ved journalføring, relativt likt som i ba-sak. Blant annet kopiert og limt inn BehandlingSøknadsinfo-klassene, samt InternStatistikkController, men med noen tilpasninger for ks-sak. Trenger f.eks ikke legge til de nye kolonnene i behandling_soknadsinfo som optional, siden tabellen ikke er tatt i bruk før nå.