### PR TITLE
Encode url før vi benytter oss av det grunnet KONTANTSTØTTE enum i url

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilbakekreving/TilbakekrevingKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilbakekreving/TilbakekrevingKlient.kt
@@ -111,8 +111,6 @@ class TilbakekrevingKlient(
     }
 }
 
-fun encodePath(path: String): String {
-    return UriUtils.encodePath(path, "UTF-8")
-}
+fun encodePath(path: String) = UriUtils.encodePath(path, "UTF-8")
 
 data class FinnesTilbakekrevingBehandlingsresponsDto(val finnesÅpenBehandling: Boolean)

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilbakekreving/TilbakekrevingKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilbakekreving/TilbakekrevingKlient.kt
@@ -17,6 +17,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
+import org.springframework.web.util.UriUtils
 import java.net.URI
 
 @Service
@@ -79,7 +80,7 @@ class TilbakekrevingKlient(
 
     fun kanTilbakekrevingsbehandlingOpprettesManuelt(fagsakId: Long): KanBehandlingOpprettesManueltRespons {
         val uri = URI.create(
-            "$familieTilbakeUri/ytelsestype/${Ytelsestype.KONTANTSTØTTE}/fagsak/$fagsakId/kanBehandlingOpprettesManuelt/v1",
+            encodePath("$familieTilbakeUri/ytelsestype/${Ytelsestype.KONTANTSTØTTE}/fagsak/$fagsakId/kanBehandlingOpprettesManuelt/v1"),
         )
 
         return kallEksternTjenesteRessurs(
@@ -100,7 +101,7 @@ class TilbakekrevingKlient(
     }
 
     fun hentTilbakekrevingsvedtak(fagsakId: Long): List<FagsystemVedtak> {
-        val uri = URI.create("$familieTilbakeUri/fagsystem/${Fagsystem.KONT}/fagsak/$fagsakId/vedtak/v1")
+        val uri = URI.create(encodePath("$familieTilbakeUri/fagsystem/${Fagsystem.KONT}/fagsak/$fagsakId/vedtak/v1"))
 
         return kallEksternTjenesteRessurs(
             tjeneste = "familie-tilbake",
@@ -108,6 +109,10 @@ class TilbakekrevingKlient(
             formål = "Henter tilbakekrevingsvedtak på fagsak",
         ) { getForEntity(uri) }
     }
+}
+
+fun encodePath(path: String): String {
+    return UriUtils.encodePath(path, "UTF-8")
 }
 
 data class FinnesTilbakekrevingBehandlingsresponsDto(val finnesÅpenBehandling: Boolean)


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15508

Vi får bad request hvis vi ikke enkoderer URL riktig.
Det feiler per i dag pga KONTANTSTØTTE i urln uten utf8 encoding.