### PR TITLE
Fiks på endretutbetaling bug der andelene erstatter hverandre

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -77,7 +77,7 @@ class BeregningService(
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
                 .filter {
                     when {
-                        endretUtbetalingAndel != null -> it.id == endretUtbetalingAndel.id
+                        endretUtbetalingAndel != null -> it.id == endretUtbetalingAndel.id || it.andelerTilkjentYtelse.isNotEmpty()
                         else -> it.andelerTilkjentYtelse.isNotEmpty()
                     }
                 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15127

Fikser at nye endretutbetalingandeler erstatter gamle, dersom det fantes andeler på den gamle endret perioden