### PR TITLE
Bug: Sørg for at minimal fagsak på oppgaver blir populert riktig

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
@@ -145,7 +145,7 @@ class FagsakService(
     fun finnMinimalFagsakForPerson(personIdent: String): MinimalFagsakResponsDto? {
         val aktør = personidentService.hentAktør(personIdent)
         val fagsak = finnFagsakForPerson(aktør)
-        return fagsak?.let { lagMinimalFagsakResponsDto(it) }
+        return fagsak?.let { hentMinimalFagsak(fagsakId = fagsak.id) }
     }
 
     @Transactional


### PR DESCRIPTION
Når jeg jobbet med en frontend-oppgave i journalføringsbildet fant jeg ut at det ikke er mulig å få opp tabellen over eksisterende behandlinger å knytte oppgaven til. Grunnen til dette er at `lagMinimalFagsakResponsDto`-funksjonen som brukes for å lage minimal fagsak (med tilhørende behandlinger) ikke sender med infoen vi trenger. Erstatter derfor bruken med en annen funksjon `hentMinimalFagsak` som henter det vi trenger av info om fagsaken.