### PR TITLE
Bytter til nais/docker-build-push

### DIFF
--- a/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
@@ -25,9 +25,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build
 
-      - name: Bygg Docker image
-        run: |
-          docker build -t $IMAGE .
+      - name: Generate and output SBOM
+        run: ./gradlew cyclonedxBom
 
       - uses: nais/docker-build-push@v0
         id: docker-push
@@ -37,6 +36,7 @@ jobs:
           push_image: true
           dockerfile: Dockerfile
           docker_context: .
+          byosbom: build/reports/bom.json
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
     outputs:

--- a/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
@@ -8,7 +8,8 @@ jobs:
     name: Bygg app/image, push til github
     runs-on: ubuntu-latest-8-cores
     permissions:
-      packages: write
+      contents: read
+      id-token: write
     steps:
       - uses: "actions/checkout@v3"
       - uses: "gradle/wrapper-validation-action@v1"
@@ -28,35 +29,18 @@ jobs:
         run: |
           docker build -t $IMAGE .
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+      - uses: nais/docker-build-push@v0
+        id: docker-push
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push Docker image med versjonstag
-        run: docker push ${IMAGE}
-      - name: Skriv ut docker-taggen
-        run: echo 'Docker-tag er ${{ github.sha }} ' >> $GITHUB_STEP_SUMMARY
-
-  lag-salsa-proveniens:
-    name: Lag salsa proveniens
-    needs: bygg-og-push-til-github
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.SALSA_CREDENTIALS }}
-
-      - name: Provenance, upload and sign attestation
-        uses: nais/salsa@v0.12
-        with:
-          key: ${{ secrets.SALSA_KMS_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          team: teamfamilie
+          tag: latest
+          push_image: true
+          dockerfile: Dockerfile
+          docker_context: .
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+    outputs:
+      image: ${{ steps.docker-push.outputs.image }}
 
   deploy-til-prod:
     name: Deploy til prod-gcp
@@ -69,3 +53,4 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
+          IMAGE: ${{ needs.bygg-og-push-til-github.outputs.image }}

--- a/.github/workflows/build-and-deploy-preprod-prod.yml
+++ b/.github/workflows/build-and-deploy-preprod-prod.yml
@@ -11,7 +11,8 @@ jobs:
     name: Bygg app/image, push til github
     runs-on: ubuntu-latest-8-cores
     permissions:
-      packages: write
+      contents: read
+      id-token: write
     steps:
       - uses: "actions/checkout@v3"
       - uses: "gradle/wrapper-validation-action@v1"
@@ -27,39 +28,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build
 
-      - name: Bygg Docker image
-        run: |
-          docker build -t $IMAGE .
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+      - uses: nais/docker-build-push@v0
+        id: docker-push
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push Docker image med versjonstag
-        run: docker push ${IMAGE}
-      - name: Skriv ut docker-taggen
-        run: echo 'Docker-tag er ${{ github.sha }} ' >> $GITHUB_STEP_SUMMARY
-
-  lag-salsa-proveniens:
-    name: Lag salsa proveniens
-    needs: bygg-og-push-til-github
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.SALSA_CREDENTIALS }}
-
-      - name: Provenance, upload and sign attestation
-        uses: nais/salsa@v0.12
-        with:
-          key: ${{ secrets.SALSA_KMS_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          team: teamfamilie
+          tag: latest
+          push_image: true
+          dockerfile: Dockerfile
+          docker_context: .
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+    outputs:
+      image: ${{ steps.docker-push.outputs.image }}
 
   deploy-til-preprod:
     name: Deploy to dev-gcp
@@ -72,10 +52,11 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
+          IMAGE: ${{ needs.bygg-og-push-til-github.outputs.image }}
 
   deploy-til-prod:
     name: Deploy til prod-gcp
-    needs: deploy-til-preprod
+    needs: [ deploy-til-preprod, bygg-og-push-til-github ]
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
@@ -84,3 +65,4 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .deploy/nais/app-prod.yaml
+          IMAGE: ${{ needs.bygg-og-push-til-github.outputs.image }}

--- a/.github/workflows/build-and-deploy-preprod-prod.yml
+++ b/.github/workflows/build-and-deploy-preprod-prod.yml
@@ -28,6 +28,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build
 
+      - name: Generate and output SBOM
+        run: ./gradlew cyclonedxBom
+
       - uses: nais/docker-build-push@v0
         id: docker-push
         with:
@@ -36,6 +39,7 @@ jobs:
           push_image: true
           dockerfile: Dockerfile
           docker_context: .
+          byosbom: build/reports/bom.json
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
     outputs:
@@ -56,7 +60,7 @@ jobs:
 
   deploy-til-prod:
     name: Deploy til prod-gcp
-    needs: [ deploy-til-preprod, bygg-og-push-til-github ]
+    needs: bygg-og-push-til-github
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -31,12 +31,13 @@ jobs:
         id: docker-push
         with:
           team: teamfamilie
-          tag: latest
           push_image: true
           dockerfile: Dockerfile
           docker_context: .
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+    outputs:
+      image: ${{ steps.docker-push.outputs.image }}
 
   deploy-til-preprod:
     name: Deploy to dev-gcp
@@ -49,4 +50,4 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          IMAGE: ${{ steps.docker-push.outputs.image }}
+          IMAGE: ${{ needs.bygg-og-push-til-github.outputs.image }}

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -49,4 +49,4 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
-          IMAGE: ${{ steps.docker-push.outputs.image }}ß
+          IMAGE: ${{ steps.docker-push.outputs.image }}

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -10,7 +10,8 @@ jobs:
     name: Bygg app/image, push til github
     runs-on: ubuntu-latest-8-cores
     permissions:
-      packages: write
+      contents: read
+      id-token: write
     steps:
       - uses: "actions/checkout@v3"
       - uses: "gradle/wrapper-validation-action@v1"

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -27,6 +27,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build
 
+      - name: Generate and output SBOM
+        run: ./gradlew cyclonedxBom
+
       - uses: nais/docker-build-push@v0
         id: docker-push
         with:
@@ -34,6 +37,7 @@ jobs:
           push_image: true
           dockerfile: Dockerfile
           docker_context: .
+          byosbom: build/reports/bom.json
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
     outputs:

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -26,40 +26,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build
 
-      - name: Bygg Docker image
-        run: |
-          docker build -t $IMAGE .
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+      - uses: nais/docker-build-push@v0
+        id: docker-push
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: ${{ env.IMAGE }}
-
-  lag-salsa-proveniens:
-    name: Lag salsa proveniens
-    needs: bygg-og-push-til-github
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.SALSA_CREDENTIALS }}
-
-      - name: Provenance, upload and sign attestation
-        uses: nais/salsa@v0.12
-        with:
-          key: ${{ secrets.SALSA_KMS_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          team: teamfamilie
+          tag: latest
+          push_image: true
+          dockerfile: Dockerfile
+          docker_context: .
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 
   deploy-til-preprod:
     name: Deploy to dev-gcp
@@ -72,3 +48,4 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .deploy/nais/app-preprod.yaml
+          IMAGE: ${{ steps.docker-push.outputs.image }}ß

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,9 @@ dependencies {
     implementation("no.nav.familie:prosessering-core:$prosesseringVersion")
     implementation("nav-foedselsnummer:core:$navFoedselsnummerVersion")
 
+    // ------------- SLSA -------------- //
+    implementation("org.cyclonedx.bom:1.7.4")
+    
     implementation("com.papertrailapp:logback-syslog4j:1.0.0")
     implementation("io.getunleash:unleash-client-java:6.1.0")
     implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,9 @@ plugins {
     id("org.jetbrains.kotlin.plugin.allopen") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.noarg") version kotlinVersion
     id("com.github.davidmc24.gradle.plugin.avro") version "1.5.0"
+
+    // ------------- SLSA -------------- //
+    id("org.cyclonedx.bom") version "1.7.4"
 }
 
 group = "no.nav"
@@ -97,9 +100,6 @@ dependencies {
     implementation("no.nav.familie:prosessering-core:$prosesseringVersion")
     implementation("nav-foedselsnummer:core:$navFoedselsnummerVersion")
 
-    // ------------- SLSA -------------- //
-    implementation("org.cyclonedx.bom:1.7.4")
-    
     implementation("com.papertrailapp:logback-syslog4j:1.0.0")
     implementation("io.getunleash:unleash-client-java:6.1.0")
     implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")


### PR DESCRIPTION
Salsa `SLSA` oppsettet sluttet å fungere samtidig som vi fikk issues med bygg relatert til endringer av permissions. Har her som i `familie-ba-sak` endret workflows til å bruke `nais/docker-build-push` for å bygge og deploye docker-imaget. I denne jobben får vi også `SLSA` ut av boksen slik at vi ikke trenger en egen jobb for dette.

Docker imagene blir nå også pushet til `GAR` fremfor `GHCR`. Vi kan altså ikke lenger "browse" tidligere images inne i GitHub, men må istedenfor gå til: [https://console.cloud.google.com/artifacts/docker/nais-management-233d/europe-north1/teamfamilie/familie-ks-sak/](https://console.cloud.google.com/artifacts/docker/nais-management-233d/europe-north1/teamfamilie/familie-ks-sak/)