### PR TITLE
Kopier EØS-skjema ved revurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
+import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
+import no.nav.familie.ks.sak.kjerne.eøs.EøsSkjemaerForNyBehandlingService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -17,6 +19,7 @@ class RegistrerPersonGrunnlagSteg(
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
+    private val eøsSkjemaerForNyBehandlingService: EøsSkjemaerForNyBehandlingService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.REGISTRERE_PERSONGRUNNLAG
 
@@ -37,6 +40,11 @@ class RegistrerPersonGrunnlagSteg(
             endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
                 behandling,
                 sisteVedtattBehandling,
+            )
+
+            eøsSkjemaerForNyBehandlingService.kopierEøsSkjemaer(
+                forrigeBehandlingSomErVedtattId = BehandlingId(sisteVedtattBehandling.id),
+                behandlingId = BehandlingId(behandling.id),
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/EøsSkjemaerForNyBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/EøsSkjemaerForNyBehandlingService.kt
@@ -1,0 +1,32 @@
+package no.nav.familie.ks.sak.kjerne.eøs
+
+import no.nav.familie.ks.sak.common.BehandlingId
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
+import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
+import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.ValutakursService
+import org.springframework.stereotype.Service
+
+@Service
+class EøsSkjemaerForNyBehandlingService(
+    private val kompetanseService: KompetanseService,
+    private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService,
+    private val valutakursService: ValutakursService,
+) {
+    fun kopierEøsSkjemaer(
+        behandlingId: BehandlingId,
+        forrigeBehandlingSomErVedtattId: BehandlingId,
+    ) {
+        kompetanseService.kopierOgErstattKompetanser(
+            fraBehandlingId = forrigeBehandlingSomErVedtattId,
+            tilBehandlingId = behandlingId,
+        )
+        utenlandskPeriodebeløpService.kopierOgErstattUtenlandskPeriodebeløp(
+            fraBehandlingId = forrigeBehandlingSomErVedtattId,
+            tilBehandlingId = behandlingId,
+        )
+        valutakursService.kopierOgErstattValutakurser(
+            fraBehandlingId = forrigeBehandlingSomErVedtattId,
+            tilBehandlingId = behandlingId,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/felles/EøsSkjemaService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/felles/EøsSkjemaService.kt
@@ -47,6 +47,20 @@ class EøsSkjemaService<T : EøsSkjemaEntitet<T>>(
         lagreDifferanseOgVarsleAbonnenter(behandlingId, eksisterendeSkjemaer, oppdaterteKompetanser)
     }
 
+    fun kopierOgErstattSkjemaer(
+        fraBehandlingId: BehandlingId,
+        tilBehandlingId: BehandlingId,
+    ) {
+        val gjeldendeTilSkjemaer = hentMedBehandlingId(tilBehandlingId)
+        val kopiAvFraSkjemaer =
+            hentMedBehandlingId(fraBehandlingId)
+                .map { it.kopier() }
+                .medBehandlingId(tilBehandlingId)
+
+        skjemaRepository.deleteAll(gjeldendeTilSkjemaer)
+        skjemaRepository.saveAll(kopiAvFraSkjemaer)
+    }
+
     fun lagreDifferanseOgVarsleAbonnenter(
         behandlingId: BehandlingId,
         eksisterende: List<T>,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -80,6 +80,13 @@ class KompetanseService(
     @Transactional
     fun slettKompetanse(kompetanseId: Long) = kompetanseSkjemaService.slettSkjema(kompetanseId)
 
+    @Transactional
+    fun kopierOgErstattKompetanser(
+        fraBehandlingId: BehandlingId,
+        tilBehandlingId: BehandlingId,
+    ) =
+        kompetanseSkjemaService.kopierOgErstattSkjemaer(fraBehandlingId, tilBehandlingId)
+
     private fun tilpassKompetanserTilRegelverk(
         eksisterendeKompetanser: Collection<Kompetanse>,
         barnaRegelverkTidslinjer: Map<Aktør, Tidslinje<RegelverkResultat>>,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
 import no.nav.familie.ks.sak.kjerne.eøs.felles.endringsabonnent.EøsSkjemaEndringAbonnent
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UtenlandskPeriodebeløpService(
@@ -33,10 +34,10 @@ class UtenlandskPeriodebeløpService(
     ) =
         skjemaService.slettSkjema(utenlandskPeriodebeløpId)
 
-//    @Transactional
-//    fun kopierOgErstattUtenlandskPeriodebeløp(
-//        fraBehandlingId: Long,
-//        tilBehandlingId: Long,
-//    ) =
-//        skjemaService.kopierOgErstattSkjemaer(fraBehandlingId, tilBehandlingId)
+    @Transactional
+    fun kopierOgErstattUtenlandskPeriodebeløp(
+        fraBehandlingId: BehandlingId,
+        tilBehandlingId: BehandlingId,
+    ) =
+        skjemaService.kopierOgErstattSkjemaer(fraBehandlingId, tilBehandlingId)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursService.kt
@@ -34,4 +34,10 @@ class ValutakursService(
         valutakursId: Long,
     ) =
         skjemaService.slettSkjema(valutakursId)
+
+    fun kopierOgErstattValutakurser(
+        fraBehandlingId: BehandlingId,
+        tilBehandlingId: BehandlingId,
+    ) =
+        skjemaService.kopierOgErstattSkjemaer(fraBehandlingId, tilBehandlingId)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
 import no.nav.familie.ks.sak.kjerne.eøs.felles.endringsabonnent.EøsSkjemaEndringAbonnent
 import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.domene.Valutakurs
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ValutakursService(
@@ -35,6 +36,7 @@ class ValutakursService(
     ) =
         skjemaService.slettSkjema(valutakursId)
 
+    @Transactional
     fun kopierOgErstattValutakurser(
         fraBehandlingId: BehandlingId,
         tilBehandlingId: BehandlingId,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersongrunnlagEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersongrunnlagEnhetTest.kt
@@ -1,0 +1,94 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ks.sak.common.BehandlingId
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
+import no.nav.familie.ks.sak.kjerne.eøs.EøsSkjemaerForNyBehandlingService
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
+import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
+import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.ValutakursService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import org.junit.jupiter.api.Test
+
+class RegistrerPersongrunnlagEnhetTest {
+    private val behandlingRepository: BehandlingRepository = mockk()
+    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk(relaxed = true)
+    private val vilkårsvurderingService: VilkårsvurderingService = mockk(relaxed = true)
+    private val endretUtbetalingAndelService: EndretUtbetalingAndelService = mockk(relaxed = true)
+    private val kompetanseService: KompetanseService = mockk(relaxed = true)
+    private val valutakursService: ValutakursService = mockk(relaxed = true)
+    private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService = mockk(relaxed = true)
+
+    private val registrerPersongrunnlagSteg =
+        RegistrerPersonGrunnlagSteg(
+            behandlingRepository = behandlingRepository,
+            vilkårsvurderingService = vilkårsvurderingService,
+            personopplysningGrunnlagService = personopplysningGrunnlagService,
+            endretUtbetalingAndelService = endretUtbetalingAndelService,
+            eøsSkjemaerForNyBehandlingService =
+                EøsSkjemaerForNyBehandlingService(
+                    kompetanseService = kompetanseService,
+                    utenlandskPeriodebeløpService = utenlandskPeriodebeløpService,
+                    valutakursService = valutakursService,
+                ),
+        )
+
+    @Test
+    fun `Kopierer kompetanser, valutakurser og utenlandsk periodebeløp til ny behandling`() {
+        val sisteVedtatteBehandling = lagBehandling()
+        val behandling2 = lagBehandling()
+
+        every { behandlingRepository.hentBehandling(behandling2.id) } returns behandling2
+        every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling.copy(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET))
+
+        registrerPersongrunnlagSteg.utførSteg(behandlingId = behandling2.id)
+
+        verify(exactly = 1) {
+            kompetanseService.kopierOgErstattKompetanser(
+                BehandlingId(sisteVedtatteBehandling.id),
+                BehandlingId(behandling2.id),
+            )
+            valutakursService.kopierOgErstattValutakurser(
+                BehandlingId(sisteVedtatteBehandling.id),
+                BehandlingId(behandling2.id),
+            )
+            utenlandskPeriodebeløpService.kopierOgErstattUtenlandskPeriodebeløp(
+                BehandlingId(sisteVedtatteBehandling.id),
+                BehandlingId(behandling2.id),
+            )
+        }
+    }
+
+    @Test
+    fun `Skal ikke kopierer kompetanser, valutakurser og utenlandsk periodebeløp for man ikke har noen siste behandling er henlagt`() {
+        val sisteVedtatteBehandling = lagBehandling()
+        val behandling2 = lagBehandling()
+
+        every { behandlingRepository.hentBehandling(behandling2.id) } returns behandling2
+        every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling.copy(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET))
+
+        registrerPersongrunnlagSteg.utførSteg(behandlingId = behandling2.id)
+
+        verify(exactly = 0) {
+            kompetanseService.kopierOgErstattKompetanser(
+                BehandlingId(sisteVedtatteBehandling.id),
+                BehandlingId(behandling2.id),
+            )
+            valutakursService.kopierOgErstattValutakurser(
+                BehandlingId(sisteVedtatteBehandling.id),
+                BehandlingId(behandling2.id),
+            )
+            utenlandskPeriodebeløpService.kopierOgErstattUtenlandskPeriodebeløp(
+                BehandlingId(sisteVedtatteBehandling.id),
+                BehandlingId(behandling2.id),
+            )
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.lagVilkårsvurderingMedSøkersVilkår
 import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.data.tilfeldigPerson
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
@@ -25,6 +26,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
+import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.jan
+import no.nav.familie.ks.sak.kjerne.eøs.util.KompetanseBuilder
 import no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering.EndretUtbetalingAndelTidslinjeService
 import no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjeService
 import no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjer
@@ -32,6 +35,7 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -635,6 +639,94 @@ internal class KompetanseServiceTest {
             barnAktører = setOf(barn1),
             hentetKompetanse = kompetanser[5],
         )
+    }
+
+    @Test
+    fun `skal kopiere over kompetanse-skjema fra forrige behandling til ny behandling`() {
+        val behandlingId1 = BehandlingId(10L)
+        val behandlingId2 = BehandlingId(11L)
+        val barn1 = tilfeldigPerson(personType = PersonType.BARN)
+        val barn2 = tilfeldigPerson(personType = PersonType.BARN)
+        val barn3 = tilfeldigPerson(personType = PersonType.BARN)
+
+        val kompetanser =
+            KompetanseBuilder(jan(2020), behandlingId1)
+                .medKompetanse(
+                    "SSS",
+                    barn1,
+                    annenForeldersAktivitetsland = null,
+                    erAnnenForelderOmfattetAvNorskLovgivning = true,
+                )
+                .medKompetanse(
+                    "---------",
+                    barn2,
+                    barn3,
+                    annenForeldersAktivitetsland = null,
+                    erAnnenForelderOmfattetAvNorskLovgivning = false,
+                )
+                .medKompetanse(
+                    "   SSSS",
+                    barn1,
+                    annenForeldersAktivitetsland = null,
+                    erAnnenForelderOmfattetAvNorskLovgivning = true,
+                )
+                .lagreTil(kompetanseRepository)
+
+        kompetanseService.kopierOgErstattKompetanser(behandlingId1, behandlingId2)
+
+        val kompetanserBehandling2 = kompetanseService.hentKompetanser(behandlingId2)
+
+        assertThat(kompetanserBehandling2).hasSize(kompetanserBehandling2.size).containsAll(kompetanser)
+
+        kompetanserBehandling2.forEach {
+            assertEquals(behandlingId2.id, it.behandlingId)
+        }
+
+        val kompetanserBehandling1 = kompetanseService.hentKompetanser(behandlingId1)
+
+        kompetanserBehandling1.forEach {
+            assertEquals(behandlingId1.id, it.behandlingId)
+        }
+
+        assertThat(kompetanserBehandling1).hasSize(kompetanserBehandling1.size).containsAll(kompetanser)
+    }
+
+    @Test
+    fun `skal kopiere kompetanser fra en behandling til en annen behandling, og overskrive eksisterende`() {
+        val behandlingId1 = BehandlingId(10L)
+        val behandlingId2 = BehandlingId(22L)
+        val barn1 = tilfeldigPerson(personType = PersonType.BARN)
+        val barn2 = tilfeldigPerson(personType = PersonType.BARN)
+        val barn3 = tilfeldigPerson(personType = PersonType.BARN)
+
+        val kompetanser1 =
+            KompetanseBuilder(jan(2020), behandlingId1)
+                .medKompetanse("SS   SS", barn1)
+                .medKompetanse("  PPP", barn1, barn2, barn3)
+                .medKompetanse("--   ----", barn2, barn3)
+                .lagreTil(kompetanseRepository)
+
+        KompetanseBuilder(jan(2020), behandlingId2)
+            .medKompetanse("PPPSSSPPPPPPP", barn1, barn2, barn3)
+            .lagreTil(kompetanseRepository)
+
+        kompetanseService.kopierOgErstattKompetanser(behandlingId1, behandlingId2)
+
+        val kompetanserBehandling2EtterEndring = kompetanseService.hentKompetanser(behandlingId2)
+
+        assertThat(kompetanserBehandling2EtterEndring).hasSize(kompetanserBehandling2EtterEndring.size).containsAll(kompetanser1)
+
+        kompetanserBehandling2EtterEndring.forEach {
+            assertEquals(behandlingId2.id, it.behandlingId)
+        }
+
+        val kompetanserBehandling1EtterEndring = kompetanseService.hentKompetanser(behandlingId1)
+
+        assertThat(kompetanserBehandling1EtterEndring).hasSize(kompetanserBehandling1EtterEndring.size).containsAll(kompetanser1)
+
+        kompetanserBehandling1EtterEndring.forEach {
+            assertEquals(behandlingId1.id, it.behandlingId)
+        }
     }
 
     private fun lagVilkårsvurdering(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/KompetanseBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/KompetanseBuilder.kt
@@ -16,28 +16,28 @@ class KompetanseBuilder(
         k: String,
         vararg barn: Person,
         annenForeldersAktivitetsland: String? = null,
-        // erAnnenForelderOmfattetAvNorskLovgivning: Boolean? = false,
+        erAnnenForelderOmfattetAvNorskLovgivning: Boolean? = false,
     ) =
         medSkjema(k, barn.toList()) {
             when (it) {
                 '-' ->
                     tomKompetanse.copy(
                         annenForeldersAktivitetsland = annenForeldersAktivitetsland,
-                        // erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
+                        erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
                     )
 
                 'S' ->
                     tomKompetanse.copy(
                         resultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
                         annenForeldersAktivitetsland = annenForeldersAktivitetsland,
-                        // erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
+                        erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
                     ).fyllUt()
 
                 'P' ->
                     tomKompetanse.copy(
                         resultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND,
                         annenForeldersAktivitetsland = annenForeldersAktivitetsland,
-                        // erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
+                        erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
                     ).fyllUt()
 
                 else -> null
@@ -49,7 +49,7 @@ class KompetanseBuilder(
 
 fun Kompetanse.fyllUt() =
     this.copy(
-        // erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning ?: false,
+        erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning ?: false,
         resultat = resultat ?: KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
         annenForeldersAktivitetsland = annenForeldersAktivitetsland ?: "DK",
         barnetsBostedsland = barnetsBostedsland ?: "NO",


### PR DESCRIPTION
NAV-17275

Kopierer valutakurs, utenlandsk_periodebeløp og kompetanser fra siste vedtatte behandling ved revurdering. Basert på tilsvarende funksjonalitet i ba-sak