### PR TITLE
Forskyv fom tidligere før det gjøres til tidslinje

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -49,7 +49,7 @@ class VilkårsvurderingTidslinjeService(
                     )
                 }.filtrerIkkeNull()
                 .tilTidslinje()
-        
+
         return erAnnenForelderOmfattetAvNorskLovgivingTidslinjeMedKunPerioderSomStrekkerSegOver1MånedForskyvetTidslinje
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
 import no.nav.familie.ks.sak.common.tidslinje.filtrerIkkeNull
 import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.filtrerIkkeNull
-import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
@@ -38,24 +37,19 @@ class VilkårsvurderingTidslinjeService(
                 .personResultater
         val søkerPersonresultater = personResultater.single { it.aktør == søker.aktør }
 
-        val erAnnenForelderOmfattetAvNorskLovgivingTidslinjeMedKunPerioderSomStrekkerSegOver1MånedTidslinje =
+        val erAnnenForelderOmfattetAvNorskLovgivingTidslinjeMedKunPerioderSomStrekkerSegOver1MånedForskyvetTidslinje =
             søkerPersonresultater.vilkårResultater
                 .filter { it.vilkårType === Vilkår.BOSATT_I_RIKET && it.erOppfylt() }
                 .filter { it.periodeFom?.month != it.periodeTom?.month }
                 .map {
                     Periode(
                         it.utdypendeVilkårsvurderinger.contains(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
-                        it.periodeFom?.førsteDagIInneværendeMåned(),
+                        it.periodeFom?.plusMonths(1)?.førsteDagIInneværendeMåned(),
                         it.periodeTom?.sisteDagIMåned(),
                     )
-                }
+                }.filtrerIkkeNull()
                 .tilTidslinje()
-
-        val erAnnenForelderOmfattetAvNorskLovgivingTidslinjeMedKunPerioderSomStrekkerSegOver1MånedForskyvetTidslinje =
-            erAnnenForelderOmfattetAvNorskLovgivingTidslinjeMedKunPerioderSomStrekkerSegOver1MånedTidslinje.tilPerioder().map { it.copy(fom = it.fom?.plusMonths(1)?.førsteDagIInneværendeMåned()) }
-                .filtrerIkkeNull()
-                .tilTidslinje()
-
+        
         return erAnnenForelderOmfattetAvNorskLovgivingTidslinjeMedKunPerioderSomStrekkerSegOver1MånedForskyvetTidslinje
     }
 }

--- a/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -11,9 +11,14 @@ import no.nav.familie.ks.sak.data.lagVilkårsvurderingMedSøkersVilkår
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårsvurderingRepository
+import no.nav.familie.ks.sak.kjerne.brev.lagPersonResultat
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
@@ -78,6 +83,74 @@ internal class VilkårsvurderingTidslinjeServiceTest {
                     verdi = true,
                     fom = LocalDate.of(2023, 2, 1),
                     tom = LocalDate.of(2023, 3, 31),
+                ),
+            ).tilTidslinje()
+
+        assertThat(faktiskTidslinje, Is(forventetTidslinje))
+    }
+
+    @Test
+    fun `skal ikke gi overlapp feil dersom tom i forrige periode og fom i neste periode er i samme måned`() {
+        val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+        val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør())
+        val fagsak = Fagsak(aktør = søker.aktør)
+        val behandling = lagBehandling(fagsak = fagsak, kategori = BehandlingKategori.EØS)
+
+        val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
+
+        val personResultat =
+            lagPersonResultat(
+                søker,
+                overstyrendeVilkårResultater =
+                    listOf(
+                        VilkårResultat(
+                            personResultat = null,
+                            vilkårType = Vilkår.BOSATT_I_RIKET,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = LocalDate.of(2023, 1, 2),
+                            periodeTom = LocalDate.of(2023, 3, 4),
+                            begrunnelse = "",
+                            behandlingId = behandling.id,
+                            vurderesEtter = Regelverk.EØS_FORORDNINGEN,
+                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
+                        ),
+                        VilkårResultat(
+                            personResultat = null,
+                            vilkårType = Vilkår.BOSATT_I_RIKET,
+                            resultat = Resultat.OPPFYLT,
+                            periodeFom = LocalDate.of(2023, 3, 5),
+                            periodeTom = LocalDate.of(2025, 5, 5),
+                            begrunnelse = "",
+                            behandlingId = behandling.id,
+                            vurderesEtter = Regelverk.EØS_FORORDNINGEN,
+                            utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING),
+                        ),
+                    ),
+            )
+
+        vilkårsvurdering.personResultater = setOf(personResultat)
+
+        every { personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId = behandling.id) } returns
+            lagPersonopplysningGrunnlag(
+                behandlingId = behandling.id,
+                søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+                barnasIdenter = listOf(barn.aktør.aktivFødselsnummer()),
+                søkerAktør = søker.aktør,
+            )
+
+        every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id) } returns vilkårsvurdering
+
+        val faktiskTidslinje =
+            vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(
+                behandlingId = behandling.id,
+            )
+
+        val forventetTidslinje =
+            listOf(
+                Periode(
+                    verdi = true,
+                    fom = LocalDate.of(2023, 2, 1),
+                    tom = LocalDate.of(2025, 5, 31),
                 ),
             ).tilTidslinje()
 


### PR DESCRIPTION
Favrokort: [NAV-17838](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17838)

Gitt følgende vilkår:
![Screenshot 2024-01-16 at 01 14 08](https://github.com/navikt/familie-ks-sak/assets/110383605/fcd72c50-9155-4e3b-8ab0-4bf101a654b8)

Første periode vil bli forskyvet til 01.04.2023 - 31.11.2023.
Andre periode vil bli forskyvet til 01.11.2023 - uendelig
Dette gjøres om til tidslinje. Dette skaper overlapp når tidslinjen opprettes.

Vi forskyver derfor fommen tidligere før vi gjør om til tidslinje slik at tidslinjen ikke får overlapp

Etter kodeendring vil vi få 
Første periode vil bli forskyvet til 01.04.2023 - 31.11.2023.
Andre periode vil bli forskyvet til 01.12.2023 - uendelig