### PR TITLE
Gjør ident public i barnmedopplysninger siden vi vil ha det med til frontend

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
@@ -44,7 +44,7 @@ data class SøkerMedOpplysningerDto(
 )
 
 data class BarnMedOpplysningerDto(
-    private val ident: String,
+    val ident: String,
     val navn: String = "",
     val fødselsdato: LocalDate? = null,
     val inkludertISøknaden: Boolean = true,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17486

Etter endringen i https://github.com/navikt/familie-ks-sak/commit/06864576780fe068bb0097fa1a874fb22acc0bd7, så sendte vi ikke lenger med ident til frontend (dette fordi ident ble satt til private).

Reverterer denne endringen. 
Vurderte å kanskje benytte oss av personnummer i frontend istedenfor, men da må det diskuteres hva ident skal brukes til i dto. Kjenner ikke 100% til grunnen personnummer ble lagt til.

Før:
<img width="1722" alt="Screenshot 2023-12-30 at 12 27 49" src="https://github.com/navikt/familie-ks-sak/assets/110383605/2b808d04-099b-40e4-a938-5b3198afab6c">

Etter:
<img width="1460" alt="Screenshot 2023-12-30 at 12 20 29" src="https://github.com/navikt/familie-ks-sak/assets/110383605/2affba94-715d-4fe5-bb36-380230f03639">
