### PR TITLE
Ikke send med gjelder-felt for fortsatt innvilget enn så lenge

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/vedtaksbrev/FortsattInnvilget.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/vedtaksbrev/FortsattInnvilget.kt
@@ -51,7 +51,7 @@ data class FortsattInnvilget(
                         ),
                     flettefelter =
                         FlettefelterForDokumentDtoImpl(
-                            gjelder = flettefelt(fellesdataForVedtaksbrev.gjelder),
+                            gjelder = null,
                             navn = flettefelt(fellesdataForVedtaksbrev.søkerNavn),
                             fodselsnummer = flettefelt(fellesdataForVedtaksbrev.søkerFødselsnummer),
                         ),


### PR DESCRIPTION
Fra kommentar på [favrooppgave](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-10617)

Gjelder feltet kommer med i fortsatt innvilget. Det skal det ikke gjøre, med mindre det er instutisjon eller verge(?)

![image](https://github.com/navikt/familie-ks-sak/assets/17828446/c1785ddf-380d-433f-82aa-360181e8f1ae)

Endrer så det ikke kommer med:

![image](https://github.com/navikt/familie-ks-sak/assets/17828446/41dcb2ac-6986-41d6-9e6b-15236a8d241d)
