### PR TITLE
Gjør ident privat og bruk personnummer som er null om ident er tom streng

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ eller kan settes til en gradle.properties i ~/.gradle/
 Deretter så kan denne kommandoen kjøres for å bygge
 
 ```
-./gradlew clean build 
+./gradlew build -x test -x integrationTest -x ktlintCheck
 ```
 
 ## Kjøring lokalt

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
@@ -44,12 +44,14 @@ data class SøkerMedOpplysningerDto(
 )
 
 data class BarnMedOpplysningerDto(
-    val ident: String,
+    private val ident: String,
     val navn: String = "",
     val fødselsdato: LocalDate? = null,
     val inkludertISøknaden: Boolean = true,
     val erFolkeregistrert: Boolean = true,
-) : BehandlingStegDto()
+) : BehandlingStegDto() {
+    val personnummer: String? = if (ident == "") null else ident
+}
 
 data class BehandlingPåVentDto(val frist: LocalDate, val årsak: VenteÅrsak)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/infotrygd/InfotrygdReplikaClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/infotrygd/InfotrygdReplikaClient.kt
@@ -75,7 +75,7 @@ class InfotrygdReplikaClient(
     }
 
     fun List<BarnMedOpplysningerDto>.tilInnsynsRequest(): InnsynRequest {
-        return InnsynRequest(barn = this.map { it.ident })
+        return InnsynRequest(barn = this.mapNotNull { it.personnummer })
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -59,7 +59,7 @@ class BehandlingsresultatService(
             YtelsePersonUtils.utledYtelsePersonerMedResultat(
                 behandlingsresultatPersoner = behandlingsresultatPersoner,
                 uregistrerteBarn =
-                    søknadGrunnlagService.finnAktiv(behandling.id)?.hentUregistrerteBarn()?.mapNotNull { it.personnummer }
+                    søknadGrunnlagService.finnAktiv(behandling.id)?.hentUregistrerteBarn()?.map { it.personnummer }
                         ?: emptyList(),
             )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -59,7 +59,7 @@ class BehandlingsresultatService(
             YtelsePersonUtils.utledYtelsePersonerMedResultat(
                 behandlingsresultatPersoner = behandlingsresultatPersoner,
                 uregistrerteBarn =
-                    søknadGrunnlagService.finnAktiv(behandling.id)?.hentUregistrerteBarn()?.map { it.ident }
+                    søknadGrunnlagService.finnAktiv(behandling.id)?.hentUregistrerteBarn()?.mapNotNull { it.personnummer }
                         ?: emptyList(),
             )
 
@@ -123,7 +123,8 @@ class BehandlingsresultatService(
             if (behandling.erSøknad()) {
                 søknadGrunnlagService.hentAktiv(behandling.id).tilSøknadDto()
                     .barnaMedOpplysninger.filter { it.inkludertISøknaden && it.erFolkeregistrert }
-                    .map { personidentService.hentAktør(it.ident) }
+                    .mapNotNull { it.personnummer }
+                    .map { personidentService.hentAktør(it) }
             } else {
                 emptyList()
             }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtils.kt
@@ -37,7 +37,7 @@ object YtelsePersonUtils {
      */
     fun utledYtelsePersonerMedResultat(
         behandlingsresultatPersoner: List<BehandlingsresultatPerson>,
-        uregistrerteBarn: List<String> = emptyList(),
+        uregistrerteBarn: List<String?>,
     ): List<YtelsePerson> {
         val altOpphørt = behandlingsresultatPersoner.all { erYtelsenOpphørt(it.andeler) }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/RegistrereSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/RegistrereSøknadSteg.kt
@@ -102,13 +102,13 @@ class RegistrereSøknadSteg(
     private fun validerAtIngenBarnFremstiltKravForFyller1ÅrSenereEnnInneværendeMåned(barnaMedOpplysninger: List<BarnMedOpplysningerDto>) {
         val sisteDagIInneværendeMåned = YearMonth.now().sisteDagIInneværendeMåned()
         barnaMedOpplysninger.filter { it.inkludertISøknaden }.forEach { barn ->
-            val barnFødselsdato = barn.fødselsdato ?: throw Feil("Fant ikke fødselsdato på barn ${barn.ident}.")
+            val barnFødselsdato = barn.fødselsdato ?: throw Feil("Fant ikke fødselsdato på barn ${barn.personnummer ?: "uten ident"}.")
             val datoBarnFyller1År = barnFødselsdato.plusYears(1)
 
             if (datoBarnFyller1År > sisteDagIInneværendeMåned) {
                 throw Feil(
                     message = "Det er ikke mulig å behandle barn som fyller 1 år senere enn inneværende måned.",
-                    frontendFeilmelding = "Det er søkt for tidlig for barn ${barn.ident}. Søknaden kan tidligst behandles ${datoBarnFyller1År.tilMånedÅr()}.",
+                    frontendFeilmelding = "Det er søkt for tidlig for barn ${barn.personnummer ?: "uten ident"}. Søknaden kan tidligst behandles ${datoBarnFyller1År.tilMånedÅr()}.",
                 )
             }
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -69,7 +69,8 @@ class PersonopplysningGrunnlagService(
 
         val valgteBarnAktører =
             søknadDto.barnaMedOpplysninger.filter { it.inkludertISøknaden && it.erFolkeregistrert }
-                .map { personidentService.hentOgLagreAktør(it.ident, true) }
+                .mapNotNull { it.personnummer }
+                .map { personidentService.hentOgLagreAktør(it, true) }
 
         val barnAktører =
             when {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
@@ -114,7 +114,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
         val lagretSøknad = søknadGrunnlag.tilSøknadDto()
         assertTrue(
             lagretSøknad.barnaMedOpplysninger.all {
-                it.ident in
+                it.personnummer in
                     listOf(
                         barn1.aktivFødselsnummer(),
                         barn2.aktivFødselsnummer(),


### PR DESCRIPTION
Vi har hatt noen feil der vi forventer at barna i behandlingen alltid har er personnummer. Dette stemmer ikke for barna som ikke er folkeregistrert. 

Gjør så personnummer er null dersom vi får en tom string fra frontend slik at vi får mer typesikring på parameteren. 