### PR TITLE
Tillat barnetsalder tom til å være dødsfallsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -267,7 +267,7 @@ fun validerAtDatoErKorrektIBarnasVilkår(
                 ) {
                     vilkårResultat.validerVilkårBarnetsAlder(
                         vilkårResultat.lagOgValiderPeriodeFraVilkår(),
-                        barn.fødselsdato,
+                        barn,
                     )?.let { funksjonelleFeil.add(it) }
                 }
             }
@@ -295,21 +295,21 @@ private fun VilkårResultat.lagOgValiderPeriodeFraVilkår(): IkkeNullbarPeriode<
 
 private fun VilkårResultat.validerVilkårBarnetsAlder(
     periode: IkkeNullbarPeriode<Long>,
-    barnFødselsdato: LocalDate,
+    barn: Person,
 ): String? =
     when {
         this.erAdopsjonOppfylt() &&
-            periode.tom.isAfter(barnFødselsdato.plusYears(6).withMonth(Month.AUGUST.value).sisteDagIMåned()) ->
+            periode.tom.isAfter(barn.fødselsdato.plusYears(6).withMonth(Month.AUGUST.value).sisteDagIMåned()) ->
             "Du kan ikke sette en t.o.m dato som er etter august året barnet fyller 6 år."
 
         // Ved adopsjon skal det være lov å ha en differanse på 1 år + 1 dag slik at man får 11 måned med kontantstøtte.
         this.erAdopsjonOppfylt() && periode.fom.diffIDager(periode.tom) > 366 ->
             "Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 1 år."
 
-        !this.erAdopsjonOppfylt() && !periode.fom.isEqual(barnFødselsdato.plusYears(1)) ->
+        !this.erAdopsjonOppfylt() && !periode.fom.isEqual(barn.fødselsdato.plusYears(1)) ->
             "F.o.m datoen må være lik barnets 1 års dag."
 
-        !this.erAdopsjonOppfylt() && !periode.tom.isEqual(barnFødselsdato.plusYears(2)) ->
+        !this.erAdopsjonOppfylt() && !periode.tom.isEqual(barn.fødselsdato.plusYears(2)) && periode.tom != barn.dødsfall?.dødsfallDato ->
             "T.o.m datoen må være lik barnets 2 års dag."
 
         else -> null


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17532

![dd](https://github.com/navikt/familie-ks-sak-frontend/assets/110383605/21f208ef-ae6d-4d82-bd89-6b95d5409c63)


Vi må tillate at tom dato på barnetsalder kan bli satt til å være barnets dødsdato hvis det finnes.