### PR TITLE
Legger til logikk for oppretting av lovlig opphold vilkår dersom det er eøs

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkår.kt
@@ -144,7 +144,7 @@ private fun alleVilkårOppfyltEllerNull(
     vilkårResultater: Iterable<VilkårResultat?>,
     personType: PersonType,
 ): List<VilkårResultat>? {
-    val skalHenteEøsSpesifikkeVilkår = vilkårResultater.any { it?.vurderesEtter == Regelverk.EØS_FORORDNINGEN }
+    val skalHenteEøsSpesifikkeVilkår = vilkårResultater.any { it?.vurderesEtter == Regelverk.EØS_FORORDNINGEN && it.vilkårType == Vilkår.BOSATT_I_RIKET }
     val vilkårForPerson = Vilkår.hentVilkårFor(personType, skalHenteEøsSpesifikkeVilkår)
 
     return if (erAlleVilkårForPersonEntenOppfyltEllerIkkeAktuelt(vilkårForPerson, vilkårResultater)) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkår.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.tilYearMonth
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
@@ -143,7 +144,8 @@ private fun alleVilkårOppfyltEllerNull(
     vilkårResultater: Iterable<VilkårResultat?>,
     personType: PersonType,
 ): List<VilkårResultat>? {
-    val vilkårForPerson = Vilkår.hentVilkårFor(personType)
+    val skalHenteEøsSpesifikkeVilkår = vilkårResultater.any { it?.vurderesEtter == Regelverk.EØS_FORORDNINGEN }
+    val vilkårForPerson = Vilkår.hentVilkårFor(personType, skalHenteEøsSpesifikkeVilkår)
 
     return if (erAlleVilkårForPersonEntenOppfyltEllerIkkeAktuelt(vilkårForPerson, vilkårResultater)) {
         vilkårResultater.filterNotNull()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityEØSBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
@@ -351,8 +352,9 @@ fun genererInitiellVilkårsvurdering(
         personResultater =
             personopplysningGrunnlag.personer.map { person ->
                 val personResultat = PersonResultat(vilkårsvurdering = this, aktør = person.aktør)
+                val skalHenteEøsSpesifikkeVilkår = behandling.kategori == BehandlingKategori.EØS
 
-                val vilkårForPerson = Vilkår.hentVilkårFor(person.type)
+                val vilkårForPerson = Vilkår.hentVilkårFor(person.type, skalHenteEøsSpesifikkeVilkår)
 
                 val vilkårResultater =
                     vilkårForPerson.map { vilkår ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/Vilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/Vilkår.kt
@@ -9,47 +9,67 @@ enum class Vilkår(
     val ytelseType: YtelseType,
     val beskrivelse: String,
     val harRegelverk: Boolean,
+    val eøsSpesifikt: Boolean,
 ) {
     BOSATT_I_RIKET(
         parterDetteGjelderFor = listOf(PersonType.SØKER, PersonType.BARN),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
         beskrivelse = "Bosatt i riket",
         harRegelverk = true,
+        eøsSpesifikt = false,
+    ),
+    LOVLIG_OPPHOLD(
+        parterDetteGjelderFor = listOf(PersonType.SØKER),
+        ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
+        beskrivelse = "Lovlig opphold",
+        harRegelverk = false,
+        eøsSpesifikt = true,
     ),
     MEDLEMSKAP(
         parterDetteGjelderFor = listOf(PersonType.SØKER),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
         beskrivelse = "Medlemskap",
         harRegelverk = true,
+        eøsSpesifikt = false,
     ),
     BARNEHAGEPLASS(
         parterDetteGjelderFor = listOf(PersonType.BARN),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
         beskrivelse = "Barnehageplass",
         harRegelverk = false,
+        eøsSpesifikt = false,
     ),
     MEDLEMSKAP_ANNEN_FORELDER(
         parterDetteGjelderFor = listOf(PersonType.BARN),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
         beskrivelse = "Medlemskap annen forelder",
         harRegelverk = true,
+        eøsSpesifikt = false,
     ),
     BOR_MED_SØKER(
         parterDetteGjelderFor = listOf(PersonType.BARN),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
         beskrivelse = "Bor fast hos søker",
         harRegelverk = true,
+        eøsSpesifikt = false,
     ),
     BARNETS_ALDER(
         parterDetteGjelderFor = listOf(PersonType.BARN),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
         beskrivelse = "Mellom 1 og 2 år eller adoptert",
         harRegelverk = false,
+        eøsSpesifikt = false,
     ),
     ;
 
     companion object {
-        fun hentVilkårFor(personType: PersonType): Set<Vilkår> = values().filter { personType in it.parterDetteGjelderFor }.toSet()
+        fun hentVilkårFor(
+            personType: PersonType,
+            skalHenteEøsSpesifikkeVilkår: Boolean = false,
+        ): Set<Vilkår> =
+            entries.filter {
+                personType in it.parterDetteGjelderFor && (skalHenteEøsSpesifikkeVilkår || !it.eøsSpesifikt)
+            }.toSet()
     }
 
     fun defaultRegelverk(behandlingKategori: BehandlingKategori): Regelverk? {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/RegelverkKombinatorer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/RegelverkKombinatorer.kt
@@ -14,7 +14,8 @@ fun kombinerVilkårResultaterTilRegelverkResultat(
     // vilkår resultater som er OPPFYLT/IKKE_AKTUELT
     alleVilkårResultater: Iterable<VilkårRegelverkResultat>,
 ): RegelverkResultat? {
-    val vilkårer = Vilkår.hentVilkårFor(personType)
+    val skalHenteEøsSpesifikkeVilkår = alleVilkårResultater.any { it.regelverk == Regelverk.EØS_FORORDNINGEN }
+    val vilkårer = Vilkår.hentVilkårFor(personType, skalHenteEøsSpesifikkeVilkår)
 
     val regelverkVilkår = vilkårer.filter { it.harRegelverk }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/RegelverkKombinatorer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/RegelverkKombinatorer.kt
@@ -14,7 +14,7 @@ fun kombinerVilkårResultaterTilRegelverkResultat(
     // vilkår resultater som er OPPFYLT/IKKE_AKTUELT
     alleVilkårResultater: Iterable<VilkårRegelverkResultat>,
 ): RegelverkResultat? {
-    val skalHenteEøsSpesifikkeVilkår = alleVilkårResultater.any { it.regelverk == Regelverk.EØS_FORORDNINGEN }
+    val skalHenteEøsSpesifikkeVilkår = alleVilkårResultater.any { it.regelverk == Regelverk.EØS_FORORDNINGEN && it.vilkår == Vilkår.BOSATT_I_RIKET }
     val vilkårer = Vilkår.hentVilkårFor(personType, skalHenteEøsSpesifikkeVilkår)
 
     val regelverkVilkår = vilkårer.filter { it.harRegelverk }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -436,8 +436,26 @@ fun lagVilkårsvurderingMedSøkersVilkår(
                 vurderesEtter = regelverk,
                 utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
             ),
-        ),
+        ) +
+            if (regelverk == Regelverk.EØS_FORORDNINGEN) {
+                setOf(
+                    VilkårResultat(
+                        personResultat = personResultat,
+                        vilkårType = Vilkår.LOVLIG_OPPHOLD,
+                        resultat = resultat,
+                        periodeFom = søkerPeriodeFom,
+                        periodeTom = søkerPeriodeTom,
+                        begrunnelse = "",
+                        behandlingId = behandling.id,
+                        vurderesEtter = regelverk,
+                        utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
+                    ),
+                )
+            } else {
+                emptySet()
+            },
     )
+
     personResultat.andreVurderinger.add(
         AnnenVurdering(
             personResultat = personResultat,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -134,10 +134,10 @@ class OppdaterVilkårsvurderingTest {
         val vilkårsvurderingForrigeBehandling =
             lagVilkårsvurderingOppfylt(
                 personer =
-                listOf(
-                    persongrunnlagForrigeBehandling.søker,
-                    persongrunnlagForrigeBehandling.barna.single(),
-                ),
+                    listOf(
+                        persongrunnlagForrigeBehandling.søker,
+                        persongrunnlagForrigeBehandling.barna.single(),
+                    ),
             )
 
         initiellVilkårsvurdering.kopierOverOppfylteOgIkkeAktuelleResultaterFraForrigeBehandling(
@@ -205,10 +205,10 @@ class OppdaterVilkårsvurderingTest {
             lagVilkårsvurderingOppfylt(
                 behandling = nyBehandling,
                 personer =
-                listOf(
-                    lagPerson(personType = PersonType.SØKER, aktør = søkerAktørId),
-                    lagPerson(personType = PersonType.BARN, aktør = randomAktør()),
-                ),
+                    listOf(
+                        lagPerson(personType = PersonType.SØKER, aktør = søkerAktørId),
+                        lagPerson(personType = PersonType.BARN, aktør = randomAktør()),
+                    ),
             )
         val aktivMedBosattIRiketDelvisIkkeOppfylt = Vilkårsvurdering(behandling = forrigeBehandling)
         val personResultat =
@@ -266,10 +266,10 @@ class OppdaterVilkårsvurderingTest {
             lagVilkårsvurderingOppfylt(
                 behandling = nyBehandling,
                 personer =
-                listOf(
-                    lagPerson(personType = PersonType.SØKER, aktør = søkerAktørId),
-                    lagPerson(personType = PersonType.BARN, aktør = randomAktør()),
-                ),
+                    listOf(
+                        lagPerson(personType = PersonType.SØKER, aktør = søkerAktørId),
+                        lagPerson(personType = PersonType.BARN, aktør = randomAktør()),
+                    ),
             )
         val vilkårsvurderingForrigeBehandling = initiellVilkårsvurderingUtenAndreVurderinger.copy()
         vilkårsvurderingForrigeBehandling.personResultater.find { it.erSøkersResultater() }!!

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -442,6 +442,13 @@ class VilkårsvurderingStegTest {
                 ),
                 lagVilkårResultat(
                     personResultat = søkerPersonResultat,
+                    vilkårType = Vilkår.LOVLIG_OPPHOLD,
+                    periodeFom = LocalDate.of(2022, 12, 15),
+                    periodeTom = null,
+                    regelverk = Regelverk.EØS_FORORDNINGEN,
+                ),
+                lagVilkårResultat(
+                    personResultat = søkerPersonResultat,
                     vilkårType = Vilkår.MEDLEMSKAP,
                     periodeFom = LocalDate.of(1992, 7, 31),
                     periodeTom = LocalDate.of(2022, 12, 14),


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16951

Vi legger til lovlig opphold som vilkår for KS når det er EØS.
Logikken er satt opp slik at vilkåret bare vises når backend returnerer vilkårresultater som inneholder LOVLIG_OPPHOLD.
Alt styring av om det er EØS sak, eller om noe vilkår er vurdert etter eøs forordninger er derfor håndtert i backend.

Bilde:
![lovligopphold](https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/c3c9d943-62c5-41fd-88cb-bbb9a3e18ab1)
