### PR TITLE
Eøs begrunnelser ved uendelige kompetanser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -398,6 +398,11 @@ class VedtaksperiodeService(
             )
                 .map { it.endretUtbetalingAndel }
 
+        val andeler =
+            andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
+                behandling.id,
+            )
+
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
 
         val andelerTilkjentYtelse =
@@ -427,6 +432,7 @@ class VedtaksperiodeService(
                             endretUtbetalingsandeler = endreteUtbetalinger,
                             erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
                             kompetanser = utfylteKompetanser,
+                            andelerTilkjentYtelse = andeler,
                         ).hentGyldigeBegrunnelserForVedtaksperiode(),
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAnde
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
 import java.time.YearMonth
 
 @Service
@@ -124,6 +125,8 @@ data class AndelTilkjentYtelseMedEndreteUtbetalinger internal constructor(
     val prosent get() = andelTilkjentYtelse.prosent
     val andel get() = andelTilkjentYtelse
     val endreteUtbetalinger get() = endreteUtbetalingerAndeler
+
+    val erInnvilget get() = this.endreteUtbetalinger.none { it.prosent == BigDecimal.ZERO && !it.erÅrsakDeltBosted() }
 
     companion object {
         fun utenEndringer(andelTilkjentYtelse: AndelTilkjentYtelse): AndelTilkjentYtelseMedEndreteUtbetalinger {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -256,6 +256,7 @@ class BrevPeriodeContext(
             endretUtbetalingsandeler = andelTilkjentYtelserMedEndreteUtbetalinger.flatMap { it.endreteUtbetalinger },
             erFørsteVedtaksperiode = erFørsteVedtaksperiode,
             kompetanser = kompetanser,
+            andelerTilkjentYtelse = andelTilkjentYtelserMedEndreteUtbetalinger,
         )
 
     fun hentNasjonalOgFellesBegrunnelseDtoer(): List<NasjonalOgFellesBegrunnelseDataDto> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -456,6 +456,7 @@ class BegrunnelserForPeriodeContextTest {
                     kompetanser = listOf(lagKompetanse(fom = jan(2020), tom = jan(2020), annenForeldersAktivitet = KompetanseAktivitet.ARBEIDER, resultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND, barnetsBostedsland = "NO", barnAktører = setOf(barnAktør))),
                     vedtaksperiodeStartsTidpunkt = 1.jan(2020),
                     vedtaksperiodeSluttTidpunkt = 31.jan(2020),
+                    andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = jan(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
             val begrunnelser =
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
@@ -494,6 +495,7 @@ class BegrunnelserForPeriodeContextTest {
                     kompetanser = listOf(lagKompetanse(fom = jan(2020), tom = jan(2020), annenForeldersAktivitet = KompetanseAktivitet.ARBEIDER, resultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND, barnetsBostedsland = "NO", barnAktører = setOf(barnAktør))),
                     vedtaksperiodeStartsTidpunkt = 1.feb(2021),
                     vedtaksperiodeSluttTidpunkt = 28.feb(2021),
+                    andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = feb(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
             val begrunnelser =
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
@@ -533,6 +535,7 @@ class BegrunnelserForPeriodeContextTest {
                     kompetanser = listOf(lagKompetanse(fom = jan(2020), tom = jan(2020), annenForeldersAktivitet = KompetanseAktivitet.ARBEIDER, resultat = KompetanseResultat.NORGE_ER_PRIMÆRLAND, barnetsBostedsland = "NO", barnAktører = setOf(barnAktør))),
                     vedtaksperiodeStartsTidpunkt = 1.feb(2020),
                     vedtaksperiodeSluttTidpunkt = 28.feb(2020),
+                    andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = jan(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
             val begrunnelser =
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
@@ -576,6 +579,7 @@ class BegrunnelserForPeriodeContextTest {
                         ),
                     vedtaksperiodeStartsTidpunkt = 1.feb(2020),
                     vedtaksperiodeSluttTidpunkt = 28.feb(2020),
+                    andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = feb(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
             val begrunnelser =
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
@@ -618,6 +622,7 @@ class BegrunnelserForPeriodeContextTest {
                         ),
                     vedtaksperiodeStartsTidpunkt = 1.feb(2020),
                     vedtaksperiodeSluttTidpunkt = 28.feb(2020),
+                    andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = feb(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
             val begrunnelser =
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17550

Vi får en feil dersom kompetansene varer uendelig lenge. Ved opphør ser vi på kompetansene som vi hadde i forrige periode, men som vi ikke har nå når vi skal finne relevante begrunnelser. Det blir litt feil når kompetansen varer lenger enn periodene med rett på utbetaling. 

Endrer så vi klipper kompetansene etter periodene med utbetaling når vi prøver å finne hvilke kompetanser som er gyldige. 