### PR TITLE
Lag dto mot familie brev for EØS

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
@@ -86,6 +86,9 @@ enum class Trigger {
     }
 }
 
+fun SanityBegrunnelse.begrunnelseGjelderOpphørFraForrigeBehandling() =
+    Trigger.GJELDER_FØRSTE_PERIODE in this.triggere
+
 data class SanityBegrunnelseDto(
     val apiNavn: String?,
     val navnISystem: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -404,7 +404,7 @@ class VedtaksperiodeService(
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
                 .map { it.andel }
 
-        val kompetanser = kompetanseService.hentKompetanser(behandling.behandlingId)
+        val utfylteKompetanser = kompetanseService.hentUtfylteKompetanser(behandling.behandlingId)
 
         return utvidedeVedtaksperioderMedBegrunnelser
             .sortedBy { it.fom }
@@ -426,7 +426,7 @@ class VedtaksperiodeService(
                             personResultater = vilkårsvurdering.personResultater.toList(),
                             endretUtbetalingsandeler = endreteUtbetalinger,
                             erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
-                            kompetanser = kompetanser,
+                            kompetanser = utfylteKompetanser,
                         ).hentGyldigeBegrunnelserForVedtaksperiode(),
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperioderController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperioderController.kt
@@ -4,9 +4,9 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.brev.BrevKlient
 import no.nav.familie.ks.sak.kjerne.brev.BrevPeriodeService
-import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.FritekstBegrunnelseDto
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
@@ -38,7 +38,7 @@ class VedtaksperioderController(
             brevPeriodeService.hentBegrunnelsesteksterForPeriode(vedtaksperiodeId).map {
                 when (it) {
                     is FritekstBegrunnelseDto -> it.fritekst
-                    is BegrunnelseDataDto -> brevKlient.hentBegrunnelsestekst(it)
+                    is NasjonalOgFellesBegrunnelseDataDto -> brevKlient.hentBegrunnelsestekst(it)
                     is EØSBegrunnelseDataDto -> brevKlient.hentBegrunnelsestekst(it)
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperioderController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperioderController.kt
@@ -4,9 +4,8 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.brev.BrevKlient
 import no.nav.familie.ks.sak.kjerne.brev.BrevPeriodeService
-import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelseDataDto
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDtoMedData
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.FritekstBegrunnelseDto
-import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
@@ -38,8 +37,7 @@ class VedtaksperioderController(
             brevPeriodeService.hentBegrunnelsesteksterForPeriode(vedtaksperiodeId).map {
                 when (it) {
                     is FritekstBegrunnelseDto -> it.fritekst
-                    is NasjonalOgFellesBegrunnelseDataDto -> brevKlient.hentBegrunnelsestekst(it)
-                    is EØSBegrunnelseDataDto -> brevKlient.hentBegrunnelsestekst(it)
+                    is BegrunnelseDtoMedData -> brevKlient.hentBegrunnelsestekst(it)
                 }
             }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -319,7 +319,7 @@ class BrevPeriodeContext(
                 val gjelderAndreForelder =
                     relevantePersoner.filter { it.type == PersonType.BARN }
                         .any {
-                            if (begrunnelse.begrunnelseType == BegrunnelseType.AVSLAG) it.erMedlemskapVurdertPåAndreforelderSamtidigSomAvslag() else it.erMedlemskapVurdertPåAndreforelder()
+                            if (begrunnelse.begrunnelseType == BegrunnelseType.AVSLAG) erMedlemskapVurdertPåAndreforelderSamtidigSomAvslag() else it.erMedlemskapVurdertPåAndreforelder()
                         }
 
                 val barnasFødselsdatoer =
@@ -573,7 +573,7 @@ class BrevPeriodeContext(
             ?: false
     }
 
-    private fun Person.erMedlemskapVurdertPåAndreforelderSamtidigSomAvslag(): Boolean {
+    private fun erMedlemskapVurdertPåAndreforelderSamtidigSomAvslag(): Boolean {
         val alleMedlemskapAnnenForelderVilkår =
             personResultater.flatMap { it.vilkårResultater }
                 .filter { it.vilkårType == Vilkår.MEDLEMSKAP_ANNEN_FORELDER }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -355,16 +355,6 @@ class BrevPeriodeContext(
             )
     }
 
-    private fun hentRelevantePersonerForEøsBegrunnelse(
-        begrunnelse: IBegrunnelse,
-        sanityBegrunnelse: SanityBegrunnelse,
-    ): Set<Person> {
-        return begrunnelserForPeriodeContext.hentPersonerSomPasserForKompetanseIPeriode(
-            begrunnelse = begrunnelse,
-            sanityBegrunnelse = sanityBegrunnelse,
-        )
-    }
-
     fun hentEøsBegrunnelseDataDtoer(): List<EØSBegrunnelseDto> {
         return this.utvidetVedtaksperiodeMedBegrunnelser
             .eøsBegrunnelser
@@ -374,7 +364,7 @@ class BrevPeriodeContext(
             }.flatMap { (begrunnelse, sanityBegrunnelse) ->
                 val personerGjeldendeForBegrunnelse =
                     hentRelevantePersonerForNasjonalOgFellesBegrunnelse(begrunnelse, sanityBegrunnelse) +
-                        hentRelevantePersonerForEøsBegrunnelse(begrunnelse, sanityBegrunnelse)
+                        begrunnelserForPeriodeContext.hentPersonerSomPasserForKompetanseIPeriode(begrunnelse, sanityBegrunnelse)
 
                 val gjelderSøker = personerGjeldendeForBegrunnelse.any { it.type == PersonType.SØKER }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -182,16 +182,16 @@ class BrevPeriodeContext(
     fun hentBarnasFødselsdagerForBegrunnelse(
         gjelderSøker: Boolean,
         personerMedVilkårSomPasserBegrunnelse: Collection<Person>,
-        nasjonalEllerFellesBegrunnelse: NasjonalEllerFellesBegrunnelse,
+        begrunnelse: IBegrunnelse,
     ): List<LocalDate> =
         when {
-            nasjonalEllerFellesBegrunnelse == NasjonalEllerFellesBegrunnelse.AVSLAG_UREGISTRERT_BARN ->
+            begrunnelse == NasjonalEllerFellesBegrunnelse.AVSLAG_UREGISTRERT_BARN ->
                 uregistrerteBarn.mapNotNull { it.fødselsdato }
 
             gjelderSøker &&
-                nasjonalEllerFellesBegrunnelse.begrunnelseType != BegrunnelseType.ENDRET_UTBETALING &&
-                nasjonalEllerFellesBegrunnelse.begrunnelseType != BegrunnelseType.ETTER_ENDRET_UTBETALING -> {
-                if (nasjonalEllerFellesBegrunnelse.begrunnelseType == BegrunnelseType.AVSLAG) {
+                begrunnelse.begrunnelseType != BegrunnelseType.ENDRET_UTBETALING &&
+                begrunnelse.begrunnelseType != BegrunnelseType.ETTER_ENDRET_UTBETALING -> {
+                if (begrunnelse.begrunnelseType == BegrunnelseType.AVSLAG) {
                     personerMedVilkårSomPasserBegrunnelse
                         .filter { it.type == PersonType.BARN }
                         .map { it.fødselsdato }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -210,10 +210,10 @@ class BrevPeriodeContext(
 
     fun hentAntallBarnForBegrunnelse(
         barnasFødselsdatoer: List<LocalDate>,
-        nasjonalEllerFellesBegrunnelse: NasjonalEllerFellesBegrunnelse,
+        begrunnelse: IBegrunnelse,
     ): Int {
         val erAvslagUregistrerteBarn =
-            nasjonalEllerFellesBegrunnelse == NasjonalEllerFellesBegrunnelse.AVSLAG_UREGISTRERT_BARN
+            begrunnelse == NasjonalEllerFellesBegrunnelse.AVSLAG_UREGISTRERT_BARN
 
         return when {
             erAvslagUregistrerteBarn -> uregistrerteBarn.size

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -459,7 +459,7 @@ class BrevPeriodeContext(
                                 vedtakBegrunnelseType = begrunnelse.begrunnelseType,
                                 apiNavn = begrunnelse.sanityApiNavn,
                                 sanityBegrunnelseType = sanityBegrunnelse.type,
-                                barnetsBostedsland = kompetanse.barnetsBostedsland,
+                                barnetsBostedsland = kompetanse.barnetsBostedsland.tilLandNavn(landkoder).navn,
                                 annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
                                 annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland?.tilLandNavn(landkoder)?.navn,
                                 sokersAktivitet = kompetanse.søkersAktivitet,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -33,12 +33,12 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvVilkårResultater
 import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
-import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseType
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelserForPeriodeContext
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.FritekstBegrunnelseDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilBrevTekst
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilSanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriodeDto
@@ -281,7 +281,7 @@ class BrevPeriodeContext(
             kompetanser = kompetanser,
         )
 
-    fun hentBegrunnelseDtoer(): List<BegrunnelseDataDto> {
+    fun hentBegrunnelseDtoer(): List<NasjonalOgFellesBegrunnelseDataDto> {
         return utvidetVedtaksperiodeMedBegrunnelser
             .begrunnelser
             .mapNotNull { vedtakBegrunnelse ->
@@ -353,7 +353,7 @@ class BrevPeriodeContext(
                     nasjonalEllerFellesBegrunnelse = begrunnelse,
                 )
 
-                BegrunnelseDataDto(
+                NasjonalOgFellesBegrunnelseDataDto(
                     gjelderSoker = gjelderSøker,
                     gjelderAndreForelder = gjelderAndreForelder,
                     barnasFodselsdatoer = barnasFødselsdatoer.tilBrevTekst(),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -7,20 +7,17 @@ import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
 import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioderIkkeNull
-import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.erDagenFør
 import no.nav.familie.ks.sak.common.util.erSenereEnnInneværendeMåned
 import no.nav.familie.ks.sak.common.util.formaterBeløp
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
-import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.slåSammen
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
-import no.nav.familie.ks.sak.common.util.tilYearMonth
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.Trigger
@@ -247,32 +244,6 @@ class BrevPeriodeContext(
             nasjonalEllerFellesBegrunnelse != NasjonalEllerFellesBegrunnelse.AVSLAG_SØKT_FOR_SENT_ENDRINGSPERIODE
         ) {
             throw IllegalStateException("Ingen personer på brevbegrunnelse $nasjonalEllerFellesBegrunnelse")
-        }
-    }
-
-    private fun endringsperioderSomPasserMedPeriodeDatoOgBegrunnelse(nasjonalEllerFellesBegrunnelse: NasjonalEllerFellesBegrunnelse): List<EndretUtbetalingAndel> {
-        val endredeUtbetalinger = andelTilkjentYtelserMedEndreteUtbetalinger.flatMap { it.endreteUtbetalinger }
-
-        return when (nasjonalEllerFellesBegrunnelse.begrunnelseType) {
-            BegrunnelseType.ETTER_ENDRET_UTBETALING -> {
-                endredeUtbetalinger.filter {
-                    it.tom?.sisteDagIInneværendeMåned()
-                        ?.erDagenFør(utvidetVedtaksperiodeMedBegrunnelser.fom?.førsteDagIInneværendeMåned()) == true
-                }
-            }
-
-            BegrunnelseType.ENDRET_UTBETALING -> {
-                endredeUtbetalinger.filter {
-                    it.periode.overlapperHeltEllerDelvisMed(
-                        MånedPeriode(
-                            (utvidetVedtaksperiodeMedBegrunnelser.fom ?: TIDENES_MORGEN).tilYearMonth(),
-                            (utvidetVedtaksperiodeMedBegrunnelser.tom ?: TIDENES_ENDE).tilYearMonth(),
-                        ),
-                    )
-                }
-            }
-
-            else -> emptyList()
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.erDagenFør
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
@@ -20,6 +21,8 @@ import no.nav.familie.ks.sak.kjerne.brev.domene.maler.RefusjonEøsAvklart
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.RefusjonEøsUavklart
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriodeDto
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.springframework.stereotype.Service
@@ -34,6 +37,7 @@ class BrevPeriodeService(
     val vedtaksperiodeHentOgPersisterService: VedtaksperiodeHentOgPersisterService,
     val vedtaksperiodeService: VedtaksperiodeService,
     val kompetanseService: KompetanseService,
+    val integrasjonClient: IntegrasjonClient,
 ) {
     fun hentBegrunnelsesteksterForPeriode(vedtaksperiodeId: Long): List<BegrunnelseDto> {
         val behandlingId = vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(vedtaksperiodeId).vedtak.behandling.id
@@ -91,7 +95,8 @@ class BrevPeriodeService(
                             ?: emptyList(),
                     barnSomDødeIForrigePeriode = barnSomDødeIForrigePeriode,
                     erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
-                    kompetanser = kompetanser,
+                    kompetanser = kompetanser.map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>(),
+                    landkoder = integrasjonClient.hentLandkoderISO2(),
                 ).genererBrevPeriodeDto()
             }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevUtil.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.brev
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.slåSammen
+import no.nav.familie.ks.sak.common.util.storForbokstav
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
@@ -242,4 +243,18 @@ private fun hentOrdinæreHjemler(
     }
 
     return hjemler.map { it.toInt() }.sorted().map { it.toString() }
+}
+
+data class Landkode(val kode: String, val navn: String) {
+    init {
+        if (this.kode.length != 2) {
+            throw Feil("Forventer landkode på 'ISO 3166-1 alpha-2'-format")
+        }
+    }
+}
+
+fun String.tilLandNavn(landkoderISO2: Map<String, String>): Landkode {
+    val kode = landkoderISO2.entries.find { it.key == this } ?: throw Feil("Fant ikke navn for landkode $this.")
+
+    return Landkode(kode.key, kode.value.storForbokstav())
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevUtil.kt
@@ -12,6 +12,9 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.Brevmal
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 
+const val HJEMMEL_60_EØS_FORORDNINGEN_987 = "60"
+const val FORVALTINIGSLOVEN_PARAGRAF_35 = "35"
+
 fun hentBrevmal(behandling: Behandling): Brevmal =
     when (behandling.opprettetÅrsak) {
         BehandlingÅrsak.DØDSFALL -> Brevmal.VEDTAK_OPPHØR_DØDSFALL
@@ -133,13 +136,21 @@ private fun hentHjemlerForEøsForordningen987(
 ): List<String> {
     val hjemler =
         begrunnelser.flatMap { it.hjemlerEØSForordningen987 } +
-            if (refusjonEøsHjemmelSkalMedIBrev) listOf("60") else emptyList()
+            if (refusjonEøsHjemmelSkalMedIBrev) {
+                listOf(HJEMMEL_60_EØS_FORORDNINGEN_987)
+            } else {
+                emptyList()
+            }
 
     return hjemler.distinct()
 }
 
 fun hentForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev: Boolean): List<String> =
-    if (vedtakKorrigertHjemmelSkalMedIBrev) listOf("35") else emptyList()
+    if (vedtakKorrigertHjemmelSkalMedIBrev) {
+        listOf(FORVALTINIGSLOVEN_PARAGRAF_35)
+    } else {
+        emptyList()
+    }
 
 private fun slåSammenHjemlerAvUlikeTyper(hjemler: List<String>) =
     when (hjemler.size) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -18,7 +18,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.SimuleringService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.feilutbetaltvaluta.FeilutbetaltValutaService
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøs
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøsRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Opphørsperiode
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
@@ -70,7 +70,7 @@ class GenererBrevService(
     private val korrigertVedtakService: KorrigertVedtakService,
     private val feilutbetaltValutaService: FeilutbetaltValutaService,
     private val saksbehandlerContext: SaksbehandlerContext,
-    private val refusjonEøs: List<RefusjonEøs>,
+    private val refusjonEøsRepository: RefusjonEøsRepository,
 ) {
     fun genererManueltBrev(
         manueltBrevRequest: ManueltBrevDto,
@@ -279,6 +279,8 @@ class GenererBrevService(
 
         val opplysningspliktHjemlerSkalMedIBrev =
             vilkårsvurdering.finnOpplysningspliktVilkår()?.resultat == Resultat.IKKE_OPPFYLT
+
+        val refusjonEøs = refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId = behandlingId)
 
         val refusjonEøsHjemmelSkalMedIBrev = refusjonEøs.isNotEmpty()
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
@@ -43,7 +43,7 @@ sealed class BegrunnelseDtoMedData(
     open val apiNavn: String,
     open val vedtakBegrunnelseType: BegrunnelseType,
     open val sanityBegrunnelseType: SanityBegrunnelseType,
-    type: BrevBegrunnelseType,
+    override val type: BrevBegrunnelseType,
 ) : BegrunnelseDto(type)
 
 data class NasjonalOgFellesBegrunnelseDataDto(
@@ -70,7 +70,19 @@ data class FritekstBegrunnelseDto(
     val fritekst: String,
 ) : BegrunnelseDto(type = BrevBegrunnelseType.FRITEKST)
 
-data class EØSBegrunnelseDataDto(
+sealed class EØSBegrunnelseDto(
+    override val apiNavn: String,
+    override val vedtakBegrunnelseType: BegrunnelseType,
+    override val sanityBegrunnelseType: SanityBegrunnelseType,
+    override val type: BrevBegrunnelseType,
+) : BegrunnelseDtoMedData(
+        apiNavn = apiNavn,
+        vedtakBegrunnelseType = vedtakBegrunnelseType,
+        sanityBegrunnelseType = sanityBegrunnelseType,
+        type = type,
+    )
+
+data class EØSBegrunnelseMedKompetanseDto(
     override val vedtakBegrunnelseType: BegrunnelseType,
     override val apiNavn: String,
     override val sanityBegrunnelseType: SanityBegrunnelseType,
@@ -82,7 +94,22 @@ data class EØSBegrunnelseDataDto(
     val maalform: String,
     val sokersAktivitet: KompetanseAktivitet,
     val sokersAktivitetsland: String?,
-) : BegrunnelseDtoMedData(
+) : EØSBegrunnelseDto(
+        type = BrevBegrunnelseType.EØS_BEGRUNNELSE,
+        apiNavn = apiNavn,
+        vedtakBegrunnelseType = vedtakBegrunnelseType,
+        sanityBegrunnelseType = sanityBegrunnelseType,
+    )
+
+data class EØSBegrunnelseUtenKompetanseDto(
+    override val vedtakBegrunnelseType: BegrunnelseType,
+    override val apiNavn: String,
+    override val sanityBegrunnelseType: SanityBegrunnelseType,
+    val barnasFodselsdatoer: String,
+    val antallBarn: Int,
+    val maalform: String,
+    val gjelderSoker: Boolean,
+) : EØSBegrunnelseDto(
         type = BrevBegrunnelseType.EØS_BEGRUNNELSE,
         apiNavn = apiNavn,
         vedtakBegrunnelseType = vedtakBegrunnelseType,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
@@ -46,7 +46,7 @@ sealed class BegrunnelseDtoMedData(
     type: BrevBegrunnelseType,
 ) : BegrunnelseDto(type)
 
-data class BegrunnelseDataDto(
+data class NasjonalOgFellesBegrunnelseDataDto(
     override val vedtakBegrunnelseType: BegrunnelseType,
     override val apiNavn: String,
     override val sanityBegrunnelseType: SanityBegrunnelseType,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -25,9 +25,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvVil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilFørskjøvetOppfylteVilkårResultatTidslinjeMap
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilFørskjøvetVilkårResultatTidslinjeMap
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
-import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
-import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.tilTidslinje
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
@@ -36,7 +34,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Personopplys
 class BegrunnelserForPeriodeContext(
     private val utvidetVedtaksperiodeMedBegrunnelser: UtvidetVedtaksperiodeMedBegrunnelser,
     private val sanityBegrunnelser: List<SanityBegrunnelse>,
-    private val kompetanser: List<Kompetanse>,
+    private val kompetanser: List<UtfyltKompetanse>,
     private val personopplysningGrunnlag: PersonopplysningGrunnlag,
     private val personResultater: List<PersonResultat>,
     private val endretUtbetalingsandeler: List<EndretUtbetalingAndel>,
@@ -108,9 +106,8 @@ class BegrunnelserForPeriodeContext(
         begrunnelse: IBegrunnelse,
         sanityBegrunnelse: SanityBegrunnelse,
     ): Set<Person> {
-        val utfylteKompetanser = this.kompetanser.map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>()
-        val alleBarna = utfylteKompetanser.flatMap { it.barnAktører }.toSet()
-        val utfylteKompetanserPerBarn = alleBarna.associateWith { barn -> utfylteKompetanser.filter { barn in it.barnAktører } }
+        val alleBarna = kompetanser.flatMap { it.barnAktører }.toSet()
+        val utfylteKompetanserPerBarn = alleBarna.associateWith { barn -> kompetanser.filter { barn in it.barnAktører } }
         val vilkårResultaterSomOverlapperVedtaksperiode =
             hentVilkårResultaterSomOverlapperVedtaksperiode(
                 standardBegrunnelse = begrunnelse,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -104,7 +104,7 @@ class BegrunnelserForPeriodeContext(
         }
     }
 
-    private fun hentPersonerSomPasserForKompetanseIPeriode(
+    fun hentPersonerSomPasserForKompetanseIPeriode(
         begrunnelse: IBegrunnelse,
         sanityBegrunnelse: SanityBegrunnelse,
     ): Set<Person> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -20,6 +20,8 @@ import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
 import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.medBehandlingId
 import no.nav.familie.ks.sak.kjerne.eøs.felles.endringsabonnent.EøsSkjemaEndringAbonnent
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering.EndretUtbetalingAndelTidslinjeService
 import no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering.RegelverkResultat
 import no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjeService
@@ -42,6 +44,8 @@ class KompetanseService(
     fun hentKompetanse(kompetanseId: Long) = kompetanseSkjemaService.hentMedId(kompetanseId)
 
     fun hentKompetanser(behandlingId: BehandlingId) = kompetanseSkjemaService.hentMedBehandlingId(behandlingId)
+
+    fun hentUtfylteKompetanser(behandlingId: BehandlingId) = hentKompetanser(behandlingId).map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>()
 
     @Transactional
     fun oppdaterKompetanse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -28,9 +28,9 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseUtils
-import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseType
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriodeType
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
@@ -96,7 +96,7 @@ class BrevPeriodeContextTest {
         Assertions.assertEquals(listOf(""), brevPeriodeDto?.fodselsdagerBarnMedNullutbetaling)
 
         Assertions.assertEquals(
-            BegrunnelseDataDto(
+            NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
                 apiNavn = "innvilgetIkkeBarnehage",
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
@@ -149,7 +149,7 @@ class BrevPeriodeContextTest {
             ).genererBrevPeriodeDto()
 
         Assertions.assertEquals(
-            BegrunnelseDataDto(
+            NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
                 apiNavn = "innvilgetDeltidBarnehage",
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
@@ -208,7 +208,7 @@ class BrevPeriodeContextTest {
             ).genererBrevPeriodeDto()
 
         Assertions.assertEquals(
-            BegrunnelseDataDto(
+            NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
                 apiNavn = "innvilgetDeltidBarnehageAdopsjon",
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
@@ -261,7 +261,7 @@ class BrevPeriodeContextTest {
             ).genererBrevPeriodeDto()
 
         Assertions.assertEquals(
-            BegrunnelseDataDto(
+            NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
                 apiNavn = "innvilgetIkkeBarnehageAdopsjon",
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
@@ -321,7 +321,7 @@ class BrevPeriodeContextTest {
             ).genererBrevPeriodeDto()
 
         Assertions.assertEquals(
-            BegrunnelseDataDto(
+            NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
                 apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON.sanityApiNavn,
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
@@ -381,7 +381,7 @@ class BrevPeriodeContextTest {
             ).genererBrevPeriodeDto()
 
         Assertions.assertEquals(
-            BegrunnelseDataDto(
+            NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
                 apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON.sanityApiNavn,
                 sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -501,6 +501,7 @@ fun lagBrevPeriodeContext(
         barnSomDødeIForrigePeriode = emptyList(),
         erFørsteVedtaksperiode = false,
         kompetanser = emptyList(),
+        landkoder = LANDKODER,
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
@@ -1,9 +1,8 @@
 package no.nav.familie.ks.sak.kjerne.brev
 
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.common.exception.Feil
@@ -19,6 +18,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.SimuleringService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.feilutbetaltvaluta.FeilutbetaltValutaService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøsRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.Brevmal
@@ -35,47 +35,28 @@ import org.junit.jupiter.params.provider.EnumSource
 
 @ExtendWith(MockKExtension::class)
 class GenererBrevServiceTest {
-    @MockK
-    private lateinit var brevKlient: BrevKlient
+    val brevKlient: BrevKlient = mockk()
+    val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk()
+    val saksbehandlerContext: SaksbehandlerContext = mockk()
+    val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
 
-    @MockK
-    private lateinit var vedtakService: VedtakService
-
-    @MockK
-    private lateinit var personopplysningGrunnlagService: PersonopplysningGrunnlagService
-
-    @MockK
-    private lateinit var simuleringService: SimuleringService
-
-    @MockK
-    private lateinit var vedtaksperiodeService: VedtaksperiodeService
-
-    @MockK
-    private lateinit var brevPeriodeService: BrevPeriodeService
-
-    @MockK
-    private lateinit var totrinnskontrollService: TotrinnskontrollService
-
-    @MockK
-    private lateinit var sanityService: SanityService
-
-    @MockK
-    private lateinit var arbeidsfordelingService: ArbeidsfordelingService
-
-    @MockK
-    private lateinit var vilkårsvurderingService: VilkårsvurderingService
-
-    @MockK
-    private lateinit var korrigertVedtakService: KorrigertVedtakService
-
-    @MockK
-    private lateinit var feilutbetaltValutaService: FeilutbetaltValutaService
-
-    @MockK
-    private lateinit var saksbehandlerContext: SaksbehandlerContext
-
-    @InjectMockKs
-    private lateinit var genererBrevService: GenererBrevService
+    val genererBrevService =
+        GenererBrevService(
+            brevKlient = brevKlient,
+            vedtakService = mockk<VedtakService>(),
+            personopplysningGrunnlagService = personopplysningGrunnlagService,
+            simuleringService = mockk<SimuleringService>(),
+            vedtaksperiodeService = mockk<VedtaksperiodeService>(),
+            brevPeriodeService = mockk<BrevPeriodeService>(),
+            totrinnskontrollService = mockk<TotrinnskontrollService>(),
+            sanityService = mockk<SanityService>(),
+            arbeidsfordelingService = arbeidsfordelingService,
+            vilkårsvurderingService = mockk<VilkårsvurderingService>(),
+            korrigertVedtakService = mockk<KorrigertVedtakService>(),
+            feilutbetaltValutaService = mockk<FeilutbetaltValutaService>(),
+            saksbehandlerContext = saksbehandlerContext,
+            refusjonEøsRepository = mockk<RefusjonEøsRepository>(),
+        )
 
     private val søker = randomAktør()
     private val fagsak = lagFagsak(søker)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/LandkoderMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/LandkoderMock.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.ks.sak.kjerne.brev
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.kontrakter.felles.objectMapper
+import org.springframework.core.io.ClassPathResource
+import java.io.BufferedReader
+
+data class LandkodeISO2(
+    val code: String,
+    val name: String,
+)
+
+fun hentLandkoderISO2(): Map<String, String> {
+    val landkoder =
+        ClassPathResource("landkoder/landkoder.json").inputStream.bufferedReader().use(BufferedReader::readText)
+
+    return objectMapper.readValue<List<LandkodeISO2>>(landkoder)
+        .associate { it.code to it.name }
+}
+
+val LANDKODER = hentLandkoderISO2()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -21,6 +21,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilFørskj
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.UtfyltKompetanse
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
@@ -748,7 +750,7 @@ class BegrunnelserForPeriodeContextTest {
         return BegrunnelserForPeriodeContext(
             utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
             sanityBegrunnelser = sanityBegrunnelser,
-            kompetanser = kompetanser,
+            kompetanser = kompetanser.map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>(),
             personopplysningGrunnlag = persongrunnlag,
             personResultater = emptyList(),
             endretUtbetalingsandeler = emptyList(),

--- a/src/test/resources/landkoder/landkoder.json
+++ b/src/test/resources/landkoder/landkoder.json
@@ -1,0 +1,1006 @@
+[
+  {
+    "code": "NO",
+    "name": "Norge"
+  },
+  {
+    "code": "AD",
+    "name": "Andorra"
+  },
+  {
+    "code": "AE",
+    "name": "De forente arabiske emirater"
+  },
+  {
+    "code": "AF",
+    "name": "Afghanistan"
+  },
+  {
+    "code": "AG",
+    "name": "Antigua og Barbuda"
+  },
+  {
+    "code": "AI",
+    "name": "Anguilla"
+  },
+  {
+    "code": "AL",
+    "name": "Albania"
+  },
+  {
+    "code": "AM",
+    "name": "Armenia"
+  },
+  {
+    "code": "AO",
+    "name": "Angola"
+  },
+  {
+    "code": "AQ",
+    "name": "Antarktis"
+  },
+  {
+    "code": "AR",
+    "name": "Argentina"
+  },
+  {
+    "code": "AS",
+    "name": "Amerikansk Samoa"
+  },
+  {
+    "code": "AT",
+    "name": "Østerrike"
+  },
+  {
+    "code": "AU",
+    "name": "Australia"
+  },
+  {
+    "code": "AW",
+    "name": "Aruba"
+  },
+  {
+    "code": "AX",
+    "name": "Åland"
+  },
+  {
+    "code": "AZ",
+    "name": "Aserbajdsjan"
+  },
+  {
+    "code": "BA",
+    "name": "Bosnia-Hercegovina"
+  },
+  {
+    "code": "BB",
+    "name": "Barbados"
+  },
+  {
+    "code": "BD",
+    "name": "Bangladesh"
+  },
+  {
+    "code": "BE",
+    "name": "Belgia"
+  },
+  {
+    "code": "BF",
+    "name": "Burkina Faso"
+  },
+  {
+    "code": "BG",
+    "name": "Bulgaria"
+  },
+  {
+    "code": "BH",
+    "name": "Bahrain"
+  },
+  {
+    "code": "BI",
+    "name": "Burundi"
+  },
+  {
+    "code": "BJ",
+    "name": "Benin"
+  },
+  {
+    "code": "BL",
+    "name": "Saint Barthelemy"
+  },
+  {
+    "code": "BM",
+    "name": "Bermuda"
+  },
+  {
+    "code": "BN",
+    "name": "Brunei Darussalam"
+  },
+  {
+    "code": "BO",
+    "name": "Bolivia"
+  },
+  {
+    "code": "BQ",
+    "name": "Bonaire, Sint Eustatius og Saba"
+  },
+  {
+    "code": "BR",
+    "name": "Brasil"
+  },
+  {
+    "code": "BS",
+    "name": "Bahamas"
+  },
+  {
+    "code": "BT",
+    "name": "Bhutan"
+  },
+  {
+    "code": "BV",
+    "name": "Bouvetøya"
+  },
+  {
+    "code": "BW",
+    "name": "Botswana"
+  },
+  {
+    "code": "BY",
+    "name": "Hviterussland"
+  },
+  {
+    "code": "BZ",
+    "name": "Belize"
+  },
+  {
+    "code": "CA",
+    "name": "Canada"
+  },
+  {
+    "code": "CC",
+    "name": "Kokosøyene (Keelingøyene)"
+  },
+  {
+    "code": "CD",
+    "name": "Kongo"
+  },
+  {
+    "code": "CF",
+    "name": "Den sentralafrikanske republikk"
+  },
+  {
+    "code": "CG",
+    "name": "Kongo-Brazzaville"
+  },
+  {
+    "code": "CH",
+    "name": "Sveits"
+  },
+  {
+    "code": "CI",
+    "name": "Elfenbenskysten"
+  },
+  {
+    "code": "CK",
+    "name": "Cookøyene"
+  },
+  {
+    "code": "CL",
+    "name": "Chile"
+  },
+  {
+    "code": "CM",
+    "name": "Kamerun"
+  },
+  {
+    "code": "CN",
+    "name": "Kina"
+  },
+  {
+    "code": "CO",
+    "name": "Colombia"
+  },
+  {
+    "code": "CR",
+    "name": "Costa Rica"
+  },
+  {
+    "code": "CU",
+    "name": "Cuba"
+  },
+  {
+    "code": "CV",
+    "name": "Kapp Verde"
+  },
+  {
+    "code": "CW",
+    "name": "Curacao"
+  },
+  {
+    "code": "CX",
+    "name": "Christmasøya"
+  },
+  {
+    "code": "CY",
+    "name": "Kypros"
+  },
+  {
+    "code": "CZ",
+    "name": "Tsjekkia"
+  },
+  {
+    "code": "DE",
+    "name": "Tyskland"
+  },
+  {
+    "code": "DJ",
+    "name": "Djibouti"
+  },
+  {
+    "code": "DK",
+    "name": "Danmark"
+  },
+  {
+    "code": "DM",
+    "name": "Dominica"
+  },
+  {
+    "code": "DO",
+    "name": "Den dominikanske republikk"
+  },
+  {
+    "code": "DZ",
+    "name": "Algerie"
+  },
+  {
+    "code": "EC",
+    "name": "Ecuador"
+  },
+  {
+    "code": "EE",
+    "name": "Estland"
+  },
+  {
+    "code": "EG",
+    "name": "Egypt"
+  },
+  {
+    "code": "EH",
+    "name": "Vest-Sahara"
+  },
+  {
+    "code": "ER",
+    "name": "Eritrea"
+  },
+  {
+    "code": "ES",
+    "name": "Spania"
+  },
+  {
+    "code": "ET",
+    "name": "Etiopia"
+  },
+  {
+    "code": "FI",
+    "name": "Finland"
+  },
+  {
+    "code": "FJ",
+    "name": "Fiji"
+  },
+  {
+    "code": "FK",
+    "name": "Falklandsøyene (Malvinas)"
+  },
+  {
+    "code": "FM",
+    "name": "Mikronesiaføderasjonen"
+  },
+  {
+    "code": "FO",
+    "name": "Færøyene"
+  },
+  {
+    "code": "FR",
+    "name": "Frankrike"
+  },
+  {
+    "code": "GA",
+    "name": "Gabon"
+  },
+  {
+    "code": "GB",
+    "name": "Storbritannia"
+  },
+  {
+    "code": "GD",
+    "name": "Grenada"
+  },
+  {
+    "code": "GE",
+    "name": "Georgia"
+  },
+  {
+    "code": "GF",
+    "name": "Fransk Guyana"
+  },
+  {
+    "code": "GG",
+    "name": "Guernsey"
+  },
+  {
+    "code": "GH",
+    "name": "Ghana"
+  },
+  {
+    "code": "GI",
+    "name": "Gibraltar"
+  },
+  {
+    "code": "GL",
+    "name": "Grønland"
+  },
+  {
+    "code": "GM",
+    "name": "Gambia"
+  },
+  {
+    "code": "GN",
+    "name": "Guinea"
+  },
+  {
+    "code": "GP",
+    "name": "Guadeloupe"
+  },
+  {
+    "code": "GQ",
+    "name": "Ekvatorial-Guinea"
+  },
+  {
+    "code": "GR",
+    "name": "Hellas"
+  },
+  {
+    "code": "GS",
+    "name": "Sør-Georgia/Sør-Sandwichøyene"
+  },
+  {
+    "code": "GT",
+    "name": "Guatemala"
+  },
+  {
+    "code": "GU",
+    "name": "Guam"
+  },
+  {
+    "code": "GW",
+    "name": "Guinea-Bissau"
+  },
+  {
+    "code": "GY",
+    "name": "Guyana"
+  },
+  {
+    "code": "HK",
+    "name": "Hongkong"
+  },
+  {
+    "code": "HM",
+    "name": "Heard- og McDonaldøyene"
+  },
+  {
+    "code": "HN",
+    "name": "Honduras"
+  },
+  {
+    "code": "HR",
+    "name": "Kroatia"
+  },
+  {
+    "code": "HT",
+    "name": "Haiti"
+  },
+  {
+    "code": "HU",
+    "name": "Ungarn"
+  },
+  {
+    "code": "ID",
+    "name": "Indonesia"
+  },
+  {
+    "code": "IE",
+    "name": "Irland"
+  },
+  {
+    "code": "IL",
+    "name": "Israel"
+  },
+  {
+    "code": "IM",
+    "name": "Isle of Man"
+  },
+  {
+    "code": "IN",
+    "name": "India"
+  },
+  {
+    "code": "IO",
+    "name": "Det Britiske terr. i Indiahavet"
+  },
+  {
+    "code": "IQ",
+    "name": "Irak"
+  },
+  {
+    "code": "IR",
+    "name": "Iran"
+  },
+  {
+    "code": "IS",
+    "name": "Island"
+  },
+  {
+    "code": "IT",
+    "name": "Italia"
+  },
+  {
+    "code": "JE",
+    "name": "Jersey"
+  },
+  {
+    "code": "JM",
+    "name": "Jamaica"
+  },
+  {
+    "code": "JO",
+    "name": "Jordan"
+  },
+  {
+    "code": "JP",
+    "name": "Japan"
+  },
+  {
+    "code": "KE",
+    "name": "Kenya"
+  },
+  {
+    "code": "KG",
+    "name": "Kirgisistan"
+  },
+  {
+    "code": "KH",
+    "name": "Kambodsja"
+  },
+  {
+    "code": "KI",
+    "name": "Kiribati"
+  },
+  {
+    "code": "KM",
+    "name": "Komorene"
+  },
+  {
+    "code": "KN",
+    "name": "Saint Kitts og Nevis"
+  },
+  {
+    "code": "KP",
+    "name": "Nord-Korea"
+  },
+  {
+    "code": "KR",
+    "name": "Sør-Korea"
+  },
+  {
+    "code": "KW",
+    "name": "Kuwait"
+  },
+  {
+    "code": "KY",
+    "name": "Caymanøyene"
+  },
+  {
+    "code": "KZ",
+    "name": "Kasakhstan"
+  },
+  {
+    "code": "LA",
+    "name": "Laos"
+  },
+  {
+    "code": "LB",
+    "name": "Libanon"
+  },
+  {
+    "code": "LC",
+    "name": "Saint Lucia"
+  },
+  {
+    "code": "LI",
+    "name": "Liechtenstein"
+  },
+  {
+    "code": "LK",
+    "name": "Sri Lanka"
+  },
+  {
+    "code": "LR",
+    "name": "Liberia"
+  },
+  {
+    "code": "LS",
+    "name": "Lesotho"
+  },
+  {
+    "code": "LT",
+    "name": "Litauen"
+  },
+  {
+    "code": "LU",
+    "name": "Luxembourg"
+  },
+  {
+    "code": "LV",
+    "name": "Latvia"
+  },
+  {
+    "code": "LY",
+    "name": "Libya"
+  },
+  {
+    "code": "MA",
+    "name": "Marokko"
+  },
+  {
+    "code": "MC",
+    "name": "Monaco"
+  },
+  {
+    "code": "MD",
+    "name": "Moldova"
+  },
+  {
+    "code": "ME",
+    "name": "Montenegro"
+  },
+  {
+    "code": "MF",
+    "name": "Saint-Martin, FR"
+  },
+  {
+    "code": "MG",
+    "name": "Madagaskar"
+  },
+  {
+    "code": "MH",
+    "name": "Marshalløyene"
+  },
+  {
+    "code": "MK",
+    "name": "Nord-Makedonia"
+  },
+  {
+    "code": "ML",
+    "name": "Mali"
+  },
+  {
+    "code": "MM",
+    "name": "Myanmar/Burma"
+  },
+  {
+    "code": "MN",
+    "name": "Mongolia"
+  },
+  {
+    "code": "MO",
+    "name": "Macao"
+  },
+  {
+    "code": "MP",
+    "name": "Nord-Marianene"
+  },
+  {
+    "code": "MQ",
+    "name": "Martinique"
+  },
+  {
+    "code": "MR",
+    "name": "Mauritania"
+  },
+  {
+    "code": "MS",
+    "name": "Montserrat"
+  },
+  {
+    "code": "MT",
+    "name": "Malta"
+  },
+  {
+    "code": "MU",
+    "name": "Mauritius"
+  },
+  {
+    "code": "MV",
+    "name": "Maldivene"
+  },
+  {
+    "code": "MW",
+    "name": "Malawi"
+  },
+  {
+    "code": "MX",
+    "name": "Mexico"
+  },
+  {
+    "code": "MY",
+    "name": "Malaysia"
+  },
+  {
+    "code": "MZ",
+    "name": "Mosambik"
+  },
+  {
+    "code": "NA",
+    "name": "Namibia"
+  },
+  {
+    "code": "NC",
+    "name": "Ny-Caledonia"
+  },
+  {
+    "code": "NE",
+    "name": "Niger"
+  },
+  {
+    "code": "NF",
+    "name": "Norfolkøya"
+  },
+  {
+    "code": "NG",
+    "name": "Nigeria"
+  },
+  {
+    "code": "NI",
+    "name": "Nicaragua"
+  },
+  {
+    "code": "NL",
+    "name": "Nederland"
+  },
+  {
+    "code": "NP",
+    "name": "Nepal"
+  },
+  {
+    "code": "NR",
+    "name": "Nauru"
+  },
+  {
+    "code": "NU",
+    "name": "Niue"
+  },
+  {
+    "code": "NZ",
+    "name": "New Zealand"
+  },
+  {
+    "code": "OM",
+    "name": "Oman"
+  },
+  {
+    "code": "PA",
+    "name": "Panama"
+  },
+  {
+    "code": "PE",
+    "name": "Peru"
+  },
+  {
+    "code": "PF",
+    "name": "Fransk Polynesia"
+  },
+  {
+    "code": "PG",
+    "name": "Papua Ny-Guinea"
+  },
+  {
+    "code": "PH",
+    "name": "Filippinene"
+  },
+  {
+    "code": "PK",
+    "name": "Pakistan"
+  },
+  {
+    "code": "PL",
+    "name": "Polen"
+  },
+  {
+    "code": "PM",
+    "name": "Saint Pierre og Miquelon"
+  },
+  {
+    "code": "PN",
+    "name": "Pitcairn"
+  },
+  {
+    "code": "PR",
+    "name": "Puerto Rico"
+  },
+  {
+    "code": "PS",
+    "name": "Palestina"
+  },
+  {
+    "code": "PT",
+    "name": "Portugal"
+  },
+  {
+    "code": "PW",
+    "name": "Palau"
+  },
+  {
+    "code": "PY",
+    "name": "Paraguay"
+  },
+  {
+    "code": "QA",
+    "name": "Qatar"
+  },
+  {
+    "code": "RE",
+    "name": "Reunion"
+  },
+  {
+    "code": "RO",
+    "name": "Romania"
+  },
+  {
+    "code": "RS",
+    "name": "Serbia"
+  },
+  {
+    "code": "RU",
+    "name": "Russland"
+  },
+  {
+    "code": "RW",
+    "name": "Rwanda"
+  },
+  {
+    "code": "SA",
+    "name": "Saudi-Arabia"
+  },
+  {
+    "code": "SB",
+    "name": "Salomonøyene"
+  },
+  {
+    "code": "SC",
+    "name": "Seychellene"
+  },
+  {
+    "code": "SD",
+    "name": "Sudan"
+  },
+  {
+    "code": "SE",
+    "name": "Sverige"
+  },
+  {
+    "code": "SG",
+    "name": "Singapore"
+  },
+  {
+    "code": "SH",
+    "name": "St. Helena"
+  },
+  {
+    "code": "SI",
+    "name": "Slovenia"
+  },
+  {
+    "code": "SK",
+    "name": "Slovakia"
+  },
+  {
+    "code": "SL",
+    "name": "Sierra Leone"
+  },
+  {
+    "code": "SM",
+    "name": "San Marino"
+  },
+  {
+    "code": "SN",
+    "name": "Senegal"
+  },
+  {
+    "code": "SO",
+    "name": "Somalia"
+  },
+  {
+    "code": "SR",
+    "name": "Surinam"
+  },
+  {
+    "code": "SS",
+    "name": "Sør-Sudan"
+  },
+  {
+    "code": "ST",
+    "name": "Sao Tome og Principe"
+  },
+  {
+    "code": "SV",
+    "name": "El Salvador"
+  },
+  {
+    "code": "SX",
+    "name": "Sint Marteen, NL"
+  },
+  {
+    "code": "SY",
+    "name": "Syria"
+  },
+  {
+    "code": "SZ",
+    "name": "Eswatini"
+  },
+  {
+    "code": "TC",
+    "name": "Turks- og Caicosøyene"
+  },
+  {
+    "code": "TD",
+    "name": "Tsjad"
+  },
+  {
+    "code": "TF",
+    "name": "Franske Sørlige Territorier"
+  },
+  {
+    "code": "TG",
+    "name": "Togo"
+  },
+  {
+    "code": "TH",
+    "name": "Thailand"
+  },
+  {
+    "code": "TJ",
+    "name": "Tadsjikistan"
+  },
+  {
+    "code": "TK",
+    "name": "Tokelau"
+  },
+  {
+    "code": "TL",
+    "name": "Øst-Timor"
+  },
+  {
+    "code": "TM",
+    "name": "Turkmenistan"
+  },
+  {
+    "code": "TN",
+    "name": "Tunisia"
+  },
+  {
+    "code": "TO",
+    "name": "Tonga"
+  },
+  {
+    "code": "TR",
+    "name": "Tyrkia"
+  },
+  {
+    "code": "TT",
+    "name": "Trinidad og Tobago"
+  },
+  {
+    "code": "TV",
+    "name": "Tuvalu"
+  },
+  {
+    "code": "TW",
+    "name": "Taiwan"
+  },
+  {
+    "code": "TZ",
+    "name": "Tanzania"
+  },
+  {
+    "code": "UA",
+    "name": "Ukraina"
+  },
+  {
+    "code": "UG",
+    "name": "Uganda"
+  },
+  {
+    "code": "UM",
+    "name": "USAs ytre småøyer"
+  },
+  {
+    "code": "US",
+    "name": "USA"
+  },
+  {
+    "code": "UY",
+    "name": "Uruguay"
+  },
+  {
+    "code": "UZ",
+    "name": "Usbekistan"
+  },
+  {
+    "code": "VA",
+    "name": "Vatikanstaten"
+  },
+  {
+    "code": "VC",
+    "name": "Saint Vincent og Grenadinene"
+  },
+  {
+    "code": "VE",
+    "name": "Venezuela"
+  },
+  {
+    "code": "VG",
+    "name": "Jomfruøyene, Britisk"
+  },
+  {
+    "code": "VI",
+    "name": "Jomfruøyene, US"
+  },
+  {
+    "code": "VN",
+    "name": "Vietnam"
+  },
+  {
+    "code": "VU",
+    "name": "Vanuatu"
+  },
+  {
+    "code": "WF",
+    "name": "Wallis- og Futunaøyene"
+  },
+  {
+    "code": "WS",
+    "name": "Samoa"
+  },
+  {
+    "code": "XB",
+    "name": "Kanariøyene"
+  },
+  {
+    "code": "XC",
+    "name": "Ceuta og Melilla"
+  },
+  {
+    "code": "XK",
+    "name": "Kosovo"
+  },
+  {
+    "code": "YE",
+    "name": "Jemen"
+  },
+  {
+    "code": "YT",
+    "name": "Mayotte"
+  },
+  {
+    "code": "ZA",
+    "name": "Sør-Afrika"
+  },
+  {
+    "code": "ZM",
+    "name": "Zambia"
+  },
+  {
+    "code": "ZW",
+    "name": "Zimbabwe"
+  }
+]


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17550

Vi må legge til logikk for å lage objektene som skal sendes til familie-brev for EØS.

Legger til BegrunnelseEøsDtoene i objektet som blir send til familie-brev. Kopierer logikk fra [ba-sak ](https://github.com/navikt/familie-ba-sak/blob/3ff5151b2750a21976daea063898cda654aad4e4/src/main/kotlin/no/nav/familie/ba/sak/kjerne/brev/brevBegrunnelseProdusent/BrevE%C3%B8sBegrunnelseProdusent.kt#L21) og det vi allerede har for nasjonale og felles begrunnelser i KS. 

Leses lettest commit for commit
