### PR TITLE
familie-ef-personhendelse trenger lesetilgang til teamfamilie.aapen-k…

### DIFF
--- a/.deploy/nais/kafka/dev/dvh_vedtak_topic.yaml
+++ b/.deploy/nais/kafka/dev/dvh_vedtak_topic.yaml
@@ -21,6 +21,9 @@ spec:
     - team: teamfamilie
       application: familie-ks-kafka-manager
       access: read
+    - team: teamfamilie
+      application: familie-ef-personhendelse
+      access: read
     - team: dv-familie
       application: dvh-fambt-konsumer
       access: read

--- a/.deploy/nais/kafka/prod/dvh_vedtak_topic.yaml
+++ b/.deploy/nais/kafka/prod/dvh_vedtak_topic.yaml
@@ -21,6 +21,9 @@ spec:
     - team: teamfamilie
       application: familie-ks-kafka-manager
       access: read
+    - team: teamfamilie
+      application: familie-ef-personhendelse
+      access: read
     - team: dv-familie
       application: dvh-fambt-konsumer
       access: read


### PR DESCRIPTION
…ontantstotte-vedtak-v1 for å kunne gjøre oppslag på personer som har fått innvilget kontantstøtte

Hvorfor trengs denne funksjonaliteten ? 

Enslig forsørger trenger å gjøre oppslag på personer som har fått innvilget kontantstøtte for å sjekke om de har løpende barnetilsyn (og i så fall opprette en oppgave). Tanken er derfor å lese fra topic for vedtak fra KS for å kunne gjøre dette. 

Favro : https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12382