### PR TITLE
Tillat at tilbakreving kan returnere null som i ba-sak

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 
     val springdocVersion = "2.2.0"
     val sentryVersion = "6.8.0"
-    val navFellesVersion = "2.20230825095715_3bcaf53"
+    val navFellesVersion = "2.20230928165350_3e5b5e9"
     val eksterneKontrakterBisysVersion = "2.0_20220609214258_f30c3ce"
     val fellesKontrakterVersion = "3.0_20230605154245_3d182db"
     val familieKontrakterSaksstatistikkVersion = "2.0_20220216121145_5a268ac"

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/FagsystemsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/FagsystemsbehandlingService.kt
@@ -50,7 +50,7 @@ class FagsystemsbehandlingService(
         val faktainfo = Faktainfo(
             revurderingsårsak = behandling.opprettetÅrsak.visningsnavn,
             revurderingsresultat = behandling.resultat.displayName,
-            tilbakekrevingsvalg = tilbakekrevingsbehandlingHentService.hentTilbakekreving(behandlingId).valg,
+            tilbakekrevingsvalg = tilbakekrevingsbehandlingHentService.hentTilbakekreving(behandlingId)?.valg,
         )
 
         val hentFagsystemsbehandling = HentFagsystemsbehandling(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
@@ -41,7 +41,7 @@ class HentFagsystemsbehandlingRequestConsumer(private val fagsystemsbehandlingSe
                 } catch (e: Exception) {
                     logger.warn(
                         "Noe gikk galt mens sender HentFagsystemsbehandlingRespons for behandling=${request.eksternId}. " +
-                                "Feiler med ${e.message}",
+                            "Feiler med ${e.message}",
                     )
                     HentFagsystemsbehandlingRespons(feilMelding = e.message)
                 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/HentFagsystemsbehandlingRequestConsumer.kt
@@ -5,10 +5,9 @@ import no.nav.familie.kontrakter.felles.tilbakekreving.HentFagsystemsbehandlingR
 import no.nav.familie.kontrakter.felles.tilbakekreving.HentFagsystemsbehandlingRespons
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import no.nav.familie.ks.sak.config.KafkaConfig
-import no.nav.familie.log.mdc.MDCConstants
+import no.nav.familie.log.mdc.kjørMedCallId
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import org.springframework.context.annotation.Profile
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
@@ -50,21 +49,6 @@ class HentFagsystemsbehandlingRequestConsumer(private val fagsystemsbehandlingSe
             }
 
             ack.acknowledge()
-        }
-    }
-}
-
-fun <T> kjørMedCallId(callId: String, body: () -> T): T {
-    val originalCallId = MDC.get(MDCConstants.MDC_CALL_ID) ?: null
-
-    return try {
-        MDC.put(MDCConstants.MDC_CALL_ID, callId)
-        body()
-    } finally {
-        if (originalCallId == null) {
-            MDC.remove(MDCConstants.MDC_CALL_ID)
-        } else {
-            MDC.put(MDCConstants.MDC_CALL_ID, originalCallId)
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingsbehandlingHentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingsbehandlingHentService.kt
@@ -15,5 +15,4 @@ class TilbakekrevingsbehandlingHentService(
     fun hentTilbakekrevingsbehandlinger(fagsakId: Long) = tilbakekrevingKlient.hentTilbakekrevingsbehandlinger(fagsakId)
 
     fun hentTilbakekreving(behandlingId: Long) = tilbakekrevingRepository.findByBehandlingId(behandlingId)
-        ?: throw Feil("Finnes ikke tilbakekreving for behandling $behandlingId")
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingsbehandlingHentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingsbehandlingHentService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.tilbakekreving
 
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.TilbakekrevingRepository
 import org.springframework.stereotype.Service


### PR DESCRIPTION
Vi har en feil i tilbake for KS, hvor man får feil:

Finnes ikke tilbakreving for behandling 1021757

Dette fordi tilbakekreving kan være tom, for hvis det ikke ble opprettet tilbakekreving ved behandlingen, så tar det 8 uker før tilbake får kravgrunnlag og plukker opp jobbewn


https://nav-it.slack.com/archives/C01G9BA8JKZ/p1695889651012189