### PR TITLE
Fjern endepunkt for å overstyre vedtaksperioder ved fortsatt innviglet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/VedtaksperiodeMedBegrunnelserController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/VedtaksperiodeMedBegrunnelserController.kt
@@ -2,14 +2,11 @@ package no.nav.familie.ks.sak.api
 
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
-import no.nav.familie.ks.sak.api.dto.GenererFortsattInnvilgetVedtaksperioderDto
 import no.nav.familie.ks.sak.api.dto.GenererVedtaksperioderForOverstyrtEndringstidspunktDto
 import no.nav.familie.ks.sak.api.dto.VedtaksperiodeMedBegrunnelserDto
 import no.nav.familie.ks.sak.api.dto.VedtaksperiodeMedFriteksterDto
-import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
@@ -102,37 +99,6 @@ class VedtaksperiodeMedBegrunnelserController(
                 behandlingService.lagBehandlingRespons(behandlingId = genererVedtaksperioderForOverstyrtEndringstidspunktDto.behandlingId),
             ),
         )
-    }
-
-    /*
-     * Dette endepnktet brukes for å overstyre hva slags vedtaksperioder man ønsker når resultatet er fortsatt innvilget.
-     * Muligheter:
-     * - skalGenererePerioderForFortsattInnvilget = false -> det blir kun generert 1 periode, uten dato (default valg for fortsatt innvilget)
-     * - skalGenererePerioderForFortsattInnvilget = true -> det blir generert 'vanlige' perioder (overstyrer default for fortsatt innvilget)
-     */
-    @PutMapping("/overstyr-fortsatt-innvilget-vedtaksperioder")
-    fun genererFortsattInnvilgetVedtaksperioder(
-        @RequestBody genererFortsattInnvilgetVedtaksperioderDto: GenererFortsattInnvilgetVedtaksperioderDto,
-    ): ResponseEntity<Ressurs<BehandlingResponsDto>> {
-        tilgangService.validerTilgangTilHandling(
-            minimumBehandlerRolle = BehandlerRolle.VEILEDER,
-            handling = "oppdater vedtaksperioder fortsatt innvilget",
-        )
-
-        val vedtak =
-            vedtakService.hentAktivVedtakForBehandling(behandlingId = genererFortsattInnvilgetVedtaksperioderDto.behandlingId)
-
-        if (vedtak.behandling.resultat != Behandlingsresultat.FORTSATT_INNVILGET) {
-            throw FunksjonellFeil(
-                melding = "Kan ikke overstyre vedtaksperioder når resultatet ikke er fortsatt innvilget.",
-            )
-        }
-
-        vedtaksperiodeService.oppdaterVedtakMedVedtaksperioder(
-            vedtak = vedtak,
-        )
-
-        return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = vedtak.behandling.id)))
     }
 
     private inline fun <reified T> konverterTilEnumverdi(it: String): T? where T : Enum<T> =


### PR DESCRIPTION
Oppfølging til https://github.com/navikt/familie-ks-sak-frontend/pull/494. Nå som endepunktet ikke brukes kan vi fjerne det. 