### PR TITLE
Fiks feil på fortsatt invilget-perioder og legg til støtte for cucumbertester på begrunnelser og brevperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/VedtaksperiodeMedBegrunnelserController.kt
@@ -130,7 +130,6 @@ class VedtaksperiodeMedBegrunnelserController(
 
         vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(
             vedtak = vedtak,
-            skalOverstyreFortsattInnvilget = genererFortsattInnvilgetVedtaksperioderDto.skalGenererePerioderForFortsattInnvilget,
         )
 
         return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = vedtak.behandling.id)))

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
@@ -23,7 +23,6 @@ data class GenererVedtaksperioderForOverstyrtEndringstidspunktDto(
 )
 
 data class GenererFortsattInnvilgetVedtaksperioderDto(
-    val skalGenererePerioderForFortsattInnvilget: Boolean,
     val behandlingId: Long,
 )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/TestVerktøyService.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ks.sak.internal
 
 import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.lagBrevTest
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -19,7 +19,7 @@ class TestVerktøyService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingRepository: EndretUtbetalingAndelRepository,
     private val vedtaksperiodeService: VedtaksperiodeService,
-    private val vedtakService: VedtakService,
+    private val vedtakRepository: VedtakRepository,
     private val kompetanseRepository: KompetanseRepository,
 ) {
     fun hentBrevTest(behandlingId: Long): String {
@@ -47,7 +47,7 @@ class TestVerktøyService(
         val kompetanseForrigeBehandling =
             forrigeBehandling?.let { kompetanseRepository.findByBehandlingId(it.id) }
 
-        val vedtaksperioder = vedtaksperiodeService.hentPersisterteVedtaksperioder(vedtakService.hentVedtak(behandlingId))
+        val vedtaksperioder = vedtaksperiodeService.hentPersisterteVedtaksperioder(vedtakRepository.findByBehandlingAndAktiv(behandlingId = behandlingId))
 
         return lagBrevTest(
             behandling = behandling,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -178,23 +178,12 @@ class VedtaksperiodeService(
         skalOverstyreFortsattInnvilget: Boolean = false,
     ) {
         vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(vedtak)
-        if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET && !skalOverstyreFortsattInnvilget) {
-            vedtaksperiodeHentOgPersisterService.lagre(
-                VedtaksperiodeMedBegrunnelser(
-                    fom = null,
-                    tom = null,
-                    vedtak = vedtak,
-                    type = Vedtaksperiodetype.FORTSATT_INNVILGET,
-                ),
-            )
-        } else {
-            vedtaksperiodeHentOgPersisterService.lagre(
-                genererVedtaksperioderMedBegrunnelser(
-                    vedtak,
-                    gjelderFortsattInnvilget = skalOverstyreFortsattInnvilget,
-                ),
-            )
-        }
+        vedtaksperiodeHentOgPersisterService.lagre(
+            genererVedtaksperioderMedBegrunnelser(
+                vedtak,
+                gjelderFortsattInnvilget = skalOverstyreFortsattInnvilget,
+            ),
+        )
     }
 
     fun genererVedtaksperioderMedBegrunnelser(
@@ -202,6 +191,17 @@ class VedtaksperiodeService(
         gjelderFortsattInnvilget: Boolean = false,
         manueltOverstyrtEndringstidspunkt: LocalDate? = null,
     ): List<VedtaksperiodeMedBegrunnelser> {
+        if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET) {
+            return listOf(
+                VedtaksperiodeMedBegrunnelser(
+                    fom = null,
+                    tom = null,
+                    vedtak = vedtak,
+                    type = Vedtaksperiodetype.FORTSATT_INNVILGET,
+                ),
+            )
+        }
+
         val opphørsperioder =
             hentOpphørsperioder(vedtak.behandling).map { it.tilVedtaksperiodeMedBegrunnelse(vedtak) }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -402,7 +402,7 @@ class VedtaksperiodeService(
 
         return utvidedeVedtaksperioderMedBegrunnelser
             .sortedBy { it.fom }
-            .mapNotNull { utvidetVedtaksperiodeMedBegrunnelser ->
+            .map { utvidetVedtaksperiodeMedBegrunnelser ->
 
                 val erFørsteVedtaksperiodePåFagsak =
                     !andelerTilkjentYtelse.any {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/brevperioder/BrevPeriodeDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/brevperioder/BrevPeriodeDto.kt
@@ -12,9 +12,13 @@ data class BrevPeriodeDto(
     val barnasFodselsdager: Flettefelt,
     val begrunnelser: List<BegrunnelseDto>,
     val type: Flettefelt,
+    @Deprecated("Dette har vi fjernet i ba. Tror vi kan fjerne det i ks også")
     val antallBarnMedUtbetaling: Flettefelt,
+    @Deprecated("Dette har vi fjernet i ba. Tror vi kan fjerne det i ks også")
     val antallBarnMedNullutbetaling: Flettefelt,
+    @Deprecated("Dette har vi fjernet i ba. Tror vi kan fjerne det i ks også")
     val fodselsdagerBarnMedUtbetaling: Flettefelt,
+    @Deprecated("Dette har vi fjernet i ba. Tror vi kan fjerne det i ks også")
     val fodselsdagerBarnMedNullutbetaling: Flettefelt,
 ) {
     constructor(
@@ -25,10 +29,10 @@ data class BrevPeriodeDto(
         brevPeriodeType: BrevPeriodeType,
         antallBarn: String,
         barnasFodselsdager: String,
-        antallBarnMedUtbetaling: String,
-        antallBarnMedNullutbetaling: String,
-        fodselsdagerBarnMedUtbetaling: String,
-        fodselsdagerBarnMedNullutbetaling: String,
+        antallBarnMedUtbetaling: String = "",
+        antallBarnMedNullutbetaling: String = "",
+        fodselsdagerBarnMedUtbetaling: String = "",
+        fodselsdagerBarnMedNullutbetaling: String = "",
     ) : this(
         fom = flettefelt(fom),
         tom = flettefelt(tom),

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -340,6 +340,7 @@ fun lagAndelTilkjentYtelse(
     kalkulertUtbetalingsbeløp: Int = sats,
     ytelseType: YtelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
     prosent: BigDecimal = BigDecimal(100),
+    nasjonaltPeriodebeløp: Int = sats,
 ) = AndelTilkjentYtelse(
     behandlingId = behandling.id,
     tilkjentYtelse = tilkjentYtelse ?: lagInitieltTilkjentYtelse(behandling),
@@ -350,7 +351,7 @@ fun lagAndelTilkjentYtelse(
     type = ytelseType,
     sats = sats,
     prosent = prosent,
-    nasjonaltPeriodebeløp = sats,
+    nasjonaltPeriodebeløp = nasjonaltPeriodebeløp,
     periodeOffset = periodeOffset,
     forrigePeriodeOffset = forrigePeriodeOffset,
     kildeBehandlingId = behandling.id,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.common.domeneparser
 
-import no.nav.familie.ba.sak.cucumber.domeneparser.Domenenøkkel
 import no.nav.familie.ba.sak.cucumber.domeneparser.ÅrMånedEllerDato
 import java.math.BigDecimal
 import java.time.LocalDate

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BrevPeriodeParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BrevPeriodeParser.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.cucumber.domeneparser
+package no.nav.familie.ks.sak.common.domeneparser
 
 object BrevPeriodeParser {
     enum class DomenebegrepBrevBegrunnelse(override val nøkkel: String) : Domenenøkkel {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BrevPeriodeParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BrevPeriodeParser.kt
@@ -6,6 +6,7 @@ object BrevPeriodeParser {
         GJELDER_SØKER("Gjelder søker"),
         BARNAS_FØDSELSDATOER("Barnas fødselsdatoer"),
         ANTALL_BARN("Antall barn"),
+        ANTALL_TIMER_BARNEHAGEPLASS("Antall timer barnehageplass"),
         MÅNED_OG_ÅR_BEGRUNNELSEN_GJELDER_FOR("Måned og år begrunnelsen gjelder for"),
         MÅLFORM("Målform"),
         BELØP("Beløp"),
@@ -13,6 +14,7 @@ object BrevPeriodeParser {
         AVTALETIDSPUNKT_DELT_BOSTED("Avtaletidspunkt delt bosted"),
         SØKERS_RETT_TIL_UTVIDET("Søkers rett til utvidet"),
         TYPE("Type"),
+        GJELDER_ANDRE_FORELDER("Gjelder andre forelder"),
     }
 
     enum class DomenebegrepBrevPeriode(override val nøkkel: String) : Domenenøkkel {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/DomeneparserUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/DomeneparserUtil.kt
@@ -1,7 +1,6 @@
-package no.nav.familie.ba.sak.cucumber.domeneparser
+package no.nav.familie.ks.sak.common.domeneparser
 
 import io.cucumber.datatable.DataTable
-import no.nav.familie.ks.sak.common.domeneparser.parseLong
 
 interface Domenenøkkel {
     val nøkkel: String

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -59,6 +59,7 @@ object VedtaksperiodeMedBegrunnelserParser {
         VURDERES_ETTER("Vurderes etter"),
         BELØP("Beløp"),
         SATS("Sats"),
+        NASJONALT_PERIODEBELØP("Nasjonalt periodebeløp"),
         ER_EKSPLISITT_AVSLAG("Er eksplisitt avslag"),
         ENDRINGSTIDSPUNKT("Endringstidspunkt"),
         BEGRUNNELSER("Begrunnelser"),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ks.sak.common.domeneparser
 
 import io.cucumber.datatable.DataTable
-import no.nav.familie.ba.sak.cucumber.domeneparser.Domenebegrep
-import no.nav.familie.ba.sak.cucumber.domeneparser.Domenenøkkel
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.NasjonalEllerFellesBegrunnelseDB
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.VedtaksperiodeMedBegrunnelser

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevBegrunnelseParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevBegrunnelseParser.kt
@@ -1,0 +1,88 @@
+package no.nav.familie.ks.sak.cucumber
+
+import io.cucumber.datatable.DataTable
+import no.nav.familie.ba.sak.cucumber.domeneparser.Domenebegrep
+import no.nav.familie.ba.sak.cucumber.domeneparser.Domenenøkkel
+import no.nav.familie.ks.sak.common.domeneparser.parseEnum
+import no.nav.familie.ks.sak.common.domeneparser.parseEnumListe
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriDato
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriEnum
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtaksperiodetype
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.IBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import java.time.LocalDate
+
+data class SammenlignbarBegrunnelse(
+    val fom: LocalDate?,
+    val tom: LocalDate?,
+    val type: Vedtaksperiodetype,
+    val inkluderteStandardBegrunnelser: Set<IBegrunnelse>,
+    val ekskluderteStandardBegrunnelser: Set<IBegrunnelse> = emptySet(),
+)
+
+object BrevBegrunnelseParser {
+    fun mapBegrunnelser(dataTable: DataTable): List<SammenlignbarBegrunnelse> {
+        return dataTable.asMaps().map { rad ->
+            val regelverkForInkluderteBegrunnelser =
+                parseValgfriEnum<Regelverk>(DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.REGELVERK_INKLUDERTE_BEGRUNNELSER, rad)
+                    ?: Regelverk.NASJONALE_REGLER
+
+            val regelverkForEkskluderteBegrunnelser =
+                parseValgfriEnum<Regelverk>(DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.REGELVERK_EKSKLUDERTE_BEGRUNNELSER, rad)
+                    ?: regelverkForInkluderteBegrunnelser
+
+            val inkluderteStandardBegrunnelser =
+                hentForventedeBegrunnelser(
+                    regelverkForInkluderteBegrunnelser,
+                    DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.INKLUDERTE_BEGRUNNELSER,
+                    rad,
+                )
+            val ekskluderteStandardBegrunnelser =
+                hentForventedeBegrunnelser(
+                    regelverkForEkskluderteBegrunnelser,
+                    DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.EKSKLUDERTE_BEGRUNNELSER,
+                    rad,
+                )
+
+            SammenlignbarBegrunnelse(
+                fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad),
+                tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad),
+                type = parseEnum(DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser.VEDTAKSPERIODE_TYPE, rad),
+                inkluderteStandardBegrunnelser = inkluderteStandardBegrunnelser,
+                ekskluderteStandardBegrunnelser = ekskluderteStandardBegrunnelser,
+            )
+        }
+    }
+
+    private fun hentForventedeBegrunnelser(
+        vurderesEtter: Regelverk,
+        inkludertEllerEkskludert: DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser,
+        rad: Map<String, String>,
+    ): Set<IBegrunnelse> {
+        return when (vurderesEtter) {
+            Regelverk.NASJONALE_REGLER -> {
+                parseEnumListe<NasjonalEllerFellesBegrunnelse>(
+                    inkludertEllerEkskludert,
+                    rad,
+                ).toSet()
+            }
+
+            Regelverk.EØS_FORORDNINGEN -> {
+                parseEnumListe<EØSBegrunnelse>(
+                    inkludertEllerEkskludert,
+                    rad,
+                ).toSet()
+            }
+        }
+    }
+
+    enum class DomenebegrepUtvidetVedtaksperiodeMedBegrunnelser(override val nøkkel: String) : Domenenøkkel {
+        VEDTAKSPERIODE_TYPE("VedtaksperiodeType"),
+        INKLUDERTE_BEGRUNNELSER("Gyldige begrunnelser"),
+        EKSKLUDERTE_BEGRUNNELSER("Ugyldige begrunnelser"),
+        REGELVERK_INKLUDERTE_BEGRUNNELSER("Regelverk Gyldige begrunnelser"),
+        REGELVERK_EKSKLUDERTE_BEGRUNNELSER("Regelverk Ugyldige begrunnelser"),
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevBegrunnelseParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevBegrunnelseParser.kt
@@ -1,8 +1,8 @@
 package no.nav.familie.ks.sak.cucumber
 
 import io.cucumber.datatable.DataTable
-import no.nav.familie.ba.sak.cucumber.domeneparser.Domenebegrep
-import no.nav.familie.ba.sak.cucumber.domeneparser.Domenenøkkel
+import no.nav.familie.ks.sak.common.domeneparser.Domenebegrep
+import no.nav.familie.ks.sak.common.domeneparser.Domenenøkkel
 import no.nav.familie.ks.sak.common.domeneparser.parseEnum
 import no.nav.familie.ks.sak.common.domeneparser.parseEnumListe
 import no.nav.familie.ks.sak.common.domeneparser.parseValgfriDato

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -1,0 +1,171 @@
+package no.nav.familie.ks.sak.cucumber
+
+import io.cucumber.datatable.DataTable
+import no.nav.familie.ks.sak.common.domeneparser.BrevPeriodeParser
+import no.nav.familie.ks.sak.common.domeneparser.VedtaksperiodeMedBegrunnelserParser
+import no.nav.familie.ks.sak.common.domeneparser.norskDatoFormatter
+import no.nav.familie.ks.sak.common.domeneparser.parseEnum
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriBoolean
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriEnum
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriInt
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriString
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseType
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDtoMedData
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelseDto
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelseMedKompetanseDto
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelseUtenKompetanseDto
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
+import java.time.LocalDate
+
+enum class Begrunnelsetype {
+    EØS,
+    STANDARD,
+}
+
+fun parseBegrunnelser(dataTable: DataTable): List<BegrunnelseDtoMedData> {
+    return dataTable.asMaps().map { rad: Tabellrad ->
+
+        val type =
+            parseValgfriEnum<Begrunnelsetype>(
+                BrevPeriodeParser.DomenebegrepBrevBegrunnelse.TYPE,
+                rad,
+            ) ?: Begrunnelsetype.STANDARD
+
+        when (type) {
+            Begrunnelsetype.STANDARD -> parseNasjonalEllerFellesBegrunnelse(rad)
+            Begrunnelsetype.EØS -> parseEøsBegrunnelse(rad)
+        }
+    }
+}
+
+fun parseNasjonalEllerFellesBegrunnelse(rad: Tabellrad): BegrunnelseDtoMedData {
+    val begrunnelse =
+        parseEnum<NasjonalEllerFellesBegrunnelse>(
+            BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BEGRUNNELSE,
+            rad,
+        )
+
+    return NasjonalOgFellesBegrunnelseDataDto(
+        vedtakBegrunnelseType = begrunnelse.begrunnelseType,
+        apiNavn = begrunnelse.sanityApiNavn,
+        gjelderSoker = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_SØKER, rad) ?: false,
+        barnasFodselsdatoer =
+            parseValgfriString(
+                BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BARNAS_FØDSELSDATOER,
+                rad,
+            ) ?: "",
+        antallBarn = parseValgfriInt(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_BARN, rad) ?: 0,
+        maanedOgAarBegrunnelsenGjelderFor =
+            parseValgfriString(
+                BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅNED_OG_ÅR_BEGRUNNELSEN_GJELDER_FOR,
+                rad,
+            ),
+        maalform =
+            (parseValgfriEnum<Målform>(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅLFORM, rad) ?: Målform.NB)
+                .tilSanityFormat(),
+        belop = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BELØP, rad)?.replace(' ', ' ') ?: "",
+        soknadstidspunkt =
+            parseValgfriString(
+                BrevPeriodeParser.DomenebegrepBrevBegrunnelse.SØKNADSTIDSPUNKT,
+                rad,
+            ) ?: "",
+        antallTimerBarnehageplass = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_TIMER_BARNEHAGEPLASS, rad) ?: 0.toString(),
+        sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
+        gjelderAndreForelder = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_ANDRE_FORELDER, rad) ?: true,
+    )
+}
+
+fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseDto {
+    val gjelderSoker = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_SØKER, rad)
+
+    val annenForeldersAktivitet =
+        parseValgfriEnum<KompetanseAktivitet>(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITET,
+            rad,
+        )
+    val annenForeldersAktivitetsland =
+        parseValgfriString(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITETSLAND,
+            rad,
+        )
+    val barnetsBostedsland =
+        parseValgfriString(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.BARNETS_BOSTEDSLAND,
+            rad,
+        )
+    val søkersAktivitet =
+        parseValgfriEnum<KompetanseAktivitet>(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITET,
+            rad,
+        )
+    val søkersAktivitetsland =
+        parseValgfriString(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITETSLAND,
+            rad,
+        )
+
+    val begrunnelse =
+        parseEnum<EØSBegrunnelse>(
+            BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BEGRUNNELSE,
+            rad,
+        )
+
+    val barnasFodselsdatoer =
+        parseValgfriString(
+            BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BARNAS_FØDSELSDATOER,
+            rad,
+        ) ?: ""
+
+    val antallBarn = parseValgfriInt(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_BARN, rad) ?: -1
+
+    val målform = (parseValgfriEnum<Målform>(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅLFORM, rad) ?: Målform.NB).tilSanityFormat()
+
+    return if (gjelderSoker == null) {
+        if (annenForeldersAktivitet == null ||
+            annenForeldersAktivitetsland == null ||
+            barnetsBostedsland == null ||
+            søkersAktivitet == null ||
+            søkersAktivitetsland == null
+        ) {
+            error("For EØS-begrunnelser må enten 'Gjelder søker' eller kompetansefeltene settes")
+        }
+
+        EØSBegrunnelseMedKompetanseDto(
+            vedtakBegrunnelseType = begrunnelse.begrunnelseType,
+            apiNavn = begrunnelse.sanityApiNavn,
+            barnasFodselsdatoer = barnasFodselsdatoer,
+            antallBarn = antallBarn,
+            maalform = målform,
+            annenForeldersAktivitet = annenForeldersAktivitet,
+            annenForeldersAktivitetsland = annenForeldersAktivitetsland,
+            barnetsBostedsland = barnetsBostedsland,
+            sokersAktivitet = søkersAktivitet,
+            sokersAktivitetsland = søkersAktivitetsland,
+            sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
+        )
+    } else {
+        EØSBegrunnelseUtenKompetanseDto(
+            vedtakBegrunnelseType = begrunnelse.begrunnelseType,
+            apiNavn = begrunnelse.sanityApiNavn,
+            barnasFodselsdatoer = barnasFodselsdatoer,
+            antallBarn = antallBarn,
+            maalform = målform,
+            gjelderSoker = gjelderSoker,
+            sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
+        )
+    }
+}
+
+fun parseNullableDato(fom: String) =
+    if (fom.uppercase() in listOf("NULL", "-", "")) {
+        null
+    } else {
+        LocalDate.parse(
+            fom,
+            norskDatoFormatter,
+        )
+    }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevperiodeUtil.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ks.sak.cucumber
+
+import io.cucumber.datatable.DataTable
+import no.nav.familie.ks.sak.common.domeneparser.BrevPeriodeParser
+import no.nav.familie.ks.sak.common.domeneparser.Domenebegrep
+import no.nav.familie.ks.sak.common.domeneparser.parseEnum
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriInt
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriString
+import no.nav.familie.ks.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriodeDto
+import no.nav.familie.ks.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriodeType
+
+typealias Tabellrad = Map<String, String>
+
+fun parseBrevPerioder(dataTable: DataTable): List<BrevPeriodeDto> {
+    return dataTable.asMaps().map { rad: Tabellrad ->
+
+        val beløp = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevPeriode.BELØP, rad)?.replace(' ', ' ') ?: ""
+        val antallBarn = parseValgfriInt(BrevPeriodeParser.DomenebegrepBrevPeriode.ANTALL_BARN, rad) ?: -1
+        val barnasFodselsdager =
+            parseValgfriString(
+                BrevPeriodeParser.DomenebegrepBrevPeriode.BARNAS_FØDSELSDAGER,
+                rad,
+            ) ?: ""
+        val duEllerInstitusjonen =
+            parseValgfriString(BrevPeriodeParser.DomenebegrepBrevPeriode.DU_ELLER_INSTITUSJONEN, rad) ?: "Du"
+
+        BrevPeriodeDto(
+            fom = parseValgfriString(Domenebegrep.FRA_DATO, rad) ?: "",
+            tom = parseValgfriString(Domenebegrep.TIL_DATO, rad) ?: "",
+            belop = beløp,
+            // egen test for dette. Se `forvent følgende brevbegrunnelser for behandling i periode`()
+            begrunnelser = emptyList(),
+            brevPeriodeType = parseEnum<BrevPeriodeType>(BrevPeriodeParser.DomenebegrepBrevPeriode.TYPE, rad),
+            antallBarn = antallBarn.toString(),
+            barnasFodselsdager = barnasFodselsdager,
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -238,7 +238,6 @@ class StepDefinition {
             mockVedtaksperiodeService().genererVedtaksperioderMedBegrunnelser(
                 vedtak = vedtakListe.single { it.behandling.id == behandlingId },
                 manueltOverstyrtEndringstidspunkt = overstyrteEndringstidspunkt[behandlingId],
-                gjelderFortsattInnvilget = false,
             )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -57,7 +57,6 @@ import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import java.time.LocalDate
 
@@ -212,7 +211,7 @@ class StepDefinition {
         val beregnetTilkjentYtelse = andelerTilkjentYtelse[behandlingId]!!
         val forventedeAndeler = lagAndelerTilkjentYtelse(dataTable, behandlingId, behandlinger, persongrunnlag)
 
-        Assertions.assertThat(beregnetTilkjentYtelse)
+        assertThat(beregnetTilkjentYtelse)
             .usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*endretTidspunkt", ".*opprettetTidspunkt", ".*kildeBehandlingId", ".*tilkjentYtelse")
             .isEqualTo(forventedeAndeler)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -408,6 +408,11 @@ fun lagAndelerTilkjentYtelse(
                 VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.SATS,
                 rad,
             ) ?: beløp,
+        nasjonaltPeriodebeløp =
+            parseValgfriInt(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.NASJONALT_PERIODEBELØP,
+                rad,
+            ) ?: beløp,
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -184,7 +184,7 @@ internal class VedtaksperiodeServiceTest {
         behandling.resultat = Behandlingsresultat.FORTSATT_INNVILGET
 
         val mocketVedtak = mockk<Vedtak>()
-        val vedtaksperiodeMedBegrunnelseSlot = slot<VedtaksperiodeMedBegrunnelser>()
+        val vedtaksperiodeMedBegrunnelseSlot = slot<List<VedtaksperiodeMedBegrunnelser>>()
 
         every { vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(mocketVedtak) } just runs
         every { vedtaksperiodeHentOgPersisterService.lagre(capture(vedtaksperiodeMedBegrunnelseSlot)) } returns mockk()
@@ -192,7 +192,7 @@ internal class VedtaksperiodeServiceTest {
 
         vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(mocketVedtak)
 
-        val lagretVedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelseSlot.captured
+        val lagretVedtaksperiodeMedBegrunnelser = vedtaksperiodeMedBegrunnelseSlot.captured.single()
 
         assertThat(lagretVedtaksperiodeMedBegrunnelser.fom, Is(nullValue()))
         assertThat(lagretVedtaksperiodeMedBegrunnelser.tom, Is(nullValue()))

--- a/src/test/resources/cucumber/fortsatt-innvilget.feature
+++ b/src/test/resources/cucumber/fortsatt-innvilget.feature
@@ -1,0 +1,75 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Fortsatt innvilget
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Behandlingskategori |
+      | 1            | 1        |                     | ENDRET_UTBETALING   | SØKNAD           | NASJONAL            |
+      | 2            | 2        | 1                   | FORTSATT_INNVILGET  | NYE_OPPLYSNINGER | NASJONAL            |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 11.04.1987  |
+      | 1            | 2       | BARN       | 07.05.2022  |
+      | 2            | 1       | SØKER      | 11.04.1987  |
+      | 2            | 2       | BARN       | 07.05.2022  |
+
+  Scenario: Skal få riktig begrunnelse for fortsatt innvilget
+    Og følgende dagens dato 15.01.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                   | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                |                  | 11.04.1987 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 2       | BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 07.05.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BOR_MED_SØKER                            |                  | 07.05.2022 | 31.12.2023 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BARNEHAGEPLASS                           |                  | 07.05.2022 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BARNETS_ALDER                            |                  | 07.05.2023 | 07.05.2024 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOR_MED_SØKER                            | DELT_BOSTED      | 01.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                                   | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                |                  | 11.04.1987 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 2       | BOR_MED_SØKER                            |                  | 07.05.2022 | 31.12.2023 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOSATT_I_RIKET |                  | 07.05.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BARNEHAGEPLASS                           |                  | 07.05.2022 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BARNETS_ALDER                            |                  | 07.05.2023 | 07.05.2024 | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BOR_MED_SØKER                            | DELT_BOSTED      | 01.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp |
+      | 2       | 01.06.2023 | 31.01.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |
+      | 2       | 01.02.2024 | 30.04.2024 | 3750  | ORDINÆR_KONTANTSTØTTE | 50      | 7500 | 3750                   |
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato | Til dato | Vedtaksperiodetype |
+      |          |          | FORTSATT_INNVILGET |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato | Til dato | VedtaksperiodeType | Gyldige begrunnelser                  |
+      |          |          | FORTSATT_INNVILGET | FORTSATT_INNVILGET_BARN_BOR_MED_SOKER |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato | Til dato | Standardbegrunnelser                  |
+      |          |          | FORTSATT_INNVILGET_BARN_BOR_MED_SOKER |
+
+    Så forvent følgende brevperioder for behandling 2
+      | Brevperiodetype    | Fra dato | Til dato | Beløp | Antall barn med utbetaling | Barnas fødselsdager |
+      | FORTSATT_INNVILGET | Du får:  |          | 7 500 | 1                          | 07.05.22            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode - til -
+      | Begrunnelse                           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder |
+      | FORTSATT_INNVILGET_BARN_BOR_MED_SOKER | STANDARD | Nei           | 07.05.22             | 1           | NB      | 7 500 |                  | 0                           | Ja                     |

--- a/src/test/resources/cucumber/restSanityBegrunnelser.json
+++ b/src/test/resources/cucumber/restSanityBegrunnelser.json
@@ -1,0 +1,27106 @@
+[
+  {
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-05-04T06:24:14Z",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "visningsnavn": "4. Barn over 2 år",
+    "_rev": "KOa0MjQMDn5FLyPT0Q73ks",
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "_key": "8a941cc37bdc",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barn fødd ",
+            "_key": "6e5e3ff5524f0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "e0513cd4d928"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er over 2 år.",
+            "_key": "8676b31f58ce"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "avslagBarnOverToAar",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "bokmaal": [
+      {
+        "_key": "c38f954317ad",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "74ca855ce6c30"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "248b696fb34c"
+          },
+          {
+            "text": " er over 2 år.",
+            "_key": "4ca0c393347e",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Barn over 2 år",
+    "_createdAt": "2023-05-04T06:24:14Z",
+    "_id": "ksBegrunnelse-006e8555-5220-4785-ae04-46b97e3cb342"
+  },
+  {
+    "apiNavn": "innvilgetPrimarlandUKOgUtlandStandard",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "7. Primærland UK og utland standard",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_createdAt": "2023-12-19T10:24:29Z",
+    "_updatedAt": "2024-01-05T15:43:50Z",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "06388d7f441e0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "47a9d59151be"
+          },
+          {
+            "marks": [],
+            "text": " ",
+            "_key": "7e57acfbdbe7",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "156c40716bdd",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " går ikkje i ein barnehage som får offentleg støtte. Du ",
+            "_key": "06388d7f441e2",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6c99ea889d16",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Den andre forelderen jobbar ikkje i ",
+            "_key": "1247edad2c1f"
+          },
+          {
+            "_key": "d5d5e1ddcb6e",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_key": "599d08d3f0c3",
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Etter avtalen får du heile kontantstøtta frå Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "bac43788aee9",
+        "markDefs": []
+      }
+    ],
+    "barnetsBostedsland": [
+      "IKKE_NORGE"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "a5927a8914dd0"
+          },
+          {
+            "_key": "4d2537dfa344",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "6ff50b76d9fc"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "c6ef08a6ebd7",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " går ikke i en barnehage som får offentlig støtte. Du ",
+            "_key": "a5927a8914dd2",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "540b3725c90f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Den andre forelderen jobber ikke i ",
+            "_key": "fdea92473e0f"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "3cf835ff6a11"
+          },
+          {
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Etter avtalen får du hele kontantstøtten fra Norge.",
+            "_key": "c2374d866f28",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f52d9099e54e"
+      }
+    ],
+    "navnISystem": "Primærland UK og utland standard",
+    "_rev": "31FBBXLBfWAGsmyBLAMzb5",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-00f26510-92a8-45ab-abf6-f472f1cf3c3c",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ]
+  },
+  {
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi retten har bestemt at",
+            "_key": "349d7eb417610"
+          },
+          {
+            "_key": "3f77a94bd747",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt skal ha delt bustad.",
+            "_key": "01f8cda3d64e"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e7ad3c4c7889"
+      }
+    ],
+    "_createdAt": "2023-12-12T12:20:56Z",
+    "_id": "ksBegrunnelse-02276027-88ba-4ed2-95f4-c73b5a19c9f7",
+    "apiNavn": "fortsattInnvilgetFortsattRettsavgjorelseOmDeltBosted",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "visningsnavn": "9. Fortsatt rettsavgjørelse om delt bosted",
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi retten har bestemt at ",
+            "_key": "e4976ebc6abb0"
+          },
+          {
+            "_key": "344cc6c1f26a",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " fortsatt skal ha delt bosted.",
+            "_key": "9a57d0d410cc",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8fa5d7746c6c"
+      }
+    ],
+    "navnISystem": "Fortsatt rettsavgjørelse om delt bosted",
+    "resultat": "FORTSATT_INNVILGET",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_rev": "QYE1lVUzcrAawv9ECZmg16",
+    "_updatedAt": "2023-12-12T12:20:56Z"
+  },
+  {
+    "triggere": [
+      "SATSENDRING"
+    ],
+    "_id": "ksBegrunnelse-0583d7e5-934a-40bd-b7cb-c3c852332802",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "86991446d9a3",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtten er endret fordi det har vært en satsendring.",
+            "_key": "4f20c9539ed30",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "tema": "NASJONAL",
+    "resultat": "REDUKSJON",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi det har vore ei satsendring.",
+            "_key": "34f4169abc4f0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "047dfeee7cb1",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "7"
+    ],
+    "visningsnavn": "15. Satsendring",
+    "_type": "ksBegrunnelse",
+    "apiNavn": "reduksjonSatsendring",
+    "_rev": "KOa0MjQMDn5FLyPT0Mwdh2",
+    "type": "STANDARD",
+    "_createdAt": "2023-05-03T15:37:36Z",
+    "_updatedAt": "2023-05-03T15:37:36Z",
+    "navnISystem": "Satsendring"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_updatedAt": "2023-12-12T11:50:09Z",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte fordi ",
+            "_key": "d481203fbc5a0",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "c1863c1ae681",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt har opphaldsløyve. ",
+            "_key": "d481203fbc5a2"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3dc6df2c74d6",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Tredjelandsborger fortsatt lovlig opphold",
+    "apiNavn": "fortsattInnvilgetTredjelandsborgerFortsattLovligOpphold",
+    "_rev": "QYE1lVUzcrAawv9ECZlL1w",
+    "resultat": "FORTSATT_INNVILGET",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-066d0adb-bc1d-407b-8e4b-341628b0ac3e",
+    "visningsnavn": "2. Tredjelandsborger fortsatt lovlig opphold",
+    "_createdAt": "2023-12-12T11:50:09Z",
+    "bokmaal": [
+      {
+        "_key": "58856c7ca70c",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte fordi ",
+            "_key": "c965ca7c89cb0",
+            "_type": "span"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "0f0e357a08a4",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            }
+          },
+          {
+            "marks": [],
+            "text": "fortsatt er bosatt i Norge.",
+            "_key": "c965ca7c89cb2",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "tema": "NASJONAL",
+    "visningsnavn": "etterEndretUtbetalingTillegsTekstEksempel",
+    "_createdAt": "2023-03-20T06:42:04Z",
+    "_rev": "VNfjOkUyv8N7GDE50DIFqa",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "navnISystem": "etterEndretUtbetalingTillegsTekstEksempel",
+    "apiNavn": "etterEndretUtbetalingTillegsTekstEksempel",
+    "endringsaarsaker": [
+      "DELT_BOSTED"
+    ],
+    "_id": "ksBegrunnelse-06e9b88c-4b2d-4801-8002-bf0e31a567a1",
+    "resultat": "ETTER_ENDRET_UTBETALINGSPERIODE",
+    "_updatedAt": "2023-03-20T06:42:04Z"
+  },
+  {
+    "_id": "ksBegrunnelse-07c13f90-ae3a-4290-bc6f-02df812bd95a",
+    "_updatedAt": "2023-07-24T07:43:22Z",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "27. Vurdering ikke medlem folketrygden i 5 år ",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2023-07-24T07:43:22Z",
+    "navnISystem": "Vurdering ikke medlem folketrygden i 5 år ",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "apiNavn": "opphorVurderingIkkeMedlemIFolketrygdenI5Aar",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "0226520e81a20"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "fb9feda80bb2",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har ikkje vore medlem i folketrygda i fem år.",
+            "_key": "0226520e81a26"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3b6147cc4d2d"
+      }
+    ],
+    "_rev": "XYs5CWqIz9KsYqFMh2s6aN",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "8bce35efd9df0",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "1003b9e518cb",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden i fem år.",
+            "_key": "8bce35efd9df6"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3687489dc276"
+      }
+    ]
+  },
+  {
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "_rev": "A3jSdym3jf5hqTWanvkWgv",
+    "resultat": "OPPHØR",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "4eb1837e9ef5",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetjenesten i kommunen har opplyst at barn født ",
+            "_key": "42bc579ce5c30"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "491f55ba9caa",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt deltidsplass i barnehage fra ",
+            "_key": "cc9293f41403"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "50edd83f67af",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor"
+          },
+          {
+            "_key": "7317643f016c",
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt deltidsplass i barnehagen kan ikke kontantstøtten deles mellom foreldrene."
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Delt bosted kommunen melder om deltidsplass",
+    "visningsnavn": "45. Delt bosted kommunen melder om deltidsplass",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-0a8ba0f5-e539-4730-a625-d7e00f88bff5",
+    "_updatedAt": "2023-09-12T11:43:33Z",
+    "apiNavn": "opphorDeltBostedKommunenMelderOmDeltidsplass",
+    "type": "STANDARD",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_key": "dfd68a26645a",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetenesta i kommunen har opplyst at barn fødd ",
+            "_key": "0d0db121a7940"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "51af3e7a0d7d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "  var tildelt fulltidsplass i barnehage frå ",
+            "_key": "c91d0009f348"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "66ebdae0aea1"
+          },
+          {
+            "marks": [],
+            "text": ". Når barnet er tildelt deltidsplass i barnehagen kan ikkje kontantstøtta delast mellom foreldra.",
+            "_key": "5fcc87a84d1d",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-09-06T10:59:33Z"
+  },
+  {
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "74a9c038ac50",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at norske regler for kontantstøtte ikke gjaldt for familien. Derfor hadde du ikke rett på kontantstøtte fra Norge.",
+            "_key": "da1328a0d72e0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECkwvPg",
+    "_createdAt": "2023-12-19T14:55:07Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_id": "ksBegrunnelse-0aeab2d7-9a79-4f9d-a1c0-efb60a9e9827",
+    "visningsnavn": "21. Norge var ikke sentrum for livsinteresse",
+    "resultat": "OPPHØR",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at norske reglar for kontantstøtte ikkje gjaldt for familien. Derfor hadde du ikkje rett på kontantstøtte frå Noreg.",
+            "_key": "8df249cf61840"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "95fec09b0c69",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Norge var ikke sentrum for livsinteresse",
+    "apiNavn": "opphorNorgeVarIkkeSentrumForLivsinteresse",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2023-12-19T14:59:30Z"
+  },
+  {
+    "_createdAt": "2022-12-07T17:32:16Z",
+    "navnISystem": "Medlemskap folketrygden",
+    "apiNavn": "innvilgetMedlemskapIFolketrygden",
+    "visningsnavn": "8. Medlemskap  folketrygden",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "skalAlltidVises": true,
+    "stotterFritekst": true,
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "cf00562506cc0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "947d9d749411"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at ",
+            "_key": "b620e618e408"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "fd4406a2a504",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har vore medlem i folketrygda i fem år. ",
+            "_key": "cf00562506cc4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "ee69f0eacc26",
+        "markDefs": []
+      },
+      {
+        "_key": "b00925ae1ddb",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "2709fa4bbda10"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_updatedAt": "2023-05-05T10:49:40Z",
+    "bokmaal": [
+      {
+        "_key": "93c18f9022e0",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "4052f98ee3d10",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "a4499cbc6d32",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "text": " fra måneden etter at ",
+            "_key": "af5ca009d1e4",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "f55fdea2b59f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har vært medlem i folketrygden i fem år.",
+            "_key": "4052f98ee3d14"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "bc31f489c5da",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "23e6916c59e10"
+          }
+        ]
+      }
+    ],
+    "hjemler": [
+      "3"
+    ],
+    "_rev": "vuzvVDrYQXJOMHanV9oHEw",
+    "_id": "ksBegrunnelse-0b315855-8ea2-47c4-875d-b326b9d2132b"
+  },
+  {
+    "apiNavn": "innvilgetMaanedenEtterEttAar",
+    "_rev": "qZCk5XjphuY3aLmQrsvwx9",
+    "type": "TILLEGGSTEKST",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "_updatedAt": "2023-03-07T08:08:50Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "e05e4a1797bb",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "4e7fb2274e930"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c7922eafff79"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "4f0aba0a0832"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e5b5128f6613"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fylte ett år.",
+            "_key": "f829f16553e5"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Måneden etter ett år",
+    "tema": "NASJONAL",
+    "_createdAt": "2022-12-07T09:14:29Z",
+    "hjemler": [
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-0c0bfa95-d21a-4c2d-93a9-883ee09393f2",
+    "visningsnavn": "1. Måneden etter ett år",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "c3007532f8ed",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "0a88ae2c3f030"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "db99f7fcedfb"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at ",
+            "_key": "2dcc5953ddd0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "fc5011757680",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fylte eitt år.",
+            "_key": "0a88ae2c3f032"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "resultat": "INNVILGET"
+  },
+  {
+    "_rev": "AOUa26DfnB8ntJraK3xHQF",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_createdAt": "2023-12-19T14:53:22Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-0d4f260b-2afd-4544-9bac-abc18293ac79",
+    "apiNavn": "opphorSeparasjonsavtalenGjaldtIkke",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Separasjonsavtalen mellom Storbritannia og Norge ikke gjaldt for familien.",
+            "_key": "bc33567a9e9d0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1b6d33cf24df"
+      }
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Separasjonsavtalen mellom Storbritannia og Noreg ikkje gjaldt for familien.",
+            "_key": "df65e170fa0b0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1c6eb93d3129"
+      }
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "resultat": "OPPHØR",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "20. Separasjonsavtalen gjaldt ikke",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "_updatedAt": "2023-12-19T14:59:24Z",
+    "navnISystem": "Separasjonsavtalen gjaldt ikke"
+  },
+  {
+    "navnISystem": "Søker ber om opphør",
+    "_id": "ksBegrunnelse-0ecf2e95-be4c-4671-98c3-3a8eaa30ed1d",
+    "apiNavn": "opphorSokerBerOmOpphor",
+    "type": "STANDARD",
+    "_updatedAt": "2023-08-22T14:09:58Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "bb910b49c8b7",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har bedt om at kontantstøtten for barn født ",
+            "_key": "b02d75a9bc060"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "a444ca730d0c",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " blir stanset.",
+            "_key": "ddf563006417"
+          }
+        ]
+      }
+    ],
+    "visningsnavn": "18. Søker ber om opphør",
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "756a20e3f871",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "214d955a6db70",
+            "_type": "span",
+            "marks": [],
+            "text": "Du har bedt om at kontantstøtta for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "e2462161ed80"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " blir stansa.",
+            "_key": "b1f8ba6fb3a8"
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2023-07-21T15:37:52Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "a0WJuBMaSZfluxupeScuVb",
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL"
+  },
+  {
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-0f8d7c3b-95e8-4de5-8343-edc102d8b242",
+    "navnISystem": "Vurdering ikke bosatt i Norge",
+    "_rev": "KOa0MjQMDn5FLyPT0RAikF",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "5ad53670c45d0"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a878eb1e102b",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje er busett i Noreg.",
+            "_key": "2915bde88089"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e2e3925913fc"
+      }
+    ],
+    "apiNavn": "avslagVurderingIkkeBosattINorge",
+    "visningsnavn": "11. Vurdering ikke bosatt i Norge",
+    "resultat": "AVSLAG",
+    "_updatedAt": "2023-05-04T09:05:38Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Vi har kommet fram til at ",
+            "_key": "23cc74b83d5c0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "ccb45c237056",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke er bosatt i Norge.",
+            "_key": "42f242da4061"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "a0e1c4a8e32f"
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_createdAt": "2023-05-04T09:05:38Z",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "tema": "EØS",
+    "_updatedAt": "2023-12-19T14:59:18Z",
+    "visningsnavn": "19. Barn bodde ikke i et EØS land",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_key": "83b7e113711e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "e50c97a2db4a0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "79cccf4d5e93"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje budde i eit EØS-land.",
+            "_key": "864078eff1a1"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_id": "ksBegrunnelse-120f5f2c-525f-48e3-8f30-fd8e066e865f",
+    "navnISystem": "Barn bodde ikke i et EØS land",
+    "apiNavn": "opphorBarnBoddeIkkeIEtEosLand",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_rev": "CM6961CqAC7W4puPRKubP0",
+    "resultat": "OPPHØR",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_createdAt": "2023-12-19T14:51:42Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barn født ",
+            "_key": "0732c1b504740",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "fd6205303f62",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_key": "357acc515ca5",
+            "_type": "span",
+            "marks": [],
+            "text": " ikke bodde i et EØS-land."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "10b82841c424"
+      }
+    ]
+  },
+  {
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "fdfb12389d02",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "fc2bdf4ec6c30",
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "818cb2a5f0d8",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "13716933ddd0",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje skal opphalde "
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d97b1ea2980b"
+          },
+          {
+            "text": " samanhengande i Noreg i over 12 månader. ",
+            "_key": "9523d68c89dd",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "_updatedAt": "2023-09-07T12:04:45Z",
+    "navnISystem": "Vurdering har og skal oppholde seg ikke over 12 mnd",
+    "_createdAt": "2023-07-21T15:26:33Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "e6bbec928ffe0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "eaea81688790",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke skal oppholde ",
+            "_key": "4872973d8feb"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "ceb8ef3d421b",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a"
+            }
+          },
+          {
+            "text": " sammenhengende i Norge i over 12 måneder. ",
+            "_key": "84f25168e8fc",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e34cd1269f87"
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "15. Vurdering har og skal oppholde seg ikke over 12 mnd",
+    "_rev": "A3jSdym3jf5hqTWanr2T8e",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-1333e49d-4f43-4b83-8c5f-f30db0a16e17",
+    "apiNavn": "opphorVurderingHarOgSkalOppholdeSegOver12Maaneder",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ]
+  },
+  {
+    "visningsnavn": "43. Vurdering annen forelder ikke medlem folketrygden i 5 år ",
+    "_rev": "Xl0tn62zVopahRtC7Lda7D",
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-133a3af5-c3ae-4a86-8caa-c0fd664f5c0f",
+    "navnISystem": "Vurdering annen forelder ikke medlem folketrygden i 5 år ",
+    "resultat": "OPPHØR",
+    "apiNavn": "opphorVurderingAnnenForelderIkkeMedlemFolketrygdenI5Aar",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-07-24T08:54:51Z",
+    "_updatedAt": "2023-07-24T08:54:51Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at den andre forelderen ikke har vært medlem i folketrygden i fem år.",
+            "_key": "46a98d25ef0f0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3a631936c00b",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "a04dfc6bf323",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at den andre forelderen har ikkje vore medlem i folketrygda i fem år.",
+            "_key": "dd993c5a01390"
+          }
+        ],
+        "_type": "block"
+      }
+    ]
+  },
+  {
+    "apiNavn": "avslagDenAndreForelderenIkkeMedlemFolketrygdenEllerEOSIFemAar",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_rev": "lxTMP95K2WARLoXUTuVAm8",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "b6f984cbf9e4",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen ikke har vært medlem i folketrygden eller i trygdeordninger i andre EØS-land i til sammen fem år.",
+            "_key": "78fcc9d2ebd60"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Den andre forelderen ikke medlem folketrygden eller EØS i fem år",
+    "resultat": "AVSLAG",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "dfcc70070354",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen ikkje har vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år.",
+            "_key": "a32b7172c6cb0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_id": "ksBegrunnelse-13b58183-7b9d-4518-9d07-785c327dff8a",
+    "visningsnavn": "31. Den andre forelderen ikke medlem folketrygden eller EØS i fem år",
+    "_createdAt": "2023-05-04T18:12:41Z",
+    "_updatedAt": "2023-05-04T18:12:41Z"
+  },
+  {
+    "_rev": "ZHptMMiGbb7440Rb5U81dm",
+    "rolle": [
+      "SOKER"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "549d971838f60"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "ca62c748eb25"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at ",
+            "_key": "29832ee451a6"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a7a05cd36508",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er busett i Noreg og har opphaldsløyve.",
+            "_key": "549d971838f66"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "79dc4183585a",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-150519d6-456c-4c9b-bc8c-3684455a837a",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "bokmaal": [
+      {
+        "_key": "c46464ee1c33",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "dc4b84f47ea60",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "bea63ddbb234"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "e3474ec10cba"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "b69f7b3990eb",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": " er bosatt i Norge og har oppholdstillatelse.",
+            "_key": "dc4b84f47ea68",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "innvilgetTredjelandsborgerLovligOppholdSamtidigBosattINorge",
+    "tema": "NASJONAL",
+    "navnISystem": "Tredjelandsborger med lovlig opphold samtidig som bosatt i Norge",
+    "visningsnavn": "IKKE I BRUK Tredjelandsborger med lovlig opphold samtidig som bosatt i Norge søker",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2022-12-08T10:59:27Z",
+    "_updatedAt": "2023-06-23T13:01:30Z"
+  },
+  {
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "f9b4cbe7af5e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "9fa2d00f63740"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "f7c397f3ea75"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage frå ",
+            "_key": "2bd122ce5cc0"
+          },
+          {
+            "_key": "210f80d6332b",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "be31e0560e3c"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_updatedAt": "2023-03-30T13:43:51Z",
+    "navnISystem": "Fulltidsplass i barnehage",
+    "_rev": "pmhuRhSUoAWbpYJtPpAmZk",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2023-03-08T10:58:21Z",
+    "_id": "ksBegrunnelse-152ef77b-8d82-4642-a490-63501458581f",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "5dbff509a809",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "e703d70b5e7c0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "860efd366a3f"
+          },
+          {
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage fra ",
+            "_key": "c15fc4ed5a5b",
+            "_type": "span"
+          },
+          {
+            "_key": "042a0f3d91f9",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "ddbf0d8b098a",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "70deb9e85d22",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "\n",
+            "_key": "57c6fce5d3490"
+          }
+        ]
+      }
+    ],
+    "apiNavn": "opphorFulltidsplassIBarnehage",
+    "visningsnavn": "1. Fulltidsplass i barnehage",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "resultat": "AVSLAG",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_rev": "q5JgLByi60irF5LU0K7w3w",
+    "navnISystem": "Selvstendig rett standard avslag",
+    "apiNavn": "avslagSelvstendigRettStandardAvslag",
+    "visningsnavn": "17. Selvstendig rett standard avslag",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at norske reglar for kontantstøtte ikkje gjeld for deg og den andre forelderen.",
+            "_key": "4bb5923499400"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b67b867286fa"
+      }
+    ],
+    "_updatedAt": "2024-01-09T16:58:37Z",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "_createdAt": "2024-01-09T16:58:37Z",
+    "_id": "ksBegrunnelse-1737f496-5e52-4490-8846-7fe3f76283e6",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "18e10fbf6d5e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at norske regler for kontantstøtte ikke gjelder for deg og den andre forelderen.",
+            "_key": "a336dc96170b0"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "OPPHØR",
+    "tema": "EØS",
+    "_updatedAt": "2023-12-19T15:03:46Z",
+    "visningsnavn": "25. Søker bodde ikke i EØS land",
+    "_createdAt": "2023-12-19T15:03:46Z",
+    "navnISystem": "Søker bodde ikke i EØS land",
+    "_rev": "QYE1lVUzcrAawv9ECkxJKQ",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje budde i eit EØS-land.",
+            "_key": "20d981734c1f0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1223a8de16aa",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-17e5a799-f7dc-4853-b763-16c2e9df94cd",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du ikke bodde i et EØS-land.",
+            "_key": "c3e9f43ca2a70",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c80356486cec"
+      }
+    ],
+    "apiNavn": "opphorSokerBoddeIkkeIEtEosLand",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ]
+  },
+  {
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi Storbritannia har hovudansvaret for utbetaling av kontantstøtte. Noreg utbetalar derfor forskjellen mellom kontantstøtta i Storbritannia og norsk kontantstøtte. Når skatteåret er over vil utbetalinga bli vurdert på nytt.",
+            "_key": "a030a2e1ea650"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "02dac25364e2"
+      }
+    ],
+    "_id": "ksBegrunnelse-1d081c0d-3d86-4c1c-8a1e-badfc129ee8e",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "0051e378276c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi Storbritannia har hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i Storbritannia og norsk kontantstøtte. Når skatteåret er over vil utbetalingen bli vurdert på nytt.",
+            "_key": "1a3a7bb8c2920"
+          }
+        ],
+        "_type": "block"
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "5f9ae805910b",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "\n",
+            "_key": "4c82ac237d040"
+          }
+        ]
+      }
+    ],
+    "visningsnavn": "6. UK midlertidig differanseutbetaling",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_updatedAt": "2024-01-10T08:07:30Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "_rev": "q5JgLByi60irF5LU0Kzx3C",
+    "_createdAt": "2023-12-19T16:35:50Z",
+    "navnISystem": "UK midlertidig differanseutbetaling",
+    "apiNavn": "reduksjonUKMidlertidigDifferanseutbetaling"
+  },
+  {
+    "navnISystem": "Avtale delt bosted ikke gyldig\t",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "6537680a5098",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Avtalen om delt bustad for barn fødd ",
+            "_key": "dc47ebe9f1610"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c673ac50c659"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje er gyldig. ",
+            "_key": "6698a9a8bfe5"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-1ffb1411-32e5-4d8b-bf63-1761bc31f559",
+    "_updatedAt": "2023-05-04T18:26:13Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Avtalen om delt bosted for barn født ",
+            "_key": "851556c3091c0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "7cb69ef29738"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke er gyldig. ",
+            "_key": "c717be2ba0ac"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "ff9f9252c992",
+        "markDefs": []
+      }
+    ],
+    "visningsnavn": "36. Avtale delt bosted ikke gyldig\t",
+    "_rev": "vuzvVDrYQXJOMHanV8hTx8",
+    "resultat": "AVSLAG",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "apiNavn": "avslagAvtaleOmDeltBostedIkkeGyldig",
+    "type": "STANDARD",
+    "_createdAt": "2023-05-04T18:26:13Z"
+  },
+  {
+    "navnISystem": "Utenlandsopphold mer enn 3 måneder",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "4becc6876c09",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "50775c0e8993"
+          },
+          {
+            "_key": "45221b2f4962",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " skal vere i utlandet i meir enn 3 månader.",
+            "_key": "9bd03803a0300",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-1ffd23b1-60ee-4ace-950c-c9aa947b3f88",
+    "visningsnavn": "20. Utenlandsopphold mer enn 3 måneder",
+    "_updatedAt": "2023-05-04T17:53:28Z",
+    "resultat": "AVSLAG",
+    "_createdAt": "2023-05-04T17:53:28Z",
+    "apiNavn": "avslagUtenlandsoppholdMerEnnTreMaaneder",
+    "_rev": "CKoJmXlM50fHJKgxS5NI7C",
+    "_type": "ksBegrunnelse",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "56202a33f52d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "705a4786d234"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "1840035c1c1c",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " skal være i utlandet i mer enn 3 måneder.",
+            "_key": "2615aafe64ee0"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "apiNavn": "opphorIkkeOppholdsrettSomFamiliemedlem",
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "stotterFritekst": false,
+    "_createdAt": "2023-12-19T12:50:52Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke lenger har oppholdsrett som familiemedlem til en statsborger i et EØS-land.",
+            "_key": "69022e2601440"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9ff83c446d6d",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "8. Ikke oppholdsrett som familiemedlem",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "_key": "4da7e2dc8fe4",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje lenger har opphaldsrett som familiemedlem til ein statsborgar i eit EØS-land.",
+            "_key": "af7343768fbf0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECkvaEp",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-20dead63-2fa7-418f-a3ad-c9dceca6f540",
+    "_updatedAt": "2023-12-19T14:44:19Z",
+    "navnISystem": "Ikke oppholdsrett som familiemedlem",
+    "resultat": "OPPHØR",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ]
+  },
+  {
+    "_updatedAt": "2024-01-09T15:28:20Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON"
+    ],
+    "apiNavn": "innvilgetPrimarlandToArbeidslandAnnetLandUtbetaler",
+    "_rev": "q5JgLByi60irF5LU0K0D3E",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "navnISystem": "Primærland to arbeidsland Annet land utbetaler",
+    "kompetanseResultat": [
+      "TO_PRIMÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "_createdAt": "2023-12-20T20:08:23Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "74d0aab404c90",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "23946710a7a4"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "ffc7063b31a8",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "66f79d2911f4",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "d1795a99f128",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d746f7d8fbbe",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "19797026bba7",
+            "_type": "span",
+            "marks": [],
+            "text": " bor i "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "cae33564388e",
+            "flettefelt": "barnetsBostedsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i ",
+            "_key": "0e674c887780"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "7fd2859b0c63"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du og den andre forelderen har rett til kontantstøtte fra Norge og ",
+            "_key": "efe4b4439f0e"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "e728bc5f7b19"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi dere jobber i andre land enn der ",
+            "_key": "1470cd3a0bdf"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8dfd9d800859",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": " bor. Landet med den høyeste kontantstøtten skal utbetale. Kontantstøtten i ",
+            "_key": "a4a88eb9398c",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "d10268c3df5a",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_key": "42c28e4f9d04",
+            "_type": "span",
+            "marks": [],
+            "text": " er høyere enn kontantstøtten i Norge. Du får derfor hele kontantstøtten fra "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "95ee098895ba"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "c01542c1e130"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "caf77ffe116f",
+        "markDefs": []
+      }
+    ],
+    "hjemlerEOSForordningen987": [
+      "58"
+    ],
+    "visningsnavn": "13. Primærland to arbeidsland Annet land utbetaler",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "36a6c05b2642",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "151b4220b0d10"
+          },
+          {
+            "_key": "971b774c5f87",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ". Du ",
+            "_key": "2a9bb9044adf",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cdbc1fce1d5b",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "0a6c7cb63ca5",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "39c95ee76db1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "d8dd59e1f864"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "9d7f09a5260e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "d02e8f9c9f75"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "ca6f7cbd97fd"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du og den andre forelderen har rett til kontantstøtte frå Noreg og ",
+            "_key": "414e13d9b182"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "dbaeae742f8c"
+          },
+          {
+            "marks": [],
+            "text": " fordi de jobbar i andre land enn der ",
+            "_key": "aac6059ece33",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5e819fe0da94",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur. Landet med den høgaste kontantstøtta skal utbetale. Kontantstøtta i ",
+            "_key": "e4b2394e15d3"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "cfb5a65c6e67"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er høgare enn kontantstøtta i Noreg. Du får derfor heile kontantstøtta frå ",
+            "_key": "40e24dac8602"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "92c55686bb86",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "dcffc13dbdb0"
+          }
+        ]
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-21196f88-fc0d-4c00-8034-30b37b26cd79"
+  },
+  {
+    "apiNavn": "opphorBrukerMelderFulltidsplassIBarnehagenForstePeriode",
+    "_rev": "pmhuRhSUoAWbpYJtPpAeQg",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_updatedAt": "2023-03-30T13:43:34Z",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du har opplyst at barn født ",
+            "_key": "9a28ff60139e0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "6bc059552a34"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage fra ",
+            "_key": "84f48d6c1d06"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "ca0f28c84d4a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "ff57038d8d21"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e8071f1a463d",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "visningsnavn": "39. Bruker melder fulltidsplass i barnehagen",
+    "resultat": "OPPHØR",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "e7572920dbcb",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "bc727f510ff50",
+            "_type": "span",
+            "marks": [],
+            "text": "Du har opplyst at barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "66306e79e6cf"
+          },
+          {
+            "_key": "1ba16a5dd1aa",
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage frå "
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "0dfe1546a4b8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "eeef618d7e8f"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-03-22T18:43:53Z",
+    "_id": "ksBegrunnelse-216453c3-cd1c-4730-bab9-542a1ee46287",
+    "navnISystem": "Bruker melder fulltidsplass i barnehagen",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ]
+  },
+  {
+    "_rev": "pmhuRhSUoAWbpYJtPpNfXg",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "de09d527dcb5",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "a391482b00c0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "8c1c5ea9bcc0"
+          },
+          {
+            "_key": "e7a35a86f6ee",
+            "_type": "span",
+            "marks": [],
+            "text": " fordi "
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "80c952f8dbe1",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt ",
+            "_key": "e85ef76c8d1b"
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "69c36d825403"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timer i barnehagen per uke.",
+            "_key": "50e9c7135732"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Deltidsplass barnehage adopsjon",
+    "_createdAt": "2022-11-17T13:07:59Z",
+    "triggere": [
+      "DELTID_BARNEHAGEPLASS"
+    ],
+    "visningsnavn": "4. Deltidsplass barnehage adopsjon",
+    "hjemler": [
+      "2",
+      "3",
+      "7",
+      "8",
+      "10"
+    ],
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "vilkaar": [
+      "BARNEHAGEPLASS",
+      "BARNETS_ALDER"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "b4443820676b",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "15ea9f3a8d230"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "1e6ba31209e4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "f40e2dc2306a"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "589d5cc7c3d4",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [
+              "em"
+            ],
+            "text": " ",
+            "_key": "15ea9f3a8d231"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "er tildelt ",
+            "_key": "15ea9f3a8d232"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "85c136f86344",
+            "flettefelt": "antallTimerBarnehageplass"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timar i barnehagen per veke.",
+            "_key": "9cf35f253b28"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "apiNavn": "innvilgetDeltidBarnehageAdopsjon",
+    "stotterFritekst": true,
+    "_id": "ksBegrunnelse-21a496c6-2653-4310-b248-a229aaeb3b6c",
+    "_updatedAt": "2023-03-30T14:05:22Z",
+    "resultat": "INNVILGET"
+  },
+  {
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "visningsnavn": "2. Bruker melder fulltidsplass i barnehage",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "tema": "NASJONAL",
+    "navnISystem": "Bruker melder fulltidsplass i barnehage",
+    "_updatedAt": "2023-03-30T13:43:17Z",
+    "resultat": "OPPHØR",
+    "_type": "ksBegrunnelse",
+    "_rev": "0vYmij9v1P7MsqVq0sDoQf",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "e1efa2542331",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har opplyst at barn fødd ",
+            "_key": "62fce1ef76080"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "a21cb995ba52"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage frå ",
+            "_key": "a16d38e010dc"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "7e7ec094211e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "1334546c2354"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2023-03-08T11:02:43Z",
+    "_id": "ksBegrunnelse-23bc6da5-c7fa-4f8b-a996-23a2a7835f5f",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du har opplyst at barn født ",
+            "_key": "94cb39f510c90",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fbff59399fd5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage fra ",
+            "_key": "9aef3cbecb1d"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "9099107ddcc9"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "5c0f1a3fd1fa"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "68072e1556da"
+      }
+    ],
+    "apiNavn": "opphorBrukerMelderFulltidsplassIBarnehage"
+  },
+  {
+    "navnISystem": "Hadde ikke ansvar for barn",
+    "apiNavn": "opphorHaddeIkkeAnsvarForBarn",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "tema": "EØS",
+    "_rev": "CM6961CqAC7W4puPRKudyC",
+    "resultat": "OPPHØR",
+    "_id": "ksBegrunnelse-2571a8da-7117-4087-9f47-80309edc4795",
+    "visningsnavn": "22. Hadde ikke ansvar for barn",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2023-12-19T14:59:40Z",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "9e1028b5ed6a0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje hadde ansvar for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "d7a83d04ed54"
+          },
+          {
+            "text": ".",
+            "_key": "449db973a918",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "ddd8306de7d3"
+      }
+    ],
+    "_createdAt": "2023-12-19T14:56:56Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke hadde ansvar for barn født ",
+            "_key": "18c4e24df0160"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "cb0df3a47fdd"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "5bb6d890281f"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "82985292ffd2"
+      }
+    ]
+  },
+  {
+    "navnISystem": "Vurdering Bor fast hos søker",
+    "tema": "NASJONAL",
+    "_createdAt": "2022-12-08T11:18:07Z",
+    "hjemler": [
+      "3"
+    ],
+    "visningsnavn": "16. Vurdering Bor fast hos søker",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_updatedAt": "2022-12-08T11:18:07Z",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte frå månaden etter at vi har kome fram til at barn fødd ",
+            "_key": "85b9b84038050"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fb83d1fb5768"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur fast hos deg.",
+            "_key": "e3870bc0c02d"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "5d90e0810fab"
+      },
+      {
+        "style": "normal",
+        "_key": "ab3be5624eb4",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "eb91eb2d0d250",
+            "_type": "span",
+            "marks": [],
+            "text": "\n"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_id": "ksBegrunnelse-26a58325-b3cb-4861-ad3b-1e6d81b6adee",
+    "apiNavn": "innvilgetVurderingBorFastHosSoker",
+    "_rev": "u4Z6kQR2byZlf6vx9I866q",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fra måneden etter at vi har kommet fram til at barn født ",
+            "_key": "df18bf04dbe30"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "b34b3dd603ed",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": " bor fast hos deg.",
+            "_key": "d7b6ea599e14",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "de198ad41f57"
+      }
+    ]
+  },
+  {
+    "type": "STANDARD",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "resultat": "OPPHØR",
+    "_rev": "CM6961CqAC7W4puPRKsOsS",
+    "_type": "ksBegrunnelse",
+    "stotterFritekst": false,
+    "_id": "ksBegrunnelse-27397527-c98c-48ae-80db-5b3b0fae86e4",
+    "_updatedAt": "2023-12-19T14:44:04Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "119635e7f2d3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Separasjonsavtalen mellom Storbritannia og Norge ikke lenger gjelder for familien.",
+            "_key": "ea4979f638990"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Separasjonsavtalen gjelder ikke",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "nynorsk": [
+      {
+        "_key": "ed8de77c01ab",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Separasjonsavtalen mellom Storbritannia og Noreg ikke lenger gjeld for familien.",
+            "_key": "e7f6fa9e27c10"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-12-19T12:05:32Z",
+    "apiNavn": "opphorSeparasjonsavtalenGjelderIkke",
+    "visningsnavn": "5. Separasjonsavtalen gjelder ikke"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "tema": "EØS",
+    "_updatedAt": "2024-01-12T08:14:10Z",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "63f74de75d900"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "5c6dbcd661ee"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "ea15b8cd0cac"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "bdbbaf919d85",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "b65557682a87"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cf206557d8a1",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "142b026810a5",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "b9fdf5f3256e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "dedf66f71233"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "2af95aba8057",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            }
+          },
+          {
+            "text": " i ",
+            "_key": "b2f537bc8809",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "4076a31017b2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "39e18640336c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "96036d1be092",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2023-12-19T09:02:24Z",
+    "bokmaal": [
+      {
+        "_key": "c2ed8175bf7e",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "2d6fe81f2b6f0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "533c9907874c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "8e772f2144af"
+          },
+          {
+            "_key": "d02c3cb42cb2",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "a8b1a493a886"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "7fdd329dfee5",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " bor i ",
+            "_key": "10aac541b3ec",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "dbfb273ef779"
+          },
+          {
+            "_key": "3bd4462a2d96",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen "
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a"
+            },
+            "_type": "valgfeltV2",
+            "_key": "06c9b244e7a6",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "dddeaf4dde8e"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "9beda87470d6"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "f768432ce698"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      },
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "",
+            "_key": "bd9034ba0f5b0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "6683da91f486",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Primærland standard",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "visningsnavn": "1. Primærland standard",
+    "_rev": "lF5yVt21tsO6ftvelrmjRD",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "apiNavn": "innvilgetPrimarlandStandard",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "TO_PRIMÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "_id": "ksBegrunnelse-27b61882-0713-4566-b419-a381171dd4b1",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "triggereIBruk": [
+      "KOMPETANSE",
+      "VILKÅRSVURDERING"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE"
+    ]
+  },
+  {
+    "navnISystem": "Ikke bosatt i riket",
+    "hjemler": [
+      "2"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-28011671-cea1-4408-94fe-cc4256f84482",
+    "_updatedAt": "2023-05-04T20:24:32Z",
+    "apiNavn": "avslagBosattIRiket",
+    "visningsnavn": "IKKE I BRUK Ikke bosatt i riket",
+    "_rev": "lxTMP95K2WARLoXUTv27gE",
+    "resultat": "AVSLAG",
+    "_createdAt": "2022-12-06T11:35:47Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "test",
+            "_key": "2eeb5d6e8817"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9ddcea6799ed",
+        "markDefs": []
+      }
+    ]
+  },
+  {
+    "_id": "ksBegrunnelse-28e46ffa-9af8-4449-8605-20937bd86754",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-07-17T08:35:12Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "762031bac18e0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "730c2b837c88"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har begynt på skolen.",
+            "_key": "8c96fa40e142"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "a8bc721677a5"
+      }
+    ],
+    "resultat": "OPPHØR",
+    "visningsnavn": "5. Begynt på skolen",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "_createdAt": "2023-07-17T08:35:12Z",
+    "hjemler": [
+      "8",
+      "10"
+    ],
+    "apiNavn": "opphorBegyntPaaSkolen",
+    "_rev": "3avgb2mvwwlEODc1cHOiEq",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "5912b4655a07",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "e520749f0f9e0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "f2e516aff31a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har begynt på skulen.",
+            "_key": "d89daa444c8e"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Begynt på skolen"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "7",
+      "8",
+      "9"
+    ],
+    "type": "TILLEGGSTEKST",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-29cfb3d7-bd8b-4f17-9bbc-6ba5eaa0bb8d",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "58b8f12a11bf0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "defbd4daca21"
+          },
+          {
+            "text": " frå månaden etter at ",
+            "_key": "1ed0f3b67f9b",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "9cac46388712",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": " slutta i barnehagen.",
+            "_key": "58b8f12a11bf2",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c1321bc0d608",
+        "markDefs": []
+      }
+    ],
+    "_updatedAt": "2023-03-07T08:19:59Z",
+    "navnISystem": "Måneden etter sluttet i barnehage",
+    "visningsnavn": "2. Måneden etter sluttet i barnehage",
+    "_createdAt": "2022-12-07T09:23:24Z",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "cd95bb7b0b920"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "58417b15cdf8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "d5a9922447e7"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "f0f4a1c0d637",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " sluttet i barnehagen.",
+            "_key": "cd95bb7b0b922"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "dbd8b50622ea"
+      }
+    ],
+    "apiNavn": "innvilgetMaanedenEtterSluttetIBarnehage",
+    "_rev": "jG7ppIILmU7BoTg03BPzF6",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET"
+  },
+  {
+    "apiNavn": "reduksjonSokerBerOmStans",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "2d9e4601f6aa",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi du har bedt om at kontantstøtta for barn fødd ",
+            "_key": "67f2b6b053960"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "7f1126a460af"
+          },
+          {
+            "_key": "14164dc069d9",
+            "_type": "span",
+            "marks": [],
+            "text": "blir stansa."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "3230ff58742e0",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi du har bedt om at kontantstøtten for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "e57b0f1b90c7"
+          },
+          {
+            "text": " blir stanset.",
+            "_key": "1643b97de53f",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "5016e93a8a1c"
+      }
+    ],
+    "visningsnavn": "17. Søker ber om stans",
+    "resultat": "REDUKSJON",
+    "_createdAt": "2023-05-03T15:41:59Z",
+    "_id": "ksBegrunnelse-2c272eb1-6f2d-4964-abbb-640d7260941e",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_updatedAt": "2023-05-03T15:41:59Z",
+    "navnISystem": "Søker ber om stans",
+    "hjemler": [
+      "3"
+    ],
+    "_rev": "KOa0MjQMDn5FLyPT0MyBMt",
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ]
+  },
+  {
+    "visningsnavn": "FortsattInnvilgetTillegsTekstEksempel",
+    "_createdAt": "2023-03-20T06:42:38Z",
+    "_rev": "VNfjOkUyv8N7GDE50DIH1P",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "apiNavn": "fortsattInnvilgetTillegsTekstEksempel",
+    "tema": "NASJONAL",
+    "resultat": "FORTSATT_INNVILGET",
+    "_updatedAt": "2023-03-20T06:42:38Z",
+    "navnISystem": "FortsattInnvilgetTillegsTekstEksempel",
+    "_id": "ksBegrunnelse-2c52a1ee-9af5-4b3d-b261-40c12b329106"
+  },
+  {
+    "navnISystem": "Mottatt i 11 måneder",
+    "apiNavn": "avslagMottattI11Maaneder",
+    "hjemler": [
+      "10"
+    ],
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "d011c22ef9c1",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du allereie har fått kontantstøtte i 11 månader for barn fødd ",
+            "_key": "310c476f7be90"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "14938894ffc4",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_key": "adb746456dfc",
+            "_type": "span",
+            "marks": [],
+            "text": "."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "6. Mottatt i 11 måneder",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-2d8bdb47-088a-4c15-8824-d211e93879fb",
+    "_rev": "RiR9GraBD8hopeC5h729Mg",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du allerede har fått kontantstøtte i 11 måneder for barn født ",
+            "_key": "7daadfd835d20"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "760d7c2fdc36"
+          },
+          {
+            "text": ".",
+            "_key": "606873e0bab4",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f57e39ca662e"
+      }
+    ],
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "_createdAt": "2023-05-04T06:32:04Z",
+    "_updatedAt": "2023-05-04T06:32:04Z"
+  },
+  {
+    "_id": "ksBegrunnelse-2dcc6b11-a91b-4cf8-865a-c9c0fe504a16",
+    "_createdAt": "2023-05-03T14:57:40Z",
+    "_updatedAt": "2023-05-03T14:57:40Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "e66250ad7098",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi barn født ",
+            "_key": "1381e9ffea9b0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c625f0d1862f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "har flyttet fra Norge ",
+            "_key": "d2da85cd5630"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "244cd1f3ec15"
+          },
+          {
+            "marks": [],
+            "text": ". Kontantstøtten reduseres fra samme måned som endringen skjedde.",
+            "_key": "36d13b1bf539",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "apiNavn": "reduksjonBarnFlyttetFraNorge",
+    "resultat": "REDUKSJON",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_rev": "RiR9GraBD8hopeC5h6EOaO",
+    "type": "STANDARD",
+    "visningsnavn": "5. Barn flyttet fra Norge",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi barn fødd ",
+            "_key": "36add8ef48830"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "a80eee62470a"
+          },
+          {
+            "_key": "b1ff1b9745cf",
+            "_type": "span",
+            "marks": [],
+            "text": " har flytta frå Noreg "
+          },
+          {
+            "_key": "1eadf5e86adb",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtta er redusert frå same månad som endringa skjedde.",
+            "_key": "1351f180e5d4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d6d472e4960b"
+      }
+    ],
+    "navnISystem": "Barn flyttet fra Norge",
+    "hjemler": [
+      "2",
+      "8"
+    ]
+  },
+  {
+    "_rev": "Xl0tn62zVopahRtC7LdzBn",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "0d1bf664fae2",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har ikkje vore medlem i folketrygda i fem år.",
+            "_key": "1e091d26675e0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_updatedAt": "2023-07-24T08:55:18Z",
+    "navnISystem": "Annen forelder ikke medlem folketrygden i 5 år ",
+    "_createdAt": "2023-07-24T08:52:34Z",
+    "tema": "NASJONAL",
+    "visningsnavn": "42. Annen forelder ikke medlem folketrygden i 5 år ",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-2fbdea2e-0b74-45a1-927e-25d701b4b6cf",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Den andre forelderen ikke har vært medlem i folketrygden i fem år.",
+            "_key": "b92dc18ed6670",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "10433e2d25ed"
+      }
+    ],
+    "apiNavn": "opphorAnnenForelderIkkeMedlemFolketrygdenI5Aar"
+  },
+  {
+    "_updatedAt": "2023-07-24T07:46:17Z",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "28. Ikke medlem folketrygden eller EØS i 5 år ",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "2de2b53b5b3a0"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6836375da31c"
+          },
+          {
+            "_key": "2de2b53b5b3a6",
+            "_type": "span",
+            "marks": [],
+            "text": " har ikkje vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "98bdaf3d1c1c"
+      }
+    ],
+    "apiNavn": "opphorIkkeMedlemFolketrygdenEllerEosI5Aar",
+    "_createdAt": "2023-07-24T07:46:17Z",
+    "_id": "ksBegrunnelse-3075a76d-e0ea-41de-bf68-fd83be3faf5f",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "2e2b6aab6e9e0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "bcbead11975a",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden eller i trygdeordninger i andre EØS-land i til sammen fem år.",
+            "_key": "2e2b6aab6e9e5"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f5cdd1250fb9",
+        "markDefs": []
+      }
+    ],
+    "_rev": "Xl0tn62zVopahRtC7KwazX",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "navnISystem": "Ikke medlem folketrygden eller EØS i 5 år ",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "tema": "NASJONAL"
+  },
+  {
+    "type": "STANDARD",
+    "_createdAt": "2023-05-04T06:57:30Z",
+    "_id": "ksBegrunnelse-318692e0-1ddd-4b8b-a2df-3600e8dcf965",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "906fca5dcd8d0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c63cc1e320cd"
+          },
+          {
+            "marks": [],
+            "text": " bor på institusjon fra ",
+            "_key": "dd8a3c38cbc1",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "cf1bf9f16ed7",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor"
+          },
+          {
+            "marks": [],
+            "text": ". Du får ikke kontantstøtte når ",
+            "_key": "4cdf6adbb427",
+            "_type": "span"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "b72e3f25ef1c",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_key": "906fca5dcd8d2",
+            "_type": "span",
+            "marks": [],
+            "text": " bor på institusjon."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "7cc1f620a1e1",
+        "markDefs": []
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "49eba2f1a2ca",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "96275df821930"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "d3fd55e81c52"
+          },
+          {
+            "text": " bur på institusjon frå ",
+            "_key": "9de688c5638f",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "838a51bd9cbe"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får ikkje kontantstøtte når ",
+            "_key": "6976e85bf80f"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d8f88d1c0130",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " bur på institusjon.",
+            "_key": "96275df821932",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "hjemler": [
+      "6"
+    ],
+    "_rev": "KOa0MjQMDn5FLyPT0QFkTC",
+    "resultat": "AVSLAG",
+    "_updatedAt": "2023-05-04T06:57:30Z",
+    "navnISystem": "Institusjon",
+    "visningsnavn": "8. Institusjon",
+    "apiNavn": "avslagInstitusjon"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "6. Sentrum for livsinteresse",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Vi har kome fram til at norske reglar for kontantstøtte ikkje lenger gjeld for familien. Derfor har du ikkje rett til kontantstøtte for barn fødd ",
+            "_key": "757e51e94db40",
+            "_type": "span"
+          },
+          {
+            "_key": "95e6232c6376",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_key": "94b340bb8441",
+            "_type": "span",
+            "marks": [],
+            "text": " frå Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "750744835dc3"
+      }
+    ],
+    "_updatedAt": "2023-12-19T14:44:09Z",
+    "_rev": "QYE1lVUzcrAawv9ECkvZdP",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-32b7b0f5-29ff-45a6-af0d-e7dfcf5db2ec",
+    "navnISystem": "Sentrum for livsinteresse",
+    "apiNavn": "opphorSentrumForLivsinteresse",
+    "_createdAt": "2023-12-19T12:06:09Z",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "resultat": "OPPHØR",
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Vi har kommet fram til at norske regler for kontantstøtte ikke lenger gjelder for familien. Derfor har du ikke rett til kontantstøtte for barn født ",
+            "_key": "a1f8abed2f720",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "7b70c6e7e535"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra Norge.",
+            "_key": "1e9d540e263d"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "749b2e7dff69"
+      }
+    ]
+  },
+  {
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_rev": "q5JgLByi60irF5LU0K0GKc",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_id": "ksBegrunnelse-32edf65a-71d7-4dba-b7e2-3875a4ada0a0",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "f3073884cde10",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "98344412ce86"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "3fc5fcfe109b"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5fce0a36f6c2",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "f462cf612069"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "572f49db939d",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "6d941a52a715",
+            "_type": "span",
+            "marks": [],
+            "text": " bor i "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "436267626804",
+            "flettefelt": "barnetsBostedsland"
+          },
+          {
+            "_key": "a70b58a05b3f",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "c9a88d677634"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Du og den andre forelderen har rett til kontantstøtte fra Norge og ",
+            "_key": "d9562118221d"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "c5be286550e9"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi dere jobber i andre land enn der ",
+            "_key": "3028c2184b64"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "63b1e1147e7d",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor. Landet med den høyeste kontantstøtten skal utbetale. Norsk kontantstøtte er høyere enn kontantstøtten i ",
+            "_key": "b7e707cf2158"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "3893334b1a37"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "48b8491f1485"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "72a0019f4afa"
+      }
+    ],
+    "navnISystem": "Primærland UK to arbeidsland Norge utbetaler",
+    "apiNavn": "innvilgetPrimarlandUKToArbeidslandNorgeUtbetaler",
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-09T15:29:17Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "resultat": "INNVILGET",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_PENSJON"
+    ],
+    "visningsnavn": "14. Primærland UK to arbeidsland Norge utbetaler",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-12-20T20:15:04Z",
+    "hjemlerEOSForordningen987": [
+      "58"
+    ],
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "0bc02428c9310"
+          },
+          {
+            "_key": "48d2095c521f",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "9a7c812a91f9",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8d9c0ffeb1ed",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "4f6e6c663948"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "2cdd349ac5b6",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "91dacc3f6b06"
+          },
+          {
+            "_key": "1bd7d309743a",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "045ff181e850",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "0fa7fbc17faa"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Du og den andre forelderen har rett til kontantstøtte frå Noreg og ",
+            "_key": "7c3c56c7c117"
+          },
+          {
+            "_key": "7dd88f9534c8",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi de jobbar i andre land enn der ",
+            "_key": "ca68285b156d"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "7bca549b9dfc",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur. Landet med den høgaste kontantstøtta skal utbetale. Norsk kontantstøtte er høgare enn kontantstøtta i ",
+            "_key": "2bcc9b23f0bc"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "2c00fb540ded"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "048e7ede81c9"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c38e3e2f6cdc",
+        "markDefs": []
+      }
+    ]
+  },
+  {
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "type": "TILLEGGSTEKST",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "df7d4bb9705f0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "bc4c0181dfec"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at ",
+            "_key": "520cb5d0f42b"
+          },
+          {
+            "_key": "1673eca7c331",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " er busett i Noreg og har opphaldsløyve.",
+            "_key": "df7d4bb9705f6",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3164513c98f5"
+      }
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "apiNavn": "innvilgetInnvandretMedLovligOppholdTredjelandsborger",
+    "_rev": "ZHptMMiGbb7440Rb5U66Wa",
+    "resultat": "INNVILGET",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-06-23T12:55:31Z",
+    "_id": "ksBegrunnelse-369ebc6e-0186-4de2-856d-d414fc0354af",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "c23d0332f2e8",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "33d298023ad20"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "1e66a471f3e6"
+          },
+          {
+            "text": " fra måneden etter at ",
+            "_key": "a68384aebdda",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d5cffabf691c",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er bosatt i Norge og har oppholdstillatelse.",
+            "_key": "33d298023ad28"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Innvandret med lovlig opphold, tredjelandsborgere",
+    "visningsnavn": "13. Innvandret med lovlig opphold, tredjelandsborgere",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_updatedAt": "2023-06-23T12:55:31Z"
+  },
+  {
+    "navnISystem": "Barn bor ikke i EØS-land",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECkvYLt",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_key": "8a8372fc21470",
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "e3dfb0273ed1"
+          },
+          {
+            "_key": "868241f47bc5",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje lenger bur i eit EØS-land."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f66292c3c2f8",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2023-12-19T14:43:53Z",
+    "apiNavn": "opphorBarnBorIkkeIEosLand",
+    "visningsnavn": "3. Barn bor ikke i EØS-land",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "_createdAt": "2023-12-19T11:57:24Z",
+    "_id": "ksBegrunnelse-38963eb5-2ddc-4332-bd16-6f6d526f7e05",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "tema": "EØS",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "stotterFritekst": false,
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "804e55ed03e0",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "79dd0b446bb40"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "209d2f31bb2e"
+          },
+          {
+            "text": " ikke lenger bor i et EØS-land.",
+            "_key": "29478645f7c4",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block"
+      }
+    ]
+  },
+  {
+    "navnISystem": "Ikke bosatt i EØS-land",
+    "visningsnavn": "2. Ikke bosatt i EØS-land",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2"
+    ],
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du og eller barnet/barna født ",
+            "_key": "624029922c7e0"
+          },
+          {
+            "_key": "1baa3eb89c0b",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke er bosatt i et EØS-land.",
+            "_key": "9d27a77fa6ea"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0a2876f5054d",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "avslagIkkeBosattIEosLand",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "_createdAt": "2024-01-09T15:22:30Z",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijMVBJ5",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_key": "1300aa2783cf0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du og eller barnet/barna fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "8cfd0884d1fc"
+          },
+          {
+            "text": " ikkje er busett i eit EØS-land.",
+            "_key": "8d146d5c054f",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9cddf3bb30ee",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-391fbb95-ef20-4ee7-9427-dcfe743f69e2",
+    "_updatedAt": "2024-01-09T15:22:30Z"
+  },
+  {
+    "navnISystem": "Tilleggstekst sekundær ikke kontantstøtte i annet land ",
+    "_rev": "5r7yBuU8wKOiVHJijLZchv",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-39799142-e932-41ee-b30c-a11cc20d78a7",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "bokmaal": [
+      {
+        "_key": "b00d61c979ef",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "a3eca49bca560",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får full kontantstøtte fra Norge fordi "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "ed65137cb4a1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har kontantstøtte.",
+            "_key": "a69608d3c35c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_updatedAt": "2024-01-08T21:47:48Z",
+    "visningsnavn": "41. Tilleggstekst sekundær ikke kontantstøtte i annet land ",
+    "type": "TILLEGGSTEKST",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får full kontantstøtte fordi ",
+            "_key": "9048f0d9de140",
+            "_type": "span"
+          },
+          {
+            "_key": "6ec5b882529a",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje har kontantstøtte.",
+            "_key": "35ae014a2987"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "12844bfc46c9"
+      }
+    ],
+    "_createdAt": "2024-01-08T21:47:48Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "apiNavn": "innvilgetTilleggstekstSekundarIkkeKontantstotteIAnnetLand",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "tema": "EØS"
+  },
+  {
+    "apiNavn": "opphorBarnOver2Aar",
+    "_rev": "3avgb2mvwwlEODc1cHNubQ",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "tema": "NASJONAL",
+    "bokmaal": [
+      {
+        "_key": "b88b814ade9b",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "1183b7e3e2fd0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "329f3aaa406b"
+          },
+          {
+            "marks": [],
+            "text": " er over 2 år.",
+            "_key": "244e4b7c1685",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-07-17T08:32:37Z",
+    "_id": "ksBegrunnelse-3a509936-54ca-4e6e-a891-3f4d0ff5ac12",
+    "navnISystem": "Barn over 2 år",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "79d342460ec00"
+          },
+          {
+            "_key": "438a736a7f48",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_key": "962e670c4b91",
+            "_type": "span",
+            "marks": [],
+            "text": " er over 2 år."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "bf8f8a4df426"
+      }
+    ],
+    "visningsnavn": "4. Barn over 2 år",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "_updatedAt": "2023-07-17T08:32:37Z"
+  },
+  {
+    "hjemler": [
+      "3"
+    ],
+    "visningsnavn": "3. Bor fast hos søker",
+    "_id": "ksBegrunnelse-3b7b388c-90d9-421a-94fd-e9bcb7a9d913",
+    "navnISystem": "Bor fast hos søker",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte frå måneden etter at barn fødd ",
+            "_key": "91f5b8b812270"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "4302d158a86e"
+          },
+          {
+            "marks": [],
+            "text": " bur fast hos deg.",
+            "_key": "1421a5b67455",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "081769e48e26",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2022-12-07T14:37:33Z",
+    "_updatedAt": "2022-12-13T12:26:20Z",
+    "apiNavn": "innvilgetBorFastHosSoker",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "d535f90981a5",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "c01e0a0a03600",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fra måneden etter at barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "aefe36e59204"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor fast hos deg.",
+            "_key": "0bd61bad21b2"
+          }
+        ]
+      }
+    ],
+    "_rev": "JaRI4X4cfqif7GPJjUZ77Y"
+  },
+  {
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnet ditt som er fødd ",
+            "_key": "bb32083eb8f40"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "5ed3539167e4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døydde. ",
+            "_key": "8146dc9bb19f"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "294967ce8be9",
+        "markDefs": []
+      }
+    ],
+    "triggere": [
+      "BARN_DØD"
+    ],
+    "_id": "ksBegrunnelse-3ba3f97f-0cdd-4107-aa95-2b743ec2ac9e",
+    "_updatedAt": "2023-12-19T14:44:47Z",
+    "apiNavn": "opphorEttBarnDodEos",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "visningsnavn": "13. Ett barn død EØS",
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "navnISystem": "Ett barn død EØS",
+    "_createdAt": "2023-12-19T13:13:39Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_rev": "CM6961CqAC7W4puPRKsUWg",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "b690a2112731",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnet ditt som er født ",
+            "_key": "bbe89f616c900"
+          },
+          {
+            "_key": "4db9ce5539c6",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "marks": [],
+            "text": " døde. ",
+            "_key": "65999fca1137",
+            "_type": "span"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "_createdAt": "2023-07-22T07:47:53Z",
+    "_updatedAt": "2023-07-22T07:47:53Z",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-3bb74c6c-94de-4f39-a318-9a7edc0f593e",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du ikke lenger har en avtale om delt bosted for barn født ",
+            "_key": "83d2813264bb0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "cd85da64b69b"
+          },
+          {
+            "text": ". Kontantstøtten kan derfor ikke deles.",
+            "_key": "bc2eb89040a4",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3d5758d554fa"
+      }
+    ],
+    "navnISystem": "Ikke avtale om delt bosted",
+    "apiNavn": "opphorIkkeAvtaleOmDeltBosted",
+    "visningsnavn": "24. Ikke avtale om delt bosted",
+    "resultat": "OPPHØR",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "f3a7cd9dc316",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du ikkje lenger har ein avtale om delt bustad for barn fødd ",
+            "_key": "621441b112c20",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "ddc11c3a99ad"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtta kan derfor ikkje delast.",
+            "_key": "4465501e5a4c"
+          }
+        ]
+      }
+    ],
+    "_rev": "Xl0tn62zVopahRtC7CPZ9r",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL"
+  },
+  {
+    "navnISystem": "Vurdering Utenlandsopphold mer enn 3 mnd fra innvilgelse",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "uDpwmdKblEGdbs8fmMnv7J",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "visningsnavn": "37. Vurdering Utenlandsopphold mer enn 3 mnd fra innvilgelse",
+    "resultat": "OPPHØR",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_updatedAt": "2023-07-28T11:34:21Z",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "87ffe733f2390"
+          },
+          {
+            "_key": "292d087fc1c0",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har vore i utlandet i meir enn 3 månader.",
+            "_key": "b5605255d8a6"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d3cd3b5d2a90",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2023-07-24T08:48:00Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_id": "ksBegrunnelse-3c2e9d3e-c498-4c62-b491-d84f2ea522a8",
+    "apiNavn": "opphorVurderingUtenlandsoppholdMerEnn3MaanederFraInnvilgelse",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "34a7ee7dca1b0"
+          },
+          {
+            "_key": "fd8f651ec31e",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " har vært i utlandet i mer enn 3 måneder.",
+            "_key": "038b42eebaec",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "05c572e2c56b"
+      }
+    ]
+  },
+  {
+    "visningsnavn": "17. Selvstendig rett opphør fra start",
+    "type": "STANDARD",
+    "stotterFritekst": false,
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "98a406f6b46b",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "e7bbf4e3d0710",
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen ikke "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "45634f2a864c",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjaldt ikke for den andre forelderen, og du hadde ikke rett til kontantstøtte for barn født ",
+            "_key": "39cd3dc8c3cf",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "17aa2fff7ee1"
+          },
+          {
+            "_key": "8dcd11aec905",
+            "_type": "span",
+            "marks": [],
+            "text": " fra Norge. "
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Selvstendig rett opphør fra start",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "NORGE_ER_SEKUNDÆRLAND",
+      "TO_PRIMÆRLAND"
+    ],
+    "resultat": "OPPHØR",
+    "tema": "EØS",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_updatedAt": "2023-12-19T14:45:08Z",
+    "apiNavn": "opphorSelvstendigRettOpphorFraStart",
+    "_rev": "AOUa26DfnB8ntJraK3wr8f",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "_key": "e35f3fd156a2",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen ikkje ",
+            "_key": "66d9029493860"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "9f3366c816b2",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjaldt derfor ikkje for den andre forelderen, og du hadde ikkje rett til kontantstøtte for barn fødd ",
+            "_key": "5aaeb0d852a5"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "84333a1b2daa"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå Noreg. ",
+            "_key": "abc3cd41f9c4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-12-19T13:47:10Z",
+    "_id": "ksBegrunnelse-3c4b58b2-1835-41c0-b92e-8ba9343495d1"
+  },
+  {
+    "_rev": "3H9OXgojExINZUA3ukB3iI",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "b023469a33df"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "c9b57990828c",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "  ikke lenger er bosatt i Norge fra ",
+            "_key": "8727523d89d80"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "4d9e79c017c4",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "047d636d44a1"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "6023492d32f3"
+      }
+    ],
+    "apiNavn": "opphorIkkeBosattINorge",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "10. Ikke bosatt i Norge",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "def452d5c7f9",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "836de46dab5b"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6aacd4e4ed56",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "312455db03ec0",
+            "_type": "span",
+            "marks": [],
+            "text": "  ikkje lenger er busett i Noreg frå "
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "7e1e422aeec2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "a831bf2cda7e"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2023-07-17T10:26:55Z",
+    "_updatedAt": "2023-07-28T07:56:48Z",
+    "navnISystem": "Ikke bosatt i Norge",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_id": "ksBegrunnelse-3cfc1465-3813-4739-840c-ba86cb929b1a"
+  },
+  {
+    "apiNavn": "innvilgetTilleggstekstDeltBosted",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_createdAt": "2024-01-08T22:09:24Z",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "172691f5271d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte for barn fødd ",
+            "_key": "4bc199fec5fb0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "6e78f54da878"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi de har ein skriftlig avtale om delt bustad, og norske reglar for kontantstøtte gjeld for begge foreldra.",
+            "_key": "5ed2d7412dc8"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_updatedAt": "2024-01-08T22:09:24Z",
+    "navnISystem": "Tilleggstekst delt bosted",
+    "visningsnavn": "56. Tilleggstekst delt bosted",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "26d94dc1a8ce",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte for barn født ",
+            "_key": "0b89be4645690"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "5baa323c1426"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi dere har en skriftlig avtale om delt bosted, og norske regler for kontantstøtte gjelder for begge foreldrene.",
+            "_key": "57a4e38e432e"
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-3d95f512-e013-4d05-8314-0c273f7fcea5",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijLaq9b",
+    "resultat": "INNVILGET",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ]
+  },
+  {
+    "visningsnavn": "IKKE I BRUK Primærland barnet flyttet til Norge ",
+    "_rev": "CM6961CqAC7W4puPRQOIUM",
+    "_type": "ksBegrunnelse",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "navnISystem": "Primærland barnet flyttet til Norge ",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-3eb10d73-b84a-4c18-bb57-ebe43bec152c",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2023-12-19T15:28:33Z",
+    "_updatedAt": "2023-12-20T20:45:45Z",
+    "apiNavn": "innvilgetPrimarlandBarnetFlyttetTilNorg",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "barnetsBostedsland": [
+      "NORGE"
+    ]
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Den andre forelderen jobbar i Noreg som utsendt frå eit anna EØS-land. Vi har derfor kome fram til at norske reglar for kontantstøtte ikkje gjeld for dykk.",
+            "_key": "21030784be380",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d36e09e2fd98",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "navnISystem": "Selvstendig rett utsendt arbeidstaker fra annet EØS-land",
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "visningsnavn": "16. Selvstendig rett utsendt arbeidstaker fra annet EØS-land",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "NORGE_ER_SEKUNDÆRLAND",
+      "TO_PRIMÆRLAND"
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECkvdmf",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_id": "ksBegrunnelse-3eb8c776-bd1e-4df0-b8ba-e8331119f7a0",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2023-12-19T14:45:03Z",
+    "annenForeldersAktivitet": [
+      "UTSENDT_ARBEIDSTAKER"
+    ],
+    "apiNavn": "opphorSelvstendigRettUtsendtArbeodstakerFraAnnetEosLand",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "_createdAt": "2023-12-19T13:43:47Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen jobber i Norge som utsendt fra et annet EØS-land. Vi har derfor kommet fram til at norske regler for kontantstøtte ikke gjelder for dere.",
+            "_key": "095cdbadd5a70"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9e4df09737a0",
+        "markDefs": []
+      }
+    ]
+  },
+  {
+    "visningsnavn": "avslagTillegsTekstEksempel",
+    "_rev": "VNfjOkUyv8N7GDE50DIJm1",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-03-20T06:44:02Z",
+    "_id": "ksBegrunnelse-3eda792e-7fe0-4af9-8d15-b5322a337565",
+    "resultat": "AVSLAG",
+    "type": "TILLEGGSTEKST",
+    "_updatedAt": "2023-03-20T06:44:02Z",
+    "navnISystem": "avslagTillegsTekstEksempel",
+    "apiNavn": "avslagTillegsTekstEksempel",
+    "tema": "NASJONAL"
+  },
+  {
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_id": "ksBegrunnelse-4033a5cd-e8a2-4743-93ba-92b2a6773686",
+    "_updatedAt": "2024-01-10T08:07:21Z",
+    "apiNavn": "innvilgetSelvstendigRettSekundarlandUKStandard",
+    "_rev": "q5JgLByi60irF5LU0KzvQY",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "889941ddcdaa",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "34c2fa5f4f280",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "bd68f3601b23"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "7104ad842382",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5f49035a6490"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "9d66f3470bd0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "1223bc3139b8",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "0728ed4352e2",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "b2eab1fdc0b6"
+          },
+          {
+            "_key": "9681f0b8a3c8",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen "
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "0dfeee00795b",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "f75037ecd1b5"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "d1c650d0eb78"
+          },
+          {
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjeld derfor for den andre forelderen. Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Storbritannia har hovudansvaret for utbetaling av kontantstøtte. Noreg utbetalar skilnaden mellom kontantstøtta i Storbritannia og norsk kontantstøtte.",
+            "_key": "9a77947b65ed",
+            "_type": "span"
+          }
+        ]
+      },
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "\n",
+            "_key": "b7ca1baee4270",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8e64b6b13a93"
+      }
+    ],
+    "bokmaal": [
+      {
+        "_key": "87ec77c1749b",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "d74f13e5a7c40"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "c42d02811c13"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "632a87f86360",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d0096421dace",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "b2ba3e74771b"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "be6afe09e41b",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "f749f8ff7234"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "70a6563e6b43"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "04e50a85b3c2"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "89abb7b76a3c",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "1721ecc7865b"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "72e13fb0cb5d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder derfor for den andre forelderen. Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Storbritannia har hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler forskjellen mellom kontantstøtten i Storbritannia og norsk kontantstøtte.",
+            "_key": "818258e9fe53"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Selvstendig rett sekundærland UK standard",
+    "visningsnavn": "48. Selvstendig rett sekundærland UK standard",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2024-01-08T23:11:38Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ]
+  },
+  {
+    "resultat": "AVSLAG",
+    "tema": "EØS",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "945abf54f8160",
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen il barn født "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "45ba239da8dd",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_key": "02a019cddaef",
+            "_type": "span",
+            "marks": [],
+            "text": " jobber i Norge som utsendt fra et annet EØS-land. Norske regler for kontantstøtte gjelder derfor ikke for dere."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8403406f3e7e"
+      }
+    ],
+    "_id": "ksBegrunnelse-4125a39d-ab71-486a-ace9-a3f4bf4e6ac0",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "_key": "73d36c4cd765",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "8cccc652ccb40",
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen til barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "dd40eda09719"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " jobbar i Noreg som utsendt frå eit anna EØS-land. Norske reglar for kontantstøtte gjeld derfor ikkje for dykk.",
+            "_key": "a5ad63588765"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2024-01-09T17:01:10Z",
+    "apiNavn": "avslagSelvstendigRettUtsendtArbeidstakerFraAnnetEosLand",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "18. Selvstendig rett utsendt arbeidstaker fra annet EØS-land",
+    "_rev": "eS4Wb2bsh0R4qyDTo1R209",
+    "type": "STANDARD",
+    "navnISystem": "Selvstendig rett utsendt arbeidstaker fra annet EØS-land",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_type": "ksBegrunnelse",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2024-01-09T17:01:10Z"
+  },
+  {
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "Du og barn fødd ",
+            "_key": "da92f02f6e780",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "27154fe3fc23"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje lenger bur i eit EØS-land.",
+            "_key": "2d1b7edeebd4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "64ac5e1607fa",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "opphorSokerOgBarnBorIkkeIEosLand",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "9. Søker og barn bor ikke i EØS-land",
+    "_rev": "QYE1lVUzcrAawv9ECkvaSr",
+    "_type": "ksBegrunnelse",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "navnISystem": "Søker og barn bor ikke i EØS-land",
+    "resultat": "OPPHØR",
+    "_updatedAt": "2023-12-19T14:44:24Z",
+    "type": "STANDARD",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_createdAt": "2023-12-19T12:54:08Z",
+    "_id": "ksBegrunnelse-423e2c39-28ad-4475-a512-e6f15a7d072e",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "2cdf11529a8d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du og barn født ",
+            "_key": "4f472c3bfeec0"
+          },
+          {
+            "_key": "1f4d3e81f15a",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke lenger bor i et EØS-land.",
+            "_key": "dc68bb2c743e"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "navnISystem": "Opphold i EØS-land",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-425dd961-bd83-4ce2-995b-569f22b82792",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "7da457f7af370"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "482f47fce5d2"
+          },
+          {
+            "text": " under oppholdet i et annet EØS-land. Opphold i et annet EØS-land likestilles med å være bosatt i Norge.",
+            "_key": "745453ade6d8",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3fe7ec8b423b"
+      }
+    ],
+    "apiNavn": "innvilgetOppholdIEosLand",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "_rev": "TaUV0kzWabg6RzeULptcYU",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "f6114c3ac1d60"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fc63e17c7f9b"
+          },
+          {
+            "_key": "ef8a9ee3cd07",
+            "_type": "span",
+            "marks": [],
+            "text": " under opphaldet i eit anna EØS-land. Opphald i eit anna EØS-land er likestilt med å vere busett i Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "779d47510c86"
+      }
+    ],
+    "visningsnavn": "11. Opphold i EØS-land",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_createdAt": "2022-12-07T17:53:48Z",
+    "_updatedAt": "2022-12-13T14:42:33Z"
+  },
+  {
+    "tema": "NASJONAL",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "52871a6e80e3"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "3ba8a8212d9a",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "587529e68cd50",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje har opphaldsløyve i Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "72a69bd29bae"
+      }
+    ],
+    "_id": "ksBegrunnelse-436128c8-8380-4dd8-b1cd-31f86e8752c1",
+    "_updatedAt": "2023-05-04T09:14:59Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG",
+    "_rev": "RiR9GraBD8hopeC5h7I7eQ",
+    "_createdAt": "2023-05-04T09:14:59Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "76ee2f6b8995"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4"
+            },
+            "_type": "valgfeltV2",
+            "_key": "fb5f7b769048",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har oppholdstillatelse i Norge.",
+            "_key": "4de0f3544f5d0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9bdb27264bc1"
+      }
+    ],
+    "navnISystem": "Ikke oppholdstillatelse",
+    "apiNavn": "avslagIkkeOppholdstillatelse",
+    "visningsnavn": "12. Ikke oppholdstillatelse",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "visningsnavn": "34. Ikke enig om deling",
+    "_createdAt": "2023-05-04T18:22:14Z",
+    "resultat": "AVSLAG",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "7933c34e03cb",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du og den andre forelderen ikkje er enige om å dele kontantstøtta for barn fødd ",
+            "_key": "63b0ba0db4620"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "49e5a9b6bd9b",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "e0c8067866d5",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Ikke enig om deling",
+    "apiNavn": "avslagIkkeEnigOmDeling",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_rev": "lxTMP95K2WARLoXUTuWfXW",
+    "type": "STANDARD",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "_id": "ksBegrunnelse-43e61a6a-82f8-4465-85bb-a11e2508e81b",
+    "_updatedAt": "2023-05-04T18:22:14Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "9520ecbdae4a",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du og den andre forelderen ikke er enige om å dele kontantstøtten for barn født ",
+            "_key": "c487ee2814490"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "e5ffd28f1ae9"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "43b1ca3598b6"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "cb4cecf25009",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi barn fødd ",
+            "_key": "b692788aa19b0",
+            "_type": "span"
+          },
+          {
+            "_key": "413ae33f685f",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_key": "f2d23e21cb90",
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt "
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "60a2f55e4af7"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timar i barnehagen frå ",
+            "_key": "92feaee08213"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "6bc4feeec2d8",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtta er redusert frå same månad som endringa skjedde. ",
+            "_key": "45ae75e502bc"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "triggere": [
+      "DELTID_BARNEHAGEPLASS"
+    ],
+    "apiNavn": "reduksjonTildeltBarnehageplass",
+    "visningsnavn": "2. Tildelt barnehageplass",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-44c5193c-8139-49ab-b680-e1fd7c3141da",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "5280ae4ba1c0",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten reduseres fordi barn født ",
+            "_key": "22ef7ea7dc680"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "396ba17b15fb",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt ",
+            "_key": "a4af4443d008"
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "63926b18128e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timer i barnehagen fra ",
+            "_key": "e27ad10ec49d"
+          },
+          {
+            "_key": "7ba3f5a0bbff",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten reduseres fra samme måned som endringen skjedde.",
+            "_key": "0c25188cf1ea"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "hjemler": [
+      "7",
+      "8"
+    ],
+    "_rev": "CKoJmXlM50fHJKgxSBYJcl",
+    "_type": "ksBegrunnelse",
+    "_updatedAt": "2023-05-08T10:54:39Z",
+    "navnISystem": "Tildelt barnehageplass",
+    "_createdAt": "2023-05-03T14:47:00Z"
+  },
+  {
+    "hjemler": [
+      "8"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "5f643581a6360"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "4a0d8d98c8f3",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i ny barnehage. Når barnet kan være i barnehagen i 33 timer eller mer i uka, regnes dette som fulltidsplass. Du får ikke kontantstøtte når barn bytter barnehage i sommerferien.",
+            "_key": "776f98a1274b"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c2bfc82bf916"
+      }
+    ],
+    "visningsnavn": "16. Bytte av barnehage i sommerferien",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "_createdAt": "2023-05-04T17:41:03Z",
+    "_id": "ksBegrunnelse-4556d1f9-a206-4095-bf2b-d9eb0a0ebdad",
+    "apiNavn": "avslagBytteAvBarnehageISommerferien",
+    "_rev": "vuzvVDrYQXJOMHanV8bgiG",
+    "utdypendeVilkaarsvurderinger": [
+      "SOMMERFERIE"
+    ],
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "8148baa0266d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "83e0c94090c60"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "ce66fbe4b12f"
+          },
+          {
+            "text": " er tildelt fulltidsplass i ny barnehage. Når barnet kan vere i barnehagen i 33 timar eller meir i veka, er dette rekna som fulltidsplass. Du får ikkje kontantstøtte når barn bytter barnehage i sommarferien.",
+            "_key": "95218702e42e",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "_updatedAt": "2023-05-04T17:41:03Z",
+    "navnISystem": "Bytte av barnehage i sommerferien",
+    "type": "STANDARD",
+    "tema": "NASJONAL"
+  },
+  {
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "_updatedAt": "2023-06-12T21:35:34Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_key": "13a137fb5016",
+            "_type": "span",
+            "marks": [],
+            "text": ""
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "36b0a70821fb",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " skal ikke oppholde ",
+            "_key": "2ef86287bb840"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "3afa66f43f9d",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "5b567f2f0173",
+            "_type": "span",
+            "marks": [],
+            "text": " sammenhengende i Norge i over 12 måneder. "
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c17aff31e22a",
+        "markDefs": []
+      }
+    ],
+    "_rev": "EBbmZMt6ZAFjWzPHrdDYSG",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "0f04267f1ddb",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "89bdd234b940"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "7540c2f7a733"
+          },
+          {
+            "_key": "1f200b0090a60",
+            "_type": "span",
+            "marks": [],
+            "text": " skal ikkje opphalde "
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5444c28ad34b"
+          },
+          {
+            "_key": "de0b24f37776",
+            "_type": "span",
+            "marks": [],
+            "text": " samanhengande i Noreg i over 12 månader. "
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2023-05-04T09:23:57Z",
+    "navnISystem": "Opphold under 12 måneder",
+    "apiNavn": "avslagOppholdUnderTolvMaaneder",
+    "visningsnavn": "14. Opphold under 12 måneder",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_id": "ksBegrunnelse-461f49d0-9297-4c24-959b-9ebe37b7a917"
+  },
+  {
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-467c4bef-bf74-44be-9190-76b23a201f37",
+    "_type": "ksBegrunnelse",
+    "visningsnavn": "11. Vurdering ikke bosatt i Norge",
+    "_rev": "3H9OXgojExINZUA3ukmHUL",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_createdAt": "2023-07-21T15:06:12Z",
+    "apiNavn": "opphorVurderingIkkeBosattINorge",
+    "_updatedAt": "2023-07-28T11:34:50Z",
+    "navnISystem": "Vurdering ikke bosatt i Norge",
+    "resultat": "OPPHØR",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "82d35d60612c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "d5902c877fa20"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "15d11286b506",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje lenger er busett i Noreg frå ",
+            "_key": "ff96c01d791d"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "437bc98686e2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "93a72043b06c"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_key": "e95827c0dcec0",
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6a45eb596097",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke lenger er bosatt i Norge fra ",
+            "_key": "5cf8185f8895"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "0299bb20e726"
+          },
+          {
+            "_key": "0125523ecf6c",
+            "_type": "span",
+            "marks": [],
+            "text": "."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "161a89146314",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ]
+  },
+  {
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "4. Utsendt arbeidstaker fra annet EØS-land",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_createdAt": "2024-01-09T16:30:16Z",
+    "navnISystem": "Utsendt arbeidstaker fra annet EØS-land",
+    "apiNavn": "avslagUtsendtArbeidstakerFraAnnetEosLand",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijMXc6J",
+    "tema": "EØS",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "af8f8923496a",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du du jobbar i Noreg som utsendt frå eit anna EØS-land. Vi har derfor kome fram til at lovgjevnaden i det andre EØS-landet gjeld for deg.",
+            "_key": "7d51f65377560"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-46dc42b8-06cb-488b-8c84-1e12a90f52c1",
+    "_updatedAt": "2024-01-09T16:30:16Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du jobber i Norge som utsendt fra et annet EØS-land. Vi har derfor kommet fram til at lovgivningen i det andre EØS-landet gjelder for deg.",
+            "_key": "3bf30500b56f0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "47215e3dcbdd"
+      }
+    ]
+  },
+  {
+    "navnISystem": "Sekundærland UK aleneansvar",
+    "apiNavn": "innvilgetSekundarlandUKAleneansvar",
+    "_rev": "5r7yBuU8wKOiVHJijN6uFD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2024-01-08T16:22:16Z",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "_updatedAt": "2024-01-10T08:06:35Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "8a44acc369010",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "6e05cc91141a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "733d3da19ec0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ee1a51f080ee",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": ". ",
+            "_key": "a2d4e2de440b",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "262ae224ebd6",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i Norge, og går ikke i en barnehage som får offentlig støtte. Du har ansvar for ",
+            "_key": "54f53a50ff04"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0b7f2c802bbf"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " alene. Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Etter avtalen har Storbritannia hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i Storbritannia og norsk kontantstøtte.",
+            "_key": "f0385ffea4a6"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0e32b0e1ec2d",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "nynorsk": [
+      {
+        "_key": "3076f9857803",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "7f75a3eb10d60"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "9a9da502d182"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "56d505a63af9"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "841f11f5154b",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "fe50dba9f8db",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8c7404685ba8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i Noreg, og går ikkje i ein barnehage som får offentleg støtte. Du har ansvar for ",
+            "_key": "d8fac91f407c"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "33a28be156db",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " åleine. Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Etter avtalen har Storbritannia hovudansvaret for utbetaling av kontantstøtte. Noreg utbetalar derfor forskjellen mellom kontantstøtta i Storbritannia og norsk kontantstøtte.",
+            "_key": "15089c46d680"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "visningsnavn": "25. Sekundærland UK aleneansvar",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-46f4dece-813a-4ba7-8be4-a7254a04e66a",
+    "annenForeldersAktivitet": [
+      "IKKE_AKTUELT"
+    ]
+  },
+  {
+    "_id": "ksBegrunnelse-4a85651c-6ebf-4755-b94e-938eeb840356",
+    "_updatedAt": "2022-12-14T17:28:44Z",
+    "hjemler": [
+      "10"
+    ],
+    "_rev": "99hNjwNJwgiqUCCUQHTDZq",
+    "tema": "NASJONAL",
+    "visningsnavn": "1. Etterbetaling tre måned tilbake i tid",
+    "type": "STANDARD",
+    "_createdAt": "2022-12-14T11:03:17Z",
+    "apiNavn": "etterEndretUtbetalingEtterbetalingTreMaanedTilbakeITid",
+    "resultat": "ETTER_ENDRET_UTBETALINGSPERIODE",
+    "endretUtbetalingsperiode": [
+      "ETTER_ENDRET_UTBETALINGSPERIODE"
+    ],
+    "endringsaarsaker": [
+      "ETTERBETALING_3MND"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du søker om kontantstøtte tilbake i tid for barn født ",
+            "_key": "efa7584811cd"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "fa70bbf9515e",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Vi fikk søknaden din ",
+            "_key": "daaf2e8c8f5d"
+          },
+          {
+            "flettefelt": "soknadstidspunkt",
+            "_type": "flettefelt",
+            "_key": "9d37743b5b53"
+          },
+          {
+            "text": ". Kontantstøtte kan ikke utbetales for mer enn tre måneder tilbake i tid fra vi fikk søknaden din. TEST TEST TEST",
+            "_key": "bc5ec80e7995",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "13a03265b59f"
+      }
+    ],
+    "navnISystem": "Etterbetaling tre måneder tilbake i tid",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "apiNavn": "opphorVurderingBorIkkeFastMedSoker",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "be6dd2a0ee88",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at barn fødd ",
+            "_key": "f580f932cdac0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "6870844c0c29"
+          },
+          {
+            "text": " ikkje lenger bur fast hos deg frå ",
+            "_key": "42b824a0b2c7",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "5a4b1037c1da"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "fa557bb0ad3c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "7e68b380307a",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Vi har kommet fram til at barn født ",
+            "_key": "e6f16f09d2550",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c5dcec446668"
+          },
+          {
+            "text": " ikke lenger bor fast hos deg fra ",
+            "_key": "24674f4477e1",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "dfd79d07214f"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "b725bd6f95e1",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_rev": "Xl0tn62zVopahRtC7CNJ8Z",
+    "resultat": "OPPHØR",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "navnISystem": "Vurdering bor ikke fast hos søker",
+    "visningsnavn": "22. Vurdering bor ikke fast hos søker",
+    "_createdAt": "2023-07-22T07:42:39Z",
+    "_updatedAt": "2023-07-22T07:42:39Z",
+    "_id": "ksBegrunnelse-4be51886-edb1-427a-9d02-8cf08feb531e"
+  },
+  {
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_rev": "q5JgLByi60irF5LU0K8eV6",
+    "type": "STANDARD",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2024-01-09T17:09:56Z",
+    "navnISystem": "Delt bosted begge foreldre ikke omfattet norsk lovvalg",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Norske reglar for kontantstøtte gjeld ikkje for begge foreldra. Kontantstøtta for barn fødd ",
+            "_key": "9d901eb185710"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "010dce803aa3"
+          },
+          {
+            "marks": [],
+            "text": " kan ikkje delast i slike tilfeller.",
+            "_key": "fbc44a2267ec",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f975145a247e"
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG",
+    "_id": "ksBegrunnelse-4cf06bd9-29a1-4ed4-af76-57b7ef966c3b",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "e85406e5ca1c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Norske regler for kontantstøtte gjelder ikke for begge foreldrene. Kontantstøtten for barn født ",
+            "_key": "e1a61acebabc0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "259c580dc08c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " kan ikke deles i slike tilfeller.",
+            "_key": "5ac0166ea6e2"
+          }
+        ]
+      }
+    ],
+    "apiNavn": "avslagDeltBostedBeggeForeldreIkkeOmfattetNorskLovvalg",
+    "visningsnavn": "21. Delt bosted begge foreldre ikke omfattet norsk lovvalg",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2024-01-09T17:09:56Z"
+  },
+  {
+    "_rev": "q5JgLByi60irF5LU0IPj8w",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtta er endra fordi det har vore ei satsendring og ei endring av valutakursen.",
+            "_key": "047db625da430",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3313238b6762"
+      }
+    ],
+    "navnISystem": "Tilleggstekst satsendring og valutajustering",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2024-01-08T21:19:34Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-4e471f13-5aa7-46f0-9d07-f0db1c334258",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T21:19:34Z",
+    "apiNavn": "innvilgetTilleggstekstSatsendringOgValutajustering",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "4b4da6aaeb6b",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "a142c5ed9bdd0",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten er endret fordi det har vært en satsendring og en endring av valutakursen."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "resultat": "INNVILGET",
+    "visningsnavn": "31. Tilleggstekst satsendring og valutajustering"
+  },
+  {
+    "_rev": "q5JgLByi60irF5LU0K557c",
+    "_createdAt": "2024-01-09T16:37:22Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "apiNavn": "avslagSeparasjonsavtalenGjelderIkke",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-4ee28869-bcf0-43e0-b59d-8d471a99517d",
+    "navnISystem": "Separasjonsavtalen gjelder ikke",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "tema": "EØS",
+    "_updatedAt": "2024-01-09T16:37:22Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Separasjonsavtalen mellom Storbritannia og Norge ikke gjelder for familien.",
+            "_key": "97c50b11b9c50",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4aa11edcf12b"
+      }
+    ],
+    "visningsnavn": "8. Separasjonsavtalen gjelder ikke",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Separasjonsavtalen mellom Storbritannia og Norge ikkje gjeld for familien.",
+            "_key": "2b78822aca1a0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "130c09f1921c",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ]
+  },
+  {
+    "_id": "ksBegrunnelse-4eff8fad-f6c3-4871-a1f3-3063389b97f2",
+    "visningsnavn": "18. Den andre forelderen har fått kontantstøtte",
+    "_rev": "vuzvVDrYQXJOMHanV8cR2r",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Den andre forelderen har fått kontantstøtte for barn født ",
+            "_key": "2bdd20521a240",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "551b76f0b3ff",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i samme tidsrom.",
+            "_key": "1fa67428a4a3"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "6199b35cb37e"
+      }
+    ],
+    "navnISystem": "Den andre forelderen har fått kontantstøtte",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "nynorsk": [
+      {
+        "_key": "63982766fdb7",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har fått kontantstøtte for barn fødd ",
+            "_key": "e690ee6c59110"
+          },
+          {
+            "_key": "d2ea9095564a",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i same tidsrom.",
+            "_key": "57307e1a510d"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-05-04T17:46:05Z",
+    "_updatedAt": "2023-05-04T17:46:05Z",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "apiNavn": "avslagDenAndreForelderenHarFaattKontantstotte",
+    "hjemler": [
+      "3",
+      "8",
+      "9"
+    ],
+    "resultat": "AVSLAG"
+  },
+  {
+    "visningsnavn": "39. Ikke oppholdsrett EØS-borger",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_updatedAt": "2023-05-04T18:33:33Z",
+    "apiNavn": "avslagOppholdsrettEOSBorger",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "vuzvVDrYQXJOMHanV8hvnQ",
+    "_createdAt": "2023-05-04T18:33:33Z",
+    "_id": "ksBegrunnelse-4f02b82c-f3de-472b-9283-ccb068cdbfbb",
+    "navnISystem": "Ikke oppholdsrett EØS-borger",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "bokmaal": [
+      {
+        "_key": "747f99049524",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at du ikke har oppholdsrett i Norge som EØS-borger.",
+            "_key": "54651d4d929b0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_key": "88ac8f087a5d",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Vi har kome fram til at du ikkje har oppholdsrett i Noreg som EØS-borger.",
+            "_key": "48d2b112866b0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "resultat": "INNVILGET",
+    "_updatedAt": "2023-01-10T07:57:23Z",
+    "navnISystem": "Erklæring om motregning",
+    "_type": "ksBegrunnelse",
+    "apiNavn": "innvilgetErklaringOmMotregning",
+    "_rev": "9Sh1niKpid77KkNKMqMhft",
+    "_createdAt": "2022-12-08T11:24:59Z",
+    "_id": "ksBegrunnelse-51705c19-961a-4c42-b5f2-aa4ce0d157d6",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "e7c9f96de147",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "378eec22dfcf0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du har tidligere fått utbetalt for mye kontantstøtte. Du har nå rett til etterbetaling av kontantstøtte. Vi reduserer etterbetalingen med det beløpet du har fått for mye utbetalt."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "19. Erklæring om motregning",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har tidligare fått utbetalt for mykje barnetrygd. Du har no rett til etterbetaling av barnetrygd. Vi kjem til å redusere etterbetalinga med det du har fått for mykje.",
+            "_key": "e43efa457ae20"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "da1d48183546",
+        "markDefs": []
+      }
+    ],
+    "tema": "NASJONAL",
+    "type": "TILLEGGSTEKST",
+    "skalAlltidVises": true
+  },
+  {
+    "apiNavn": "innvilgetTredjelandsborgerLovligOppholdSamtidigBosattINorgeSoker",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "_rev": "NQv0PO3qFOizdWKMlw5LsD",
+    "type": "TILLEGGSTEKST",
+    "tema": "NASJONAL",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "rolle": [
+      "SOKER"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "41300de6d504"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "50c755863ac8"
+          },
+          {
+            "marks": [],
+            "text": " fra måneden etter at du er bosatt i Norge og har oppholdstillatelse. ",
+            "_key": "4684fa3df889",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f20c865c6679"
+      }
+    ],
+    "navnISystem": "Tredjelandsborger med lovlig opphold samtidig som bosatt i Norge søker",
+    "visningsnavn": "IKKE I BRUK Tredjelandsborger med lovlig opphold samtidig som bosatt i Norge søker",
+    "_updatedAt": "2023-06-23T13:01:50Z",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "e2a41e51a265"
+          },
+          {
+            "_key": "b5ecc4b34d7e",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at du er busett i Noreg og har opphaldsløyve.",
+            "_key": "d915991a07d3"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d86ebc1927ad"
+      }
+    ],
+    "_createdAt": "2023-01-09T07:59:36Z",
+    "_id": "ksBegrunnelse-51b25b3c-f089-48bf-9555-693bd6d20013"
+  },
+  {
+    "apiNavn": "avslagDenAndreForelderenIkkeMedlemIFemAar",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "_id": "ksBegrunnelse-52022796-7e82-4aa7-a4ea-c44694fcc681",
+    "resultat": "AVSLAG",
+    "tema": "NASJONAL",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Den andre forelderen ikke har vært medlem i folketrygden i fem år.",
+            "_key": "674b51cf3a300",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "50fdf484f092",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Den andre forelderen ikke medlem i 5 år ",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "27. Den andre forelderen ikke medlem i 5 år ",
+    "_rev": "rKyoPlAvQSvCLakyN3GYcl",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "164f14f99b6c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen ikkje har vore medlem i folketrygda i fem år.",
+            "_key": "99f4682ab8890"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2023-04-14T19:54:06Z",
+    "_updatedAt": "2023-04-25T13:15:50Z"
+  },
+  {
+    "apiNavn": "innvilgetIkkeBarnehage",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "d19dc2cc08e20",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "7fe583cfe488",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_key": "7616e8e85f53",
+            "_type": "span",
+            "marks": [],
+            "text": " fordi "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "7f78cf4bdfab",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er under 2 år og ikkje har fått tildelt barnehageplass.",
+            "_key": "b4ee7e446e56"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0d3d72630368",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-5478ff72-bfc0-4c3f-bddd-b7d15f3e78d7",
+    "hjemler": [
+      "2",
+      "3",
+      "7",
+      "8",
+      "9"
+    ],
+    "visningsnavn": "1. Ikke barnehage",
+    "_rev": "q78nlzlQCcCXR6QugeDLKE",
+    "vilkaar": [
+      "BARNEHAGEPLASS",
+      "BARNETS_ALDER"
+    ],
+    "_updatedAt": "2022-12-07T14:20:58Z",
+    "navnISystem": "Ikke barnehage",
+    "bokmaal": [
+      {
+        "_key": "2ff6ba44e5a0",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "32a55c5dc3c6"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "cba40ddf1060"
+          },
+          {
+            "marks": [],
+            "text": " fordi ",
+            "_key": "fe80d9e525cb",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e7befbfed85f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er under 2 år og ikke har fått tildelt barnehageplass.",
+            "_key": "a5af9cd22a8f"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2022-11-17T13:03:48Z"
+  },
+  {
+    "visningsnavn": "30. Tilleggstekst valutajustering",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_updatedAt": "2024-01-08T21:17:23Z",
+    "navnISystem": "Tilleggstekst valutajustering",
+    "apiNavn": "innvilgetTilleggstekstValutajustering",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi det har vore ei endring av valutakursen.",
+            "_key": "900d9b52573c0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0cd04c7cde1b",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-554708b5-57ae-41dc-943a-00bc5a31d455",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "bokmaal": [
+      {
+        "_key": "d714a39ca572",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten er endret fordi det har vært en endring av valutakursen.",
+            "_key": "23900cb96b0a0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTo035wv",
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2024-01-08T21:17:23Z",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ]
+  },
+  {
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "visningsnavn": "20. Selvstendig rett foreldrene bor sammen ",
+    "resultat": "AVSLAG",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "apiNavn": "avslagSelvstendigRettForeldreneBorSammen",
+    "_rev": "5r7yBuU8wKOiVHJijMbYvT",
+    "_id": "ksBegrunnelse-55d02c3c-8e39-4fd0-bd1a-aee04b8c9488",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "743155cbc726",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen til barn født ",
+            "_key": "ff287535a94e0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "a1ad8d0bddc1"
+          },
+          {
+            "text": " allerede får kontantstøtte for ",
+            "_key": "700ea81c9ce1",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "f81252244f11",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "ff287535a94e2"
+          }
+        ]
+      }
+    ],
+    "type": "STANDARD",
+    "tema": "EØS",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Den andre forelderen til barn fødd ",
+            "_key": "8cbb30d2bd9d0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "7920ed47c2ab"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " allereie mottek barnetrygd for ",
+            "_key": "799f6aea2bca"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "86a2f8ead116",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "8cbb30d2bd9d1",
+            "_type": "span",
+            "marks": [
+              "em"
+            ],
+            "text": "."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "52c9de074950"
+      }
+    ],
+    "_createdAt": "2024-01-09T17:03:51Z",
+    "_updatedAt": "2024-01-09T17:07:44Z",
+    "navnISystem": "Selvstendig rett foreldrene bor sammen ",
+    "hjemler": [
+      "3",
+      "8"
+    ]
+  },
+  {
+    "navnISystem": "Barn død EØS",
+    "apiNavn": "reduksjonBarnDodEos",
+    "_rev": "QYE1lVUzcrAawv9ECl3abu",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T16:25:47Z",
+    "_updatedAt": "2023-12-19T16:25:47Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-5727f49e-9b16-46b5-a138-90c233794135",
+    "visningsnavn": "1, Barn død EØS",
+    "resultat": "REDUKSJON",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "14684123944a",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra frå månaden etter at barn fødd ",
+            "_key": "8971c2b4f0190"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "f6cab2185b1f",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_key": "02fbdb65f9b4",
+            "_type": "span",
+            "marks": [],
+            "text": " døydde."
+          }
+        ]
+      }
+    ],
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "triggere": [
+      "BARN_DØD"
+    ],
+    "bokmaal": [
+      {
+        "_key": "b0fd9564d0b6",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fra måneden etter at barn født ",
+            "_key": "2c932cb27e260"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "e0ff23fb2627"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døde.",
+            "_key": "f68e6bea6ad2"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "0e42ee3072fe0"
+          },
+          {
+            "_key": "5fbac9ea3b23",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "07afd9f7fd91"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb"
+            },
+            "_type": "valgfeltV2",
+            "_key": "9503ce78d67f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": ". ",
+            "_key": "79b3ad4fcacc",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "3fd1f88de297",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "b81ea77d0279"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "ff66a22bf701"
+          },
+          {
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "3d15d9a501e1",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5d2af7a74387",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder derfor for den andre forelderen. Du får hele kontantstøtten fra Norge.",
+            "_key": "8b890897a398"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "91308acc29dd",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "innvilgetSelvstendigRettPrimarlandForYtelseIUtlandet",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T22:45:42Z",
+    "annenForeldersAktivitet": [
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "resultat": "INNVILGET",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2024-01-08T22:45:42Z",
+    "navnISystem": "Selvstendig rett primærland får ytelse i utlandet",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "_key": "78edc9391dcf",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "7e87e911afd90",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "3186b04ad422"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "28b256915d6e",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "849adeeea860",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "9ca2c907253a",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "efc8c9a81fb4",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "3b34248fd233",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "1e233c91fd7b"
+          },
+          {
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "8264b6818572",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "690c78ffeee7",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": ". Norske reglar for kontantstøtte gjeld derfor for den andre forelderen. Du får heile kontantstøtta frå Noreg.",
+            "_key": "3b5508e919f0",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-588deb4d-0890-4680-9b33-a2aa1cb5447b",
+    "visningsnavn": "50. Selvstendig rett primærland får ytelse i utlandet",
+    "_rev": "5r7yBuU8wKOiVHJijLbZ8J"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "11. Primærland særkullsbarn/andre barn overtatt ansvar",
+    "_createdAt": "2023-12-20T16:14:52Z",
+    "_updatedAt": "2024-01-09T15:26:18Z",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-58ee4102-6e25-48be-8211-88761e05236a",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "2bfa6094abdb",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "f5a0dcfd14940"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "e59207a5d32d"
+          },
+          {
+            "text": ". Du ",
+            "_key": "982e0758ee6c",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "6c09ab688bbb",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "05c0ecb437f3"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cc9344e9dca6",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bor i ",
+            "_key": "bad7d85f238a",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "38d78d45d6f7"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Du har ansvar for ",
+            "_key": "e710603e0b2e"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cb2785aaa9e2",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "931c8b82c7b0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "82b9395393bf",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "9fb5d46bd1bd0"
+          },
+          {
+            "_key": "45d3219dbda4",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "ce50c8396aad"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ad60bfce1876"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "7546563e9dd6"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5c2df0387747",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " bur i ",
+            "_key": "b81ce45b94f0",
+            "_type": "span"
+          },
+          {
+            "_key": "ef77c0bb7556",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Du har ansvar for ",
+            "_key": "8cd7dfa48c86",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "76b33e31065f",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_key": "a1d0a0dc4e87",
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor heile kontantstøtta frå Noreg."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "annenForeldersAktivitet": [
+      "MOTTAR_PENSJON",
+      "IKKE_AKTUELT"
+    ],
+    "navnISystem": "Primærland særkullsbarn/andre barn overtatt ansvar",
+    "apiNavn": "innvilgetPrimarlandSarkullsbarnAndreBarnOvertattAnsvar",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijMVHjT"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "FORTSATT_INNVILGET",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "visningsnavn": "1. Opphold i Norge",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fordi ",
+            "_key": "024006497c8c0"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d56a6f06d00b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt er busett i Noreg.",
+            "_key": "024006497c8c2"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "a7d89e77ed01",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Opphold i Norge",
+    "apiNavn": "fortsattInnvilgetOppholdINorge",
+    "_rev": "eS4Wb2bsh0R4qyDTnxD85x",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_createdAt": "2023-12-12T11:46:34Z",
+    "_id": "ksBegrunnelse-595e8456-266a-4e85-b288-bfe5b997ed86",
+    "_updatedAt": "2024-01-05T11:02:37Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fordi ",
+            "_key": "2c430fcf2f580"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "b7e070683c10",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt er bosatt i Norge.",
+            "_key": "7e09cddb4ea7"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "63be94f3961f",
+        "markDefs": []
+      }
+    ]
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "_createdAt": "2023-05-04T09:02:54Z",
+    "_id": "ksBegrunnelse-599c67b1-e2fe-411f-b0de-84a25232a7ff",
+    "_updatedAt": "2023-06-22T09:34:40Z",
+    "_rev": "cQbHktflgzaIIKHTEkqHiu",
+    "apiNavn": "avslagIkkeBosattINorge",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "1f5b18d083a8",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "c354505db3c3"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "83dfbb6f7d65",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke er bosatt i Norge.",
+            "_key": "91fe2a3908230"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Ikke bosatt i Norge",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "",
+            "_key": "fa4cdfac0bec",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "4b6eb003b273",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje er busett i Noreg. ",
+            "_key": "9030e9b7f8750"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "56ec45299b77"
+      }
+    ],
+    "visningsnavn": "10. Ikke bosatt i Norge"
+  },
+  {
+    "apiNavn": "avslagIkkeLovligOppholdSomEosBorger",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG",
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "visningsnavn": "9. Ikke lovlig opphold som EØS-borger",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-5adaef54-a265-4147-a551-c1f52a2b995a",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "7f9f88a03c05",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "28f59f8398650",
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at du ikke har lovlig opphold som EØS-borger."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Ikke lovlig opphold som EØS-borger",
+    "tema": "EØS",
+    "_updatedAt": "2024-01-09T16:39:07Z",
+    "_rev": "5r7yBuU8wKOiVHJijMYGNH",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_key": "c90f5fbcc20b",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Vi har kome fram til at du ikkje har lovleg opphald som EØS-borgar.",
+            "_key": "593a593ab4c90",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2024-01-09T16:39:07Z"
+  },
+  {
+    "resultat": "OPPHØR",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_createdAt": "2023-12-19T15:01:53Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-5b063a22-de3f-42b4-8ab7-c289488db93c",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du og barn født ",
+            "_key": "f2adffe436310",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "816f43712bc8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke bodde i et EØS-land.",
+            "_key": "6f5e6c483034"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "097dff0685e1"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "visningsnavn": "24. Søker og barn bodde ikke i EØS land",
+    "apiNavn": "opphorSokerOgBarnBoddeIkkeIEosLand",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "_key": "b925bb9067ce",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du og barn fødd ",
+            "_key": "a423262513d10",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "bbf47902aeeb"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje budde i eit EØS-land.",
+            "_key": "7304a392e03d"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_updatedAt": "2023-12-19T15:01:53Z",
+    "navnISystem": "Søker og barn bodde ikke i EØS land",
+    "_rev": "AOUa26DfnB8ntJraK3xMm5"
+  },
+  {
+    "apiNavn": "innvilgetSekundarlandUKStandard",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "bokmaal": [
+      {
+        "_key": "dab3e6c931c6",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "704ecd6797200",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "7abd354a18a9"
+          },
+          {
+            "text": ". Du ",
+            "_key": "9433a7322e23",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "09afe922b98f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "b99e27b830b9"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "4976c3171f06",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "64591410cb32"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "b7a43c2be5d5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i ",
+            "_key": "874b291d329f"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "cfabf60693be"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Etter avtalen har Storbritannia hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i Storbritannia og norsk kontantstøtte.",
+            "_key": "024501a1ef26"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "visningsnavn": "24. Sekundærland UK standard",
+    "_rev": "q5JgLByi60irF5LU0KzqYc",
+    "type": "STANDARD",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_createdAt": "2024-01-08T16:13:53Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "36083222c058",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "12f7d8ae5d4e0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "564e31ca7c1f",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "cb66c372a8c6"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "ce40e7ea614c",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "fca95c7527e8"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "473317ff5c5d",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "6092e62357a1"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "e002d27d77a5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "c8d4d783f983"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "690ed1e30a16"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Etter avtalen har Storbritannia hovudansvaret for utbetaling av kontantstøtte. Noreg utbetalar derfor forskjellen mellom kontantstøtta i Storbritannia og norsk kontantstøtte.",
+            "_key": "a41bd2e3a6e2"
+          }
+        ]
+      }
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-10T08:06:26Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "navnISystem": "Sekundærland UK standard",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "_id": "ksBegrunnelse-5b6e01fe-7214-40c9-8f83-4f7699c2247d"
+  },
+  {
+    "tema": "NASJONAL",
+    "_createdAt": "2023-07-24T07:34:54Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "55c70fb23b8c",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barnet ditt som er født ",
+            "_key": "63f77c0a47360",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "25e4eccbe26b",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_key": "af62bf6813c1",
+            "_type": "span",
+            "marks": [],
+            "text": " døde."
+          }
+        ]
+      }
+    ],
+    "apiNavn": "opphorEtBarnErDod",
+    "_rev": "0w3lID6Lsk7VK2mhOLMIbb",
+    "type": "STANDARD",
+    "_updatedAt": "2023-07-24T07:34:54Z",
+    "navnISystem": "Et barn er død",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "_id": "ksBegrunnelse-5c543508-8ad1-48c2-9684-56823ec17b4c",
+    "resultat": "OPPHØR",
+    "triggere": [
+      "BARN_DØD"
+    ],
+    "nynorsk": [
+      {
+        "_key": "c212b5a1902e",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Barnet ditt som er fødd ",
+            "_key": "193a3b58f2d40",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "5e04324fdfe3"
+          },
+          {
+            "text": " døydde.",
+            "_key": "135297616dd8",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "visningsnavn": "25a. Et barn er død",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ]
+  },
+  {
+    "resultat": "AVSLAG",
+    "visningsnavn": "2. Bruker melder fulltidsplass i barnehage",
+    "_rev": "Tll0zet2a2PTsXq0BgRvLZ",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "_createdAt": "2023-05-04T06:18:08Z",
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du har opplyst at barn fødd ",
+            "_key": "5ac5d9930e3b0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "6dd27ac470d8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage frå ",
+            "_key": "878f82abaa16"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "d50bb91d6cd3"
+          },
+          {
+            "_key": "0ed06fae744f",
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "85938055c39a"
+      }
+    ],
+    "_updatedAt": "2023-09-26T12:49:59Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har opplyst at barn født ",
+            "_key": "394ab24e6c1f0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "5918181fae57"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage fra ",
+            "_key": "459284ddb3e3"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "da090ca3b244"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "c6aeb9f689fd"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "117c457f2a06"
+      }
+    ],
+    "apiNavn": "avslagBrukerMelderFulltidsplassIBarnehage",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-5c99bd93-e6ff-42df-bb6f-35efc7982281",
+    "navnISystem": "Bruker melder fulltidsplass i barnehage"
+  },
+  {
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_id": "ksBegrunnelse-5cae789c-6c34-4593-a503-873a75e7daf6",
+    "apiNavn": "reduksjonIkkeAnsvarForBarn",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "2e049835f73d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi du ikkje lenger har ansvar for barn fødd ",
+            "_key": "bb3476e83bef0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "92b947b62f19"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "8f4c9ac97be3"
+          }
+        ]
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "navnISystem": "Ikke ansvar for barn",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_rev": "CM6961CqAC7W4puPRL9CJM",
+    "resultat": "REDUKSJON",
+    "_createdAt": "2023-12-19T16:31:37Z",
+    "visningsnavn": "4. Ikke ansvar for barn",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "_updatedAt": "2023-12-19T16:31:37Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "5b3a388777da",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "58706aabad1e0",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi du ikke lenger har ansvar for barn født "
+          },
+          {
+            "_key": "8522a5e4b4a4",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "6df825e38436"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "hjemler": [
+      "3"
+    ],
+    "_rev": "1xmt9No8Jphy1iSrgJfDpc",
+    "type": "TILLEGGSTEKST",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "be974cc5eee7",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "c602239e5cc9"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "42845c43188e",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_key": "c40d4462ec16",
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at du er busett i Noreg. "
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Bosatt i Norge Søker",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_updatedAt": "2023-07-04T19:13:31Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "65bc8604e995"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fd3b4e47cdab"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at du er bosatt i Norge.",
+            "_key": "fec19c38669f"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f7d239a7d940"
+      }
+    ],
+    "visningsnavn": "20. Bosatt i Norge søker",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_id": "ksBegrunnelse-5caf27e0-c94e-4a45-991e-13c908b9cbf0",
+    "apiNavn": "innvilgetBosattINorgeSoker",
+    "resultat": "INNVILGET",
+    "_createdAt": "2023-01-09T07:56:10Z"
+  },
+  {
+    "navnISystem": "Selvstendig rett var ikke utsendt arbeidstaker fra annet EØS land",
+    "_updatedAt": "2023-12-19T14:09:10Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen jobbet i Norge som utsendt fra et annet EØS-land. Vi har derfor kommet fram til at norske regler for kontantstøtte ikke gjaldt for dere.",
+            "_key": "b151cb696a820"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f499ee7349bd"
+      }
+    ],
+    "annenForeldersAktivitet": [
+      "UTSENDT_ARBEIDSTAKER"
+    ],
+    "stotterFritekst": false,
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_id": "ksBegrunnelse-5ed7b3b3-9ae3-45c0-be02-e027a8bbfa51",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "apiNavn": "opphorSelvstendigRettVarIkkeUtsendtArbeidstakerFraAnnetEosLand",
+    "_rev": "AOUa26DfnB8ntJraK3w6ND",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Den andre forelderen jobba i Noreg som utsendt frå eit anna EØS-land. Vi har derfor kome fram til at norske reglar for kontantstøtte ikkje gjaldt for dykk.",
+            "_key": "8097b6a40c0d0",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "474c8221018b"
+      }
+    ],
+    "_createdAt": "2023-12-19T13:49:17Z",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "18. Selvstendig rett var ikke utsendt arbeidstaker fra annet EØS land",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "NORGE_ER_SEKUNDÆRLAND",
+      "TO_PRIMÆRLAND"
+    ],
+    "resultat": "OPPHØR"
+  },
+  {
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "109457ba5f850",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "27d5375d6581"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "cf7a508e7cd4"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "c60d4b4201c6",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "b1e06013d0d3"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "1d915488e5fe",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "marks": [],
+            "text": " bor i Norge, og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i ",
+            "_key": "677e4c11b703",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "8cad2549e460"
+          },
+          {
+            "text": ". Landene dere jobber i har hovedansvar for utbetaling av kontantstøtte. Norsk kontantstøtte er høyere enn kontantstøtten i ",
+            "_key": "b5236ae4a5ba",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "1974e87b2786",
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og i ",
+            "_key": "63cbda578f7c"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "73f784fc9fc1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norge utbetaler derfor forskjellen mellom kontantstøtten i disse landene og norsk kontantstøtte.",
+            "_key": "a3dc652922e9"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "6e2cf50b8aaa"
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "6b175cb2fbc2",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "\n",
+            "_key": "9ce82213cc8a0",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Sekundærland to arbeidsland Norge utbetaler",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_PENSJON"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "27. Sekundærland to arbeidsland Norge utbetaler",
+    "_rev": "q5JgLByi60irF5LU0JyqZU",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "e6408e5726a6",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "19a35543c5590"
+          },
+          {
+            "_key": "40452cd028eb",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "b5ddaf09e083"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "466491189b2d",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "8290879a4a20"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "02c7af936f07"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i Noreg, og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "93ad4c7161b1"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "270ac337bf0e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Landa de jobbar i har hovudansvar for utbetaling av kontantstøtte. Norsk kontantstøtte er høgare enn kontantstøtta i ",
+            "_key": "3def204f9696"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "4a9613ff9d53"
+          },
+          {
+            "_key": "6c759fc74734",
+            "_type": "span",
+            "marks": [],
+            "text": " og i "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "aa43f6bbc85a",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Noreg utbetalar derfor forskjellen mellom kontantstøtta i desse landa og norsk kontantstøtte.",
+            "_key": "0c3807463296"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2024-01-08T21:03:25Z",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "hjemlerEOSForordningen987": [
+      "58"
+    ],
+    "apiNavn": "innvilgetSekundarlandToArbeidslandNorgeUtbetaler",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_id": "ksBegrunnelse-60eb59cc-32b6-4f8b-ae3b-1e731888980a",
+    "_updatedAt": "2024-01-09T15:01:12Z"
+  },
+  {
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "47f25c0a6c0d",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtte kan ikke utbetales for mer enn tre måneder tilbake i tid fra vi fikk søknaden din. Vi fikk søknaden ",
+            "_key": "6b788f92e952",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "soknadstidspunkt",
+            "_type": "flettefelt",
+            "_key": "3479c2e11659"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "a7bc609b0ef5"
+          }
+        ]
+      }
+    ],
+    "apiNavn": "avslagSokerForSentEndringsperiode",
+    "_id": "ksBegrunnelse-61599802-7427-43a6-8a90-deee9f782dd8",
+    "_rev": "KXPDYOyPiZZvJZqhKhHfHl",
+    "type": "ENDRINGSPERIODE",
+    "_createdAt": "2023-05-29T15:52:28Z",
+    "_updatedAt": "2023-05-29T17:46:39Z",
+    "navnISystem": "avslagSokerForSentEndringsperiode",
+    "hjemler": [
+      "8"
+    ],
+    "visningsnavn": "37. Søker for sent",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtte kan ikke utbetales for mer enn tre måneder tilbake i tid fra vi fikk søknaden din. Vi fikk søknaden ",
+            "_key": "011d6e74bd3f"
+          },
+          {
+            "flettefelt": "soknadstidspunkt",
+            "_type": "flettefelt",
+            "_key": "8c1fe387c69c"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "0347bc4cb607",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3f5a431e6db6",
+        "markDefs": []
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "tema": "NASJONAL"
+  },
+  {
+    "navnISystem": "Ikke oppholdstillatelse",
+    "apiNavn": "opphorIkkeOppholdstillatelse",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "95f40ed4d563"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "86083722817c",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "20ef2f01552a0",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje lenger har opphaldsløyve i Noreg frå "
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "75bf6a32379f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "c063eab8a93b"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f8592c74f9bf",
+        "markDefs": []
+      }
+    ],
+    "_updatedAt": "2023-07-28T11:35:18Z",
+    "_rev": "3H9OXgojExINZUA3ukmHi1",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-61bf3503-b41b-473d-a2f1-a007fbc0a76b",
+    "visningsnavn": "12. Ikke oppholdstillatelse",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "_createdAt": "2023-07-21T15:11:32Z",
+    "bokmaal": [
+      {
+        "_key": "ac6eb8900505",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "d634142e8740"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "7faf44a7549e",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke lenger har oppholdstillatelse i Norge fra ",
+            "_key": "a7499bec5c180"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "9f7cb2bb594d"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "937b178e43b2",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "_updatedAt": "2023-05-04T06:21:32Z",
+    "apiNavn": "avslagKommunenMelderFulltidsplassIBarnehage",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetenesta i kommunen har opplyst at barn fødd ",
+            "_key": "89a78798ac430"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "12c2a215b83f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage frå ",
+            "_key": "0a2306d4802a"
+          },
+          {
+            "_key": "d06b06fb2780",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "7bd3980434ff"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8d66802e0cc6"
+      }
+    ],
+    "_createdAt": "2023-05-04T06:21:32Z",
+    "_id": "ksBegrunnelse-6218b529-561a-417d-be63-324a21dec010",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_key": "e77f31a51a810",
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetjenesten i kommunen har opplyst at barn født "
+          },
+          {
+            "_key": "3308ef7d4621",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage fra ",
+            "_key": "922c7f244b11"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "a82c92607c77"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "31b9c1759102"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c182c4fb701b",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Kommunen melder fulltidsplass i barnehage",
+    "_rev": "RiR9GraBD8hopeC5h71tdl",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "visningsnavn": "3. Kommunen melder fulltidsplass i barnehage"
+  },
+  {
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtta er endra fordi du ikkje har ein avtale om delt bustad for barn fødd ",
+            "_key": "532640d41a250",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "aa7a1f13bd02"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "0ff8c3d82d0c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "61d3085098ae"
+      }
+    ],
+    "apiNavn": "reduksjonHarIkkeAvtaleOmDeltBosted",
+    "type": "STANDARD",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "navnISystem": "Har ikke avtale om delt bosted",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-05-03T15:05:22Z",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "resultat": "REDUKSJON",
+    "_id": "ksBegrunnelse-64420b71-7509-4cbf-b982-58eef475a0b2",
+    "_updatedAt": "2023-05-03T15:05:22Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "25e28e2106c3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi du ikke har en avtale om delt bosted for barn født ",
+            "_key": "547aa10c1b2c0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "ef51ffcc38f2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "dbe18a39b365"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "8. Har ikke avtale om delt bosted",
+    "_rev": "sNO2L38EwIVNY4VMy4UkX4"
+  },
+  {
+    "apiNavn": "avslagVurderingOppholdUnderTolvMaaneder",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG",
+    "navnISystem": "Vurdering opphold under 12 måneder",
+    "_rev": "b4KQss9Lf6DqDWn0I2gnMU",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "ffe6dba8cdfe0",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "380b6ba8539b"
+          },
+          {
+            "_key": "6a2da9c97c15",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje skal opphalde "
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "dc8cb61fa200",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " samanhengande i Noreg i over 12 månader. ",
+            "_key": "d8b35915da9c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "2b79bc35632d"
+      }
+    ],
+    "_updatedAt": "2023-06-08T12:11:44Z",
+    "visningsnavn": "15. Vurdering opphold under 12 måneder",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "tema": "NASJONAL",
+    "type": "STANDARD",
+    "_createdAt": "2023-05-04T10:59:34Z",
+    "_id": "ksBegrunnelse-670d7b14-ed33-4446-945a-e4e9302d3300",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "3ec61c465971",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "e349388786260"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "693191f83197",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke skal oppholde ",
+            "_key": "c79fc607d6c5"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "24af2edf7e29",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " sammenhengende i Norge i over 12 måneder. ",
+            "_key": "4e5a562ce36c"
+          }
+        ],
+        "_type": "block"
+      }
+    ]
+  },
+  {
+    "navnISystem": "Deltidsplass barnehage ",
+    "hjemler": [
+      "2",
+      "3",
+      "7",
+      "8",
+      "9"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "6acf46efca870",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "821b371e2a61",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "marks": [],
+            "text": " fordi ",
+            "_key": "5368366c70b1",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a2a813f27a67",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er under 2 år og er tildelt ",
+            "_key": "6acf46efca872"
+          },
+          {
+            "_key": "2e479c84e8df",
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timar i barnehagen per veke.",
+            "_key": "d9683c648185"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3852fb95d081"
+      }
+    ],
+    "visningsnavn": "3. Deltidsplass barnehage ",
+    "vilkaar": [
+      "BARNEHAGEPLASS",
+      "BARNETS_ALDER"
+    ],
+    "tema": "NASJONAL",
+    "triggere": [
+      "DELTID_BARNEHAGEPLASS"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "925557b3d329"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "85efc13217af"
+          },
+          {
+            "marks": [],
+            "text": " fordi ",
+            "_key": "bd861b196602",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6f9c6e0b502e",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er under 2 år og er tildelt ",
+            "_key": "7a2a47cf64c8"
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "636beee1509d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timer i barnehagen per uke. ",
+            "_key": "78215151b1bc"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b4a0554d0654"
+      }
+    ],
+    "apiNavn": "innvilgetDeltidBarnehage",
+    "stotterFritekst": true,
+    "_createdAt": "2022-11-17T13:06:44Z",
+    "_id": "ksBegrunnelse-672231b8-964a-40d1-91dd-0ac992f1ed6e",
+    "_updatedAt": "2023-03-30T14:05:03Z",
+    "_rev": "pmhuRhSUoAWbpYJtPpNZs7"
+  },
+  {
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "0f69bf33327a",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barn fødd ",
+            "_key": "e286e85618860",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "c6ef1782c685",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i fosterheim frå ",
+            "_key": "eb08ff754aa6"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "a8edd120977d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "acfbd41d5be8"
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2023-07-17T10:10:03Z",
+    "_updatedAt": "2023-07-17T10:10:03Z",
+    "navnISystem": "Forsterhjem",
+    "visningsnavn": "7. Fosterhjem",
+    "_rev": "3JnjoNwBZ41U8L0QcHu0Ic",
+    "resultat": "OPPHØR",
+    "_id": "ksBegrunnelse-67541f18-889f-4195-9831-8f6a4d3d3765",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "4260d1f3fb590",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "a37e3738a9fb"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i fosterhjem fra ",
+            "_key": "1a5c72980f1e"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "f4bfe285489b"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "23915da495bc",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4ff3bdd1ecb8",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "opphorFosterhjem",
+    "hjemler": [
+      "6",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL"
+  },
+  {
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-67587388-d5f5-4ad4-bd1b-b1622221b971",
+    "navnISystem": "Institusjon",
+    "visningsnavn": "8. Institusjon",
+    "hjemler": [
+      "6",
+      "8"
+    ],
+    "_rev": "KKtpRp2hoR2wxEL4Fh9Nvn",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "1a6881e022fa",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barn fødd ",
+            "_key": "7bd7155e42c30",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "8d7698c0109a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur på institusjon frå ",
+            "_key": "59ecd2779cd7"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "559b3db03d24"
+          },
+          {
+            "text": ".",
+            "_key": "424c30ad9675",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2023-07-17T10:12:55Z",
+    "_updatedAt": "2023-07-17T10:12:55Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "2f485ca273770",
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "0b25a07d9ee7"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor på institusjon fra ",
+            "_key": "7c11d378bd16"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "d76bb55a5825"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "f5f8b63c1d1c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f1ac741de820"
+      }
+    ],
+    "apiNavn": "opphorInstitusjon",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ]
+  },
+  {
+    "_rev": "eS4Wb2bsh0R4qyDTo1OTuz",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "68669b71bade",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du ikkje får pengar frå NAV som erstattar løn.",
+            "_key": "2400ddc9dc3b0",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2024-01-09T16:35:48Z",
+    "visningsnavn": "7. Ikke penger fra NAV som erstatter lønn",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2024-01-09T16:35:48Z",
+    "apiNavn": "avslagIkkePengerFraNAVSomErstatterLonn",
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "67"
+    ],
+    "tema": "EØS",
+    "navnISystem": "Ikke penger fra NAV som erstatter lønn",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-6a531bcc-0161-438b-a840-4673cc5588ae",
+    "bokmaal": [
+      {
+        "_key": "6588d70cb01f",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke får penger fra NAV som erstatter lønn.",
+            "_key": "153b5bafe7df0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "navnISystem": "Sekundærland standard",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTnzfNib",
+    "type": "STANDARD",
+    "visningsnavn": "21. Sekundærland standard",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_id": "ksBegrunnelse-6c0fd54d-ff06-4c0f-8e9d-85aa95fd964b",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_updatedAt": "2024-01-08T15:02:14Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "64f9688f4db6",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "e32dc0759f790",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "88259dcd40eb",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ". Du ",
+            "_key": "6ccb5d4b1e88",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "3da6866e5dfe",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "cbd97a60d510"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "af1097a0e5b1",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bor i ",
+            "_key": "965dac752593",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "2e94dfa837af"
+          },
+          {
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "d9e9f88e2bcb",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "efc0e218ab8c"
+          },
+          {
+            "_key": "8da4b148a5b8",
+            "_type": "span",
+            "marks": [],
+            "text": " i "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "84bb30570161"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "0db22521dfe5"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "0da6982a13b8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i ",
+            "_key": "ebc6158b4954"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "37c5efba2b47"
+          },
+          {
+            "marks": [],
+            "text": " og norsk kontantstøtte.",
+            "_key": "d20749175edf",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "apiNavn": "innvilgetSekundarlandStandard",
+    "resultat": "INNVILGET",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "05a4fd5569f70",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "cf1deed08f29"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "c9ebc9d2d409",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "dca84de7ab6e",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "709473bd07d4"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "dcaf9bfb6bc3",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bur i ",
+            "_key": "904d803e258d",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "bdeebc52c55a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "546dfa02d655"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "2acf5425379f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "c8a4abc483e1"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "e6caf3cb8279"
+          },
+          {
+            "text": ". ",
+            "_key": "d278d7d4ac51",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "f253186f30ad",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovudansvaret for utbetaling av kontantstøtte. Noreg utbetaler derfor skilnaden mellom kontantstøtta i ",
+            "_key": "8943e9e83b2d"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "fc1432c70023"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte.",
+            "_key": "fa28606ed271"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3c499a425b09",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2024-01-08T14:41:24Z"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "navnISystem": "Oppholdsrett",
+    "visningsnavn": "5. Oppholdsrett",
+    "resultat": "FORTSATT_INNVILGET",
+    "bokmaal": [
+      {
+        "_key": "3dc2b49f07bf",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fordi vi har kommet fram til at ",
+            "_key": "fedc86be1a330"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "75cb9c14c3f4",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "fedc86be1a332",
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt har oppholdsrett."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "fortsattInnvilgetOppholdsrett",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "AOUa26DfnB8ntJraJzw8LV",
+    "_id": "ksBegrunnelse-6c1b8060-fcbd-4c85-b6f7-c03efcdb486a",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fordi vi har kome fram til at ",
+            "_key": "ec74aae0a57f0"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "056345d41571",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt har opphaldsrett. ",
+            "_key": "ec74aae0a57f2"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9b2412ee5310"
+      }
+    ],
+    "_createdAt": "2023-12-12T12:00:32Z",
+    "_updatedAt": "2023-12-12T12:00:32Z"
+  },
+  {
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi barn fødd ",
+            "_key": "867112142d350",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "e17f7cb5f4ac"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er 2 år. Du får kontantstøtte til og med månaden før barnet fyller 2 år.",
+            "_key": "f0fd962d040c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3b136b86cf7c",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2023-05-03T15:15:52Z",
+    "_updatedAt": "2023-05-03T15:15:52Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi barn født ",
+            "_key": "ebe89759cb490"
+          },
+          {
+            "_key": "e6938eeec984",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_key": "d448cdc7a60c",
+            "_type": "span",
+            "marks": [],
+            "text": " er 2 år. Du får kontantstøtte til og med måneden før barnet fyller 2 år."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "93eaa57edd15"
+      }
+    ],
+    "navnISystem": "Barn har fylt to år",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_type": "ksBegrunnelse",
+    "resultat": "REDUKSJON",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "_id": "ksBegrunnelse-6c67a0a1-bfb0-49cb-bc4d-7fc414e59742",
+    "apiNavn": "reduksjonBarnHarFyltToAar",
+    "visningsnavn": "12. Barn har fylt to år",
+    "_rev": "sNO2L38EwIVNY4VMy4VHfm"
+  },
+  {
+    "apiNavn": "reduksjonForeldreneIkkeLengerEnigOmAaDeleKontantstotten",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "navnISystem": "Foreldrene ikke lenger enig om å dele kontantstøtten",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta er endra for barn fødd ",
+            "_key": "9425063fec160",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "7746cc836f3d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi du og den andre forelderen ikkje lenger er samde om at kontantstøtta skal delast ",
+            "_key": "3b1900c365c2"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "aab80b9c8d2e"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "fd52c2e9745e",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "983ecd26b426",
+        "markDefs": []
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "visningsnavn": "11. Foreldrene ikke lenger enig om å dele kontantstøtten",
+    "_rev": "sNO2L38EwIVNY4VMy4VCzS",
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-6dace0f4-ac54-4978-9662-d5a04455da85",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "_updatedAt": "2023-05-03T15:14:01Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "9fca9b1b83a1",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres for barn født ",
+            "_key": "73ff3dbeb2df0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "57e47e4862a4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi du og den andre forelderen ikke lenger er enige om at kontantstøtten skal deles ",
+            "_key": "89813392ba73"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "38fc2d10352a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "ec462d7f28b9"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2023-05-03T15:14:01Z"
+  },
+  {
+    "visningsnavn": "14. Har og skal oppholde seg ikke over 12 mnd",
+    "_rev": "3H9OXgojExINZUA3ukmHt8",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "",
+            "_key": "9b35e8c5f9cc",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "56cb50424a34",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje skal opphalde ",
+            "_key": "4dd664f77a9f0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8ecd0654cfac",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " samanhengande i Noreg i over 12 månader. ",
+            "_key": "70669d5e7e8c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3d15c6c755e2"
+      }
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "7b8ac2dfe314",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "3e0fef6cc46e",
+            "_type": "span",
+            "marks": [],
+            "text": ""
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "e33a9f722b3b",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke skal oppholde ",
+            "_key": "c8890e4c02250"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "8fa9559f-9e65-4ae7-8422-3f55b255945a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e31bc8e579e1",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " sammenhengende i Norge i over 12 måneder. ",
+            "_key": "1fdbeed70aec"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_updatedAt": "2023-07-28T11:35:49Z",
+    "navnISystem": "Har og skal oppholde seg  ikke over 12 mnd",
+    "_createdAt": "2023-07-21T15:21:42Z",
+    "_id": "ksBegrunnelse-6eac576a-6a30-4957-84a7-1efb7067b0b4",
+    "tema": "NASJONAL",
+    "apiNavn": "opphorHarOgSkalOppholdeSegIkkeOver12Maaneder",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR"
+  },
+  {
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "0d007dd79944",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje har opphaldsrett som familiemedlem til ein EØS-borgar.",
+            "_key": "2ab787415b400"
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2024-01-09T16:39:26Z",
+    "_updatedAt": "2024-01-09T16:41:33Z",
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "apiNavn": "avslagIkkeOppholdsrettSomFamiliemedlemAvEosBorger",
+    "_rev": "q5JgLByi60irF5LU0K6KCA",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "navnISystem": "Ikke oppholdsrett som familiemedlem av EØS-borger",
+    "visningsnavn": "10. Ikke oppholdsrett som familiemedlem av EØS-borger",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "tema": "EØS",
+    "hjemler": [
+      "3",
+      "7",
+      "8"
+    ],
+    "_id": "ksBegrunnelse-6fd95365-01a3-42f4-9c47-cb1610e834a1",
+    "bokmaal": [
+      {
+        "_key": "85674076f40b",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "793e67784cba0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke har oppholdsrett som familiemedlem til en EØS-borger."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ]
+  },
+  {
+    "_rev": "sT5C1Zuvjux67St1xVHuyt",
+    "type": "TILLEGGSTEKST",
+    "_id": "ksBegrunnelse-717f2f97-ab4c-4f88-9dc5-2aa5dd90abfe",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "_updatedAt": "2022-12-07T15:54:28Z",
+    "navnISystem": "Delt bosted måneden etter søknad",
+    "visningsnavn": "6. Delt bosted måneden etter søknad",
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED"
+    ],
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi barn fødd ",
+            "_key": "33449afca12b0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "02e13bf13d85"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "har delt bustad og de er einige om at kontantstøtta skal delast. Du får delt kontantstøtte frå månaden etter at du søkte.",
+            "_key": "1d751addb8c1"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "45b32ffebdaf"
+      }
+    ],
+    "_createdAt": "2022-12-07T15:54:28Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "d9ff89226898",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi barn født ",
+            "_key": "cedf4859a5820"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "44a5cc468cf5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har delt bosted og dere er enige om at kontantstøtten skal deles. Du får delt kontantstøtte fra måneden etter at du søkte.",
+            "_key": "5fe9a996904c"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "apiNavn": "innvilgetDeltBostedMaanedEtterSoknad",
+    "hjemler": [
+      "9"
+    ]
+  },
+  {
+    "_id": "ksBegrunnelse-71839de5-88e0-4660-b962-e993ff79421a",
+    "apiNavn": "avslagBegyntPaaSkolen",
+    "_rev": "KOa0MjQMDn5FLyPT0Q7Sl7",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "_createdAt": "2023-05-04T06:29:16Z",
+    "navnISystem": "Begynt på skolen",
+    "visningsnavn": "5. Begynt på skolen",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-05-04T06:29:16Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "text": "Barn født ",
+            "_key": "c5b77e5c9b040",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "81c680b6b4a4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har begynt på skolen. ",
+            "_key": "ff655d11fb51"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0529b2443fcd",
+        "markDefs": []
+      }
+    ],
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "hjemler": [
+      "10"
+    ],
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "ac442201f742",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "b5c54778fad20",
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "2ed3cd7a78f7"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har begynt på skulen.",
+            "_key": "ceb88e4073dc"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "visningsnavn": "26. Sekundærland UK og utland standard",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2024-01-08T20:50:27Z",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-10T08:06:45Z",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-7242120f-ef56-4df9-a799-5765426d257f",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "a3d24f076a210"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "b5926260e389",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "d3cc27c68d35",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "08510cf51383"
+          },
+          {
+            "_key": "2f8e1a470ece",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "d594a02f4e77",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "e0da9e0cd6ee"
+          },
+          {
+            "_key": "77cf17c84820",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "1d1896a28c73",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "7df471b991cd",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "d9862d897815"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "4567c28e065f",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Etter avtalen har Storbritannia hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i Storbritannia og norsk kontantstøtte. ",
+            "_key": "8d9d37f5815d",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b598bad5d1a5",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Sekundærland UK og utland standard",
+    "_rev": "5r7yBuU8wKOiVHJijN6uhP",
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "e74607c572ab0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "3113b59a73b1"
+          },
+          {
+            "text": ". Du ",
+            "_key": "30474aa5aaaf",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6e0e2e96e5d1"
+          },
+          {
+            "text": ". ",
+            "_key": "49d9de33234d",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0b8e2904f8b8",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "bcf9ff6865a5"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "a6b3d3eae41f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "e65f727d6d59"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "1eefc5e0fabf"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "f545876dd9b3"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "8800543b8625"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Etter avtalen har Storbritannia hovudansvaret for utbetaling av kontantstøtte. Noreg utbetalar derfor forskjellen mellom kontantstøtta i Storbritannia og norsk kontantstøtte. ",
+            "_key": "a5ef33345959"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "5df58206bc4c",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER"
+    ],
+    "apiNavn": "innvilgetSekundarlandUKogUtlandStandard",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "tema": "EØS"
+  },
+  {
+    "_updatedAt": "2023-05-07T12:46:16Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "dc2fafef3178",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten reduseres fordi du har opplyst at barn født ",
+            "_key": "577ff182e35f0"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "4bd2fd40b384",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": " er tildelt ",
+            "_key": "5cf3bfaf6fde",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "961a64a2d295"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timer i barnehagen fra ",
+            "_key": "a6eec4f12bab"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "c7a321e10cc1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten reduseres fra samme måned som endringen skjedde.",
+            "_key": "49ea689d3930"
+          }
+        ]
+      }
+    ],
+    "_rev": "XghJoDIHyYaQPLh884EdTN",
+    "_type": "ksBegrunnelse",
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-7266bd59-d666-4966-8637-2046ce91e480",
+    "navnISystem": "Søker opplyst om  barnehageplass",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "_createdAt": "2023-05-03T14:51:29Z",
+    "triggere": [
+      "DELTID_BARNEHAGEPLASS"
+    ],
+    "apiNavn": "reduksjonSokerOpplystOmBarnehageplass",
+    "hjemler": [
+      "7",
+      "8"
+    ],
+    "visningsnavn": "3. Søker opplyst om  barnehageplass",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "1e977bf7c3e1",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtta er endra fordi du har opplyst at barn fødd ",
+            "_key": "15d7dff1aef00",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "39b02ecb4b78"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt ",
+            "_key": "2bcac98daf7c"
+          },
+          {
+            "_key": "56b2d317e069",
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt"
+          },
+          {
+            "text": " timar i barnehagen frå ",
+            "_key": "727486877ff3",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "5b83bdec4b78"
+          },
+          {
+            "text": ". Kontantstøtta er redusert frå same månad som endringa skjedde.",
+            "_key": "8de891734c57",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "_createdAt": "2023-05-03T14:54:44Z",
+    "apiNavn": "reduksjonKommunenOpplystOmBarnehageplass",
+    "hjemler": [
+      "7",
+      "8"
+    ],
+    "visningsnavn": "4. Kommunen opplyst om  barnehageplass",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten reduseres fordi barnehagetjenesten i kommunen har opplyst at barn født ",
+            "_key": "af9759862a280"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "00732401681d",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt ",
+            "_key": "dad8246682d3"
+          },
+          {
+            "_key": "7d48a99f0c4c",
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timer i barnehagen fra ",
+            "_key": "0b6e71c08f53"
+          },
+          {
+            "_key": "7d5fc0e9df8e",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten reduseres fra samme måned som endringen skjedde.",
+            "_key": "81564d317cd5"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "856470f8a51b"
+      }
+    ],
+    "_id": "ksBegrunnelse-739381fa-d1c9-4217-9217-476bcbef781e",
+    "navnISystem": "Kommunen opplyst om  barnehageplass",
+    "_rev": "CKoJmXlM50fHJKgxSBYfDO",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "fc822486be7f",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "a6766673d1c20",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi barnehagetenesta i kommunen har opplyst at barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "16f8e44695e4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt ",
+            "_key": "c9967a20248c"
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "fc8410c3ee1a"
+          },
+          {
+            "marks": [],
+            "text": " timar i barnehagen frå ",
+            "_key": "0d664b747488",
+            "_type": "span"
+          },
+          {
+            "_key": "d5fb6b445fa1",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtta er redusert frå same månad som endringa skjedde.",
+            "_key": "e314d5587fa8"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "triggere": [
+      "DELTID_BARNEHAGEPLASS"
+    ],
+    "_updatedAt": "2023-05-08T10:56:16Z"
+  },
+  {
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "08e00a4260a6",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vedtaket er gjort før vi har fått opplysningar frå ",
+            "_key": "926381c41b150"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "d8182735a22b"
+          },
+          {
+            "_key": "b7bd13b70307",
+            "_type": "span",
+            "marks": [],
+            "text": ". Saka må vurderast på nytt dersom vi mottar nye opplysningar."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2024-01-08T07:57:46Z",
+    "_updatedAt": "2024-01-08T13:58:40Z",
+    "hjemlerEOSForordningen987": [
+      "60"
+    ],
+    "navnISystem": "Tilleggsbegrunnelse vedtak før SED",
+    "visningsnavn": "33. Tilleggsbegrunnelse vedtak før SED",
+    "tema": "EØS",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijLD7bL",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-73c851f8-e025-4fcd-8f4e-3d1c06cc2ca3",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vedtaket er gjort før vi har fått opplysninger fra ",
+            "_key": "70f28383dc920"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "af40f8380d57"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Saken må vurderes på nytt dersom vi mottar nye opplysninger.",
+            "_key": "405e54189548"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8a9be0f02340"
+      }
+    ],
+    "type": "TILLEGGSTEKST",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "apiNavn": "innvilgetTilleggsbegrunnelseVedtakForSed",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET"
+  },
+  {
+    "_rev": "KOa0MjQMDn5FLyPT0MqllF",
+    "type": "STANDARD",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "nynorsk": [
+      {
+        "_key": "73fd7b0c635e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi du har ein avtale om delt bustad for barn fødd ",
+            "_key": "0051735d90070"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "1c2f4172bc31"
+          },
+          {
+            "_key": "5c3711bb6fba",
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtta blir delt frå månaden etter at den andre forelderen har søkt om kontantstøtta."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_id": "ksBegrunnelse-762d7cee-baa6-442a-ac88-f58625ea3a0c",
+    "navnISystem": "Avtale om delt bosted",
+    "apiNavn": "reduksjonAvtaleOmDeltBosted",
+    "_type": "ksBegrunnelse",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "df3cb6db95f6",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtten endres fordi du har en avtale om delt bosted for barn født ",
+            "_key": "5b5f12c2364c0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "decf5dc19e8f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten deles fra måneden etter at den andre forelderen har søkt om kontantstøtte.",
+            "_key": "bb8701f2ca8b"
+          }
+        ]
+      }
+    ],
+    "resultat": "REDUKSJON",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2023-05-03T15:10:34Z",
+    "_updatedAt": "2023-05-03T15:10:34Z",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "visningsnavn": "10. Avtale om delt bosted"
+  },
+  {
+    "apiNavn": "opphorBarnBoddeIkkeMedSoker",
+    "_rev": "0w3lID6Lsk7VK2mhOLT4Ub",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_id": "ksBegrunnelse-7632294c-22ef-4eba-b2cc-e079542104fd",
+    "visningsnavn": "31. Barn bodde ikke med søker",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "7471f6747c14",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Vi har kome fram til at barn fødd ",
+            "_key": "4b81cbe3a4640",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "9381e6eb8b99"
+          },
+          {
+            "marks": [],
+            "text": " ikkje budde fast hos deg. ",
+            "_key": "6ef2a0641b0f",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2023-07-24T08:00:51Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "25f40a7daa37",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at barn født ",
+            "_key": "69ba285338500"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c1a32a05b074"
+          },
+          {
+            "marks": [],
+            "text": " ikke bodde fast hos deg. ",
+            "_key": "795850e559f2",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Barn bodde ikke med søker",
+    "hjemler": [
+      "2"
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_updatedAt": "2023-07-24T08:00:51Z"
+  },
+  {
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "71dbced4893f0"
+          },
+          {
+            "_key": "13d42634af85",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden i fem år.",
+            "_key": "71dbced4893f4",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "ea1f6b59991d",
+        "markDefs": []
+      }
+    ],
+    "visningsnavn": "28. Vurdering ikke medlem folketrygden i 5 år ",
+    "_type": "ksBegrunnelse",
+    "_updatedAt": "2023-04-25T13:16:11Z",
+    "resultat": "AVSLAG",
+    "_id": "ksBegrunnelse-779b7bdc-33d9-4dab-af9a-aece1b73ad97",
+    "apiNavn": "avslagVurderingIkkeMedlemFolketrygdenIFemAar",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_rev": "4MfBp9HJw6JHUbUYbY7Jkz",
+    "_createdAt": "2023-04-14T19:57:44Z",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "6b18bcdfd215",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "d95c00882ded0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "dda2cef87eb3",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje har vore medlem i folketrygda i fem år.",
+            "_key": "d95c00882ded4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Vurdering ikke medlem folketrygden i 5 år ",
+    "type": "STANDARD",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ]
+  },
+  {
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "7e5391a0cf31",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "535e580ddf7a0",
+            "_type": "span",
+            "marks": [],
+            "text": "Barna dine som er fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "3067697c4f26"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døydde. ",
+            "_key": "9366139f4481"
+          }
+        ]
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-77bb64e1-3d16-4268-9f0d-e023761bd073",
+    "_updatedAt": "2023-12-19T14:44:52Z",
+    "_rev": "AOUa26DfnB8ntJraK3wqpV",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T13:25:55Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barna dine som er født ",
+            "_key": "8f2df140ac420"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "44f8874a05eb"
+          },
+          {
+            "_key": "dde5ead8bb0d",
+            "_type": "span",
+            "marks": [],
+            "text": " døde."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "bfd4b6706c53"
+      }
+    ],
+    "navnISystem": "Flere barn er døde EØS",
+    "visningsnavn": "14. Flere barn er døde EØS",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "triggere": [
+      "BARN_DØD"
+    ],
+    "apiNavn": "opphorFlereBarnErDodeEos"
+  },
+  {
+    "visningsnavn": "5. Primærland UK standard",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "655c127175360"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "ebc0ac4eade2"
+          },
+          {
+            "text": ". Du ",
+            "_key": "30f039658a13",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "23964cc27cff",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "8fe07d08e5a1",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "4824ef31645e",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bur i ",
+            "_key": "62c5c4dfe679",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "31b6375df886"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar ikkje i ",
+            "_key": "423da75d8e1f"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "df5c4b6a9aee"
+          },
+          {
+            "_key": "e5effa146ce2",
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Etter avtalen får du heile kontantstøtta frå Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9caef8c1941d",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-7ae1fa6f-bc63-438e-96ac-ee9c1759955e",
+    "navnISystem": "Primærland UK standard",
+    "type": "STANDARD",
+    "annenForeldersAktivitet": [
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "984adcf8e7ca",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "143bde5fb1ea0"
+          },
+          {
+            "_key": "5b6ba2238baa",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "5fe84d70f1a2",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a9377093c34a",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "4f240bb257b9"
+          },
+          {
+            "_key": "b8520b9dc245",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_key": "12503387359c",
+            "_type": "span",
+            "marks": [],
+            "text": " bor i "
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "893cdfc1762c"
+          },
+          {
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber ikke i ",
+            "_key": "58f45ec94e9b",
+            "_type": "span"
+          },
+          {
+            "_key": "cd407aa8b07d",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Etter avtalen får du hele kontantstøtten fra Norge.",
+            "_key": "58b4fc88d513"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "apiNavn": "innvilgetPrimarlandUKStandard",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijJWs7b",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_createdAt": "2023-12-19T10:12:18Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_updatedAt": "2024-01-05T15:41:38Z"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "nynorsk": [
+      {
+        "_key": "bd0643fb0f71",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "f2c0636bc03f0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "25b960747936"
+          },
+          {
+            "_key": "aeb66dac48d4",
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "f814cb3a5c97",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " kom tilbake til Noreg etter opphaldet i utlandet. ",
+            "_key": "f2c0636bc03f6"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_id": "ksBegrunnelse-7d16e8c0-9b82-4d91-81ca-25ab9590b375",
+    "apiNavn": "innvilgetBosattEtterUtenlandsopphold",
+    "resultat": "INNVILGET",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-06-19T14:41:28Z",
+    "_rev": "NQv0PO3qFOizdWKMlw4T2z",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_updatedAt": "2023-06-23T13:00:06Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "ff4e05bca253",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "244b5d998d350",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "382abbaca98e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "88322286b401"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8935b94bd778",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " kom tilbake til Norge etter oppholdet i utlandet.",
+            "_key": "244b5d998d356"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Bosatt etter utenlandsopphold",
+    "visningsnavn": "20. Bosatt etter utenlandsopphold",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ]
+  },
+  {
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "44e8094184e3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har avtale om delt bustad for barn fødd ",
+            "_key": "4b60c2615c7d0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "04a48ea73633"
+          },
+          {
+            "marks": [],
+            "text": ". Avtalen gjeld frå ",
+            "_key": "3339a92138a4",
+            "_type": "span"
+          },
+          {
+            "_key": "172befedeb3f",
+            "flettefelt": "avtaletidspunktDeltBosted",
+            "_type": "flettefelt"
+          },
+          {
+            "text": ".",
+            "_key": "d02236866326",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-8064f722-006e-4f9d-a8cf-7c7c05af2197",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "navnISystem": "Tilleggstekst sekundær avtale delt bosted",
+    "hjemler": [
+      "9"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2024-01-08T21:53:27Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "bab2b7771833",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du har avtale om delt bosted for barn født ",
+            "_key": "18b5f6ccc1760",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "cc2e09463fd6"
+          },
+          {
+            "_key": "9ada0fcb56cf",
+            "_type": "span",
+            "marks": [],
+            "text": ". Avtalen gjelder fra "
+          },
+          {
+            "flettefelt": "avtaletidspunktDeltBosted",
+            "_type": "flettefelt",
+            "_key": "0d716e28386a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "e024636d911d"
+          }
+        ]
+      }
+    ],
+    "apiNavn": "innvilgetTilleggstekstSekundarAvtaleDeltBosted",
+    "visningsnavn": "37. Tilleggstekst sekundær avtale delt bosted",
+    "_rev": "5r7yBuU8wKOiVHJijLa1GN",
+    "tema": "EØS",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T21:53:27Z",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ]
+  },
+  {
+    "resultat": "AVSLAG",
+    "navnISystem": "Flere barn er døde",
+    "apiNavn": "avslagFlereBarnErDode",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2023-05-04T18:05:31Z",
+    "triggere": [
+      "BARN_DØD"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "5f57e48e1610",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barna dine som er fødd ",
+            "_key": "f33e29433a7b0"
+          },
+          {
+            "_key": "66dd7ac1e310",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "text": " døydde.",
+            "_key": "81083411f1ef",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "_updatedAt": "2023-05-04T18:05:31Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barna dine som er født ",
+            "_key": "c5c1740ca9610",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "9367c5a7a18c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døde.",
+            "_key": "b6d4d0c8de90"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d15dd31fce0c"
+      }
+    ],
+    "visningsnavn": "25. Flere barn er døde",
+    "_rev": "vuzvVDrYQXJOMHanV8fFZq",
+    "_id": "ksBegrunnelse-83182921-83b7-4bcd-826e-01f5d9ded495"
+  },
+  {
+    "navnISystem": "Sekundærland aleneansvar",
+    "visningsnavn": "23. Sekundærland aleneansvar",
+    "resultat": "INNVILGET",
+    "tema": "EØS",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "type": "STANDARD",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T15:18:41Z",
+    "apiNavn": "innvilgetSekundarlandAleneansvar",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTnzhSiX",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2024-01-08T15:00:51Z",
+    "_id": "ksBegrunnelse-83c65dff-39a4-45e7-ae15-d229c9b2e2e9",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "2b49d3cd6b860"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "6af39480aed5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "b6a27f981c04"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0ccf752c9bbf",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " i ",
+            "_key": "d87a612c901c",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "7e4019c9b311"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "2bf2db1c3b93"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "727dbbc1d633"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "cb7c8668ed11"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "f66f2a14eabd"
+          },
+          {
+            "_key": "5f186772a27c",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Du har ansvar for "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "09a182bc578e",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": " alene. ",
+            "_key": "e9335f7ce35f",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "c24b7ca3cc6d",
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_key": "4f812d05fca2",
+            "_type": "span",
+            "marks": [],
+            "text": " har hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i "
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "7bd40421dd01"
+          },
+          {
+            "marks": [],
+            "text": " og norsk kontantstøtte.\n",
+            "_key": "e501f81fb833",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "212e33a22687"
+      },
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "\n",
+            "_key": "3642f2f0f8fd0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "7d972f30ecdc"
+      },
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "\n",
+            "_key": "cdaac002263e0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b0469bad3593"
+      }
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "3508f4e05a570"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "bfb8771ed2dc"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "3fec07dc65a4"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6bfc1c0581a3",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "0ccf9cf1199a"
+          },
+          {
+            "_key": "548cfd61002a",
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "2a642d8c337b"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8bd6dc125bb9",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "40546c57d82f"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "faecc0bcfa0c"
+          },
+          {
+            "_key": "6f2d677506dc",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Du har ansvar for "
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "60c70ddb6078",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " åleine. ",
+            "_key": "a6f359ebaf76"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "5976cdfad902"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovudansvaret for utbetaling av kontantstøtte. Noreg utbetalar derfor forskjellen mellom kontantstøtta i ",
+            "_key": "98abce71eb11"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "52f4e8b250db"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte.",
+            "_key": "86fa09cd4e32"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "efbbdf7307b4"
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "IKKE_AKTUELT"
+    ]
+  },
+  {
+    "navnISystem": "Medlemskap folketrygden og EØS-land",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "_createdAt": "2022-12-07T17:47:33Z",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "4901e26891cb0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "bdb42c8c25d6"
+          },
+          {
+            "_key": "91e6d7e53f03",
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e1716c58c4c4",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " har vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år.",
+            "_key": "4901e26891cb4",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8f56da072dba",
+        "markDefs": []
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "686ed28109f8",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "515688b9089e0"
+          }
+        ]
+      }
+    ],
+    "visningsnavn": "9. Medlemskap folketrygden og EØS-land",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "skalAlltidVises": true,
+    "stotterFritekst": true,
+    "hjemler": [
+      "3"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-85d3d806-7ac3-44a7-9bc2-dd9c28240b35",
+    "_updatedAt": "2023-02-16T20:20:06Z",
+    "apiNavn": "innvilgetMedlemskapFolketrygdenOgEOSLand",
+    "_rev": "Xi9D0gcZJF8O0QeDkoYMN1",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "9d55adb2b6f90"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "d2d9b106bf05"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "46d08aa91a01"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "28a71e6e7b0e",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har vært medlem i folketrygden og trygdeordninger i andre EØS-land i til sammen fem år.",
+            "_key": "9d55adb2b6f94"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "062d71eaed71"
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "20c997cc1078",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "d6cfdb2f67870"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "visningsnavn": "41. Barn uten fødselsnummer",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "abd7ff37cc0b",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at det ikke er bekreftet at ",
+            "_key": "1b08c53877ef0"
+          },
+          {
+            "_key": "3064b363f691",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " er bosatt i Norge.",
+            "_key": "1b08c53877ef2",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "21abeff66ef3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har komme fram til at det ikkje er stadfesta at ",
+            "_key": "0e6025caf80b0"
+          },
+          {
+            "_key": "bdca9a75f079",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er busett i Noreg.",
+            "_key": "0e6025caf80b2"
+          }
+        ]
+      }
+    ],
+    "_updatedAt": "2023-11-22T09:06:53Z",
+    "hjemler": [
+      "2"
+    ],
+    "_rev": "kKZ8yWBgonvfDRoPP8MjLJ",
+    "resultat": "AVSLAG",
+    "_id": "ksBegrunnelse-8656eb42-f48b-41bd-969f-d0ff15890375",
+    "navnISystem": "Barn uten fødselsnummer",
+    "apiNavn": "avslagUregistrertBarn",
+    "_createdAt": "2022-11-17T13:10:47Z"
+  },
+  {
+    "_id": "ksBegrunnelse-869b5525-4e5c-484d-8174-5ff61a3902aa",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T22:23:50Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "navnISystem": "Selvstendig rett primærland standard",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "f955ea05269b",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "30f6cc3ffe8d0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "34695bd7374c"
+          },
+          {
+            "_key": "a970974adfcd",
+            "_type": "span",
+            "marks": [],
+            "text": ". Du "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "966c28350b7f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "16704107117f"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "2cb05d107e7a",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " bur i ",
+            "_key": "7ada2737cd5a",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "c6f4d7fc997b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "7e1864e3963b"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6ddf141b433a"
+          },
+          {
+            "marks": [],
+            "text": " i ",
+            "_key": "6d781778481e",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "feae43cf2348"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjeld derfor for den andre forelderen. Du får heile kontantstøtta frå Noreg.",
+            "_key": "04643dc12451"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "apiNavn": "innvilgetSelvstendigRettPrimarlandStandard",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "resultat": "INNVILGET",
+    "_createdAt": "2024-01-08T22:23:50Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "ad3a7e902b9c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "28cb97f75d360"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "c027225ed3d4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "36a9b4331b40"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ca76ae8627fb",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "271986d5cf26"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ed31fb22c117"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "18030a3c38ad"
+          },
+          {
+            "_key": "e07148e631e8",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "5384c641573e"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d3ac36d88220",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "c34e3dcd3033",
+            "_type": "span",
+            "marks": [],
+            "text": " i "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "6faa12b9e85a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder derfor for den andre forelderen. Du får hele kontantstøtten fra Norge. ",
+            "_key": "b7c727ce3822"
+          }
+        ],
+        "_type": "block"
+      },
+      {
+        "_key": "5940812b9e09",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "\n",
+            "_key": "e7dc2390ecbb0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "visningsnavn": "43. Selvstendig rett primærland standard",
+    "_rev": "eS4Wb2bsh0R4qyDTo06RW5",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ]
+  },
+  {
+    "_rev": "QYE1lVUzcrAawv9ECZlZhh",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_updatedAt": "2023-12-12T11:55:58Z",
+    "apiNavn": "fortsattInnvilgetVurderingBarnBorMedSoker",
+    "_id": "ksBegrunnelse-86d6e796-e89f-4891-9b27-8fd9526fda13",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-12-12T11:55:58Z",
+    "navnISystem": "Vurdering barn bor med søker",
+    "visningsnavn": "4. Vurdering barn bor med søker",
+    "resultat": "FORTSATT_INNVILGET",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "9bd94affb6f9",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fordi vi har kome fram til at ",
+            "_key": "6067cc0b79bb0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "de68684aeb38",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt bur hos deg.",
+            "_key": "8e492c2405d7"
+          }
+        ]
+      }
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "747a6597a822",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fordi vi har kommet fram til at ",
+            "_key": "d1e3e2a346370"
+          },
+          {
+            "_key": "536f74242f73",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt bor hos deg. ",
+            "_key": "a663b6ad08bc"
+          }
+        ]
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ]
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_createdAt": "2023-12-20T20:25:57Z",
+    "_id": "ksBegrunnelse-8b93f1d5-b03c-4a17-9db1-19532fdae0d9",
+    "_updatedAt": "2024-01-09T15:30:08Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_PENSJON"
+    ],
+    "apiNavn": "innvilgetPrimarlandUKToArbeidslandAnnetLandUtbetaler",
+    "_rev": "q5JgLByi60irF5LU0K0IE2",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "d6e00452f51e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "dd1b388bcc980"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "90ed0c060529",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "text": ". Du ",
+            "_key": "3c845f24e76d",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "559989051c51",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "8d380a9095e1"
+          },
+          {
+            "_key": "b2b2e49fff0b",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " bur i ",
+            "_key": "52f11be86765",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "69adb46c46eb"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "f08daa5d0573"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "58e1cf56e462"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Du og den andre forelderen har rett til kontantstøtte frå Noreg og ",
+            "_key": "2473443e876b"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "a0f8d9a99f7d"
+          },
+          {
+            "marks": [],
+            "text": " fordi de jobbar i andre land enn der ",
+            "_key": "3cb5208e34b8",
+            "_type": "span"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "6b6b477b06d9",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "text": " bur. Landet med den høgaste kontantstøtta skal utbetale. ",
+            "_key": "a1f8d405a27e",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "7c40d4d30ded",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er høgare enn kontantstøtta i Noreg. Du får derfor heile kontantstøtta frå ",
+            "_key": "a9050e1944f3"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "56266e1d38af"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "257d54120075"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "15. Primærland UK to arbeidsland. Annet land utbetaler",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "hjemlerEOSForordningen987": [
+      "58"
+    ],
+    "navnISystem": "Primærland UK to arbeidsland. Annet land utbetaler",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "7c6ab17bd6ee",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "c6fa00d14ad70",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "544e8be90c40"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "c1d0def61517"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "9cb0e2400a69"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "509b7abf9eaa"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e97414c27aad",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "8f118cb3016f"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "0ad998401e28",
+            "flettefelt": "barnetsBostedsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i ",
+            "_key": "2202521f34f8"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "bd2ccf0cc526",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Du og den andre forelderen har rett til kontantstøtte fra Norge og ",
+            "_key": "594c5d52d907"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "86edff57cfe6"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi dere jobber i andre land enn der ",
+            "_key": "638b0867ed12"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "766e91a5da1c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor. Landet med den høyeste kontantstøtten skal utbetale. Kontantstøtten i ",
+            "_key": "e8a4d5392519"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "ef783ecfa403"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er høyere enn kontantstøtten i Norge. Du får derfor hele kontantstøtten fra ",
+            "_key": "04ad25189e3a"
+          },
+          {
+            "_key": "58dcd8adc065",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "b1301553eeee"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_id": "ksBegrunnelse-8c428aad-b4b6-486f-883c-66c6bee91dfe",
+    "visningsnavn": "23. Vurdering Bor ikke fast hos søker",
+    "nynorsk": [
+      {
+        "_key": "36d3bec21359",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "061b38ba3f920",
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "84a96fd5602b"
+          },
+          {
+            "text": " ikkje bur fast hos deg.",
+            "_key": "678781249d2c",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_updatedAt": "2023-05-04T18:01:24Z",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "bokmaal": [
+      {
+        "_key": "aa1d3f082939",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Vi har kommet fram til at barn født ",
+            "_key": "3e016d30444e0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "30c502009df1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke bor fast hos deg.",
+            "_key": "1dccb234c7d1"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "avslagVurderingBorIkkeFastHosSoker",
+    "_rev": "lxTMP95K2WARLoXUTuRaQk",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-05-04T18:01:24Z",
+    "navnISystem": "Vurdering Bor ikke fast hos søker",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG"
+  },
+  {
+    "navnISystem": "Selvstendig rett sekundærland standard",
+    "visningsnavn": "47. Selvstendig rett sekundærland standard",
+    "tema": "EØS",
+    "_createdAt": "2024-01-08T23:02:48Z",
+    "_updatedAt": "2024-01-08T23:02:48Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "98d2d15582a30"
+          },
+          {
+            "_key": "2c71410c6b26",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ". Du ",
+            "_key": "73e47bcc6d6d",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "897b688aeb6c",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "987b92e14995"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8808b732ae5a",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bor i ",
+            "_key": "90e2a95a37e4",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "fdabd8e447ac"
+          },
+          {
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "d8e83f1e2920",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8edacac93837"
+          },
+          {
+            "_key": "442eedbcc6b7",
+            "_type": "span",
+            "marks": [],
+            "text": " i "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "57ddb7df8c60",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder derfor for den andre forelderen. ",
+            "_key": "f883da400f67"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "0a32e39f2a9f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i ",
+            "_key": "0708459e8a01"
+          },
+          {
+            "_key": "96851810b036",
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte.",
+            "_key": "673af7e82a6b"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "5972dd1a51e3"
+      }
+    ],
+    "apiNavn": "innvilgetSelvstendigRettSekundarlandStandard",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijLc5Zr",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "e0c43606884c0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "33a76f0ed865"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "fe1f7ea62884"
+          },
+          {
+            "_key": "40d985b3d6a1",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "43f1678453c9"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "5e23ec4257e7",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "928d2969348b"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "c3415691526f"
+          },
+          {
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "dc8204c26384",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8dfb3e41ceef",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " i ",
+            "_key": "b55881a1c1d0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "5f05fb67c67f"
+          },
+          {
+            "text": ". Norske reglar for kontantstøtte gjeld derfor for den andre forelderen. ",
+            "_key": "5d43e15bd8c1",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "76b806a3566f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovudansvaret for utbetaling av kontantstøtte. Noreg utbetaler skilnaden mellom kontantstøtta i ",
+            "_key": "a7685ab95c69"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "f2b50e1b6370"
+          },
+          {
+            "text": " og norsk kontantstøtte.",
+            "_key": "6101938dc6bf",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9c8a12fbc6a0"
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-8c82a934-1c01-4ed8-bbf8-14fa8eec4404"
+  },
+  {
+    "navnISystem": "Den andre forelderen har fått for samme tidsrom",
+    "hjemler": [
+      "3"
+    ],
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi den andre forelderen har fått barnetrygd for barn fødd ",
+            "_key": "b8162c113e5e0"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "805c39332424",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i same tidsrom.",
+            "_key": "a09208a6d7db"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "ad58c18051f0"
+      }
+    ],
+    "_createdAt": "2023-05-03T16:00:38Z",
+    "_id": "ksBegrunnelse-8d4308a5-827b-4a1e-8a40-65f5385e4a7d",
+    "visningsnavn": "21. Den andre forelderen har fått for samme tidsrom",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_updatedAt": "2023-05-03T16:00:38Z",
+    "apiNavn": "reduksjonDenAndreForelderenHarFottFraSammeTidsrom",
+    "_rev": "KOa0MjQMDn5FLyPT0N7bZD",
+    "_type": "ksBegrunnelse",
+    "resultat": "REDUKSJON",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtteendres fordi den andre forelderen har fått kontantstøtte for barn født ",
+            "_key": "41c7ab1dc83b0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "4a89ee356900"
+          },
+          {
+            "marks": [],
+            "text": " i samme tidsrom.",
+            "_key": "61c4ead8b603",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9f19fdaf593c"
+      }
+    ]
+  },
+  {
+    "visningsnavn": "51. Selvstendig rett sekundærland får ytelse i utlandet",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "db88e037e59e0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "75a907fc6ff9"
+          },
+          {
+            "_key": "d3a1a8358783",
+            "_type": "span",
+            "marks": [],
+            "text": ". Du "
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "2e2bd2554e82",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "78ddd81f22b3"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ca33d235d7d5",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "ebdf134f4da9",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "_key": "6b2811a6d049",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "080bf3b85f0f",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "e31d2ea7614f",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            }
+          },
+          {
+            "_key": "c85d5f8294f0",
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjeld derfor for den andre forelderen. "
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "9f07e62c0eb2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovudansvaret for utbetaling av kontantstøtte. Noreg utbetaler skilnaden mellom kontanstøtta i ",
+            "_key": "691026fafcff"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "b2df247bde20"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte.",
+            "_key": "67c46954f0c0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "eef6d2e28888"
+      }
+    ],
+    "_id": "ksBegrunnelse-8db368d1-4cb3-4dba-9e72-591c960a49a1",
+    "bokmaal": [
+      {
+        "_key": "590eee5bb84f",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "5de1069e3d500"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "0e1c02bff73f"
+          },
+          {
+            "_key": "ceb16980a6d3",
+            "_type": "span",
+            "marks": [],
+            "text": ". Du "
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e5219427e3da"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "1eae5b060b4f"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cb52cbcfbdf4",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " bor i ",
+            "_key": "b68c118df110",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "c61746c824ab"
+          },
+          {
+            "_key": "7fd8e9041b4b",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e1495c958122",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder derfor for den andre forelderen. ",
+            "_key": "f60967da5acf"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "816142492a0c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovedansvaret for utbetaling av kontantstøtte. Norge utbetaler derfor forskjellen mellom kontantstøtten i ",
+            "_key": "5fc43fd2436b"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "5a7d10c36a2b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte.",
+            "_key": "a2299238e09a"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "annenForeldersAktivitet": [
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTo08Rzt",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2024-01-08T23:21:07Z",
+    "navnISystem": "Selvstendig rett sekundærland får ytelse i utlandet",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T23:21:07Z",
+    "apiNavn": "innvilgetSelvstendigRettSekundarlandForYtelseIUtlandet",
+    "resultat": "INNVILGET"
+  },
+  {
+    "type": "TILLEGGSTEKST",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har ikkje fått svar på opplysningar vi har bedt om frå ",
+            "_key": "b53d66ec800d0"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "404283df1871",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Noreg utbetalar derfor forskjellen mellom kontantstøtta familien kan ha rett på frå ",
+            "_key": "81dc72092aad"
+          },
+          {
+            "_key": "010a2f928123",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte. Saka må vurderast på nytt dersom vi får svar frå ",
+            "_key": "9fc111e6a15d"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "436729aba8b4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "5928edca4716"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "07265c15bffc",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Tilleggstekst sekundær ikke fått svar på SED",
+    "visningsnavn": "40. Tilleggstekst sekundær ikke fått svar på SED",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijLaiBb",
+    "resultat": "INNVILGET",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_createdAt": "2024-01-08T14:06:36Z",
+    "_id": "ksBegrunnelse-8f6da75b-5b1f-4544-85cf-2ca3d8162151",
+    "_updatedAt": "2024-01-08T22:04:47Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har ikke fått svar på opplysninger vi har bedt om fra ",
+            "_key": "ab0a1c3473d20"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "410567a7c118"
+          },
+          {
+            "text": ". Norge utbetaler derfor forskjellen mellom kontantstøtten familien kan ha rett på fra ",
+            "_key": "a902482b76b4",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "a64be32bf2ab"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte. Saken må vurderes på nytt hvis vi får svar fra ",
+            "_key": "d492686db15f"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "bb1eb330a0f9"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "479ebebe2186"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b907f87063ff"
+      }
+    ],
+    "apiNavn": "innvilgetTilleggstekstSekundarIkkeFattSvarPaaSed",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ]
+  },
+  {
+    "_rev": "5r7yBuU8wKOiVHJijMYzX1",
+    "_id": "ksBegrunnelse-8f71d1c9-8e7f-4e48-b13b-fc60fdf0ed19",
+    "_updatedAt": "2024-01-09T16:45:05Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "5f4cf9594c66",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke har ansvar for ",
+            "_key": "beb514c9eefa0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "989289bf2154",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "a6daa1a0e804",
+            "_type": "span",
+            "marks": [],
+            "text": "."
+          }
+        ]
+      }
+    ],
+    "visningsnavn": "12. Ikke ansvar for barn",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "navnISystem": "Ikke ansvar for barn",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du ikkje har ansvar for ",
+            "_key": "a69d40a4492e0",
+            "_type": "span"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "698d4817f2f7",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "517fe2ff2095"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "41f5115d8d88",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "avslagIkkeAnsvarForBarn",
+    "tema": "EØS",
+    "_createdAt": "2024-01-09T16:45:05Z",
+    "resultat": "AVSLAG"
+  },
+  {
+    "apiNavn": "avslagMottarFulleForeldrepenger",
+    "_rev": "jyITl2R0P6PN5zEcIGDxZX",
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får foreldrepengar for barn fødd ",
+            "_key": "0d5c210356a40"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "026ddcac47b4"
+          },
+          {
+            "marks": [],
+            "text": ". Kontantstøtta kan ikkje utbetalast samtidig som du får fulle foreldrepengar for ",
+            "_key": "543ba95b8c9c",
+            "_type": "span"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "e55f95aeb5b8",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            }
+          },
+          {
+            "_key": "1312cb1bf013",
+            "_type": "span",
+            "marks": [],
+            "text": "."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d77bd82f2bce"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-9278aca0-29a6-46aa-b438-b26dda069e06",
+    "navnISystem": "Mottar fulle foreldrepenger",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "a0865daf2234",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får foreldrepenger for barn født ",
+            "_key": "f81c3ccfd8ed0",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "6221e1919021",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten kan ikke utbetales samtidig som du får fulle foreldrepenger for ",
+            "_key": "9f5e6ff2f1be"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "8560e653b0a0",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "5c24e87ec63a"
+          }
+        ]
+      }
+    ],
+    "hjemler": [
+      "10"
+    ],
+    "visningsnavn": "40. Mottar fulle foreldrepenger",
+    "type": "STANDARD",
+    "_createdAt": "2023-09-08T12:45:03Z",
+    "_updatedAt": "2023-09-08T12:45:03Z"
+  },
+  {
+    "annenForeldersAktivitet": [
+      "MOTTAR_PENSJON",
+      "IKKE_AKTUELT"
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTnxVbL7",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T10:18:12Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "navnISystem": "Primærland UK aleneansvar",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "resultat": "INNVILGET",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "8c0561894b950"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "fef0fa8ec5ce"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "2a782d6deb4a"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "be4b18ba92a8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "1a0531398bf5"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6b80140034e7",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bor i Storbritannia og går ikke i en barnehage som får offentlig støtte. Du har ansvar for ",
+            "_key": "b8bc2088e509",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "e49ba8070b34",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_key": "ef161f116f65",
+            "_type": "span",
+            "marks": [],
+            "text": " alene. Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Etter avtalen får du hele kontantstøtten fra Norge."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "a0df2fea2995",
+        "markDefs": []
+      }
+    ],
+    "_updatedAt": "2024-01-05T15:42:46Z",
+    "apiNavn": "innvilgetPrimarlandUKAleneansvar",
+    "visningsnavn": "6. Primærland UK aleneansvar",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "ffefaa6e3a31",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "8c7a4a21a4330"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "248c34f3708c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "4d374f16f157"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e63976634552",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "e75dbdfd9e93"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0eb498a1d7ad",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "375fbf93bd3b",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i Storbritannia, og går ikkje i ein barnehage som får offentleg støtte. Du har ansvar for "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8a5b847dc878",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " åleine. Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Etter avtalen får du heile kontantstøtta frå Noreg.",
+            "_key": "2199a607a0b3"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_id": "ksBegrunnelse-981a47bc-1cf2-4795-9b92-305b121a2251"
+  },
+  {
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "ec24053fe5ef",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "",
+            "_key": "bc02b22fbf9d0",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f"
+            },
+            "_type": "valgfeltV2",
+            "_key": "07176584278c",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " har ikkje vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år.",
+            "_key": "bc02b22fbf9d4",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "avslagIkkeMedlemFolketrygdenEllerEOSIFemAar",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "30. Ikke medlem folketrygden eller EØS i 5 år ",
+    "type": "STANDARD",
+    "_rev": "CKoJmXlM50fHJKgxS5OUNE",
+    "_id": "ksBegrunnelse-99672239-c753-43a3-a87e-00a242043bca",
+    "_createdAt": "2023-05-04T18:10:35Z",
+    "_updatedAt": "2023-05-04T18:10:35Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "396ce7f96407",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "bdca772b3a720"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "dac249880406",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden eller i trygdeordninger i andre EØS-land i til sammen fem år.",
+            "_key": "bdca772b3a723"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Ikke medlem folketrygden eller EØS i 5 år ",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ]
+  },
+  {
+    "tema": "NASJONAL",
+    "_createdAt": "2023-03-22T18:57:04Z",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "_rev": "lzy5EEVzxJlmTsIwrRwoSh",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "e8730433952d0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "dac7eafa1c21"
+          },
+          {
+            "text": " var tildelt fulltidsplass i barnehage frå ",
+            "_key": "02438619f823",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "9d2d786fdee1"
+          },
+          {
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "7e90c260459c",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9b0a7bbb7482"
+      }
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_updatedAt": "2023-03-30T13:42:59Z",
+    "navnISystem": "Fulltidsplass i barnehagen",
+    "apiNavn": "opphorFulltidsplassIBarnehagenForstePeriode",
+    "visningsnavn": "38. Fulltidsplass i barnehagen",
+    "_id": "ksBegrunnelse-9ab6e557-650d-47fe-be65-e94041d1c90e",
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "e34278a460620"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fdc90d0b09ae"
+          },
+          {
+            "_key": "b8391c795c73",
+            "_type": "span",
+            "marks": [],
+            "text": " var tildelt fulltidsplass i barnehage fra "
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "b853c8269f92"
+          },
+          {
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "a48d05bd0f38",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e51826a7a88f"
+      }
+    ]
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi barn fødd ",
+            "_key": "13fa910cd99e0",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "47f1fce43a13",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje bur fast hos deg frå ",
+            "_key": "b8dff87ad777"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "ff5b56fbee80"
+          },
+          {
+            "text": ". Kontantstøtta er redusert frå same månad som endringa skjedde.",
+            "_key": "3a03fb45c582",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "64d17f6d2bf4",
+        "markDefs": []
+      }
+    ],
+    "_updatedAt": "2023-05-03T14:43:14Z",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-9b92a123-f414-439a-8d57-7723adacb4a9",
+    "navnISystem": "Barn flyttet fra søker",
+    "apiNavn": "reduksjonBarnFlyttetFraSoker",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_createdAt": "2023-05-03T14:43:14Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "cfbd33479b9e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi barn født ",
+            "_key": "1116864d2d170"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "b2d550e18273"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke bor fast hos deg fra ",
+            "_key": "75c8563bf331"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "79fbe91388f4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten reduseres fra samme måned som endringen skjedde.",
+            "_key": "8abe55dc0f7b"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_rev": "sNO2L38EwIVNY4VMy4Sq3W",
+    "resultat": "REDUKSJON",
+    "visningsnavn": "1. Barn flyttet fra søker"
+  },
+  {
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "_updatedAt": "2023-12-19T16:29:37Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "db7236dec5a90",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "75cc16b45589"
+          },
+          {
+            "text": " ikke lenger bor i et EØS-land.",
+            "_key": "e40c80c17372",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0ddbe0440b4e"
+      }
+    ],
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtta er endra fordi barn fødd ",
+            "_key": "923328743ed90",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "72e836762a2b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje lenger bur i eit EØS-land.",
+            "_key": "8b86b67ca58c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1bb9b9ad0a8b"
+      }
+    ],
+    "navnISystem": "Barn bor ikke i EØS-land",
+    "_rev": "AOUa26DfnB8ntJraK3zn7B",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_id": "ksBegrunnelse-9c0da240-f894-42f2-afbf-46a4aa317e9f",
+    "apiNavn": "reduksjonBarnBorIkkeIEosLand",
+    "visningsnavn": "3. Barn bor ikke i EØS-land",
+    "resultat": "REDUKSJON",
+    "_createdAt": "2023-12-19T16:29:37Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ]
+  },
+  {
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du jobber i Norge og et annet EØS land. Du jobber mer enn 25 prosent i det andre EØS-landet, der du også bor. Vi har derfor kommet fram til at lovgivningen i det andre EØS-landet gjelder for deg.",
+            "_key": "767a73872ae30",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "92dd1d656204",
+        "markDefs": []
+      }
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "apiNavn": "opphorArbeiderMerEnn25ProsentIAnnetEosLand",
+    "visningsnavn": "11. Arbeider mer enn 25 prosent i annet EØS-land",
+    "_type": "ksBegrunnelse",
+    "stotterFritekst": false,
+    "_id": "ksBegrunnelse-9c438ee9-40f3-4ef2-ba24-5ca21710c227",
+    "_updatedAt": "2023-12-19T14:44:35Z",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du jobbar i Noreg og eit anna EØS land. Du jobbar meir enn 25 prosent i det andre EØS-landet, der du også bur. Vi har derfor kome fram til at lovgjevnaden i det andre EØS-landet gjeld for deg.",
+            "_key": "7057987efeaa0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "eeeede04fc66"
+      }
+    ],
+    "_createdAt": "2023-12-19T13:03:46Z",
+    "navnISystem": "Arbeider mer enn 25 prosent i annet EØS-land",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECkvbYg",
+    "type": "STANDARD"
+  },
+  {
+    "_updatedAt": "2023-12-19T16:27:42Z",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi du har bedt om at kontantstøtta for barn fødd ",
+            "_key": "b787429bb5750"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "22047d535e94"
+          },
+          {
+            "text": " blir stansa.",
+            "_key": "5c8b5f8bef70",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "603799d89136"
+      }
+    ],
+    "_id": "ksBegrunnelse-9d7cd1c7-9b1a-4e99-a28f-1ec6ad0f83ff",
+    "_rev": "CM6961CqAC7W4puPRL8iEW",
+    "resultat": "REDUKSJON",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi du har bedt om at kontantstøtten for barn født ",
+            "_key": "9c758fdfe6410"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "e934939807b5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " blir stanset.",
+            "_key": "771e4bb250aa"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "49c5f1dd28d1"
+      }
+    ],
+    "navnISystem": "Søker ber om opphør EØS",
+    "apiNavn": "reduksjonSokerBerOmOpphorEos",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_createdAt": "2023-12-19T16:27:42Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "2. Søker ber om opphør EØS",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "bokmaal": [
+      {
+        "_key": "03646febc799",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du bare har jobbet i Norge i korte perioder.",
+            "_key": "4181a02e11e10"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "visningsnavn": "6. Kun korte usammenhengende arbeidsperioder",
+    "_rev": "eS4Wb2bsh0R4qyDTo1OOYr",
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "8800301ea052",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "edf667f7a4760",
+            "_type": "span",
+            "marks": [],
+            "text": "Du berre har jobba i Noreg i korte periodar."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_createdAt": "2024-01-09T16:33:48Z",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "navnISystem": "Kun korte usammenhengende arbeidsperioder",
+    "apiNavn": "avslagKunKorteUsammenhengendeArbeidsperioder",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_id": "ksBegrunnelse-9d8d36b7-71ab-48c7-a307-6c5c65d20cf1",
+    "_updatedAt": "2024-01-09T16:33:48Z"
+  },
+  {
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "10. Søker bor ikke i EØS-land",
+    "_rev": "QYE1lVUzcrAawv9ECkvazb",
+    "_createdAt": "2023-12-19T12:55:55Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-9e428fe9-986d-4a49-85c3-10649d2eacb0",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "11573ee9beed",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke lenger bor i et EØS-land.",
+            "_key": "763ff20b06fb0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Søker bor ikke i EØS-land",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du ikkje lenger bur i eit EØS-land.",
+            "_key": "aaa15ed1b5590",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1576c54c04a1"
+      }
+    ],
+    "apiNavn": "opphorSokerBorIkkeIEosLand",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "_type": "ksBegrunnelse",
+    "_updatedAt": "2023-12-19T14:44:29Z"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-a058306b-1f10-4e9c-b76d-4806802a4243",
+    "_updatedAt": "2023-07-28T11:36:18Z",
+    "bokmaal": [
+      {
+        "_key": "bbf8712ffacd",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "b9892542e111"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ae6eec5ded78",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " skal være i utlandet i mer enn 3 måneder.",
+            "_key": "dae5a186760f0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Utenlandsopphold mer enn 3 mnd",
+    "tema": "NASJONAL",
+    "apiNavn": "opphorUtenlandsoppholdMerEnn3Maaneder",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_rev": "3H9OXgojExINZUA3ukmI4F",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "d14adeba96a5"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "9c369d77775e",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " skal vere i utlandet i meir enn 3 månader.",
+            "_key": "938badd692060",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "baddffe30e58"
+      }
+    ],
+    "_createdAt": "2023-07-21T15:41:21Z",
+    "visningsnavn": "19. Utenlandsopphold mer enn 3 mnd"
+  },
+  {
+    "annenForeldersAktivitet": [
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "fefec6bd4ee3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har rett til kontantstøtte for barn født ",
+            "_key": "2758c64df55b0"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "c81ff6eba619",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "text": ". Du ",
+            "_key": "7874ca70d6ac",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "268eb3f4201c",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "abfa2c70fa98"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "532efdbfeaf4",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "764588bd5106"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "1b0b096e2bbb"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Den andre forelderen jobber ikke i ",
+            "_key": "683ceabd2497"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "827cc757e8ed"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Etter avtalen får du hele kontantstøtten fra Norge. Det blir ingen utbetaling fordi den andre forelderen allerede har fått kontantstøtten for perioden.",
+            "_key": "3f997a3f67f0"
+          }
+        ],
+        "_type": "block"
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "b420af00950b",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "\n",
+            "_key": "71b0e54652d00"
+          }
+        ]
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8",
+      "9"
+    ],
+    "type": "STANDARD",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "_createdAt": "2024-01-05T16:58:26Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_updatedAt": "2024-01-09T13:58:37Z",
+    "_id": "ksBegrunnelse-a1d7be5c-33dc-4ea0-87a1-749552c8938e",
+    "barnetsBostedsland": [
+      "IKKE_NORGE"
+    ],
+    "apiNavn": "innvilgetPrimarlandUKKontantstotteAlleredeUtbetalt",
+    "visningsnavn": "20. Primærland UK kontantstøtte allerede utbetalt",
+    "resultat": "INNVILGET",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har rett til kontantstøtte for barn fødd ",
+            "_key": "400f9aaecde20"
+          },
+          {
+            "_key": "8be5e3a212a6",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "bcbe1f53e35d"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5e945e3f169b",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "2d7f65dce221"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0db4b9da6547",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "f11e82f5e59b"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "9cfc3598c13e",
+            "flettefelt": "barnetsBostedsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Den andre forelderen jobbar ikkje i ",
+            "_key": "14917e008e67"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "cfabef3d44e0"
+          },
+          {
+            "_key": "ff62e92059d6",
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Etter avtalen får du heile kontantstøtta frå Noreg. Det blir ingen utbetaling fordi den andre forelderen allereie har fått kontantstøtta for perioden."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "997edfd3d743"
+      }
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_type": "ksBegrunnelse",
+    "navnISystem": "Primærland UK kontantstøtte allerede utbetalt",
+    "_rev": "eS4Wb2bsh0R4qyDTo0yMxt"
+  },
+  {
+    "nynorsk": [
+      {
+        "_key": "ffe19b27781d",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "0c4530676b560",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får heile kontantstøtta for barn fødd "
+          },
+          {
+            "_key": "ebac4f43967e",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " sjølv om de har ein avtale om delt bustad for ",
+            "_key": "405ff08c5a6a"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "dabcf4c08815",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjeld ikkje for begge foreldra. Kontantstøtta kan ikkje delast i slike tilfeller. Vi har kome fram til at ",
+            "_key": "a5ef2cd19a9a"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d0c561906915",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur fast saman med deg.",
+            "_key": "5c7d0fe07e07"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2024-01-08T22:14:06Z",
+    "_updatedAt": "2024-01-08T22:14:06Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får hele kontantstøtten for barn født ",
+            "_key": "d86e26acddf90",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "aaae0486f4af"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " selv om dere har en avtale om delt bosted for",
+            "_key": "eb0c468f631b"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "956165e0ec81",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": ". Norske regler for kontantstøtte gjelder ikke for begge foreldrene. Kontantstøtten kan ikke deles i slike tilfeller. Vi har kommet fram til at ",
+            "_key": "b6c4ba58a7d1",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "1fa36c5bbfd2",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "text": " bor fast sammen med deg.",
+            "_key": "ad2b0674712e",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d956607391a6"
+      }
+    ],
+    "apiNavn": "innvilgetTilleggstekstFullKontantstotteHarAvtaleDelt",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "type": "TILLEGGSTEKST",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "resultat": "INNVILGET",
+    "tema": "EØS",
+    "_rev": "5r7yBuU8wKOiVHJijLay3v",
+    "_type": "ksBegrunnelse",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-a312e220-51e5-4756-b2c5-83e09de7620e",
+    "navnISystem": "Tilleggstekst full kontantstøtte har avtale delt",
+    "visningsnavn": "57. Tilleggstekst full kontantstøtte har avtale delt",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ]
+  },
+  {
+    "_id": "ksBegrunnelse-a3179079-d26a-444d-b6c1-b5785eaa5d6b",
+    "navnISystem": "Delt bosted begge foreldre ikke omfattet norsk lovvalg",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "7. Delt bosted begge foreldre ikke omfattet norsk lovvalg",
+    "_createdAt": "2023-12-19T16:37:58Z",
+    "_updatedAt": "2023-12-19T16:37:58Z",
+    "apiNavn": "reduksjonDeltBostedBeggeForeldreIkkeOmfattetNorskLovvalg",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "EØS",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "Kontantstøtta er endra for barn fødd ",
+            "_key": "89203d4eac610",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "5fdb35866f18"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjeld ikkje for begge foreldra, og kontantstøtta kan ikkje delast i slike tilfeller.",
+            "_key": "aded61e004de"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0af433528b9f",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "bokmaal": [
+      {
+        "_key": "68feee3320e1",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "fb408c553f730",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "726a4076a8a3"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder ikke for begge foreldrene, og kontantstøtten kan ikke deles i slike tilfeller.",
+            "_key": "0303de2b26dc"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_rev": "AOUa26DfnB8ntJraK3zz5F",
+    "resultat": "REDUKSJON",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ]
+  },
+  {
+    "apiNavn": "opphorMottattI11Maaneder",
+    "visningsnavn": "6. Mottatt i 11 mnd",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "_updatedAt": "2023-07-17T09:11:43Z",
+    "navnISystem": "Mottatt i 11 mnd",
+    "_rev": "3JnjoNwBZ41U8L0QcHabFr",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du allereie har fått kontantstøtte i 11 månader for barn fødd ",
+            "_key": "2eee837190ee0",
+            "_type": "span"
+          },
+          {
+            "_key": "cbf133ced66e",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "d7ca72800a4e"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "dea953b0dfb0"
+      }
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "d46492673d24",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du allerede har fått kontantstøtte i 11 måneder for barn født ",
+            "_key": "9c8e19c3b9220",
+            "_type": "span"
+          },
+          {
+            "_key": "20ee4b2f1f8a",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "a245e539966a"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "type": "STANDARD",
+    "_createdAt": "2023-07-17T09:11:43Z",
+    "_id": "ksBegrunnelse-a5512fcd-2b64-4b68-bac8-8f7f8bd98324",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "tema": "NASJONAL",
+    "hjemler": [
+      "8",
+      "10"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR"
+  },
+  {
+    "tema": "NASJONAL",
+    "_type": "ksBegrunnelse",
+    "_rev": "cG5BJUCqeF1qSoLWBDrMde",
+    "type": "TILLEGGSTEKST",
+    "_updatedAt": "2022-12-08T11:15:29Z",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "apiNavn": "innvilgetTredjelandsborgerBosattForLovligOppholdINorge",
+    "visningsnavn": "15. Tredjelandsborger bosatt før lovlig opphold i Norge",
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "c7d3a88e16500"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "bd319ee7fd3b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at ",
+            "_key": "dd4c5789d766"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "217add114f1e",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": " har opphaldsløyve",
+            "_key": "c7d3a88e16506",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "88f61ada3aed"
+      }
+    ],
+    "_createdAt": "2022-12-08T11:15:29Z",
+    "_id": "ksBegrunnelse-a59b6c2b-f995-404d-966b-a6d38403d1ef",
+    "navnISystem": "Tredjelandsborger bosatt før lovlig opphold i Norge",
+    "bokmaal": [
+      {
+        "_key": "5a3e407aa678",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "e15ad4a9b2070",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "2b1ce7f87912",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "019c4f2ae8c9",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6a52cea69eab"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har oppholdstillatelse.",
+            "_key": "e15ad4a9b2076"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ]
+  },
+  {
+    "apiNavn": "reduksjonTekstEksempel",
+    "visningsnavn": "Reduksjon tekst eksempel",
+    "_createdAt": "2023-03-16T21:35:01Z",
+    "type": "STANDARD",
+    "_updatedAt": "2023-03-16T21:35:01Z",
+    "navnISystem": "reduksjonTekstEksempel",
+    "tema": "NASJONAL",
+    "_rev": "tJkE4jzThi95LfmzqYFWLB",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-a6a71715-e0b7-48e9-8a86-1fae574c9c11",
+    "resultat": "REDUKSJON"
+  },
+  {
+    "_id": "ksBegrunnelse-a6fe4277-8e77-4d2e-9c9b-3d745c55f516",
+    "_updatedAt": "2023-12-19T14:44:14Z",
+    "visningsnavn": "7. Ikke ansvar for barn",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_key": "12f6f025e9de",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "5d9aafc298030",
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje lenger har ansvar for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "884d999c0cea"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "9a1af0334e77"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke lenger har ansvar for barn født ",
+            "_key": "86ff93c5d9780"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "86e92f91d055"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "fd299ebd9ccc"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "2c162a93a9e0"
+      }
+    ],
+    "navnISystem": "Ikke ansvar for barn",
+    "apiNavn": "opphorIkkeAnsvarForBarn",
+    "resultat": "OPPHØR",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T12:49:20Z",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECkvZyS",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "type": "STANDARD"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_createdAt": "2023-12-19T16:40:20Z",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_key": "e1dab2bb425f",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta for barn fødd ",
+            "_key": "5b67062308340"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "e42c870afccd"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "59b1641a91b6"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "9ab691cbf253"
+          },
+          {
+            "text": " ikkje bur fast saman med deg.",
+            "_key": "7fe523bcbbef",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2023-12-19T16:40:20Z",
+    "apiNavn": "reduksjonSelvstendigRettBarnFlyttetFraSoker",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "visningsnavn": "8. Selvstendig rett barn flyttet fra søker",
+    "_type": "ksBegrunnelse",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "feec98f1ef4b0",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten for barn født "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "842c3cee3636",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " endres fordi ",
+            "_key": "acca2c782ec8"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "b572728b736f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": " ikke bor fast sammen med deg.",
+            "_key": "3a2b69afbbd7",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8bb0f7c1a429"
+      }
+    ],
+    "navnISystem": "Selvstendig rett barn flyttet fra søker",
+    "_rev": "QYE1lVUzcrAawv9ECl4gME",
+    "resultat": "REDUKSJON",
+    "_id": "ksBegrunnelse-a85f8daa-91ec-4ea4-8401-57913efba826"
+  },
+  {
+    "resultat": "OPPHØR",
+    "navnISystem": "Flere barn er døde",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "_rev": "0w3lID6Lsk7VK2mhOLMn1b",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "apiNavn": "opphorFlereBarnErDode",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Barna dine som er fødd ",
+            "_key": "554a43b76deb0",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "b191d9c9c0d2",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døydde. ",
+            "_key": "decf1c690f36"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f318e47bb605",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-a897a0aa-1646-4fd8-a10a-06ccc8c96fe2",
+    "_updatedAt": "2023-07-24T07:37:12Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barna dine som er født ",
+            "_key": "491babc1d5a00"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "4c87bf113905"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døde.",
+            "_key": "8656d5c38ceb"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "201f9132f786"
+      }
+    ],
+    "visningsnavn": "25b. Flere barn er døde",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-07-24T07:37:12Z",
+    "triggere": [
+      "BARN_DØD"
+    ]
+  },
+  {
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-ab2a8c07-6f9c-4a38-9e4b-4053fb76c4a9",
+    "_updatedAt": "2023-05-03T16:14:26Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "dc5a40f7f1a8",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "5fee9d815d5b0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "996dacee48d3"
+          },
+          {
+            "text": " er tildelt fulltidsplass i barnehage fra ",
+            "_key": "a6de8774da70",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "3fcfe98d1861"
+          },
+          {
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "5158fd0f0eff",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2023-05-03T16:14:26Z",
+    "navnISystem": "Fulltidsplass i barnehage",
+    "apiNavn": "avslagFulltidsplassIBarnehage",
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "_rev": "RiR9GraBD8hopeC5h6Juvx",
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "643aebddfa7a",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barn fødd ",
+            "_key": "f13629ae05160",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c48dd68cc5fb"
+          },
+          {
+            "_key": "0b6ea972894a",
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage frå "
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "7756aaf36f79"
+          },
+          {
+            "_key": "9e580fc3e271",
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass."
+          }
+        ]
+      }
+    ],
+    "visningsnavn": "1. Fulltidsplass i barnehage",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "tema": "NASJONAL"
+  },
+  {
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "_id": "ksBegrunnelse-ab6c080d-36bf-45c3-9ab0-e53b32108781",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "83d3c207d540",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har opplyst at barn født ",
+            "_key": "78a8db06e6020"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "ed22449f1a27"
+          },
+          {
+            "_key": "80ae0d9db75d",
+            "_type": "span",
+            "marks": [],
+            "text": " var tildelt fulltidsplass i barnehage fra "
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "6e0a749b6907"
+          },
+          {
+            "_key": "aaec5cd5a361",
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass."
+          }
+        ]
+      }
+    ],
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_createdAt": "2023-03-22T18:50:45Z",
+    "_updatedAt": "2023-03-30T13:40:58Z",
+    "apiNavn": "opphorBrukerMeldtFulltidsplassIBarnehageForstePeriode",
+    "visningsnavn": "40. Bruker meldt fulltidsplass i barnehage",
+    "_rev": "lzy5EEVzxJlmTsIwrRwfvL",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du har opplyst at barn fødd ",
+            "_key": "938f068891d40",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "6148b4f0711f"
+          },
+          {
+            "text": " var tildelt fulltidsplass i barnehage frå ",
+            "_key": "b402ecf2d7d7",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "3fda16fecc7b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "20affa245a3b"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "34704236b0fe"
+      }
+    ],
+    "navnISystem": "Bruker meldt fulltidsplass i barnehage",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "navnISystem": "Selvstendig rett primærland utsendt arbeidstaker ",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "3bc65c2ebd66",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "1e90915daaaa0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "b8b121b90bd1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du jobber ikke i ",
+            "_key": "8dca7534b17f"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "0cd027c46e53"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "4bfea5a85b25"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "47c5cf16e144",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "5bbb5ef55ced"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "436b2f76d2c1"
+          },
+          {
+            "_key": "46944d801060",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen "
+          },
+          {
+            "_key": "751e7e0a6cce",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " i ",
+            "_key": "6fc36054a05b",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "c38b0b4b50dc"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder derfor for den andre forelderen. Du får hele kontantstøtten fra Norge.",
+            "_key": "45a4ff4cd811"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "_updatedAt": "2024-01-08T22:38:58Z",
+    "_rev": "5r7yBuU8wKOiVHJijLbOL1",
+    "nynorsk": [
+      {
+        "_key": "d17c06173a1a",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "bb33bb076f850"
+          },
+          {
+            "_key": "41d97b97ada5",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du jobbar ikkje i ",
+            "_key": "f69297600705"
+          },
+          {
+            "_key": "6e28b52daa6f",
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "304cfd8375fb"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5fc497680858",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "ba56da804abe",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "_key": "1a5cb21f4bc2",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_key": "c9b05a868d8d",
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0d8e86208162",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " i ",
+            "_key": "1032859e22b8",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "4d7e214a6bea"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " Norske reglar for kontantstøtte gjeld derfor for den andre forelderen. Du får heile kontantstøtta frå Noreg.",
+            "_key": "be7d6ad8d6f3"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-ab9d455f-e6ee-4cf6-977e-1cee4f2933fe",
+    "apiNavn": "innvilgetSelvstendigRettPrimarlandUtsendtArbeidstaker",
+    "visningsnavn": "46. Selvstendig rett primærland utsendt arbeidstaker ",
+    "_createdAt": "2024-01-08T22:38:58Z"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "triggere": [
+      "BARN_DØD"
+    ],
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_id": "ksBegrunnelse-afccb961-ac96-4a69-b32d-7701858b38d9",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "26df400d395c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnet ditt som er født ",
+            "_key": "ddc9069fed0b0"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "d2c5b7bea1fe",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døde.",
+            "_key": "a31cd76a2c7e"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "apiNavn": "avslagEtBarnErDod",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "visningsnavn": "24. Et barn er død",
+    "resultat": "AVSLAG",
+    "_createdAt": "2023-05-04T18:03:39Z",
+    "_updatedAt": "2023-05-04T18:03:39Z",
+    "navnISystem": "Et barn er død",
+    "_rev": "vuzvVDrYQXJOMHanV8f9oA",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_key": "a9c5b6e49161",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barnet ditt som er fødd ",
+            "_key": "ebff119011350",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "e7edc8c8bf68"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " døydde.",
+            "_key": "029023c75927"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "115b359e9d790"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "d8f2b2cf1d48"
+          },
+          {
+            "text": " bur saman med ein av foreldra sine. I slike tilfelle er det forelderen til barnet/barna som har rett til kontantstøtta.",
+            "_key": "2de10ef4d236",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "cc0e95adfeca"
+      }
+    ],
+    "hjemler": [
+      "3"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_createdAt": "2023-05-04T18:31:16Z",
+    "_id": "ksBegrunnelse-b0627a31-f03d-4169-9f3a-fa2c7d7e1a85",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "62f326299e31",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "859746a3d4fe0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "a02786274d58"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor sammen med en av foreldrene sine. I slike tilfeller er det forelderen til barnet/barna som har rett til kontantstøtten.",
+            "_key": "642c640af4da"
+          }
+        ]
+      }
+    ],
+    "_rev": "vuzvVDrYQXJOMHanVEfW7v",
+    "resultat": "AVSLAG",
+    "visningsnavn": "38. Ektefelle eller samboers særkullsbarn",
+    "_updatedAt": "2023-05-08T06:49:50Z",
+    "navnISystem": "Ektefelle eller samboers særkullsbarn",
+    "apiNavn": "avslagEktefelleEllerSamboerssearkullsbarn"
+  },
+  {
+    "_rev": "CKoJmXlM50fHJKgxS5NO7m",
+    "resultat": "AVSLAG",
+    "_createdAt": "2023-05-04T17:55:53Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-b0fd22d2-93d4-4d67-840e-9616e24e0d4d",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "9b49bdd40552",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "36a74a1f8b560"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "34e7592505f1",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " skal være i utlandet i mer enn 3 måneder. ",
+            "_key": "93ce1d4e722e"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "21. Vurdering Utenlandsopphold mer enn 3 måneder",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "5583d9cd7ebe",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "d4fc962113560"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "13e7318b27bf",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            }
+          },
+          {
+            "_key": "7d43ca6b3381",
+            "_type": "span",
+            "marks": [],
+            "text": " skal vere i utlandet i meir enn 3 månader. "
+          }
+        ]
+      }
+    ],
+    "_updatedAt": "2023-05-04T17:55:53Z",
+    "navnISystem": "Vurdering Utenlandsopphold mer enn 3 måneder",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "apiNavn": "avslagVurderingUtenlandsoppholdMerEnnTreMaaneder"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "nynorsk": [
+      {
+        "_key": "f69b861e0fd7",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "f2ba0816daac0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "2638b9c1e752"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "8c68d37b75c1"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb"
+            },
+            "_type": "valgfeltV2",
+            "_key": "6c9e633d0fba",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "515f0c985cac"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "49d3bced1ced",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "cff2abeabb5a"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "69583dc98d9e"
+          },
+          {
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Du har ansvar for barnet åleine. Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "913a05a1cc1e",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_updatedAt": "2024-01-05T15:37:30Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "81bee9f0992c0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "6f0bfdfc11b2"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "5077a5e09828",
+            "_type": "span"
+          },
+          {
+            "_key": "1778a815a567",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "3c9ff1453b16"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "2b9da549e16d",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bor i ",
+            "_key": "584403d0b1d8",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "fc9b5d41ea70"
+          },
+          {
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Du har ansvar for barnet alene. Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "f85da5f25428",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e12d807b9e17"
+      }
+    ],
+    "visningsnavn": "2. Primærland aleneansvar",
+    "_rev": "eS4Wb2bsh0R4qyDTnxVIcL",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "resultat": "INNVILGET",
+    "_id": "ksBegrunnelse-b13eb0a2-5140-43f9-ad98-7d0629c927cd",
+    "annenForeldersAktivitet": [
+      "MOTTAR_PENSJON",
+      "IKKE_AKTUELT"
+    ],
+    "navnISystem": "Primærland aleneansvar",
+    "apiNavn": "innvilgetPrimarlandAleneansvar",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "type": "STANDARD",
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T09:12:10Z"
+  },
+  {
+    "navnISystem": "Utsendt arbeidstaker fra annet EØS-land",
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T13:05:28Z",
+    "_id": "ksBegrunnelse-b1982442-1a9c-4e32-b13b-aca7cdcee8d1",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du jobbar i Noreg som utsendt frå eit anna EØS-land. Vi har derfor kome fram til at lovgjevnaden i det andre EØS-landet gjeld for deg.",
+            "_key": "59a2074154070"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "015cc7dcf840",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_updatedAt": "2023-12-19T14:44:41Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "text": "Du jobber i Norge som utsendt fra et annet EØS-land. Vi har derfor kommet fram til at lovgivningen i det andre EØS-landet gjelder for deg.",
+            "_key": "4ae6d83bd4200",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1e5f79d1b651",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "opphorUtsendtArbeidstakerFraAnnetEosLand",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "12. Utsendt arbeidstaker fra annet EØS-land",
+    "_rev": "QYE1lVUzcrAawv9ECkvcqC",
+    "resultat": "OPPHØR",
+    "_type": "ksBegrunnelse",
+    "stotterFritekst": false
+  },
+  {
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijMXUnz",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "_key": "eafa43bf75fa",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje jobbar i Noreg.",
+            "_key": "6f69c19f3c5b0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2024-01-09T16:28:27Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "apiNavn": "avslagJobberIkke",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG",
+    "tema": "EØS",
+    "bokmaal": [
+      {
+        "_key": "c166a441afc0",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "e88c94658aae0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke jobber i Norge."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Jobber ikke",
+    "visningsnavn": "3. Jobber ikke",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-b2e260e5-2bee-411e-8948-1c0e4b8fd983",
+    "_updatedAt": "2024-01-09T16:28:27Z"
+  },
+  {
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2023-12-19T14:58:44Z",
+    "tema": "EØS",
+    "_id": "ksBegrunnelse-b3175435-bb4c-45ad-b1f7-b0c47cac563e",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke hadde oppholdsrett som familiemedlem til en statsborger i et EØS-land.",
+            "_key": "59d67e388be80"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "a23e22c47b7a"
+      }
+    ],
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "apiNavn": "opphorHaddeIkkeOppholdsrettSomFamiliemedlem",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje hadde opphaldsrett som familiemedlem til ein statsborgar i eit EØS-land.",
+            "_key": "78bef7987cb60"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e018fc474ed8"
+      }
+    ],
+    "_createdAt": "2023-12-19T14:58:44Z",
+    "navnISystem": "Hadde ikke oppholdsrett som familiemedlem",
+    "visningsnavn": "23. Hadde ikke oppholdsrett som familiemedlem",
+    "_rev": "AOUa26DfnB8ntJraK3xF33",
+    "resultat": "OPPHØR"
+  },
+  {
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du ikkje ",
+            "_key": "328568b20f560",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "254638f701ef",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "04049cefdf91"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "75f39c3b46c1"
+      }
+    ],
+    "resultat": "OPPHØR",
+    "stotterFritekst": false,
+    "bokmaal": [
+      {
+        "_key": "001234a81fce",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke ",
+            "_key": "4f7e6d0c93620"
+          },
+          {
+            "_key": "80f8e48bb8e0",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "50e4c271381d"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Opphør standard",
+    "visningsnavn": "1. Opphør standard",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-b37013ec-8c42-4d72-9164-28838b27bdc5",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER"
+    ],
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T11:48:51Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "apiNavn": "opphorEosStandard",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "NORGE_ER_SEKUNDÆRLAND",
+      "TO_PRIMÆRLAND"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijInDeh",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-04T14:18:13Z"
+  },
+  {
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "df9ae765c59d",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "f6f354dfc6110",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "7d6dd0e32009"
+          },
+          {
+            "text": " er tildelt fulltidsplass i ny barnehage. Når barnet kan vere i barnehagen i 33 timar eller meir i veka, er dette rekna som fulltidsplass. Du får ikkje kontantstøtte når barn bytter barnehage i sommarferien.",
+            "_key": "47689e56f3e3",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2023-07-21T15:29:10Z",
+    "_id": "ksBegrunnelse-b8ba58a8-c7f4-4731-b713-1000578b089a",
+    "_updatedAt": "2023-07-21T15:29:10Z",
+    "utdypendeVilkaarsvurderinger": [
+      "SOMMERFERIE"
+    ],
+    "tema": "NASJONAL",
+    "navnISystem": "Bytte av barnehage i sommerferien",
+    "apiNavn": "opphorBytteAvBarnehageISommerferien",
+    "_rev": "Xl0tn62zVopahRtC76HZSx",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "hjemler": [
+      "8"
+    ],
+    "visningsnavn": "16. Bytte av barnehage i sommerferien",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "a20916b9bd840"
+          },
+          {
+            "_key": "5dd867e99c3e",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i ny barnehage. Når barnet kan være i barnehagen i 33 timer eller mer i uka, regnes dette som fulltidsplass. Du får ikke kontantstøtte når barn bytter barnehage i sommerferien.",
+            "_key": "7da35de00c96"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8288e8ef131d"
+      }
+    ]
+  },
+  {
+    "type": "STANDARD",
+    "_updatedAt": "2023-03-16T21:35:40Z",
+    "apiNavn": "fortsattInnvilgetTekstEksempel",
+    "tema": "NASJONAL",
+    "_rev": "YIi4f8LF3tHreXJEWmau4e",
+    "resultat": "FORTSATT_INNVILGET",
+    "_id": "ksBegrunnelse-b8c46c41-eb38-4ed1-84d5-5d774912fa2d",
+    "navnISystem": "FortsattInnvilgetTekstEksempel",
+    "visningsnavn": "FortsattInnvilgetTekstEksempel",
+    "_createdAt": "2023-03-16T21:35:40Z",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "navnISystem": "Primærland begge foreldre jobber i Norge",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON"
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECngXit",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "0429138a247c0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "6a83aafdee10"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "d5fd68ec6c81"
+          },
+          {
+            "_key": "a05355a49211",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "dce04c88d21e"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "53f442f83e4b",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "a8302475f281",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "8f866e552d89",
+            "flettefelt": "barnetsBostedsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "ab3bc67edcfd"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a2d5d3073e83",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "80ae7e311842"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "abaabee4b971"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "41d5b479dbf0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4096e62f6a2a"
+      }
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2023-12-20T20:41:38Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "3d4efe773b3e0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "8b903231667f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "eefdd9ce3249"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "935a751fd4fa",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "e143398b8361"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "2d49e973f7b5",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "b14352562782"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "da29412e2de2"
+          },
+          {
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "6fd6c85876d3",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "49430332e7dc"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "a4d1a87cf966"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "5fe3b2e7ad6c",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "c931bd847f49",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "370cf013d9e2",
+        "markDefs": []
+      },
+      {
+        "children": [
+          {
+            "_key": "9db9510903060",
+            "_type": "span",
+            "marks": [],
+            "text": "\n"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "87e29fbb0f20",
+        "markDefs": []
+      }
+    ],
+    "visningsnavn": "4. Primærland begge foreldre jobber i Norge",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2023-12-19T09:54:13Z",
+    "apiNavn": "innvilgetPrimarlandBeggeForeldreJobberINorge",
+    "_id": "ksBegrunnelse-ba480d83-ff9d-470a-90a7-f9bde77c89e8"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "resultat": "FORTSATT_INNVILGET",
+    "visningsnavn": "10. Ikke barnehageplass",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "ef6af006deee",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får uendret kontantstøtte for barn født ",
+            "_key": "34d00cec9f280",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "247e6cbef1be"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "c054696cb1a7"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "514eb5579bac",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [
+              "em"
+            ],
+            "text": " ikke er",
+            "_key": "34d00cec9f281"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " tildelt barnehageplass. ",
+            "_key": "34d00cec9f282"
+          }
+        ]
+      }
+    ],
+    "nynorsk": [
+      {
+        "_key": "9f48540f32ea",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "53106aa676280",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendra kontantstøtte for barn fødd "
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "3a3533ac421b",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "e6281e400f0f"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "52440275992d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje er tildelt barnehageplass.",
+            "_key": "53106aa676282"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2023-12-12T14:06:51Z",
+    "_id": "ksBegrunnelse-ba520cb9-b3cc-4a82-b823-6711f2ec25c4",
+    "_updatedAt": "2023-12-12T15:04:41Z",
+    "apiNavn": "fortsattInnvilgetIkkeBarnehage",
+    "_rev": "QYE1lVUzcrAawv9ECZyyFP",
+    "navnISystem": "Ikke barnehageplass"
+  },
+  {
+    "_rev": "vuzvVDrYQXJOMHanV8hLou",
+    "_type": "ksBegrunnelse",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "04a824d35009",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke har en avtale om delt bosted for barn født ",
+            "_key": "5eb8075c651d0"
+          },
+          {
+            "_key": "3ab946dba2b0",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_key": "4a58d1163eae",
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten kan derfor ikke deles."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "visningsnavn": "35. Ikke avtale om delt bosted",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_id": "ksBegrunnelse-bcd17bfb-ee86-4245-826b-b325de2d0f56",
+    "_updatedAt": "2023-05-04T18:24:13Z",
+    "navnISystem": "Ikke avtale om delt bosted",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "305ba2d5938e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje har ein avtale om delt bustad for barn fødd ",
+            "_key": "4758139ba2d70"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "f52dc8932652"
+          },
+          {
+            "text": ". Kontantstøtta kan derfor ikkje delast.",
+            "_key": "ef3f33f19582",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2023-05-04T18:24:13Z",
+    "apiNavn": "avslagIkkeAvtaleOmDeltBosted"
+  },
+  {
+    "visningsnavn": "13. Adopsjon mottatt kontantstøtte i 11 måneder",
+    "_rev": "sNO2L38EwIVNY4VMy4W106",
+    "_createdAt": "2023-05-03T15:34:42Z",
+    "bokmaal": [
+      {
+        "_key": "7a52d0c0264a",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "8c030cd819ce0",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "b480a44f5e02"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "har fått kontantstøtte i 11 måneder.",
+            "_key": "868bb4922684"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "reduksjonMottattKontantstotteI11Maaneder",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "nynorsk": [
+      {
+        "_key": "4c1bf9401ca3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi barn fødd ",
+            "_key": "801668557c3d0"
+          },
+          {
+            "_key": "283c17577b6c",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "marks": [],
+            "text": "har fått kontantstøtte i 11 månader.",
+            "_key": "f5c9b3b96d57",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Adopsjon mottatt kontantstøtte i 11 måneder",
+    "hjemler": [
+      "10"
+    ],
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-05-03T15:34:42Z",
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-bf2d09bf-3a47-4c99-8c88-d1f11d5100b3"
+  },
+  {
+    "apiNavn": "reduksjonTilleggstekstValutajustering",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "navnISystem": "Tilleggstekst valutajustering",
+    "_updatedAt": "2023-12-19T16:33:40Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi det har vært en endring av valutakursen.",
+            "_key": "148432b0d7a80"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "02a6b886c24b"
+      }
+    ],
+    "_id": "ksBegrunnelse-bf776cab-9655-45f0-a8a1-259159d9d8ca",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "_rev": "CM6961CqAC7W4puPRL9TYE",
+    "_type": "ksBegrunnelse",
+    "resultat": "REDUKSJON",
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T16:33:40Z",
+    "visningsnavn": "5. Tilleggstekst valutajustering",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "ca616ac6a49c",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi det har vore ei endring av valutakursen.",
+            "_key": "9a48b843894a0",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ]
+  },
+  {
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "af8197162f2c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetjenesten i kommunen har opplyst at barn født ",
+            "_key": "70151c44ed3d0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fe9441b28ff7"
+          },
+          {
+            "text": " var tildelt fulltidsplass i barnehage fra ",
+            "_key": "27a6df04e932",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "2eeab1d0ee28"
+          },
+          {
+            "_key": "014c2c3ed1ba",
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "3eafc88ff7340",
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetenesta i kommunen har opplyst at barn fødd "
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "13b23b361814",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_key": "333866286df0",
+            "_type": "span",
+            "marks": [],
+            "text": " var tildelt fulltidsplass i barnehage frå "
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "f1f2a3b07884",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor"
+          },
+          {
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "dfbe8a278ce6",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0bf9307da5f3"
+      }
+    ],
+    "_updatedAt": "2023-03-30T13:42:18Z",
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "visningsnavn": "41. Kommunen meldt fulltidsplass i barnehage",
+    "resultat": "OPPHØR",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_id": "ksBegrunnelse-bfc3b2ba-f048-4a88-8f92-19fc9128f763",
+    "apiNavn": "opphorKommunenMeldtFulltidsplassIBarnehageForstePeriode",
+    "_rev": "pmhuRhSUoAWbpYJtPpAGrx",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-03-22T18:53:46Z",
+    "navnISystem": "Kommunen meldt fulltidsplass i barnehage",
+    "type": "STANDARD"
+  },
+  {
+    "resultat": "REDUKSJON",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "5e3b6bc6f48c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi vi har fått en avtale som sier at barn født ",
+            "_key": "a35e9e5152ce0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "40588a978835"
+          },
+          {
+            "_key": "4fe76282f73c",
+            "_type": "span",
+            "marks": [],
+            "text": " skal bo fast hos den andre forelderen fra"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "6e10e5f629ab"
+          },
+          {
+            "marks": [],
+            "text": ". ",
+            "_key": "b3dbb53f2208",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi vi har fått ein avtale som seier at barn fødd ",
+            "_key": "34550f49d22f0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "5383f3a6183e"
+          },
+          {
+            "text": " skal bu fast hos den andre forelderen frå ",
+            "_key": "302c359eea17",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "f40119c5b6a0"
+          },
+          {
+            "_key": "266f3ada4dee",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "fc741db6393a"
+      }
+    ],
+    "_id": "ksBegrunnelse-c282714f-f065-4ab1-8411-20db5bbba3e3",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "9. Avtale om at barnet bor hos den andre forelderen",
+    "_rev": "vuzvVDrYQXJOMHanV9psr5",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_updatedAt": "2023-05-05T11:14:13Z",
+    "apiNavn": "reduksjonAvtaleOmAtBarnetBorHOsDenAndreForelderen",
+    "navnISystem": "Avtale om at barnet bor hos den andre forelderen",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-05-03T15:08:35Z"
+  },
+  {
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "68e018dd001f",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Vi ikke kan se å ha fått opplysninger som viser at du har ansvar for barn født ",
+            "_key": "718a207d53050",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "12506f5c4d42"
+          },
+          {
+            "text": ".",
+            "_key": "f0a9f77d4cf4",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Barn uten d-nummer",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijMarT9",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "ec6e02ed2f0f",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Vi ikkje kan sjå å ha fått opplysningar som viser at du har ansvar for barn fødd ",
+            "_key": "da8197c9d8440",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "262d1e0d3e92",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_key": "5fe9560599fb",
+            "_type": "span",
+            "marks": [],
+            "text": "."
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2024-01-09T16:51:38Z",
+    "_id": "ksBegrunnelse-c2e4e92f-349b-4775-a49c-2b3239f84c65",
+    "apiNavn": "avslagBarnUtenDNummer",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "visningsnavn": "14. Barn uten d-nummer",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "tema": "EØS",
+    "_updatedAt": "2024-01-09T16:51:38Z",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "type": "STANDARD"
+  },
+  {
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "_rev": "lzy5EEVzxJlmTsIwrRwdnj",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-c36c5b12-9491-413c-a73b-6e6dc320c985",
+    "_updatedAt": "2023-03-30T13:40:13Z",
+    "navnISystem": "Kommunen melder fulltidsplass i barnehage",
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "_key": "616bbfb833f4",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetenesta i kommunen har opplyst at barn fødd ",
+            "_key": "21124bc915970"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fbea8e8d6dc6"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage frå ",
+            "_key": "713fd11bf334"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "03fb356106d4"
+          },
+          {
+            "text": ". Når barnet er tildelt barnehageplass med 33 timar eller meir i veka, er dette rekna som fulltidsplass.",
+            "_key": "14851742c8fa",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-03-13T18:28:57Z",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "apiNavn": "opphorKommunenMelderFulltidsplassIBarnehage",
+    "visningsnavn": "3. Kommunen melder fulltidsplass i barnehage",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "_key": "6227c10f01cf",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barnehagetjenesten i kommunen har opplyst at barn født ",
+            "_key": "290d97069f0a0"
+          },
+          {
+            "_key": "366e8fe59d17",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt fulltidsplass i barnehage fra ",
+            "_key": "7231f8a4ed22"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "8c541454d4ac"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Når barnet er tildelt barnehageplass med 33 timer eller mer i uka, regnes dette som fulltidsplass.",
+            "_key": "bc2ffdd29932"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "type": "STANDARD",
+    "_createdAt": "2023-12-19T11:54:38Z",
+    "_id": "ksBegrunnelse-c3f28c10-7d09-41cc-b236-dfe9594a4845",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "2. Søker ber om opphør",
+    "_rev": "QYE1lVUzcrAawv9ECkvXyV",
+    "stotterFritekst": false,
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har bedt om at kontantstøtten for barn født ",
+            "_key": "72bc8a9842d40"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "cd04031ec1d2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " blir stanset.",
+            "_key": "89f0578ce73e"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "fe8a34cf81a8",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Søker ber om opphør",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du har bedt om at kontantstøtta for barn fødd ",
+            "_key": "47aca41dcb200",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "6d0b5c329941"
+          },
+          {
+            "text": " blir stansa.",
+            "_key": "073dd6b3b4b7",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "71a23754d4c6"
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2023-12-19T14:43:48Z",
+    "apiNavn": "opphorEosSokerBerOmOpphor",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "tema": "EØS"
+  },
+  {
+    "_createdAt": "2023-05-04T18:29:20Z",
+    "navnISystem": "Søker for sent",
+    "apiNavn": "avslagSokerForSent",
+    "_rev": "CKoJmXlM50fHJKgxS5PbAO",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-c4b2d839-6ced-4d67-a040-ae2fb16df5dc",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtte kan ikkje utbetalast for meir enn tre månadar tilbake i tid frå vi fekk søknaden din. Vi fekk søknaden ",
+            "_key": "03099746e1040",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "soknadstidspunkt",
+            "_type": "flettefelt",
+            "_key": "c545654a1b4e"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "e36530668204",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "7da6f02bd5a8"
+      }
+    ],
+    "hjemler": [
+      "8"
+    ],
+    "visningsnavn": "37. Søker for sent",
+    "resultat": "AVSLAG",
+    "_updatedAt": "2023-05-04T18:29:20Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "5c697842d35a",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtte kan ikke utbetales for mer enn tre måneder tilbake i tid fra vi fikk søknaden din. Vi fikk søknaden ",
+            "_key": "7e94e1e35b680"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "02510a50538d",
+            "flettefelt": "soknadstidspunkt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "6c4ea8e6e55b"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "navnISystem": "Tilleggstekst satsendring",
+    "_rev": "eS4Wb2bsh0R4qyDTo02xYv",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "visningsnavn": "29. Tilleggstekst satsendring",
+    "nynorsk": [
+      {
+        "_key": "376ca9f89cee",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "b6d506253dc40",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi det har vore ei satsendring."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2024-01-08T21:14:50Z",
+    "_updatedAt": "2024-01-08T21:14:50Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "d8af11279bb3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten er endret fordi det har vært en satsendring.",
+            "_key": "db34eafded990"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "tema": "EØS",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "apiNavn": "innvilgetTilleggstekstSatsendring",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-c4bb3966-9e3d-4b5b-8949-83c5d6797836"
+  },
+  {
+    "_id": "ksBegrunnelse-c4c22876-d335-4349-9127-401767054838",
+    "resultat": "REDUKSJON",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "b547428d5adb",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtte er endra fordi ",
+            "_key": "34a6e55c986c0"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4"
+            },
+            "_type": "valgfeltV2",
+            "_key": "42917c08ed4c",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "113dc94f67b9",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje hadde opphaldsløyve i Noreg. "
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Ikke oppholdstillatelse",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_createdAt": "2023-05-03T15:58:36Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtte endres fordi ",
+            "_key": "60de69e38a0b0",
+            "_type": "span"
+          },
+          {
+            "_key": "46d1b12bf023",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke hadde oppholdstillatelse i Norge. ",
+            "_key": "766aab9c22b0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "77d01162c168",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "reduksjonIkkeOppholdstillatelse",
+    "_type": "ksBegrunnelse",
+    "_rev": "RiR9GraBD8hopeC5h6J7sz",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-05-03T15:58:36Z",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "visningsnavn": "20. Ikke oppholdstillatelse"
+  },
+  {
+    "apiNavn": "innvilgetSelvstendigRettTilleggstekstSekundarlandIkkeFattSvarPaaSed",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "_id": "ksBegrunnelse-c53ebacf-d950-4144-aefb-a13579e87653",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har ikke fått svar på opplysninger vi har bedt om fra ",
+            "_key": "5874cb528d2d0"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "d773dde8f2c2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norge utbetaler derfor forskjellen mellom kontantstøtten familien kan ha rett på fra ",
+            "_key": "9543025be94c"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "0d097c8ff35a"
+          },
+          {
+            "_key": "9dfe6b1ad24f",
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte. Saken må vurderes på nytt hvis vi får svar fra "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "084167250a4b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "4e9aed8f84c1"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "acc30b9afc56"
+      }
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "visningsnavn": "55. Selvstendig rett tilleggstekst sekundær ikke fått svar på SED",
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Vi har ikkje fått svar på opplysningar vi har bedt om frå ",
+            "_key": "6e1111b291360",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "9cb134a3a9b5"
+          },
+          {
+            "_key": "dfc1e72cf7db",
+            "_type": "span",
+            "marks": [],
+            "text": ". Noreg utbetalar derfor forskjellen mellom kontantstøtta familien kan ha rett på frå "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "2d41ccfa96c8"
+          },
+          {
+            "marks": [],
+            "text": " og norsk kontantstøtte. Saka må vurderast på nytt dersom vi får svar frå ",
+            "_key": "e212c969b288",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "eecd2b108bad"
+          },
+          {
+            "text": ".",
+            "_key": "bfaaa36b5394",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "676a011b9980"
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_updatedAt": "2024-01-08T23:33:06Z",
+    "navnISystem": "Selvstendig rett tilleggstekst sekundær ikke fått svar på SED",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "q5JgLByi60irF5LU0IUzQc",
+    "tema": "EØS",
+    "_createdAt": "2024-01-08T23:33:06Z"
+  },
+  {
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "",
+            "_key": "dfeef18fc012",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8576829ebaeb"
+          },
+          {
+            "text": "  har vore i utlandet i meir enn 3 månader.",
+            "_key": "99d3868f41250",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "d40873b83ec2",
+        "markDefs": []
+      }
+    ],
+    "_rev": "3H9OXgojExINZUA3ukmIjH",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_id": "ksBegrunnelse-c5a144fe-c123-4a1a-80ac-ba0aad42e15f",
+    "_updatedAt": "2023-07-28T11:38:12Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "",
+            "_key": "04d60975f74f",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "02775d35676e",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " har vært i utlandet i mer enn 3 måneder.",
+            "_key": "42e5e74caa8a0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "eb8de769e794"
+      }
+    ],
+    "apiNavn": "opphorUtenlandsoppholdMerEnn3MaanederFraInnvilgelse",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "36. Utenlandsopphold mer enn 3 mnd fra innvilgelse",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "navnISystem": "Utenlandsopphold mer enn 3 mnd fra innvilgelse",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-07-24T08:43:21Z"
+  },
+  {
+    "_rev": "QYE1lVUzcrAawv9ECkvYlc",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-12-19T12:00:41Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "apiNavn": "opphorIkkeStatsborgerIEosLand",
+    "visningsnavn": "4. Ikke statsborger i EØS-land",
+    "resultat": "OPPHØR",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "354b96bb55e4",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du ikkje lenger er statsborgar i eit EØS-land.",
+            "_key": "f2fbec505cd10",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "10ac54ed5bb4",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "9986ca3619b00",
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke lenger er statsborger i et EØS-land."
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Ikke statsborger i EØS-land",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-c6d00fac-e64c-4e09-b844-6c28ef7eef14",
+    "_updatedAt": "2023-12-19T14:43:59Z",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ]
+  },
+  {
+    "hjemler": [
+      "6"
+    ],
+    "visningsnavn": "7. Fosterbarn",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "957b5e391b3e0"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "2592bcee85ea",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "text": " bor i fosterhjem hos deg. Du får ikke kontantstøtte for fosterbarn.\n",
+            "_key": "e51d9b69fa0d",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f7d7c541a64f"
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "748857a49e07",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "\n",
+            "_key": "d7029549e5050",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2023-05-04T06:52:18Z",
+    "_id": "ksBegrunnelse-c7947b02-633f-4c91-9d71-d15f0742a279",
+    "_updatedAt": "2023-05-04T06:58:03Z",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "navnISystem": "Fosterbarn",
+    "apiNavn": "avslagFosterbarn",
+    "_rev": "RiR9GraBD8hopeC5h749rJ",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_key": "da516d62c0020",
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd "
+          },
+          {
+            "_key": "1e1f63bf3af6",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "text": " bur i fosterheim hos deg. Du får ikkje kontantstøtte for fosterbarn.",
+            "_key": "af42bc06d5ab",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9079c2092ec7",
+        "markDefs": []
+      }
+    ]
+  },
+  {
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_createdAt": "2023-07-21T15:44:24Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "7b72691ba70c0"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "1d54584ccfcf"
+          },
+          {
+            "marks": [],
+            "text": " skal være i utlandet i mer enn 3 måneder. ",
+            "_key": "7a6bc80b6865",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "420111233503"
+      }
+    ],
+    "navnISystem": "Vurdering Utenlandsopphold mer enn 3 mnd",
+    "visningsnavn": "20. Vurdering Utenlandsopphold mer enn 3 mnd",
+    "_type": "ksBegrunnelse",
+    "_updatedAt": "2023-07-28T11:38:31Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "resultat": "OPPHØR",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "7177fb47797e0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "81491ebe69ef",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " skal vere i utlandet i meir enn 3 månader. ",
+            "_key": "c743e07e4d45"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e309d1411bcd"
+      }
+    ],
+    "_id": "ksBegrunnelse-c7cb5e5f-1da1-40bc-bd04-013355b20202",
+    "apiNavn": "opphorVurderingUtenlandsoppholdMerEnn3Maaneder",
+    "_rev": "dRxFLGF5sQv15PB3jfjTAN",
+    "type": "STANDARD"
+  },
+  {
+    "resultat": "INNVILGET",
+    "_createdAt": "2022-11-17T13:05:23Z",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "72b035fd10670"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "35a8d47a93f1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "524ef032dbbf"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a74d23e2f048",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje har fått tildelt barnehageplass.",
+            "_key": "72b035fd10672"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "7d2eca5cf696"
+      }
+    ],
+    "_id": "ksBegrunnelse-c8eb9656-037f-4fff-816a-5dedb775bdba",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "898425076361"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "fb46422b5e52"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "7ac416076360"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "33cf62c278f2",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "text": " ikke har fått tildelt barnehageplass. ",
+            "_key": "d70ce9727a4b",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "62af8ab5b904"
+      }
+    ],
+    "visningsnavn": "2. Ikke barnehage adopsjon",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BARNEHAGEPLASS",
+      "BARNETS_ALDER"
+    ],
+    "_updatedAt": "2024-01-11T07:16:16Z",
+    "navnISystem": "Ikke barnehage adopsjon",
+    "hjemler": [
+      "2",
+      "3",
+      "7",
+      "8",
+      "10"
+    ],
+    "_rev": "OOiqc75kBHa0MG8GSylFVa",
+    "apiNavn": "innvilgetIkkeBarnehageAdopsjon",
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ]
+  },
+  {
+    "tema": "EØS",
+    "_createdAt": "2024-01-09T16:32:10Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2024-01-09T16:32:10Z",
+    "navnISystem": "Arbeider mer enn 25 prosent i annet EØS-land",
+    "apiNavn": "avslagArbeiderMerEnn25ProsentIAnnetEosLand",
+    "visningsnavn": "5. Arbeider mer enn 25 prosent i annet EØS-land",
+    "_rev": "eS4Wb2bsh0R4qyDTo1OGWf",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "nynorsk": [
+      {
+        "_key": "ef93f503b1a2",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "2aec10d488390",
+            "_type": "span",
+            "marks": [],
+            "text": "Du jobbar meir enn 25 prosent i eit anna EØS-land, der du også bur. Vi har derfor kome fram til at lovgjevnaden i det andre EØS-landet gjeld for deg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "_id": "ksBegrunnelse-c8ff89b5-547d-4c20-89c5-81a4e01e8b9d",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "95b8d65687a4",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du jobber mer enn 25 prosent i et annet EØS-land, der du også bor. Vi har derfor kommet fram til at lovgivningen i det andre EØS-landet gjelder for deg.",
+            "_key": "041d61ac96000"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "944c2d885b7f",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendra kontantstøtte for barn fødd ",
+            "_key": "2cbe6e628d660"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "da8fc21f9524"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "fordi den andre forelderen har vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år.",
+            "_key": "da9af37fb759"
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-c9fb423f-0804-4213-accc-29862ab0013d",
+    "_rev": "5r7yBuU8wKOiVHJijJH3MF",
+    "_type": "ksBegrunnelse",
+    "resultat": "FORTSATT_INNVILGET",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "text": "Du får uendret kontantstøtte for barn født ",
+            "_key": "69c811654e6c0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "4a5fb03d3545",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "text": " fordi den andre forelderen har vært medlem i folketrygden og trygdeordninger i andre EØS-land i til sammen fem år.",
+            "_key": "97c4fec20e57",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "793db43327f1",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Medlemskap folketrygden og EØS-land den andre forelderen",
+    "apiNavn": "fortsattInnvilgetMedlemskapFolketrygdenOgEosLandDenAndreForelderen",
+    "_updatedAt": "2024-01-05T09:32:42Z",
+    "_createdAt": "2023-12-13T10:01:30Z",
+    "visningsnavn": "15. Medlemskap folketrygden og EØS-land den andre forelderen",
+    "type": "STANDARD",
+    "tema": "NASJONAL"
+  },
+  {
+    "resultat": "INNVILGET",
+    "hjemlerEOSForordningen883": [
+      "68"
+    ],
+    "tema": "EØS",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "4a9d5ef5a5e2",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har søkt om å få kontantstøtten utbetalt til seg. Vi har kommet fram til at kontantstøtten ikke kommer barnet til gode. Vi utbetaler derfor barnetrygden til den andre forelderen. ",
+            "_key": "5336271830890"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Tilleggsbegrunnelse utbetaling til annen forelder",
+    "apiNavn": "innvilgetTilleggsbegrunnelseUtbetalingTilAnnenForelder",
+    "_id": "ksBegrunnelse-cb15b866-4b84-4504-b2c2-64692e7dc955",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har søkt om å få kontantstøtta utbetalt til seg. Vi har kome fram til at kontantstøtta ikke kjem barnet til gode. Vi utbetalar derfor kontantstøtta til den andre forelderen.",
+            "_key": "183eb50da2a80"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "5141cbb171ff"
+      }
+    ],
+    "_createdAt": "2024-01-05T16:08:55Z",
+    "visningsnavn": "16. Tilleggsbegrunnelse utbetaling til annen forelder",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijM2mNP",
+    "type": "TILLEGGSTEKST",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_updatedAt": "2024-01-09T11:50:46Z"
+  },
+  {
+    "visningsnavn": "16. Selvstendig næringsdrivende Norge arbeidstaker i annet EØS land",
+    "_rev": "eS4Wb2bsh0R4qyDTo1QmCX",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "d7e087e176f8",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du jobbar som sjølvstendig næringsdrivande i Noreg, samtidig som du er arbeidstakar i eit anna EØS-land. Vi har derfor kome fram til at lovgjevnaden i det andre EØS-landet gjeld for deg.",
+            "_key": "9139016534210"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "bokmaal": [
+      {
+        "_key": "409e2066c522",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du jobber som selvstendig næringsdrivende i Norge, samtidig som du er arbeidstaker i et annet EØS-land. Vi har derfor kommet fram til at lovgivningen i det andre EØS-landet gjelder for deg.",
+            "_key": "01b17b892af20",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "_createdAt": "2024-01-09T16:56:46Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-cce67da3-31ea-4ae9-ad51-1a7e6ec67a07",
+    "_updatedAt": "2024-01-09T16:56:46Z",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "navnISystem": "Selvstendig næringsdrivende Norge arbeidstaker i annet EØS land",
+    "apiNavn": "avslagSelvstendigNaringsdrivendeNorgeArbeidstakerIAnnetEosLand"
+  },
+  {
+    "visningsnavn": "6. Har kontantstøtten det er søkt om",
+    "_updatedAt": "2023-12-12T12:11:15Z",
+    "resultat": "FORTSATT_INNVILGET",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendra kontantstøtte fordi du allereie mottek kontantstøtta som du har søkt om.",
+            "_key": "248e055e96e20"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "363522f36621"
+      }
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "db78fcf25ade",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendret kontantstøtte fordi du allerede mottar kontantstøtten som du har søkt om.",
+            "_key": "03ea43e48dd20"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Har kontantstøtten det er søkt om",
+    "apiNavn": "fortsattInnvilgetHarKontantstottenDetErSoktOm",
+    "_createdAt": "2023-12-12T12:11:15Z",
+    "skalAlltidVises": true,
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-cd4a4b1f-07cb-4194-92c2-8c3ce7d4ff41",
+    "hjemler": [
+      "2",
+      "3",
+      "7",
+      "8"
+    ],
+    "_rev": "QYE1lVUzcrAawv9ECZmLsE",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "STANDARD",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTnxVi9p",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "b50e50da14f6",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "8913597531d60",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "db64a0b1fe72"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "6ef339d9e4d1",
+            "_type": "span"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "b67178779ec8",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "8ef4e18344f1"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "4e517d7ba63b"
+          },
+          {
+            "marks": [],
+            "text": " bur saman med deg i Noreg og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "19544946ca11",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "7a7bac16be92",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "943a1073fdb2",
+            "_type": "span",
+            "marks": [],
+            "text": " i "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "6022cc5b0e7e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "aa20b56c6a3a"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "barnetsBostedsland": [
+      "NORGE"
+    ],
+    "_updatedAt": "2024-01-05T15:44:38Z",
+    "visningsnavn": "8. Primærland barnet bor i Norge",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "bokmaal": [
+      {
+        "_key": "469c36d062f6",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "ef9e822d21a60"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "12defcc68b8c"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "f2e78b582d1a",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cdd0cb9609d8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "35adae0be695"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "db441132f395",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor sammen med deg i Norge og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "c0944ed568bf"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8cf1435bae78"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "db00dc1e168f"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "e1916002fa41"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "e46c44007f25"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Primærland barnet bor i Norge",
+    "_createdAt": "2023-12-19T10:54:55Z",
+    "_id": "ksBegrunnelse-ce34fd43-c510-4241-a86f-5b282fbcc9aa",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "apiNavn": "innvilgetPrimarlandBarnetBorINorge"
+  },
+  {
+    "type": "STANDARD",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "tema": "NASJONAL",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "FORTSATT_INNVILGET",
+    "visningsnavn": "14. Medlemskap folketrygden og EØS-land",
+    "apiNavn": "fortsattInnvilgetMedlemskapFolketrygdenOgEosLand",
+    "_type": "ksBegrunnelse",
+    "_updatedAt": "2023-12-13T09:58:59Z",
+    "navnISystem": "Medlemskap folketrygden og EØS-land",
+    "nynorsk": [
+      {
+        "_key": "18f818c091c3",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendra kontantstøtte for barn fødd ",
+            "_key": "3e897134712a0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "0e8e62ba1805"
+          },
+          {
+            "text": "fordi ",
+            "_key": "c3557c44535d",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "2bf40257c278",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år.",
+            "_key": "3e897134712a4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-12-13T09:58:59Z",
+    "_id": "ksBegrunnelse-cedc4c25-e453-407e-a448-903d127ab88e",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendret kontantstøtte for barn født ",
+            "_key": "b66f2291b22e0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "118f9fe971a1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "87a30da82d46"
+          },
+          {
+            "_key": "e2e5b36f4dc3",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har vært medlem i folketrygden og trygdeordninger i andre EØS-land i til sammen fem år.",
+            "_key": "b66f2291b22e4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "743669712601",
+        "markDefs": []
+      }
+    ],
+    "_rev": "AOUa26DfnB8ntJraK0YH9L"
+  },
+  {
+    "navnISystem": "Den andre forelderen mottar kontantstøtte",
+    "_rev": "HlYUfgLvnxhSVUqkyO4Oos",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "_id": "ksBegrunnelse-d0bf1105-67bf-4eae-abd1-bf3198c0e995",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_key": "cb763cf810b60",
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen allerede får kontantstøtte for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "6e151f3975c3"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "dbe75e7b420d"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b753cc423b5f",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8",
+      "9"
+    ],
+    "visningsnavn": "19. Den andre forelderen mottar kontantstøtte",
+    "type": "STANDARD",
+    "_updatedAt": "2023-05-22T11:51:18Z",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-05-04T17:50:08Z",
+    "apiNavn": "avslagDenAndreForelderenMottarKontantstotte",
+    "resultat": "AVSLAG",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen allereie får kontantstøtte for barn fødd ",
+            "_key": "373ce09b6afe0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "57df872ce360"
+          },
+          {
+            "marks": [],
+            "text": ".",
+            "_key": "03a4cbb2ebb3",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8dfb93a2dfc3"
+      }
+    ]
+  },
+  {
+    "_id": "ksBegrunnelse-d2eaf943-59c8-4bfa-8e29-d76cb4314c5b",
+    "resultat": "REDUKSJON",
+    "_updatedAt": "2023-03-20T06:43:11Z",
+    "tema": "NASJONAL",
+    "visningsnavn": "ReduksjonTillegsTekstEksempel",
+    "_type": "ksBegrunnelse",
+    "_rev": "VNfjOkUyv8N7GDE50DII3u",
+    "type": "TILLEGGSTEKST",
+    "navnISystem": "reduksjonTillegsTekstEksempel",
+    "apiNavn": "reduksjonTillegsTekstEksempel",
+    "_createdAt": "2023-03-20T06:43:11Z"
+  },
+  {
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "8234951e7877",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtten endres fordi barn født ",
+            "_key": "5355499cd4880",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "e0019ee81a8a",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har begynt på skolen.",
+            "_key": "c158c44fb001"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "resultat": "REDUKSJON",
+    "_createdAt": "2023-05-03T15:36:23Z",
+    "_id": "ksBegrunnelse-d2f86c45-408c-4b04-a527-bd5df84f79ae",
+    "apiNavn": "reduksjonBarnBegyntPaaSkolen",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "hjemler": [
+      "10"
+    ],
+    "_rev": "sNO2L38EwIVNY4VMy4W7ze",
+    "_updatedAt": "2023-05-03T15:36:23Z",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "nynorsk": [
+      {
+        "_key": "b97a789da158",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "3fe01521b2410",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi barn fødd "
+          },
+          {
+            "_key": "f6c3fb7c7788",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har begynt på skulen.",
+            "_key": "3e90fa8261e9"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Adopsjon barn begynt på skolen",
+    "visningsnavn": "14. Adopsjon barn begynt på skolen",
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "c5f935337725",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "d6bd2f8c8da90"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "3b1e5b991cdd"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " . ",
+            "_key": "de46d3057f3f"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "219021b1a769",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bur i ",
+            "_key": "017b31b62343",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "2cf8f2deea0c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Du og den andre forelderen bur i Noreg. Det er ikkje rett til kontantstøtte frå ",
+            "_key": "faada15b2a54"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "dd5589c55466"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi vi har kome fram til at norsk lovgjevnad gjeld for barnet. Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "0600aac76c30"
+          }
+        ]
+      }
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "acf8b1f0076b0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født "
+          },
+          {
+            "_key": "aa7e4db387ba",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " . ",
+            "_key": "8a31955010f8"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "abb3f13de7a9",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "cc6390830817"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "86c7f6740972"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Du og den andre forelderen bor i Norge. Det er ikke rett til kontantstøtte fra ",
+            "_key": "aa2f5193bf4c"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "eddf5eb2bd9a"
+          },
+          {
+            "text": " fordi vi har kommet fram til at norsk lovgivning gjelder for barnet. Du får derfor hele kontantstøtten fra Norge. ",
+            "_key": "f2fa917b3d36",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "af7840994146"
+      }
+    ],
+    "navnISystem": "Primærland begge foreldre bosatt i Norge",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "visningsnavn": "3. Primærland begge foreldre bosatt i Norge",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "_createdAt": "2023-12-19T09:45:49Z",
+    "apiNavn": "innvilgetPrimarlandBeggeForeldreBosattINorge",
+    "_rev": "AOUa26DfnB8ntJraK4xvSd",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_id": "ksBegrunnelse-d3b1258b-cf56-490e-b5a8-130dd459ae7d",
+    "_updatedAt": "2023-12-20T20:42:40Z"
+  },
+  {
+    "tema": "EØS",
+    "_createdAt": "2024-01-08T14:44:55Z",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "apiNavn": "innvilgetTilleggstekstNullutbetaling",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_updatedAt": "2024-01-08T14:44:55Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten i ",
+            "_key": "3233627cedc20"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "63adf1b5f80a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er høyere enn norsk kontantstøtte. Derfor får du ikke utbetalt kontantstøtte fra Norge.",
+            "_key": "d6dc112efbe2"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b59fbc66d743",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Tilleggstekst nullutbetaling",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTnzeFGb",
+    "resultat": "INNVILGET",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "visningsnavn": "22. Tilleggstekst nullutbetaling",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "nynorsk": [
+      {
+        "_key": "0ab23e1233bf",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "b40834a4d3da0",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta i "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "12979699a132"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er høgare enn norsk kontantstøtte. Derfor får du ikkje utbetalt kontantstøtte frå Noreg.",
+            "_key": "97d794d88054"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_id": "ksBegrunnelse-d42865ed-a073-457e-bcdf-d0c087dc79da"
+  },
+  {
+    "apiNavn": "innvilgetPrimarlandToArbeidslandNorgeUtbetaler",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "kompetanseResultat": [
+      "TO_PRIMÆRLAND"
+    ],
+    "_id": "ksBegrunnelse-d49845cd-cd99-47be-83bd-7fb1bcd14cdb",
+    "resultat": "INNVILGET",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "ec24a4b83bb60",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "650a8808682d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "b645d2b71e5a"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e8510efd8d30",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "text": ". ",
+            "_key": "5a013d8e48dc",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a1af2e8a72a1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "b72f863a6024"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "de5c9d6f8219"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i ",
+            "_key": "e6e9b1a592fc"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "e7ff5d7b8137"
+          },
+          {
+            "_key": "69b64d414955",
+            "_type": "span",
+            "marks": [],
+            "text": ". Du og den andre forelderen har rett til kontantstøtte fra Norge og "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "6072d26bcd45"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi dere jobber i andre land enn der ",
+            "_key": "4015d2f9545e"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "723fb99ce514",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " bor. Landet med den høyeste kontantstøtten skal utbetale. Norsk kontantstøtte er høyere enn kontantstøtten i ",
+            "_key": "274b54718bdd",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "b617f642f050"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "246ecf744584"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "835473ab75c5"
+      }
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON"
+    ],
+    "navnISystem": "Primærland to arbeidsland Norge utbetaler",
+    "visningsnavn": "12. Primærland to arbeidsland Norge utbetaler",
+    "_rev": "5r7yBuU8wKOiVHJijMVJpP",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "tema": "EØS",
+    "_updatedAt": "2024-01-09T15:27:15Z",
+    "hjemlerEOSForordningen987": [
+      "58"
+    ],
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "844e9731fe5b0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "f3ad5b019861"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "3cd893251a88"
+          },
+          {
+            "_key": "d3d04e3e6c27",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": ". ",
+            "_key": "102909101703",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "f8b6e087a698",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "2dc77dcf183f",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "_key": "9b4394b5a456",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "5676cf77c954",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "f4a9c92d5945"
+          },
+          {
+            "_key": "52c025e5235a",
+            "_type": "span",
+            "marks": [],
+            "text": ". Du og den andre forelderen har rett til kontantstøtte frå Noreg og "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "3e3b627f01e9"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi de jobbar i andre land enn der ",
+            "_key": "c26c5f0d8d8f"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "1b2d1e8e546f",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "text": " bur. Landet med den høgaste kontantstøtta skal utbetale. Norsk kontantstøtte er høgare enn kontantstøtta i ",
+            "_key": "cca76ca185e4",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "c32338983b40"
+          },
+          {
+            "_key": "bb56bf4db947",
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor heile kontantstøtta frå Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "5bc155f8b34a"
+      }
+    ],
+    "_createdAt": "2023-12-20T20:00:09Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ]
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "apiNavn": "opphorForeldreneBorSammen",
+    "_rev": "XYs5CWqIz9KsYqFMgfnSgp",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "visningsnavn": "17. Foreldrene bor sammen",
+    "nynorsk": [
+      {
+        "_key": "5f69f4461d98",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "e3de212660270",
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har søkt om kontantstøtte for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "87d5396d3774"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "d9e699b97884"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_id": "ksBegrunnelse-d5182b53-cefb-4a0d-8819-70071f29367f",
+    "_updatedAt": "2023-07-21T15:31:41Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "c4e67e3e59f9",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har søkt om kontantstøtte for barn født ",
+            "_key": "86b07487b60d0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "89d3f51c1934"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "422f3ae389c8"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Foreldrene bor sammen",
+    "hjemler": [
+      "3",
+      "8",
+      "9"
+    ],
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-07-21T15:31:41Z"
+  },
+  {
+    "visningsnavn": "4. Bosatt i Norge",
+    "_rev": "99hNjwNJwgiqUCCUQZx7Mh",
+    "tema": "NASJONAL",
+    "navnISystem": "Bosatt i Norge",
+    "hjemler": [
+      "3"
+    ],
+    "_type": "ksBegrunnelse",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "078f37d09e53",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "5b9746837e320"
+          },
+          {
+            "_key": "f9bb756be9f0",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "20cb32533ecf"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "2b6361081f56",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er bosatt i Norge.",
+            "_key": "5b9746837e326"
+          }
+        ]
+      }
+    ],
+    "type": "TILLEGGSTEKST",
+    "_id": "ksBegrunnelse-d61b14f7-4085-49ab-87b0-31f70f934843",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_key": "888e673e11ff0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd "
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "3aee41aa512d",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at ",
+            "_key": "99e12ccdce16"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "411b1b2b240b",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            }
+          },
+          {
+            "_key": "888e673e11ff6",
+            "_type": "span",
+            "marks": [],
+            "text": " er busett i Noreg. "
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4465230581e7",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2022-12-07T14:42:38Z",
+    "_updatedAt": "2022-12-16T08:48:18Z",
+    "apiNavn": "innvilgetBosattINorge",
+    "resultat": "INNVILGET"
+  },
+  {
+    "_rev": "5r7yBuU8wKOiVHJijJavC7",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "_updatedAt": "2024-01-05T16:47:32Z",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "870f5340d195",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "e979d6de5f640",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte frå same tidspunkt som utbetalinga til den andre forelderen er stansa."
+          }
+        ]
+      }
+    ],
+    "bokmaal": [
+      {
+        "_key": "7aa796d9ced5",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fra samme tidspunkt som utbetalingen til den andre forelderen er stanset.",
+            "_key": "a87606bb489f0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2024-01-05T16:47:32Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "navnISystem": "Kontantstøtte allerede utbetalt",
+    "apiNavn": "innvilgetKontantstotteAlleredeUtbetalt",
+    "hjemler": [
+      "9"
+    ],
+    "visningsnavn": "19. Kontantstøtte allerede utbetalt",
+    "tema": "EØS",
+    "_id": "ksBegrunnelse-d61bc78f-d5e7-4c9e-806c-46cfa55833e7"
+  },
+  {
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "resultat": "FORTSATT_INNVILGET",
+    "tema": "NASJONAL",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED"
+    ],
+    "_id": "ksBegrunnelse-d6dca7d6-064a-4096-a74e-de098dc13cf7",
+    "visningsnavn": "8. Fortsatt avtale om delt bosted",
+    "_rev": "QYE1lVUzcrAawv9ECZmajg",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi du fortsatt har avtale om delt bustad for ",
+            "_key": "37893019e4040",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "a3ddfd580859",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "33ad704440b0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "7d8d55c7a91f",
+        "markDefs": []
+      }
+    ],
+    "_updatedAt": "2023-12-12T12:18:12Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi du fortsatt har avtale om delt bosted for ",
+            "_key": "f3697445010d0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "074685ea15ba",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "b6e1f38091ed"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b160c43deb8b"
+      }
+    ],
+    "navnISystem": "Fortsatt avtale om delt bosted",
+    "apiNavn": "fortsattInnvilgetFortsattAvtaleOmDeltBosted",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_createdAt": "2023-12-12T12:18:12Z"
+  },
+  {
+    "apiNavn": "avslagVurderingDenAndreForelderenIkkeMedlemFolketrygdenEllerEOSIFemAar",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "tema": "NASJONAL",
+    "visningsnavn": "33. Vurdering den andre forelderen ikke medlem folketrygden eller EØS i fem år",
+    "_updatedAt": "2023-05-04T18:17:47Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "cc90d82facca",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at den andre forelderen ikke har vært medlem i folketrygden eller i trygdeordninger i andre EØS-land i til sammen fem år.",
+            "_key": "a480382ddef70"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Vurdering den andre forelderen ikke medlem folketrygden eller EØS i fem år",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_key": "7d39b8c14ba0",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "daf34119397d0",
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at den andre forelderen ikkje har vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-05-04T18:17:47Z",
+    "_rev": "CKoJmXlM50fHJKgxS5Omno",
+    "resultat": "AVSLAG",
+    "_id": "ksBegrunnelse-d755f5b6-b38f-4d81-934a-a92d3ea1f9f8"
+  },
+  {
+    "_id": "ksBegrunnelse-d8329907-e55d-470c-a388-387731c586ba",
+    "_updatedAt": "2024-01-09T16:48:10Z",
+    "_rev": "eS4Wb2bsh0R4qyDTo1QBFB",
+    "tema": "EØS",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "8d997f11e28a",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at du ikkje har ansvar for ",
+            "_key": "dcd1f483ec540"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "46b4a0344905",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "1ea8731fd22f"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "bokmaal": [
+      {
+        "_key": "159c85482c2c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at du ikke har ansvar for ",
+            "_key": "8a734a8d58ea0"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2",
+            "_key": "021033560392",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "06adbd4d3dee"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "visningsnavn": "13. Vurdering ikke ansvar for barn",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "navnISystem": "Vurdering ikke ansvar for barn",
+    "apiNavn": "avslagVurderingIkkeAnsvarForBarn",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_createdAt": "2024-01-09T16:48:10Z"
+  },
+  {
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "visningsnavn": "13. Ikke oppholdstillatelse mer enn 12 måneder",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "navnISystem": "Ikke oppholdstillatelse mer enn 12 måneder",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "3d917bfd1bbd",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "a5aef262cbad"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "fc7bd70eadb5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje har opphaldsløyve i Noreg i meir enn 12 månader.",
+            "_key": "adea826f571d0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_id": "ksBegrunnelse-d84e2612-1b49-43fd-b065-448e81810ac4",
+    "apiNavn": "avslagIkkeOppholdstillatelseMerEnnTolvMaaneder",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "RiR9GraBD8hopeC5h7IoX3",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "_createdAt": "2023-05-04T09:22:27Z",
+    "_updatedAt": "2023-05-04T09:22:27Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "eccf35d8529d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "dc6f00b88bf2"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0f655852d307",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har oppholdstillatelse i Norge i mer enn 12 måneder.",
+            "_key": "60a256e4e7a30"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får kontantstøtte fordi ",
+            "_key": "0c79ebe4fa1f0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0c03e1b84ca4",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " fortsatt bur hos deg..",
+            "_key": "2bc60cc75852",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "77365c80c1f7"
+      }
+    ],
+    "_createdAt": "2023-12-12T11:53:08Z",
+    "apiNavn": "fortsattInnvilgetBarnBorMedSoker",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "3. Barn bor med søker",
+    "_type": "ksBegrunnelse",
+    "navnISystem": "Barn bor med søker",
+    "_rev": "AOUa26DfnB8ntJraJzw3p3",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-12-12T11:53:08Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fordi ",
+            "_key": "2791dcd484c30"
+          },
+          {
+            "_key": "ae65d9b906c9",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_key": "2791dcd484c32",
+            "_type": "span",
+            "marks": [],
+            "text": " fortsatt bor hos deg. "
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "946bfa7b64b3"
+      }
+    ],
+    "resultat": "FORTSATT_INNVILGET",
+    "_id": "ksBegrunnelse-d8edd042-fb6b-4e36-871b-7c2ee341ebd6"
+  },
+  {
+    "visningsnavn": "29. Vurdering ikke medlem folketrygden eller EØS i 5 år",
+    "resultat": "OPPHØR",
+    "bokmaal": [
+      {
+        "_key": "618ee2524733",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "93bed075c7160"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "efc1bf63fe1d",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "93bed075c7166",
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden eller i trygdeordninger i andre EØS-land i til sammen fem år."
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-07-24T07:48:48Z",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "_createdAt": "2023-07-24T07:48:48Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "navnISystem": "Vurdering ikke medlem folketrygden eller EØS i 5 år",
+    "apiNavn": "opphorVurderingIkkeMedlemIFolketrygdenEllerEosI5Aar",
+    "_rev": "Xl0tn62zVopahRtC7KzQ4l",
+    "type": "STANDARD",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "e5ce3ed533730"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "819673ba4bdf",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " har ikkje vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år.",
+            "_key": "e5ce3ed533736",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b3f845fee73c",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-d9ceaeae-e544-4ce9-b908-72b568e8337d"
+  },
+  {
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_updatedAt": "2024-01-08T13:58:52Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "7a6126698373",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten kan ikke deles etter EØS reglene. Du får derfor hele kontantstøtten for barn født ",
+            "_key": "19c9d3e6daa20"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "f6003b462709"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", som du har avtale om delt bosted for.",
+            "_key": "c0d875da50c7"
+          }
+        ]
+      }
+    ],
+    "visningsnavn": "35. Tilleggstekst primær delt bosted annen forelder ikke rett",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_rev": "q5JgLByi60irF5LU0HtpgM",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "hjemler": [
+      "9"
+    ],
+    "apiNavn": "innvilgetTilleggstekstPrimarlandDeltBostedAnnenForelderIkkeRett",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "navnISystem": "Tilleggstekst primær delt bosted annen forelder ikke rett",
+    "_createdAt": "2024-01-08T13:42:57Z",
+    "_id": "ksBegrunnelse-d9d3cace-d0e8-4d51-91d1-49069c049de3",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "c83603f488e9",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtta kan ikkje delast etter EØS reglane. Du får derfor heile kontantstøtta for barn fødd ",
+            "_key": "512b0d2a76a50",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "ad6a05206a40"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", som du har avtale om delt bustad for.",
+            "_key": "24072693047f"
+          }
+        ],
+        "_type": "block"
+      }
+    ]
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "tema": "NASJONAL",
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "_createdAt": "2023-04-14T19:59:43Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "605d94c5f574",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "3159cb24daaa0",
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at den andre forelderen ikke har vært medlem i folketrygden i fem år."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Vurdering den andre forelderen ikke medlem i 5 år ",
+    "apiNavn": "avslagVurderingDenAndreForelderenIkkeMedlemIFemAar",
+    "_rev": "4MfBp9HJw6JHUbUYbY7On7",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at den andre forelderen ikkje har vore medlem i folketrygda i fem år.",
+            "_key": "3fdc32ad44580"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9fb1dfba6c5d",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "29. Vurdering den andre forelderen ikke medlem i 5 år ",
+    "_id": "ksBegrunnelse-da3d7f1c-a911-44c3-bcc4-4b469ea969ca",
+    "_updatedAt": "2023-04-25T13:16:38Z"
+  },
+  {
+    "type": "STANDARD",
+    "navnISystem": "Ikke Student",
+    "eosVilkaar": [
+      "LOVLIG_OPPHOLD"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_id": "ksBegrunnelse-db9c72c6-e7d6-4cf9-a35f-a13a3f8ce42f",
+    "apiNavn": "avslagIkkeStudent",
+    "visningsnavn": "11. Ikke student",
+    "_rev": "eS4Wb2bsh0R4qyDTo1Pmwr",
+    "_updatedAt": "2024-01-09T16:43:11Z",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "cd234d147895",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje studerar ved ein godkjend utdanningsinstitusjon.",
+            "_key": "15b44a3649cf0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "a9ba977d01b4",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikke studerer ved en godkjent utdanningsinstitusjon.",
+            "_key": "fd9607d996fe0"
+          }
+        ]
+      }
+    ],
+    "resultat": "AVSLAG",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_createdAt": "2024-01-09T16:43:11Z"
+  },
+  {
+    "_createdAt": "2023-05-04T18:15:27Z",
+    "apiNavn": "avslagVurderingIkkeMedlemFolketrygdenEllerEOSIFemAar",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "tema": "NASJONAL",
+    "navnISystem": "Vurdering ikke medlem folketrygden eller EØS i 5 år ",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "_updatedAt": "2023-05-04T18:15:27Z",
+    "_rev": "lxTMP95K2WARLoXUTuVVC2",
+    "_id": "ksBegrunnelse-dbd25873-5cbf-4c2b-9481-452dc664555a",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at ",
+            "_key": "5e249dcbd7d60"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "056d93077a93",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "5e249dcbd7d68",
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden eller i trygdeordninger i andre EØS-land i til sammen fem år."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c2a23c5a497d"
+      }
+    ],
+    "visningsnavn": "32. Vurdering ikke medlem folketrygden eller EØS i 5 år ",
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kome fram til at ",
+            "_key": "81677a5615050"
+          },
+          {
+            "_key": "0b10006d6623",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje har vore medlem i folketrygda og trygdeordningar i andre EØS-land i til saman fem år.",
+            "_key": "81677a5615054"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e61b2c60d460",
+        "markDefs": []
+      }
+    ]
+  },
+  {
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "navnISystem": "Primærland særkullsbarn/andre barn",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "1526d62a181c",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "2c5df8543abe0",
+            "_type": "span"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "3b8bd4b3b0b9",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "6abed2302461",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cddac4741d94"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "9d96bdd464f4"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "bd141ef35e2f",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_key": "e4d485a5a6b5",
+            "_type": "span",
+            "marks": [],
+            "text": " bur i "
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "a8d309827035"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Du har ansvar for ",
+            "_key": "0bf56cb9022d"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "4252ebc29e14",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "62d652dbee7c"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_id": "ksBegrunnelse-dc3c3bf7-0194-49bf-a6b5-97787b8ea25a",
+    "visningsnavn": "10.  Primærland særkullsbarn/andre barn",
+    "_createdAt": "2023-12-19T15:48:48Z",
+    "annenForeldersAktivitet": [
+      "MOTTAR_PENSJON",
+      "IKKE_AKTUELT"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "9b2777237e48",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "7d39faa5df800"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "498b0455db28"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "f9e2e2bf0d6b"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "92482420aeb5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "ea5965be819d"
+          },
+          {
+            "_key": "86e1fa8db737",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "283f4b1ce12b"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "2606f47e8d21"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Du har ansvar for ",
+            "_key": "8a7b9c89b772"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d10593122874",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "8aa04d7ae564"
+          }
+        ]
+      }
+    ],
+    "apiNavn": "innvilgetPrimarlandSarkullsbarnAndreBarn",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "tema": "EØS",
+    "_updatedAt": "2024-01-09T15:25:15Z",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijMVFiR",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET"
+  },
+  {
+    "_updatedAt": "2023-07-21T15:15:01Z",
+    "visningsnavn": "13. Ikke oppholdsrett EØS-borger",
+    "_rev": "0w3lID6Lsk7VK2mhOEJ4cb",
+    "type": "STANDARD",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_createdAt": "2023-07-21T15:15:01Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-dc83ed15-68fb-4657-8529-4771de1f81dc",
+    "navnISystem": "Ikke oppholdsrett EØS-borger",
+    "apiNavn": "opphorIkkeOppholdsrettEOSBorger",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "fe279c6a2205",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Vi har kome fram til at du ikkje lenger har oppholdsrett i Noreg som EØS-borger frå ",
+            "_key": "d989740b46d50",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "d09f5d18982e"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "e528a789630c"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "resultat": "OPPHØR",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vi har kommet fram til at du ikke lenger har oppholdsrett i Norge som EØS-borger i Norge fra ",
+            "_key": "5d80e63d35e50"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "cd3fac850d02"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "7c08a81e2897"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "3ec2ebd76367",
+        "markDefs": []
+      }
+    ]
+  },
+  {
+    "hjemler": [
+      "2",
+      "7",
+      "8"
+    ],
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får uendret kontantstøtte for barn født ",
+            "_key": "381d4efaa6570",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "383c9b7506bb"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "822a2bf2277e"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "d8f5571146a2",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364"
+            }
+          },
+          {
+            "_key": "381d4efaa6572",
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt "
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "29b95f798573"
+          },
+          {
+            "_key": "8f8e9479cb85",
+            "_type": "span",
+            "marks": [],
+            "text": " timer i barnehagen per uke. Du har rett til den samme utbetalingen som tidligere."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b63363ee9770"
+      },
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "",
+            "_key": "1d862f72743e0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f28916cb4e80",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "fortsattInnvilgetDeltidsplassIBarnehage",
+    "_rev": "CM6961CqAC7W4puPR0Qpn6",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-12-12T15:11:55Z",
+    "visningsnavn": "11. Deltidsplass i barnehage",
+    "resultat": "FORTSATT_INNVILGET",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "nynorsk": [
+      {
+        "_key": "a0c99a74bfdb",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "c741a493f46a0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendra kontantstøtte for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "31e223e6efff"
+          },
+          {
+            "_key": "8e32cbf80e4e",
+            "_type": "span",
+            "marks": [],
+            "text": ". "
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "0fdd206bd37a",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "er tildelt ",
+            "_key": "c741a493f46a2"
+          },
+          {
+            "flettefelt": "antallTimerBarnehageplass",
+            "_type": "flettefelt",
+            "_key": "8541ef818003"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " timar i barnehagen per veke. Du har rett til den same utbetalinga som før.",
+            "_key": "539c8791a075"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      },
+      {
+        "_key": "bbff5e13c475",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "60a3da277f0d0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2023-12-12T15:05:32Z",
+    "_id": "ksBegrunnelse-dc980d97-612d-4993-88fb-46d465e408a1",
+    "navnISystem": "Deltidsplass i barnehage"
+  },
+  {
+    "navnISystem": "Barnet bodde ikke fast hos søker",
+    "visningsnavn": "19. Barnet bodde ikke fast hos søker",
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtta er endra fordi vi har kome fram til at barn fødd ",
+            "_key": "62082d5fa79f0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "a6a37eaeffa5"
+          },
+          {
+            "marks": [],
+            "text": " ikkje budde fast hos deg. ",
+            "_key": "8fbe3d96c307",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4ffeb68c9ddf"
+      }
+    ],
+    "_createdAt": "2023-05-03T15:55:12Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtte endres fordi vi har kommet fram til at barn født ",
+            "_key": "5c8f64feed090"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "f35c1bb419a7"
+          },
+          {
+            "text": "] ikke bodde fast hos deg. ",
+            "_key": "9b2de6b35381",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e619fa9261d6",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-dd80d8a9-2c7c-4b2d-b65a-97b7fbe89b72",
+    "_updatedAt": "2023-05-03T15:55:12Z",
+    "hjemler": [
+      "3"
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "apiNavn": "reduksjonBarnetBoddeIkkeFastHosSoker",
+    "_rev": "RiR9GraBD8hopeC5h6Iw4F",
+    "_type": "ksBegrunnelse",
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ]
+  },
+  {
+    "_rev": "u4Z6kQR2byZlf6vx9I9AhU",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-de3124ae-10dc-463c-b3f8-00852b363cc1",
+    "_updatedAt": "2022-12-08T11:21:23Z",
+    "apiNavn": "innvilgetRettsavgjorelseBorFastHosSoker",
+    "hjemler": [
+      "3"
+    ],
+    "nynorsk": [
+      {
+        "_key": "b96835b49b78",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte frå månaden etter det vart bestemt at barn fødd ",
+            "_key": "e1d8a5aba32b0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "ad748d105a62"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " skal bu fast hos deg.",
+            "_key": "ba13c75ab219"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2022-12-08T11:21:23Z",
+    "resultat": "INNVILGET",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte fra måneden etter at det ble bestemt at barn født ",
+            "_key": "001de25982db0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "9893c4ca9d2a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " skal bo fast hos deg.",
+            "_key": "e1d796db0561"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4b37ab7d92ec",
+        "markDefs": []
+      }
+    ],
+    "navnISystem": "Rettsavgjørelse bor fast hos søker",
+    "visningsnavn": "17. Rettsavgjørelse bor fast hos søker",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST"
+  },
+  {
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_rev": "eS4Wb2bsh0R4qyDTo1KPFZ",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2"
+    ],
+    "_id": "ksBegrunnelse-de834f21-79ef-4b19-8163-66c0e881aaa8",
+    "bokmaal": [
+      {
+        "_key": "406200f0bde7",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du ikke er EØS-borger.",
+            "_key": "656641be19f80",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje er EØS-borgar.",
+            "_key": "3d071272c40d0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "a87b62476eb5",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "visningsnavn": "1. Ikke EØS-borger",
+    "tema": "EØS",
+    "_createdAt": "2024-01-09T15:18:17Z",
+    "navnISystem": "Ikke EØS-borger",
+    "apiNavn": "avslagIkkeEosBorger",
+    "resultat": "AVSLAG",
+    "_updatedAt": "2024-01-09T15:18:17Z"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "resultat": "INNVILGET",
+    "_id": "ksBegrunnelse-de83d448-1b68-432e-acb2-63d2caadcc91",
+    "navnISystem": "Sekundærland begge foreldre bosatt i Norge",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "tema": "EØS",
+    "_createdAt": "2024-01-08T21:32:03Z",
+    "barnetsBostedsland": [
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T21:32:03Z",
+    "visningsnavn": "34. Sekundærland begge foreldre bosatt i Norge",
+    "_rev": "5r7yBuU8wKOiVHJijLZ1Ux",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "38fc55bb734b0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "3766261c59aa"
+          },
+          {
+            "text": ". ",
+            "_key": "8bcd22acd2a5",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "07f86d841cf6",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " bur i ",
+            "_key": "078c2e4a1327",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "25f3cc9889f5"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Du og den andre forelderen bur i Noreg. Du og den andre forelderen er ikkje i arbeidsaktivitet i Noreg. ",
+            "_key": "7ef0e2d7524e"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "23b02616f435"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har hovudansvaret for utbetaling av kontantstøtte fordi vi har kome fram til at lovgjevnaden i ",
+            "_key": "430e0a74dd0a"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "dfe7ac90aa63",
+            "flettefelt": "barnetsBostedsland"
+          },
+          {
+            "text": " gjeld for barnet. Noreg utbetalar derfor forskjellen mellom kontantstøtta i ",
+            "_key": "226c84d862f7",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "9fcc41208a2a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og norsk kontantstøtte.",
+            "_key": "88f7eb7681ba"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "8ab7ec4c69b8"
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "3ca985847617",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "5a2f587c44290"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "bcefa1a591a8"
+          },
+          {
+            "text": ". ",
+            "_key": "b900f2875239",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "b298a580d441",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i ",
+            "_key": "da1b69b90218"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "2182b65b951d"
+          },
+          {
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Du og den andre forelderen bor i Norge. Du og den andre forelderen er ikke i arbeidsaktivitet i Norge. ",
+            "_key": "efffec550c70",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "e6f1133c3acb"
+          },
+          {
+            "_key": "37b9f05e62a1",
+            "_type": "span",
+            "marks": [],
+            "text": " har hovedansvaret for utbetaling av kontantstøtte fordi vi har kommet fram til at lovgivningen i "
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "b30aa54675bb"
+          },
+          {
+            "_key": "c431b367415c",
+            "_type": "span",
+            "marks": [],
+            "text": " gjelder for barnet. Norge utbetaler derfor forskjellen mellom kontantstøtten i "
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "8977c0073a8d"
+          },
+          {
+            "text": " og norsk kontantstøtte.",
+            "_key": "02a4c2e8236f",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "apiNavn": "innvilgetSekundarlandBeggeForeldreBosattINorge",
+    "type": "STANDARD",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "type": "TILLEGGSTEKST",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får hele kontantstøtten. Norge utbetaler for barn født ",
+            "_key": "437d8f1470c50",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "d0a1b0befdf1",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": " som har delt bosted. Du og den andre forelderen er ikke enige om å dele kontantstøtten. Kontantstøtten kan først deles fra måneden etter at dere er enige om at kontantstøtten skal deles.",
+            "_key": "cc43a3ee924c",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "7f1ab48b8dc3"
+      }
+    ],
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "resultat": "INNVILGET",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2024-01-08T21:23:30Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_updatedAt": "2024-01-08T21:23:30Z",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "visningsnavn": "32. Tilleggstekst sekundær delt bosted annen forelder ikke søkt",
+    "_id": "ksBegrunnelse-ded0d55f-9ab7-47f5-8451-44f0b741ce06",
+    "apiNavn": "innvilgetTilleggstekstSekundarDeltBostedAnnenForeldreIkkeSokt",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får heile kontantstøtta. Noreg utbetalar for barn fødd ",
+            "_key": "48cdcc624a900"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "2a8cd9fd0d7c",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " som har delt bustad. Du andre forelderen er ikkje samde om å dele kontantstøtta. Kontantstøtta kan først delast frå månaden etter de er samde om at kontantstøtta kan delast.",
+            "_key": "8d9faef0053a"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e1034555fd8e",
+        "markDefs": []
+      }
+    ],
+    "tema": "EØS",
+    "navnISystem": "Tilleggstekst sekundær delt bosted annen forelder ikke søkt",
+    "_rev": "5r7yBuU8wKOiVHJijLYaWx"
+  },
+  {
+    "navnISystem": "Får dagpenger fra annet EØS land",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "5edab8b93acd",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får dagpenger fra et annet EØS-land når du bor i Norge. Vi har derfor kommet fram til at lovgivningen i det andre EØS-landet gjelder for deg.",
+            "_key": "e037b907bbec0"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "15. Får dagpenger fra annet EØS land",
+    "_rev": "eS4Wb2bsh0R4qyDTo1mHCz",
+    "type": "STANDARD",
+    "eosVilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får dagpengar frå eit anna EØS-land når du bur i Noreg. Vi har derfor kome fram til at lovgjevnaden i det andre EØS-landet gjeld for deg.",
+            "_key": "f0c852d8e7ed0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "c466e8fe0f20",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2024-01-09T16:54:22Z",
+    "apiNavn": "avslagForDagpengerFraAnnetEosLand",
+    "_id": "ksBegrunnelse-df07bd32-10a6-4245-9774-508e3a21fed5",
+    "_updatedAt": "2024-01-09T23:11:57Z"
+  },
+  {
+    "visningsnavn": "28. Sekundærland UK to arbeidsland Norge utbetaler",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "ed0deb0995740"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "a23cf452ad5a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "a205aef69731"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "e4eee75dd356",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "6d797d676780"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "81ecdde4dde3",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bor i Norge, og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i ",
+            "_key": "69b43714253a"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "4bb7ff609701"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Landene dere jobber i har hovedansvar for utbetaling av kontantstøtte. Norsk kontantstøtte er høyere enn kontantstøtten i ",
+            "_key": "c47fa882d83d"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "7ad16ef2ba67"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og i ",
+            "_key": "a34e96413cf8"
+          },
+          {
+            "_key": "39efeac93a64",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".  Norge utbetaler derfor forskjellen mellom kontantstøtten i disse landene og norsk kontantstøtte.",
+            "_key": "c11de6b862e9"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4ba14f84aae8"
+      },
+      {
+        "style": "normal",
+        "_key": "50b07d720988",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "\n",
+            "_key": "10f1735cb82c0",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "resultat": "INNVILGET",
+    "_updatedAt": "2024-01-10T08:06:55Z",
+    "barnetsBostedsland": [
+      "NORGE"
+    ],
+    "apiNavn": "innvilgetSekundarlandUKToArbeidslandNorgeUtbetaler",
+    "_rev": "q5JgLByi60irF5LU0Kzsio",
+    "_type": "ksBegrunnelse",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "acb42b90dcde",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "b5fc06ca995d0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "b721e98e1a27"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "d246361dc9dc",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ba28bf95c27b",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "f6b68fa0aeb5"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "594382ad6fd2",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i Noreg, og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "01a6d02f3880"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "bee2fcaacbeb"
+          },
+          {
+            "marks": [],
+            "text": ". Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Landa de jobbar i har hovudansvar for utbetaling av kontantstøtte. Norsk kontantstøtte er høgare enn kontantstøtta i ",
+            "_key": "0d63f6638cdb",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "c6d5ace8e979"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " og i ",
+            "_key": "5e0997dfa362"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "1dd87b6630c2",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_key": "3fa616b1f601",
+            "_type": "span",
+            "marks": [],
+            "text": ". Noreg utbetalar derfor forskjellen mellom kontantstøtta i desse landa og norsk kontantstøtte."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2024-01-08T21:12:11Z",
+    "_id": "ksBegrunnelse-df31347b-e62e-4d70-8d05-4bf92e700de3",
+    "annenForeldersAktivitet": [
+      "I_ARBEID"
+    ],
+    "navnISystem": "Sekundærland UK to arbeidsland Norge utbetaler",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ]
+  },
+  {
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "NORGE_ER_SEKUNDÆRLAND",
+      "TO_PRIMÆRLAND"
+    ],
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "Den andre forelderen ikkje ",
+            "_key": "9e9fc7bdf86c0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "951b3dc12e2f",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjeld derfor ikkje for den andre forelderen, og du har ikkje lenger rett til kontantstøtte for barn fødd ",
+            "_key": "91fe87ab82ac"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "74f87520aa62"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " frå Noreg. ",
+            "_key": "e71e6ff9e48c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "07ef926b3366",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2023-12-19T13:40:59Z",
+    "_id": "ksBegrunnelse-df5c8edc-3613-459f-a82b-dcf4b9a6ed92",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "apiNavn": "opphorSelvstendigRettOpphor",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "15. Selvstendig rett opphør",
+    "stotterFritekst": false,
+    "tema": "EØS",
+    "navnISystem": "Selvstendig rett opphør",
+    "_type": "ksBegrunnelse",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "_updatedAt": "2023-12-19T14:44:57Z",
+    "_rev": "AOUa26DfnB8ntJraK3wqwT",
+    "resultat": "OPPHØR",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "7d6db757ab55",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Den andre forelderen ikke ",
+            "_key": "a0433beeb8460",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "8fb11e69d2be",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder ikke for den andre forelderen, og du har ikke lenger rett til kontantstøtte for barn født ",
+            "_key": "64d5c359855b"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "fc4833e84148"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra Norge. ",
+            "_key": "1e7ffcee3f1b"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_rev": "lxTMP95K2WARLoXUTuQwii",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "c06c60e5feab",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "36b4833e3a710"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "30f7a77eb66e"
+          },
+          {
+            "_key": "750b1c461200",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje bur fast hos deg."
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-e034f704-7f96-4710-ab5a-ce984603cb8d",
+    "_updatedAt": "2023-05-04T17:57:49Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "049cc6187d90",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barn født ",
+            "_key": "7b3fe925b0300",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "199144b0ebc8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke bor fast hos deg.",
+            "_key": "403306ad3e23"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "22. Bor ikke fast hos søker",
+    "tema": "NASJONAL",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "navnISystem": "Bor ikke fast hos søker",
+    "apiNavn": "avslagBorIkkeFastHosSoker",
+    "resultat": "AVSLAG",
+    "type": "STANDARD",
+    "_createdAt": "2023-05-04T17:57:49Z"
+  },
+  {
+    "_rev": "u4Z6kQR2byZlf6vx9I9Otu",
+    "triggere": [
+      "SATSENDRING"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "6ab394dc3bdf",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtten er endret fordi det har vært en satsendring.",
+            "_key": "fa397ba2bc090",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "18. Satsendring",
+    "tema": "NASJONAL",
+    "navnISystem": "Satsendring",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi det har vore ei satsendring.",
+            "_key": "0c9ae8950a760"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b24cf2ff8427",
+        "markDefs": []
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "2692e507166c",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "\n",
+            "_key": "a1da565599c40"
+          }
+        ]
+      }
+    ],
+    "_updatedAt": "2022-12-08T11:23:17Z",
+    "apiNavn": "innvilgetSatsendring",
+    "hjemler": [
+      "7"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2022-12-08T11:23:17Z",
+    "_id": "ksBegrunnelse-e0c1117f-65a0-46d9-bf82-aefd8f3586dd"
+  },
+  {
+    "navnISystem": "Ikke bosatt i Norge fra innvilgelse",
+    "apiNavn": "opphorFraStartIkkeBosattINorge",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "16e78ada93fc",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "46bba395e296"
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4"
+            },
+            "_type": "valgfeltV2",
+            "_key": "334933838ee2",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke var bosatt i Norge.",
+            "_key": "a49ce47ed0860"
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-e1368c5e-c9e4-4bf7-ad20-ec4197789e9b",
+    "visningsnavn": "30. Ikke bosatt i Norge fra innvilgelse",
+    "_rev": "uDpwmdKblEGdbs8fmMo3ZB",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "0c68886f5c5d"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "1f85f1750d90",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            }
+          },
+          {
+            "_key": "dc86c7ff86ba0",
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje var busett i Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "627698f126c3"
+      }
+    ],
+    "_createdAt": "2023-07-24T07:56:06Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_updatedAt": "2023-07-28T11:39:10Z"
+  },
+  {
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "bokmaal": [
+      {
+        "_key": "702604749223",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "175b39632c8e0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får full kontantstøtte fra Norge fordi det ikke er rett til kontantstøtte fra "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "126e728a281e",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "bf9e8b51183e"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Tilleggstekst sekundær full utbetaling",
+    "visningsnavn": "36. Tilleggstekst sekundær full utbetaling",
+    "_type": "ksBegrunnelse",
+    "type": "TILLEGGSTEKST",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får full kontantstøtte frå Noreg fordi det ikkje er rett til kontantstøtte frå ",
+            "_key": "93322ad7644d0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "fec6dacda4cf"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "0e5114e6444f"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "bc15111a8091"
+      }
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_id": "ksBegrunnelse-e138b332-8c73-452c-8470-16cd4849d671",
+    "_updatedAt": "2024-01-08T21:36:00Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "apiNavn": "innvilgetTilleggstekstSekundarFullUtbetaling",
+    "_rev": "5r7yBuU8wKOiVHJijLZFIZ",
+    "resultat": "INNVILGET",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "_createdAt": "2024-01-08T21:36:00Z"
+  },
+  {
+    "type": "STANDARD",
+    "hjemler": [
+      "2",
+      "8"
+    ],
+    "apiNavn": "reduksjonBarnDod",
+    "_rev": "KOa0MjQMDn5FLyPT0Mo4Uv",
+    "resultat": "REDUKSJON",
+    "_id": "ksBegrunnelse-e13ac2ec-01c6-4084-8710-390c905ec34e",
+    "_updatedAt": "2023-05-03T14:59:32Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "b4bccce3fc3f",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Kontantstøtten er endret fra måneden etter at barn født ",
+            "_key": "6521760cb44a0",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "7c213cf0ecff",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "] døde.",
+            "_key": "71aaf8955f74"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Barn død",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra frå månaden etter at barn fødd ",
+            "_key": "ab7c402802ac0"
+          },
+          {
+            "_key": "bd05556cf263",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "text": "] døydde. ",
+            "_key": "66910be47af0",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4b8d50d1a503",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2023-05-03T14:59:32Z",
+    "tema": "NASJONAL",
+    "_type": "ksBegrunnelse",
+    "triggere": [
+      "BARN_DØD"
+    ],
+    "visningsnavn": "6. Barn død"
+  },
+  {
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_createdAt": "2023-05-04T17:43:35Z",
+    "_id": "ksBegrunnelse-e2af8938-d24c-4c2a-a4ed-5213ca643b2b",
+    "_updatedAt": "2023-05-04T17:43:35Z",
+    "apiNavn": "avslagDenAndreForelderenHarSokt",
+    "_type": "ksBegrunnelse",
+    "resultat": "AVSLAG",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "_rev": "lxTMP95K2WARLoXUTuJe6C",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "d3ec2c62a1f8",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har søkt om kontantstøtte for barn født ",
+            "_key": "e40fa9a1bcbb0"
+          },
+          {
+            "_key": "18f933b410f7",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "750223050918"
+          }
+        ]
+      },
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "b60dada712a8",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "\n",
+            "_key": "d66ae6821fa20",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Den andre forelderen har søkt",
+    "hjemler": [
+      "3",
+      "8",
+      "9"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har søkt om kontantstøtte for barn fødd ",
+            "_key": "697cf3c359e20"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c0a3a5cf8680"
+          },
+          {
+            "text": ".",
+            "_key": "b628d91d693f",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "0a433d1847c4",
+        "markDefs": []
+      }
+    ],
+    "visningsnavn": "17. Den andre forelderen har søkt",
+    "tema": "NASJONAL"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "hjemlerEOSForordningen987": [
+      "60"
+    ],
+    "navnISystem": "Selvstendig rett tilleggsbegrunnelse vedtak før SED",
+    "visningsnavn": "52. Selvstendig rett tilleggsbegrunnelse vedtak før SED",
+    "type": "TILLEGGSTEKST",
+    "tema": "EØS",
+    "_id": "ksBegrunnelse-e2bf18c3-9b72-4b4b-8287-32e773323fb5",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND",
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T22:49:20Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "5474d52ae6fc",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vedtaket er gjort før vi har fått opplysninger fra ",
+            "_key": "697ce812ee680"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "5fc983c8aa6b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Saken må vurderes på nytt dersom vi mottar nye opplysninger.",
+            "_key": "15042ad4f0cb"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "apiNavn": "innvilgetSelvstendigRettTilleggsbegrunnelseVedtakForSed",
+    "_rev": "eS4Wb2bsh0R4qyDTo07IPR",
+    "nynorsk": [
+      {
+        "_key": "cc387ec23e6b",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Vedtaket er gjort før vi har fått opplysningar frå ",
+            "_key": "bd1857345f470"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "cc8827949d41"
+          },
+          {
+            "text": ". Saka må vurderast på nytt dersom vi mottar nye opplysningar.",
+            "_key": "1558db77d95e",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_createdAt": "2024-01-08T22:49:20Z"
+  },
+  {
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_id": "ksBegrunnelse-e30cd910-f96b-4e23-b8a6-c60bc587320e",
+    "navnISystem": "Delt bosted praktiseres fortsatt",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "_type": "ksBegrunnelse",
+    "_rev": "CM6961CqAC7W4puPQzzB7e",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi vi har kome fram til at de fortsatt føl avtalen om delt bustad for ",
+            "_key": "30d84536ddbd0"
+          },
+          {
+            "_key": "80c178880803",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "text": ".",
+            "_key": "30d84536ddbd1",
+            "_type": "span",
+            "marks": [
+              "em"
+            ]
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "ece867b2a496"
+      }
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får delt kontantstøtte fordi vi har kommet fram til at dere fortsatt følger avtalen om delt bosted for ",
+            "_key": "efc71929f93f0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "dbaef04e105d",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [
+              "em"
+            ],
+            "text": ".",
+            "_key": "efc71929f93f1"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "662e38feb5fc"
+      }
+    ],
+    "apiNavn": "fortsattInnvilgetDeltKontantstottePraktiseresFortsatt",
+    "resultat": "FORTSATT_INNVILGET",
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-12-12T12:14:14Z",
+    "visningsnavn": "7. Delt bosted praktiseres fortsatt",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED"
+    ],
+    "_createdAt": "2023-12-12T12:14:14Z"
+  },
+  {
+    "_rev": "QYE1lVUzcrAawv9ECbRp4F",
+    "vilkaar": [
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "navnISystem": "Medlemskap folketrygden den andre forelderen",
+    "visningsnavn": "13. Medlemskap folketrygden den andre forelderen",
+    "type": "STANDARD",
+    "_updatedAt": "2023-12-13T09:46:50Z",
+    "bokmaal": [
+      {
+        "_key": "9f6b317352de",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendret kontantstøtte for barn født ",
+            "_key": "5433665616550"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "317137d969d4"
+          },
+          {
+            "text": " fordi den andre forelderen har vært medlem i folketrygden i fem år.",
+            "_key": "6842e343aef1",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "fortsattInnvilgetMedlemskapDenAndreForelderen",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "Du får uendra kontantstøtte for barn fødd ",
+            "_key": "3b3004a63a680",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "f197dcdc8a7a"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi den andre forelderen har vore medlem i folketrygda i fem år.",
+            "_key": "302affae9ebd"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "5de877647713",
+        "markDefs": []
+      }
+    ],
+    "_id": "ksBegrunnelse-e3cf0f2a-01c7-4c66-931d-30746a46ea17",
+    "_type": "ksBegrunnelse",
+    "resultat": "FORTSATT_INNVILGET",
+    "_createdAt": "2023-12-13T09:29:55Z"
+  },
+  {
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "tema": "NASJONAL",
+    "_updatedAt": "2023-12-12T15:16:16Z",
+    "apiNavn": "fortsattInnvilgetMedlemskapIFolketrygden",
+    "_type": "ksBegrunnelse",
+    "resultat": "FORTSATT_INNVILGET",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får uendra kontantstøtte for barn fødd ",
+            "_key": "83065b3d51a40"
+          },
+          {
+            "_key": "79c8f063e428",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "6746d97afa0d"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "cabf872150d1",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "83065b3d51a44",
+            "_type": "span",
+            "marks": [],
+            "text": " har vore medlem i folketrygda i fem år."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "fdcf34259b01"
+      }
+    ],
+    "_createdAt": "2023-12-12T15:16:16Z",
+    "bokmaal": [
+      {
+        "_key": "271606ee7e8c",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får uendret kontantstøtte for barn født ",
+            "_key": "c6511981dcea0",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "2e870e6f12ec",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "text": " fordi ",
+            "_key": "4bf2dd82f16a",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "517f8bb3363b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har vært medlem i folketrygden i fem år.",
+            "_key": "c6511981dcea4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Medlemskap folketrygden ",
+    "visningsnavn": "12. Medlemskap folketrygden ",
+    "_rev": "QYE1lVUzcrAawv9ECZzvQq",
+    "_id": "ksBegrunnelse-e47f5142-c2ed-40f8-8586-8aa260fc4804"
+  },
+  {
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "acf115b109cb"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ad132b16f6eb"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har flyttet fra Norge i ",
+            "_key": "0530c3720a860"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "0c722ce53304"
+          },
+          {
+            "text": ".",
+            "_key": "361965daad80",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "809e544a28cb"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "c3aeb38058f3",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "fb62fe6b5722",
+            "_type": "span",
+            "marks": [],
+            "text": ""
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "1b7383ae853c",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " har flytta frå Noreg i ",
+            "_key": "e5bb54bec9380",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "aa27cd556bc6",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor"
+          },
+          {
+            "_key": "b20007da8d94",
+            "_type": "span",
+            "marks": [],
+            "text": "."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Flyttet fra Norge",
+    "apiNavn": "opphorFlyttetFraNorge",
+    "visningsnavn": "9. Flyttet fra Norge",
+    "resultat": "OPPHØR",
+    "tema": "NASJONAL",
+    "_rev": "uDpwmdKblEGdbs8fmMo4Jx",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "_createdAt": "2023-07-17T10:18:12Z",
+    "_id": "ksBegrunnelse-e4c41eed-ce43-47dd-8ab4-9642478c1f68",
+    "_updatedAt": "2023-07-28T11:39:32Z"
+  },
+  {
+    "type": "STANDARD",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "bd736c8ff6be0"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "ad37050e80a2",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har ikkje vore medlem i folketrygda i fem år.",
+            "_key": "bd736c8ff6be6"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "75d1f4ed87f5"
+      }
+    ],
+    "_createdAt": "2023-07-24T07:40:55Z",
+    "_rev": "0w3lID6Lsk7VK2mhOLNRob",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "tema": "NASJONAL",
+    "navnISystem": "Ikke medlem folketrygden i 5 år ",
+    "visningsnavn": "26. Ikke medlem folketrygden i 5 år ",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_id": "ksBegrunnelse-e54fbdc9-9dce-4c75-b51b-77c04f07c451",
+    "_updatedAt": "2023-07-24T07:40:55Z",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "031e2aaa1c57",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "3dd70bd68a590"
+          },
+          {
+            "_key": "0dcc51c380c1",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden i fem år.",
+            "_key": "3dd70bd68a596",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "apiNavn": "opphorIkkeMedlemIFolketrygdenI5Aar"
+  },
+  {
+    "bokmaal": [
+      {
+        "_key": "76197e14946e",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du og den andre forelderen ikke lenger er enige om å dele kontantstøtten for barn født ",
+            "_key": "d75dc92587be0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "d8b76f7a1469"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "e7f202217ca9"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-e58a9ce2-9c8c-4afb-8e7d-798ea1524848",
+    "visningsnavn": "23. Ikke enig om deling",
+    "_rev": "XYs5CWqIz9KsYqFMgpP28F",
+    "_updatedAt": "2023-07-22T07:45:39Z",
+    "navnISystem": "Ikke enig om deling",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "marks": [],
+            "text": "Du og den andre forelderen ikkje lenger er enige om å dele kontantstøtta for barn fødd ",
+            "_key": "01c1c356451a0",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "de3c30916e7d"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "f1f661e554a5"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "e26c64c4359c",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2023-07-22T07:45:39Z",
+    "resultat": "OPPHØR",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "apiNavn": "opphorIkkeEnigOmDeling",
+    "type": "STANDARD"
+  },
+  {
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2022-12-07T15:56:39Z",
+    "_updatedAt": "2022-12-07T15:56:39Z",
+    "apiNavn": "innvilgetDeltBostedMaanedEtterEnighet",
+    "hjemler": [
+      "9"
+    ],
+    "_type": "ksBegrunnelse",
+    "_rev": "q78nlzlQCcCXR6QugfSkf6",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED"
+    ],
+    "tema": "NASJONAL",
+    "navnISystem": "Delt bosted måned etter enighet",
+    "resultat": "INNVILGET",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får delt kontantstøtte fordi barn født ",
+            "_key": "64d47a44ebc20",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "c2274a026546",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "text": " har delt bosted. Du får delt kontantstøtte fra måneden etter dere ble enige om at kontantstøtten skal deles.",
+            "_key": "a8b56d401b94",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "bbd58da43f13"
+      }
+    ],
+    "visningsnavn": "7. Delt bosted måned etter enighet",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "23117b6e61df",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Du får delt kontantstøtte fordi barn fødd ",
+            "_key": "ab49b104e2f00",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "46efbb798808"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har delt bustad. Du får delt kontantstøtte frå månaden etter de vart einige om at kontantstøtta skal delast.",
+            "_key": "977684fd412d"
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-e63e8d93-b2d9-42fe-9edc-75942076db9a"
+  },
+  {
+    "_id": "ksBegrunnelse-e8e1c2dc-f8bf-4b64-b905-61093bd47278",
+    "navnISystem": "Ikke oppholdstillatelse mer enn 12 måneder",
+    "apiNavn": "opphorIkkeOppholdstillatelseMerEnn12Maaneder",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "OPPHØR",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "f4ad55a0d7b40",
+            "_type": "span",
+            "marks": [],
+            "text": "Du ikkje har opphaldsløyve i Noreg i meir enn 12 månader."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1c77f37dc947"
+      }
+    ],
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "_rev": "0w3lID6Lsk7VK2mhOLbUvb",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-07-24T08:38:37Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_updatedAt": "2023-07-24T08:38:37Z",
+    "visningsnavn": "35. Ikke oppholdstillatelse mer enn 12 måneder",
+    "type": "STANDARD",
+    "rolle": [
+      "SOKER"
+    ],
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "bda6e9db31c3",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du ikke har oppholdstillatelse i Norge i mer enn 12 måneder.",
+            "_key": "97cfc7bd729f0",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ]
+  },
+  {
+    "visningsnavn": "1. Opphør tekst tillegstekst placeholder",
+    "_createdAt": "2023-03-08T11:03:28Z",
+    "type": "TILLEGGSTEKST",
+    "_rev": "cplyYjrMe4MdorOqExPfWs",
+    "_type": "ksBegrunnelse",
+    "_id": "ksBegrunnelse-e8f58f37-0464-4bcf-b6c3-71f2ebc976e2",
+    "resultat": "OPPHØR",
+    "_updatedAt": "2023-03-08T11:03:44Z",
+    "navnISystem": "opphorTekstTilleggsTekstPlaceholder",
+    "apiNavn": "opphorTekstTilleggsTekstPlaceholder",
+    "tema": "NASJONAL"
+  },
+  {
+    "visningsnavn": "54. Selvstendig rett tilleggstekst nullutbetaling",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2024-01-08T23:28:28Z",
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "q5JgLByi60irF5LU0IUohw",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-e952bb00-5fa6-49f2-841b-fad15214bb07",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "_key": "ab81218a0571",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "0148f67d41c00",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten i "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "a4bd9a46a6e9"
+          },
+          {
+            "marks": [],
+            "text": " er høyere enn norsk kontantstøtte. Derfor får du ikke utbetalt kontantstøtte fra Norge.",
+            "_key": "3fad23f2daab",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "apiNavn": "innvilgetSelvstendigRettTilleggstekstNullutbetaling",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "tema": "EØS",
+    "nynorsk": [
+      {
+        "_key": "026cc61349dd",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "ec94ce7e12c20",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta i "
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "0c11f86bdb25"
+          },
+          {
+            "text": " er høgare enn norsk kontantstøtte. Derfor får du ikkje utbetalt kontantstøtte frå Noreg.",
+            "_key": "4c8759bf642b",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_updatedAt": "2024-01-08T23:28:28Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "navnISystem": "Selvstendig rett tilleggstekst nullutbetaling",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ]
+  },
+  {
+    "_updatedAt": "2023-07-24T08:34:54Z",
+    "navnISystem": "Begge foreldre fått kontantstøtte",
+    "apiNavn": "opphorBeggeForeldreneHarFottKontantstotte",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "type": "STANDARD",
+    "_createdAt": "2023-07-24T08:34:54Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_rev": "XYs5CWqIz9KsYqFMh3Vv9z",
+    "tema": "NASJONAL",
+    "visningsnavn": "34. Begge foreldre fått kontantstøtte",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har fått kontantstøtte for barn født ",
+            "_key": "88adddbadb940"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "86eda75b0a15"
+          },
+          {
+            "_key": "9ab20f1e272c",
+            "_type": "span",
+            "marks": [],
+            "text": " i samme tidsrom."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "bc364cc08cbf"
+      }
+    ],
+    "resultat": "OPPHØR",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Den andre forelderen har fått kontantstøtte for barn fødd ",
+            "_key": "73240b7d78580"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "36331d5e1e0c"
+          },
+          {
+            "_key": "a35dede05843",
+            "_type": "span",
+            "marks": [],
+            "text": " i same tidsrom."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1e73a0043909"
+      }
+    ],
+    "_id": "ksBegrunnelse-ea70601f-e8c8-4cf0-819b-fe833a877177"
+  },
+  {
+    "apiNavn": "avslagSelvstendigRettBorIkkeFastMedBarnet",
+    "_rev": "5r7yBuU8wKOiVHJijMbQyh",
+    "tema": "EØS",
+    "_createdAt": "2024-01-09T17:03:32Z",
+    "triggereIBruk": [
+      "VILKÅRSVURDERING"
+    ],
+    "_id": "ksBegrunnelse-eb062586-603a-47dc-b5c1-bd0fa51ccaa4",
+    "_updatedAt": "2024-01-09T17:03:32Z",
+    "navnISystem": "Selvstendig rett bor ikke fast med barnet",
+    "eosVilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "resultat": "AVSLAG",
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Barn fødd ",
+            "_key": "a4169106149f0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "5d3707844938",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje bur fast saman med deg.",
+            "_key": "f8871e798b7c"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "febe3a9ecd1a"
+      }
+    ],
+    "visningsnavn": "19. Selvstendig rett bor ikke fast med barnet",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67"
+    ],
+    "bokmaal": [
+      {
+        "_key": "e43853bb1533",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "eb085c8f4caf0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "4f4ba07b56ac"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke bor fast sammen med deg.",
+            "_key": "136e7c518f20"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ]
+  },
+  {
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "rolle": [
+      "SOKER",
+      "BARN"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "54558d83ccb5"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "e42ae3004763"
+          },
+          {
+            "text": " ikkje hadde opphaldsløyve i Noreg. ",
+            "_key": "695413cfbfae0",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "da78958d2f32"
+      }
+    ],
+    "_rev": "uDpwmdKblEGdbs8fmMo7iR",
+    "resultat": "OPPHØR",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "visningsnavn": "32. Ikke oppholdstillatelse",
+    "type": "STANDARD",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "navnISystem": "Ikke oppholdstillatelse",
+    "apiNavn": "opphorIkkeOppholdtillatelse",
+    "_type": "ksBegrunnelse",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "3de435f44c0d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "d58f40844da3"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "c7769d58e6fa",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " ikke hadde oppholdstillatelse i Norge. ",
+            "_key": "898ed99ba6d40",
+            "_type": "span"
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-ebbb6f7a-f7a5-472d-a5e9-6d9e14e973c0",
+    "_updatedAt": "2023-07-28T11:40:12Z",
+    "tema": "NASJONAL",
+    "_createdAt": "2023-07-24T08:12:13Z"
+  },
+  {
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "d4b6928c42fe",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtta er endra fordi den andre forelderen har søkt om kontantstøtte for barn fødd ",
+            "_key": "15db06379e850",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "82351867459f"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "b79b6d9c37f2"
+          }
+        ]
+      }
+    ],
+    "_createdAt": "2023-05-03T15:37:48Z",
+    "navnISystem": "Den andre forelderen har søkt",
+    "apiNavn": "reduksjonDenAndreForelderenHarSokt",
+    "visningsnavn": "16. Den andre forelderen har søkt",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "_rev": "sNO2L38EwIVNY4VMy4WXn8",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-ec5368a1-16fa-458c-8b2c-8a1f62caef1e",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtten endres fordi den andre forelderen har søkt om kontantstøtte for barn født ",
+            "_key": "4b6ac3afdd420"
+          },
+          {
+            "_key": "e36cb410d3be",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "db6c34c08b6a"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "b214393709c2"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "_updatedAt": "2023-05-03T15:40:10Z"
+  },
+  {
+    "apiNavn": "innvilgetTredjelandsborgerLovligOppholdForBosattINorge",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "type": "TILLEGGSTEKST",
+    "tema": "NASJONAL",
+    "navnISystem": "Tredjelandsborger lovlig opphold før bosatt i Norge",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_key": "a472a84557b00",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "f174d7532f55"
+          },
+          {
+            "_key": "18530845fd65",
+            "_type": "span",
+            "marks": [],
+            "text": " frå månaden etter at "
+          },
+          {
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "60b105524f38",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_key": "a472a84557b06",
+            "_type": "span",
+            "marks": [],
+            "text": " har opphaldsløyve og er busett i Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "ecf8ab187b41",
+        "markDefs": []
+      }
+    ],
+    "_createdAt": "2022-12-08T11:08:56Z",
+    "bokmaal": [
+      {
+        "_key": "57f0d39f031e",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "09ba68e7e4b30",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født "
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "a168f73d1a62",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": " fra måneden etter at ",
+            "_key": "09b13c67319c",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "49509c87-0882-429c-9604-f4fbfc5876ca",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "bec9749d2a24"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " har oppholdstillatelse og er bosatt i Norge.",
+            "_key": "09ba68e7e4b36"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "visningsnavn": "14. Tredjelandsborger lovlig opphold før bosatt i Norge",
+    "_rev": "u4Z6kQR2byZlf6vx9I6SPe",
+    "resultat": "INNVILGET",
+    "_id": "ksBegrunnelse-ed76e6cf-873f-4806-8d92-6c05c476518a",
+    "_updatedAt": "2022-12-08T11:08:56Z"
+  },
+  {
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "4cc46f221db6",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "f97de10095f10"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "334903d4c1a2",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "87cf32b10387"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "f8470eb543bd"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "a10219873ce4"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "d371f65a5f25",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " bur saman med deg i Noreg og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen jobbar i ",
+            "_key": "113f6743967b",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "18ae1625b177"
+          },
+          {
+            "text": ". Du får derfor heile kontantstøtta frå Noreg.",
+            "_key": "780e1ef0a28c",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_updatedAt": "2024-01-05T15:45:20Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV"
+    ],
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "6006e4d2583e",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "ad4225656d250"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "6231f8f74a28"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "533891db86e5",
+            "_type": "span"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "6d9a6a6e6b22",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". ",
+            "_key": "46beb5c1e3a6"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "ba3a6f02587a",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "text": " bor sammen med deg i Norge og går ikke i en barnehage som får offentlig støtte. Den andre forelderen jobber i ",
+            "_key": "b7acd8d57582",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "59609e1779e4"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "7c4fee9ba0c7"
+          }
+        ]
+      }
+    ],
+    "navnISystem": "Primærland barnet flyttet til Norge ",
+    "apiNavn": "innvilgetPrimarlandBarnetFlyttetTilNorge",
+    "barnetsBostedsland": [
+      "NORGE"
+    ],
+    "_createdAt": "2023-12-19T15:34:53Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_rev": "5r7yBuU8wKOiVHJijJX1Eh",
+    "tema": "EØS",
+    "_id": "ksBegrunnelse-ee3faae1-22fb-4969-899e-5d8ebac751de",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "visningsnavn": "9. Primærland barnet flyttet til Norge ",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ]
+  },
+  {
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "tema": "NASJONAL",
+    "_updatedAt": "2022-12-13T14:42:47Z",
+    "navnISystem": "Opphold i utlandet under 3 måneder",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "VURDERING_ANNET_GRUNNLAG"
+    ],
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "48b3aed7bf430"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "b8fd631e5081"
+          },
+          {
+            "_key": "9b33406a56e1",
+            "_type": "span",
+            "marks": [],
+            "text": " under opphaldet i utlandet. Når opphaldet i utlandet ikkje varer lenger enn 3 månader, er de rekna som busett i Noreg."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f78efb72c134"
+      }
+    ],
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "c9ec7c4d08820"
+          },
+          {
+            "_key": "594644722ef8",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " under oppholdet i utlandet. Når oppholdet i utlandet ikke varer lenger enn 3 måneder, regnes dere som bosatt i Norge.",
+            "_key": "3a91ac844fd4"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "adb3c95676ee",
+        "markDefs": []
+      },
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "\n",
+            "_key": "a4c707cc502a0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f7d647375936"
+      }
+    ],
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2022-12-07T17:56:07Z",
+    "_id": "ksBegrunnelse-ef426e7c-c42b-4c15-8906-aaa6638fbde6",
+    "apiNavn": "innvilgetOppholdIUtlandetUnderTreMaaneder",
+    "visningsnavn": "12. Opphold i utlandet under 3 måneder",
+    "_rev": "TaUV0kzWabg6RzeULptgMx"
+  },
+  {
+    "resultat": "REDUKSJON",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtte er endra fordi ",
+            "_key": "1ef579b689c10",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "2ed1b6d80c22",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje var busett i Noreg. ",
+            "_key": "fdb3337a92b8"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "f98f8b422382"
+      }
+    ],
+    "_createdAt": "2023-05-03T15:47:36Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-eff63180-2462-4bdf-bc74-dd58dfbd5580",
+    "_updatedAt": "2023-05-03T15:53:12Z",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "navnISystem": "Ikke bosatt i Norge",
+    "apiNavn": "reduksjonIkkeBosattINorge",
+    "hjemler": [
+      "2",
+      "3"
+    ],
+    "visningsnavn": "18. Ikke bosatt i Norge",
+    "_rev": "sNO2L38EwIVNY4VMy4YIg6",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "9abe2416ecc6",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtte endres fordi ",
+            "_key": "866c09f2bf190",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "df1cd12dded3",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": " ikke var bosatt i Norge.",
+            "_key": "50b600a5d459",
+            "_type": "span"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "visningsnavn": "42. Primærland den andre forelderen utsendt arbeidstaker ",
+    "_rev": "eS4Wb2bsh0R4qyDTo1HlQn",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "f9b287f83a2d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglane for barn fødd ",
+            "_key": "7782934ae1d50"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "38e27681ec09"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du jobbar ikkje i ",
+            "_key": "bc1162663f38"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "3e6861bee561"
+          },
+          {
+            "text": ". Barnet bur i ",
+            "_key": "c99ee5bd523e",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "091034451fc8",
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "f651b443aa0e",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "10679d5633fd",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a"
+            }
+          },
+          {
+            "_key": "2dcfa1832d41",
+            "_type": "span",
+            "marks": [],
+            "text": ". Heile familien er pliktig medlem i folketrygda. Du får derfor heile kontantstøtta frå Noreg."
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_createdAt": "2024-01-08T14:25:47Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte etter EØS-reglene for barn født ",
+            "_key": "85d0a592d62a0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "976230265a0b"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du jobber ikke i ",
+            "_key": "6dcd7ae0c9bd"
+          },
+          {
+            "flettefelt": "sokersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "7d20194857bb"
+          },
+          {
+            "_key": "851fb441dc1c",
+            "_type": "span",
+            "marks": [],
+            "text": ". Barnet bor i "
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "e076bc025e15",
+            "flettefelt": "barnetsBostedsland"
+          },
+          {
+            "text": ", og går ikke i en barnehage som får offentlig støtte. Den andre forelderen ",
+            "_key": "a65a8803e9d0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a"
+            },
+            "_type": "valgfeltV2",
+            "_key": "5392540365fe",
+            "skalHaStorForbokstav": false
+          },
+          {
+            "marks": [],
+            "text": ". Hele familien er pliktig medlem i folketrygden. Du får derfor hele kontantstøtten fra Norge.",
+            "_key": "5f4bf009423e",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "6a1b0352e01a"
+      }
+    ],
+    "apiNavn": "innvilgetPrimarlandDenAndreForelderenUtsendtArbeidstaker",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "_updatedAt": "2024-01-09T14:48:51Z",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "_id": "ksBegrunnelse-f0f55f93-f8e4-4067-b752-9f8f0c23fa3a",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "annenForeldersAktivitet": [
+      "UTSENDT_ARBEIDSTAKER",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE"
+    ],
+    "navnISystem": "Primærland den andre forelderen utsendt arbeidstaker ",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET"
+  },
+  {
+    "_rev": "KOa0MjQMDn5FLyPT0Mow3F",
+    "type": "STANDARD",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2023-05-03T15:03:02Z",
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "41ac715f88f7",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "e14ccada1bb60",
+            "_type": "span",
+            "marks": [],
+            "text": "Kontantstøtta er endra fordi avtalen om delt bustad for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "9bcdb393c2c3"
+          },
+          {
+            "text": " er oppheva frå ",
+            "_key": "1b894c9b51cb",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "b1fbf8d9b546"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtta er redusert frå same månad som endringa skjedde.",
+            "_key": "69a09ddf46ac"
+          }
+        ]
+      }
+    ],
+    "_id": "ksBegrunnelse-f1c07499-9373-4f51-a390-9c9fae338d20",
+    "navnISystem": "Avtale om delt bosted opphørt",
+    "_updatedAt": "2023-05-03T15:03:02Z",
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "text": "Kontantstøtten endres fordi avtalen om delt bosted for barn født ",
+            "_key": "56a5706bc6f60",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "0e105451d035"
+          },
+          {
+            "marks": [],
+            "text": " er opphørt fra ",
+            "_key": "ce18984b6cab",
+            "_type": "span"
+          },
+          {
+            "_key": "95cfd481da46",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_key": "432e47853b59",
+            "_type": "span",
+            "marks": [],
+            "text": ". Kontantstøtten reduseres fra samme måned som endringen skjedde."
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "757419b6f639"
+      },
+      {
+        "children": [
+          {
+            "_key": "e2097b553a740",
+            "_type": "span",
+            "marks": [],
+            "text": "\n"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4f1795b600b9",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "reduksjonAvtaleOmDeltBostedOpphort",
+    "visningsnavn": "7. Avtale om delt bosted opphørt",
+    "resultat": "REDUKSJON",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ]
+  },
+  {
+    "navnISystem": "Foreldrene bor sammen, endret mottaker",
+    "hjemler": [
+      "9"
+    ],
+    "type": "TILLEGGSTEKST",
+    "nynorsk": [
+      {
+        "_key": "8ba3225352ad",
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "d9b78b744f170",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får barnetrygd for barn fødd "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "c134ba1e6e91"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "1068059cda3b"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "f9954ab96daf"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur saman med deg. Du får barnetrygd frå same tidspunkt som barnetrygda til den andre forelderen opphøyrer. ",
+            "_key": "d9b78b744f172"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "resultat": "INNVILGET",
+    "visningsnavn": "5. Foreldrene bor sammen, endret mottaker",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "tema": "NASJONAL",
+    "bokmaal": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "eea70735cd51",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "a302c5866a340"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "a0dd72bf3f50",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fordi ",
+            "_key": "aa59bbdce71e"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "c1c759ad663d",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "text": " bor sammen med deg. Du får kontantstøtte fra samme tidspunkt som kontantstøtten til den andre forelderen opphører.",
+            "_key": "a302c5866a342",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      }
+    ],
+    "apiNavn": "innvilgetForeldreneBorSammenEndretMottaker",
+    "_rev": "sT5C1Zuvjux67St1xUgLq5",
+    "_type": "ksBegrunnelse",
+    "_createdAt": "2022-12-07T14:48:51Z",
+    "_id": "ksBegrunnelse-f3f198ff-2c01-4f56-89c4-272ab89a260f",
+    "_updatedAt": "2022-12-07T14:48:51Z"
+  },
+  {
+    "type": "TILLEGGSTEKST",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "5e86342403a90"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "8f4a839bb7fe",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "marks": [],
+            "text": "frå månaden etter at foreldrepengeperioden med 100 prosent utbetaling er ferdig.",
+            "_key": "5f020ea1e360",
+            "_type": "span"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "31ad27e6c32e"
+      },
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "04d0f65b28c60"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "9f34a56fd3e2"
+      }
+    ],
+    "apiNavn": "innvilgetFraMaanedenEtterForeldrepenger",
+    "vilkaar": [
+      "BARNETS_ALDER"
+    ],
+    "_id": "ksBegrunnelse-f4d83736-efa5-42bf-b1af-2a469a55e2f6",
+    "navnISystem": "Fra måneden etter foreldrepenger",
+    "visningsnavn": "10. Fra måneden etter foreldrepenger",
+    "_rev": "zqag8GS6B90CQ3V7FXwbbA",
+    "utdypendeVilkaarsvurderinger": [
+      "ADOPSJON"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2022-12-07T17:50:30Z",
+    "hjemler": [
+      "10"
+    ],
+    "resultat": "INNVILGET",
+    "stotterFritekst": true,
+    "_updatedAt": "2023-02-06T13:52:15Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "37657043f451",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født ",
+            "_key": "d7b4c53aac8c0"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "183416a06e77",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " fra måneden etter at foreldrepengeperioden med 100 prosent utbetaling er ferdig.",
+            "_key": "c89055367e47"
+          }
+        ],
+        "_type": "block"
+      },
+      {
+        "_key": "b98b6becf245",
+        "markDefs": [],
+        "children": [
+          {
+            "text": "",
+            "_key": "20973ec77f160",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_type": "ksBegrunnelse"
+  },
+  {
+    "visningsnavn": "58. Selvstendig rett tilleggstekst ikke kontantstøtte i annet land",
+    "nynorsk": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får full kontantstøtte fordi ",
+            "_key": "6f3b12eaed110"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "460c70e65bf1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje har kontanstøtte.",
+            "_key": "57f7ae4f3a2b"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "2019686f1675"
+      }
+    ],
+    "_id": "ksBegrunnelse-f664f7ba-846c-4bab-b4e9-83de00930921",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "_updatedAt": "2024-01-08T23:38:27Z",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "apiNavn": "innvilgetSelvstendigRettTilleggstekstIkkeKontantstotteIAnnetLand",
+    "_rev": "q5JgLByi60irF5LU0IVLNQ",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "type": "TILLEGGSTEKST",
+    "_createdAt": "2024-01-08T23:38:27Z",
+    "bokmaal": [
+      {
+        "_key": "29a05ba428e4",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får full kontantstøtte fra Norge fordi ",
+            "_key": "a842399319170"
+          },
+          {
+            "_key": "37e3b51eb137",
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har kontantstøtte.",
+            "_key": "34e0214d3476"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "navnISystem": "Selvstendig rett tilleggstekst ikke kontantstøtte i annet land",
+    "tema": "EØS",
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ]
+  },
+  {
+    "_updatedAt": "2023-07-22T07:39:38Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn født ",
+            "_key": "f40f0a8ebc7c0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "f013eaafd0e0"
+          },
+          {
+            "marks": [],
+            "text": " ikke lenger bor fast hos deg fra ",
+            "_key": "2b6b31816a5a",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "52536e0d7eaf"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "b441bfbafd98"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "2f49664b2c27",
+        "markDefs": []
+      }
+    ],
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "visningsnavn": "21. Bor ikke fast hos søker",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "_createdAt": "2023-07-22T07:39:38Z",
+    "apiNavn": "opphorBorIkkeFastHosSoker",
+    "tema": "NASJONAL",
+    "_type": "ksBegrunnelse",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "nynorsk": [
+      {
+        "_key": "a689e51caf45",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Barn fødd ",
+            "_key": "d9ea6e8d5d4e0"
+          },
+          {
+            "_key": "40531e3f7b29",
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje lenger bur fast hos deg frå ",
+            "_key": "f006b640aba4"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "3573ddfd9c4c"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "6a30c7bfe973"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_id": "ksBegrunnelse-f9e74f7a-ffae-4e74-860c-13635dd42685",
+    "navnISystem": "Bor ikke fast hos søker",
+    "_rev": "Xl0tn62zVopahRtC7CMEyN"
+  },
+  {
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "IKKE_AKTUELT",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "apiNavn": "innvilgetSelvstendigRettTilleggstekstSekundarFullUtbetaling",
+    "type": "TILLEGGSTEKST",
+    "_updatedAt": "2024-01-08T23:25:14Z",
+    "resultat": "INNVILGET",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "tema": "EØS",
+    "_createdAt": "2024-01-08T23:25:14Z",
+    "_id": "ksBegrunnelse-fad7019a-5798-4ebb-8a64-2abce9852f73",
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får full kontantstøtte fra Norge fordi det ikke er rett til kontantstøtte fra ",
+            "_key": "1a29cef479750"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "67dcb5034478"
+          },
+          {
+            "text": ".",
+            "_key": "c45856c48c67",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "59f0c67cdc7d"
+      }
+    ],
+    "navnISystem": "Selvstendig rett tilleggstekst sekundær full utbetaling",
+    "visningsnavn": "53. Selvstendig rett tilleggstekst sekundær full utbetaling",
+    "_rev": "q5JgLByi60irF5LU0IUixU",
+    "_type": "ksBegrunnelse",
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du får full kontantstøtte frå Noreg fordi det ikkje er rett til kontantstøtte frå ",
+            "_key": "152ae5516f3c0"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "e7ef4f97e885"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "07176985c4fd"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4410e265c10d",
+        "markDefs": []
+      }
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ]
+  },
+  {
+    "_updatedAt": "2023-07-24T08:17:01Z",
+    "navnISystem": "Avtale delt bosted ikke gyldig",
+    "apiNavn": "opphorAvtaleOmDeltBostedIkkeGyldig",
+    "_rev": "0w3lID6Lsk7VK2mhOLVa3b",
+    "resultat": "OPPHØR",
+    "vilkaar": [
+      "BOR_MED_SØKER"
+    ],
+    "visningsnavn": "33. Avtale delt bosted ikke gyldig",
+    "type": "STANDARD",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "eef122d0bf8f",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Avtalen om delt bosted for barn født ",
+            "_key": "52831f502f550"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "e74303e62ef3"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke var gyldig. ",
+            "_key": "d0ec6dccceaf"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "hjemler": [
+      "9"
+    ],
+    "tema": "NASJONAL",
+    "nynorsk": [
+      {
+        "_key": "15af9ca408eb",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Avtalen om delt bustad for barn fødd ",
+            "_key": "2c2f8f94dc340"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "9de52a57ff60"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikkje var gyldig. ",
+            "_key": "5530546b8711"
+          }
+        ],
+        "_type": "block",
+        "style": "normal"
+      }
+    ],
+    "_type": "ksBegrunnelse",
+    "utdypendeVilkaarsvurderinger": [
+      "DELT_BOSTED",
+      "DELT_BOSTED_SKAL_IKKE_DELES"
+    ],
+    "_createdAt": "2023-07-24T08:17:01Z",
+    "triggere": [
+      "GJELDER_FØRSTE_PERIODE"
+    ],
+    "_id": "ksBegrunnelse-fc4e397a-a1f3-4f22-adc5-5ed98ab23e3b"
+  },
+  {
+    "type": "STANDARD",
+    "_createdAt": "2023-12-14T23:10:27Z",
+    "triggere": [
+      "SATSENDRING",
+      "BARN_DØD"
+    ],
+    "_updatedAt": "2023-12-14T23:10:27Z",
+    "hjemlerEOSForordningen987": [
+      "58"
+    ],
+    "navnISystem": "innvilgetEosTest",
+    "eosVilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "hjemler": [
+      "8"
+    ],
+    "visningsnavn": "EØS TEST",
+    "_type": "ksBegrunnelse",
+    "resultat": "INNVILGET",
+    "tema": "EØS",
+    "_id": "ksBegrunnelse-fcd08b47-e0d1-46f4-97a5-7ac9a9bba6df",
+    "annenForeldersAktivitet": [
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL"
+    ],
+    "apiNavn": "innvilgetEosTest",
+    "triggereIBruk": [
+      "KOMPETANSE",
+      "VILKÅRSVURDERING"
+    ],
+    "barnetsBostedsland": [
+      "NORGE"
+    ],
+    "kompetanseResultat": [
+      "NORGE_ER_SEKUNDÆRLAND"
+    ],
+    "_rev": "CM6961CqAC7W4puPRA0hn8",
+    "hjemlerEOSForordningen883": [
+      "11-16"
+    ],
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ]
+  },
+  {
+    "resultat": "INNVILGET",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "c66f1738ab82",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du får kontantstøtte for barn fødd ",
+            "_key": "bad581dee2520",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "44c6896af5c8"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Du ",
+            "_key": "16c219c67dc0"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "0da4cc873c38",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            }
+          },
+          {
+            "text": ". ",
+            "_key": "dede2c7a49f0",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "d0d3029ad88e",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " bur i ",
+            "_key": "67c8f3ea5c70"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "1db308e04871"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ", og går ikkje i ein barnehage som får offentleg støtte. Den andre forelderen ",
+            "_key": "fe3b82ab4ec7"
+          },
+          {
+            "_type": "valgfeltV2",
+            "_key": "0cb74d298b7c",
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_type": "reference",
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a"
+            }
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "e0167bfeae79"
+          },
+          {
+            "flettefelt": "annenForeldersAktivitetsland",
+            "_type": "eosFlettefelt",
+            "_key": "49f0fb83ba84"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske reglar for kontantstøtte gjeld derfor for den andre forelderen. Separasjonsavtalen mellom Storbritannia og Noreg gjeld for familien. Du får heile kontantstøtta frå Noreg.",
+            "_key": "e1fd5857ebf1"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_id": "ksBegrunnelse-fcd6bc98-8c53-4f65-8247-0b3c23feb57e",
+    "_updatedAt": "2024-01-10T08:07:11Z",
+    "annenForeldersAktivitet": [
+      "I_ARBEID",
+      "MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN",
+      "FORSIKRET_I_BOSTEDSLAND",
+      "MOTTAR_PENSJON",
+      "INAKTIV",
+      "UTSENDT_ARBEIDSTAKER",
+      "ARBEIDER",
+      "SELVSTENDIG_NÆRINGSDRIVENDE",
+      "UTSENDT_ARBEIDSTAKER_FRA_NORGE",
+      "MOTTAR_UFØRETRYGD",
+      "ARBEIDER_PÅ_NORSKREGISTRERT_SKIP",
+      "ARBEIDER_PÅ_NORSK_SOKKEL",
+      "ARBEIDER_FOR_ET_NORSK_FLYSELSKAP",
+      "ARBEIDER_VED_UTENLANDSK_UTENRIKSSTASJON",
+      "MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET",
+      "MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET"
+    ],
+    "visningsnavn": "44. Selvstendig rett primærland UK standard",
+    "kompetanseResultat": [
+      "NORGE_ER_PRIMÆRLAND"
+    ],
+    "barnetsBostedsland": [
+      "NORGE",
+      "IKKE_NORGE"
+    ],
+    "bokmaal": [
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_key": "d32beef3d33d0",
+            "_type": "span",
+            "marks": [],
+            "text": "Du får kontantstøtte for barn født "
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "eosFlettefelt",
+            "_key": "f3ebc48e4d70"
+          },
+          {
+            "marks": [],
+            "text": ". Du ",
+            "_key": "1673d077038a",
+            "_type": "span"
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "c76d7bb2-2871-492f-8c13-95c31d2dd0cb",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "73f3731283b1"
+          },
+          {
+            "text": ". ",
+            "_key": "69b42c12c47c",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "valgReferanse": {
+              "_ref": "df8dc282-2637-4047-a656-8527205dc364",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "528c05790366",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " bor i ",
+            "_key": "fb46655ef851",
+            "_type": "span"
+          },
+          {
+            "flettefelt": "barnetsBostedsland",
+            "_type": "eosFlettefelt",
+            "_key": "24d13a51708f"
+          },
+          {
+            "text": ", og går ikke i en barnehage som får offentlig støtte.Den andre forelderen ",
+            "_key": "082e35aec39d",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "skalHaStorForbokstav": false,
+            "valgReferanse": {
+              "_ref": "44a17a41-a760-44f7-8d7d-a3cf1676b85a",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "1037cbb3a887"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " i ",
+            "_key": "359300e05d9a"
+          },
+          {
+            "_type": "eosFlettefelt",
+            "_key": "2c913be27898",
+            "flettefelt": "annenForeldersAktivitetsland"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ". Norske regler for kontantstøtte gjelder derfor for den andre forelderen. Separasjonsavtalen mellom Storbritannia og Norge gjelder for familien. Du får hele kontantstøtten fra Norge.",
+            "_key": "0d55c76a58e3"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "4b7a0296e5a5"
+      }
+    ],
+    "apiNavn": "innvilgetSelvstendigRettPrimarlandUKStandard",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "hjemlerSeperasjonsavtalenStorbritannina": [
+      "29"
+    ],
+    "tema": "EØS",
+    "_createdAt": "2024-01-08T22:31:08Z",
+    "navnISystem": "Selvstendig rett primærland UK standard",
+    "_rev": "5r7yBuU8wKOiVHJijN6w8t",
+    "type": "STANDARD",
+    "hjemlerEOSForordningen883": [
+      "2",
+      "11-16",
+      "67",
+      "68"
+    ],
+    "triggereIBruk": [
+      "KOMPETANSE"
+    ]
+  },
+  {
+    "_updatedAt": "2023-04-25T13:15:28Z",
+    "bokmaal": [
+      {
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "18ef56d53c520"
+          },
+          {
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "b1976358f759"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " ikke har vært medlem i folketrygden i fem år.",
+            "_key": "18ef56d53c526"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "57f2c3bad057",
+        "markDefs": []
+      }
+    ],
+    "apiNavn": "avslagIkkeMedlemFolketrygdenIFemAar",
+    "_rev": "rKyoPlAvQSvCLakyN3GSu0",
+    "resultat": "AVSLAG",
+    "nynorsk": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "_key": "cef1aecf0236",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "",
+            "_key": "e5bcca7353b50",
+            "_type": "span"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "eabd7ae8-23ab-42f9-bb3b-e148c7d4028f",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "697bc2bd8eb2",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "text": " ikkje har vore medlem i folketrygda i fem år.",
+            "_key": "e5bcca7353b56",
+            "_type": "span",
+            "marks": []
+          }
+        ]
+      },
+      {
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "\n",
+            "_key": "3ce9c0135c9c0"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "759fada7ce91"
+      }
+    ],
+    "navnISystem": "Ikke medlem folketrygden i 5 år ",
+    "hjemler": [
+      "3",
+      "8"
+    ],
+    "_type": "ksBegrunnelse",
+    "type": "STANDARD",
+    "visningsnavn": "26. Ikke medlem folketrygden i 5 år ",
+    "vilkaar": [
+      "MEDLEMSKAP",
+      "MEDLEMSKAP_ANNEN_FORELDER"
+    ],
+    "tema": "NASJONAL",
+    "_createdAt": "2023-04-14T19:43:33Z",
+    "_id": "ksBegrunnelse-fdf9d65d-0d62-405c-a1dc-6bef510cb262"
+  },
+  {
+    "hjemler": [
+      "8",
+      "9"
+    ],
+    "_rev": "A3jSdym3jf5hqTWanvkWFs",
+    "vilkaar": [
+      "BARNEHAGEPLASS"
+    ],
+    "_createdAt": "2023-09-06T09:27:20Z",
+    "_updatedAt": "2023-09-12T11:43:23Z",
+    "navnISystem": "Delt bosted bruker melder om deltidsplass",
+    "resultat": "OPPHØR",
+    "type": "STANDARD",
+    "apiNavn": "opphorDeltBostedBrukerMelderOmDeltidsplass",
+    "_type": "ksBegrunnelse",
+    "tema": "NASJONAL",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "1c53d7cc66c9",
+        "markDefs": [],
+        "children": [
+          {
+            "marks": [],
+            "text": "Du har opplyst at barn født ",
+            "_key": "8a43dbf710bb0",
+            "_type": "span"
+          },
+          {
+            "_type": "flettefelt",
+            "_key": "dbb95ac22ae4",
+            "flettefelt": "barnasFodselsdatoer"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt deltidsplass i barnehage fra ",
+            "_key": "13944e1a2acf"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "a89fa7601ccd"
+          },
+          {
+            "marks": [],
+            "text": ". Når barnet er tildelt deltidsplass i barnehagen kan ikke kontantstøtten deles mellom foreldrene.",
+            "_key": "76a031753172",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "visningsnavn": "44. Delt bosted bruker melder om deltidsplass",
+    "nynorsk": [
+      {
+        "style": "normal",
+        "_key": "1aac2ee23b33",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "Du har opplyst at barn fødd ",
+            "_key": "b59386d0bb4b0"
+          },
+          {
+            "flettefelt": "barnasFodselsdatoer",
+            "_type": "flettefelt",
+            "_key": "b7e40d40b1d1"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": " er tildelt deltidsplass i barnehage frå ",
+            "_key": "e7a106725356"
+          },
+          {
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt",
+            "_key": "43275e882dc4"
+          },
+          {
+            "marks": [],
+            "text": ". Når barnet er tildelt deltidsplass i barnehagen kan ikkje kontantstøtta delast mellom foreldra.",
+            "_key": "66686b2f0b07",
+            "_type": "span"
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "_id": "ksBegrunnelse-fecf44b0-dcc5-4879-9b04-5220f45e9472"
+  },
+  {
+    "visningsnavn": "9. Flyttet fra Norge",
+    "resultat": "AVSLAG",
+    "_updatedAt": "2023-05-04T09:00:14Z",
+    "hjemler": [
+      "2",
+      "3",
+      "8"
+    ],
+    "_rev": "KOa0MjQMDn5FLyPT0R9PvR",
+    "type": "STANDARD",
+    "tema": "NASJONAL",
+    "_id": "ksBegrunnelse-fffff6cc-6f1d-42bd-8168-9615c93f92b5",
+    "_createdAt": "2023-05-04T08:19:19Z",
+    "bokmaal": [
+      {
+        "style": "normal",
+        "_key": "86e818d9721d",
+        "markDefs": [],
+        "children": [
+          {
+            "_type": "span",
+            "marks": [],
+            "text": "",
+            "_key": "e32c781d51dd"
+          },
+          {
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2",
+            "_key": "0d907e5f15b6",
+            "skalHaStorForbokstav": true
+          },
+          {
+            "marks": [],
+            "text": " har flyttet fra Norge i ",
+            "_key": "008786452b5e0",
+            "_type": "span"
+          },
+          {
+            "_key": "7fb1f0ef14ba",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "text": ".",
+            "_key": "3e2f54fd94f2",
+            "_type": "span",
+            "marks": []
+          }
+        ],
+        "_type": "block"
+      }
+    ],
+    "navnISystem": "Flyttet fra Norge",
+    "apiNavn": "avslagFlyttetFraNorge",
+    "_type": "ksBegrunnelse",
+    "vilkaar": [
+      "BOSATT_I_RIKET"
+    ],
+    "nynorsk": [
+      {
+        "children": [
+          {
+            "text": "",
+            "_key": "9824014440d1",
+            "_type": "span",
+            "marks": []
+          },
+          {
+            "_key": "d5588f219080",
+            "skalHaStorForbokstav": true,
+            "valgReferanse": {
+              "_ref": "1b0efd70-3dcd-43f2-8b1c-c40511a601f4",
+              "_type": "reference"
+            },
+            "_type": "valgfeltV2"
+          },
+          {
+            "marks": [],
+            "text": "] har flytta frå Noreg i ",
+            "_key": "ae5ed5fad7c90",
+            "_type": "span"
+          },
+          {
+            "_key": "2aa262274d7d",
+            "flettefelt": "maanedOgAarBegrunnelsenGjelderFor",
+            "_type": "flettefelt"
+          },
+          {
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+            "_key": "a0bb5e94091d"
+          }
+        ],
+        "_type": "block",
+        "style": "normal",
+        "_key": "1ab4bbb1c9fe",
+        "markDefs": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Leses enklest commit for commit

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17808

Ved forstatt innvilget henter vi inn alle andeler i hele behandlingen når vi skal beregne UtbetalingsperiodeDetaljene. Endrer så vi kun tar med andelene som hører til siste periode før dagens dato.

Legger også til cucumbertester for å teste løypa fra vedtaksperiodene til brevobjektene. 

