### PR TITLE
Splitt pushing til gar og kjøring av tester i forskjellige jobber

### DIFF
--- a/.github/workflows/build-and-deploy-preprod-prod.yml
+++ b/.github/workflows/build-and-deploy-preprod-prod.yml
@@ -7,6 +7,27 @@ env:
   IMAGE: ghcr.io/navikt/familie-ks-sak:${{ github.sha }}
   IMAGE_LATEST: ghcr.io/navikt/familie-ks-sak:latest
 jobs:
+  bygg-og-kjor-tester:
+    name: Bygg og test
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "gradle/wrapper-validation-action@v1"
+      - uses: "actions/setup-java@v4"
+        with:
+          java-version: "21"
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Bygg med gradle
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean build
+
   bygg-og-push-til-github:
     name: Bygg app/image, push til github
     runs-on: ubuntu-latest-8-cores
@@ -26,7 +47,7 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean build
+        run: ./gradlew clean build -x test -x integrationTest -x ktlintCheck
 
       - name: Generate and output SBOM
         run: ./gradlew cyclonedxBom
@@ -47,7 +68,7 @@ jobs:
 
   deploy-til-preprod:
     name: Deploy to dev-gcp
-    needs: bygg-og-push-til-github
+    needs: [ bygg-og-kjor-tester, bygg-og-push-til-github ]
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +81,7 @@ jobs:
 
   deploy-til-prod:
     name: Deploy til prod-gcp
-    needs: bygg-og-push-til-github
+    needs: [ bygg-og-kjor-tester, bygg-og-push-til-github ]
     runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -6,8 +6,8 @@ env:
   IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
 jobs:
-  bygg-og-push-til-github:
-    name: Bygg app/image, push til github
+  bygg-og-kjor-tester:
+    name: Bygg og test
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
@@ -27,6 +27,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build
 
+  bygg-og-push-til-github:
+    name: Bygg app/image, push til github
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "gradle/wrapper-validation-action@v1"
+      - uses: "actions/setup-java@v4"
+        with:
+          java-version: "21"
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Bygg med gradle
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean build -x test -x integrationTest -x ktlintCheck
+
       - name: Generate and output SBOM
         run: ./gradlew cyclonedxBom
 
@@ -45,7 +66,7 @@ jobs:
 
   deploy-til-preprod:
     name: Deploy to dev-gcp
-    needs: bygg-og-push-til-github
+    needs: [ bygg-og-kjor-tester, bygg-og-push-til-github ]
     runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Nå kjører vi testene før vi pusher til gar. Det er litt unødvendig å vente på. Testene skal ha kjørt grønt i PRen, så dette burde være OK i 99% av tilfellene. 

Endrer så vi kjører testene og pusher til GAR samtidig. Dersom en av jobbene ikke kjører OK deployer vi ikke. 