### PR TITLE
NAV-17087 - Fiks for å komme videre med uregistrerte barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -68,7 +68,7 @@ class PersonopplysningGrunnlagService(
                 ?: throw Feil("Det finnes ikke noe aktivt personopplysningsgrunnlag for ${behandling.id}")
 
         val valgteBarnAktører =
-            søknadDto.barnaMedOpplysninger.filter { it.inkludertISøknaden }
+            søknadDto.barnaMedOpplysninger.filter { it.inkludertISøknaden && it.erFolkeregistrert }
                 .map { personidentService.hentOgLagreAktør(it.ident, true) }
 
         val barnAktører =


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17087
Fiks for å komme videre fra "Registrer søknad" for uregistrerte barn - ved å filtrere vekk barn dersom de ikke "erFolkeregistrert". 

**OBS!** Feiler i neste steg i no/nav/familie/ks/sak/kjerne/brev/begrunnelser/Begrunnelse.kt da "Collection contains no element matching the predicate": `avslagUregistrertBarn`
Sannsynligvis noe som mangler i Sanity for ks-sak
Anna er informert via Favro-kort-kommentar.
