### PR TITLE
feature/NAV 16945 bosatt i riket ny verdi

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/BisysConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/BisysConfig.kt
@@ -24,8 +24,13 @@ class BisysConfig(
                 response: HttpServletResponse,
                 filterChain: FilterChain,
             ) {
-                val clientNavn = oidcUtil.getClaim("azp_name")
-                val erKallerBisys = clientNavn.contains("bidrag")
+                val clientNavn: String? =
+                    try {
+                        oidcUtil.getClaim("azp_name")
+                    } catch (throwable: Throwable) {
+                        null
+                    }
+                val erKallerBisys = clientNavn?.contains("bidrag") ?: false
                 val harForvalterRolle = SikkerhetContext.harInnloggetBrukerForvalterRolle(rolleConfig)
                 val erBisysRequest = request.requestURI.startsWith("/api/bisys")
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/UtdypendeVilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/UtdypendeVilkårsvurdering.kt
@@ -24,6 +24,7 @@ enum class UtdypendeVilkårsvurdering {
     BARN_BOR_I_STORBRITANNIA_MED_SØKER, // Bor med søker vilkår
     BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER, // Bor med søker vilkår
     BARN_BOR_ALENE_I_ANNET_EØS_LAND, // Bor med søker vilkår
+    ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING,
 }
 
 @Converter

--- a/src/test/integrasjonstester/kotlin/DevLauncherPostgresPreprod.kt
+++ b/src/test/integrasjonstester/kotlin/DevLauncherPostgresPreprod.kt
@@ -37,6 +37,7 @@ private fun settClientIdOgSecret() {
     }
 
     val inputStream = BufferedReader(InputStreamReader(process.inputStream))
+    inputStream.readLine() // "Switched to context dev-gcp"
     val clientIdOgSecret = inputStream.readLine().split(";")
     inputStream.close()
 


### PR DESCRIPTION
- Fikser postgres-preprod launcher til å hente ut clientid/clientsecret
- BisysConfig skal ikke kaste feil hvis azp_name mangler i token
- Lagt til ny enum ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING for utdypende vilkårsvurdering

Frontend PR: https://github.com/navikt/familie-ks-sak-frontend/pull/343
