### PR TITLE
Kun ta med kompetanser som gjelder vedtaksperioden i begrunnelsene

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/TestVerktøyService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.internal
 
 import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.lagBrevTest
+import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
@@ -8,6 +9,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.Vilkårsvu
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseRepository
+import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
+import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.ValutakursService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
 import org.springframework.stereotype.Service
 
@@ -21,6 +24,8 @@ class TestVerktøyService(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val vedtakRepository: VedtakRepository,
     private val kompetanseRepository: KompetanseRepository,
+    private val valutakursService: ValutakursService,
+    private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService,
 ) {
     fun hentBrevTest(behandlingId: Long): String {
         val behandling = behandlingService.hentBehandling(behandlingId)
@@ -62,6 +67,10 @@ class TestVerktøyService(
             endredeUtbetalingerForrigeBehandling = endredeUtbetalingerForrigeBehandling,
             kompetanse = kompetanse,
             kompetanseForrigeBehandling = kompetanseForrigeBehandling,
+            utenlandskePeriodebeløp = utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(BehandlingId(behandlingId)),
+            utenlandskePeriodebeløpForrigeBehandling = forrigeBehandling?.id?.let { utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(BehandlingId(it)) },
+            valutakurser = valutakursService.hentValutakurser(BehandlingId(behandlingId)),
+            valutakurserForrigeBehandling = forrigeBehandling?.id?.let { valutakursService.hentValutakurser(BehandlingId(it)) },
         )
     }
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -341,6 +341,7 @@ fun lagAndelTilkjentYtelse(
     ytelseType: YtelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
     prosent: BigDecimal = BigDecimal(100),
     nasjonaltPeriodebeløp: Int = sats,
+    differanseberegnetPeriodebeløp: Int? = null,
 ) = AndelTilkjentYtelse(
     behandlingId = behandling.id,
     tilkjentYtelse = tilkjentYtelse ?: lagInitieltTilkjentYtelse(behandling),
@@ -355,6 +356,7 @@ fun lagAndelTilkjentYtelse(
     periodeOffset = periodeOffset,
     forrigePeriodeOffset = forrigePeriodeOffset,
     kildeBehandlingId = behandling.id,
+    differanseberegnetPeriodebeløp = differanseberegnetPeriodebeløp,
 )
 
 fun lagPerson(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -58,6 +58,7 @@ object VedtaksperiodeMedBegrunnelserParser {
         BELØP("Beløp"),
         SATS("Sats"),
         NASJONALT_PERIODEBELØP("Nasjonalt periodebeløp"),
+        DIFFERANSEBEREGNET_BELØP("Differanseberegnet beløp"),
         ER_EKSPLISITT_AVSLAG("Er eksplisitt avslag"),
         ENDRINGSTIDSPUNKT("Endringstidspunkt"),
         BEGRUNNELSER("Begrunnelser"),

--- a/src/test/integrasjonstester/kotlin/DevLauncherPostgresPreprod.kt
+++ b/src/test/integrasjonstester/kotlin/DevLauncherPostgresPreprod.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ks.sak
 
 import no.nav.familie.ks.sak.config.ApplicationConfig
 import no.nav.familie.ks.sak.config.DbContainerInitializer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.boot.builder.SpringApplicationBuilder
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -20,7 +22,9 @@ fun main(args: Array<String>) {
         springBuilder.initializers(DbContainerInitializer())
     }
 
-    settClientIdOgSecret()
+    if (System.getProperty("AZURE_APP_CLIENT_ID") == null) {
+        settClientIdOgSecret()
+    }
 
     springBuilder.run(*args)
 }
@@ -28,6 +32,8 @@ fun main(args: Array<String>) {
 private fun settClientIdOgSecret() {
     val cmd = "./hentMiljøvariabler.sh"
 
+    val logger: Logger = LoggerFactory.getLogger("main -> settClientIdOgSecret")
+    logger.info("Henter miljøvariabler fra Kubernetes...")
     val process = ProcessBuilder(cmd).start()
 
     val status = process.waitFor()
@@ -46,4 +52,5 @@ private fun settClientIdOgSecret() {
         val keyValuePar = it.split("=")
         System.setProperty(keyValuePar[0], keyValuePar[1])
     }
+    logger.info("Miljøvariabler hentet og satt \u2713")
 }

--- a/src/test/resources/cucumber/sekundærland/innvilgelse.feature
+++ b/src/test/resources/cucumber/sekundærland/innvilgelse.feature
@@ -1,0 +1,76 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Sekundærland - innvilgelse
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Behandlingskategori |
+      | 1            | 1        |                     | INNVILGET           | SØKNAD           | EØS                 |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 16.08.1988  |
+      | 1            | 2       | BARN       | 15.09.2022  |
+
+  Scenario: Skal få riktig begrunnelser for sekundærland innvilgelse
+    Og følgende dagens dato 18.01.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | LOVLIG_OPPHOLD                                         |                  | 16.08.1988 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 16.08.1988 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+
+      | 2       | BARNEHAGEPLASS                                         |                  | 15.09.2022 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOSATT_I_RIKET,BOR_MED_SØKER |                  | 15.09.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BARNETS_ALDER                                          |                  | 15.09.2023 | 15.09.2024 | OPPFYLT  | Nei                  |                      |                  |
+
+    Og følgende kompetanser for behandling 1
+      | AktørId | Fra dato   | Til dato   | Resultat              | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.10.2023 | 30.11.2023 | NORGE_ER_SEKUNDÆRLAND | ARBEIDER         | INAKTIV                   | NO                    | PL                             | PL                  |
+      | 2       | 01.12.2023 |            | NORGE_ER_PRIMÆRLAND   | ARBEIDER         | INAKTIV                   | NO                    | PL                             | PL                  |
+
+    Og følgende utenlandske periodebeløp for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 01.10.2023 | 30.11.2023 | 1000  | PLN         | MÅNEDLIG  | PL              |
+
+    Og følgende valutakurser for behandling 1
+      | AktørId | Fra dato   | Til dato   | Valutakursdato | Valuta kode | Kurs         |
+      | 2       | 01.10.2023 | 30.11.2023 | 2023-10-24     | PLN         | 2.6496751064 |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.10.2023 | 30.11.2023 | 4851  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   | 4851                     |
+      | 2       | 01.12.2023 | 31.08.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og vedtaksperioder er laget for behandling 1
+
+    Så forvent følgende vedtaksperioder på behandling 1
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.10.2023 | 30.11.2023 | UTBETALING         |           |
+      | 01.12.2023 | 31.08.2024 | UTBETALING         |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 1
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser            | Ugyldige begrunnelser |
+      | 01.10.2023 | 30.11.2023 | UTBETALING         |                                |                                 |                       |
+      | 01.10.2023 | 30.11.2023 | UTBETALING         | EØS_FORORDNINGEN               | INNVILGET_SEKUNDÆRLAND_STANDARD |                       |
+      | 01.12.2023 | 31.08.2024 | UTBETALING         |                                |                                 |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato   | Standardbegrunnelser | Eøsbegrunnelser                 | Fritekster |
+      | 01.10.2023 | 30.11.2023 |                      | INNVILGET_SEKUNDÆRLAND_STANDARD |            |
+      | 01.12.2023 | 31.08.2024 |                      |                                 |            |
+
+    Så forvent følgende brevperioder for behandling 1
+      | Brevperiodetype | Fra dato        | Til dato              | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
+      | INNVILGELSE     | 1. oktober 2023 | til 30. november 2023 | 4 851 | 1                          | 15.09.22            | Du                     |
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.10.2023 til 30.11.2023
+      | Begrunnelse                     | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | INNVILGET_SEKUNDÆRLAND_STANDARD | EØS  | 15.09.22             | 1           | NB      | arbeider         | inaktiv                   | Norge                 | Polen                          | Polen               |

--- a/src/test/resources/cucumber/sekundærland/innvilgelse.feature
+++ b/src/test/resources/cucumber/sekundærland/innvilgelse.feature
@@ -44,23 +44,7 @@ Egenskap: Sekundærland - innvilgelse
 
     Og andeler er beregnet for behandling 1
 
-    Så forvent følgende andeler tilkjent ytelse for behandling 1
-      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
-      | 2       | 01.10.2023 | 30.11.2023 | 4851  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   | 4851                     |
-      | 2       | 01.12.2023 | 31.08.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
-
     Og vedtaksperioder er laget for behandling 1
-
-    Så forvent følgende vedtaksperioder på behandling 1
-      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
-      | 01.10.2023 | 30.11.2023 | UTBETALING         |           |
-      | 01.12.2023 | 31.08.2024 | UTBETALING         |           |
-
-    Så forvent at følgende begrunnelser er gyldige for behandling 1
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser            | Ugyldige begrunnelser |
-      | 01.10.2023 | 30.11.2023 | UTBETALING         |                                |                                 |                       |
-      | 01.10.2023 | 30.11.2023 | UTBETALING         | EØS_FORORDNINGEN               | INNVILGET_SEKUNDÆRLAND_STANDARD |                       |
-      | 01.12.2023 | 31.08.2024 | UTBETALING         |                                |                                 |                       |
 
     Og når disse begrunnelsene er valgt for behandling 1
       | Fra dato   | Til dato   | Standardbegrunnelser | Eøsbegrunnelser                 | Fritekster |

--- a/src/test/resources/cucumber/sekundærland/opphør.feature
+++ b/src/test/resources/cucumber/sekundærland/opphør.feature
@@ -45,22 +45,7 @@ Egenskap: Sekundærland - opphør
 
     Og andeler er beregnet for behandling 1
 
-    Så forvent følgende andeler tilkjent ytelse for behandling 1
-      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
-      | 2       | 01.10.2023 | 31.10.2023 | 4851  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   | 4851                     |
-
     Og vedtaksperioder er laget for behandling 1
-
-    Så forvent følgende vedtaksperioder på behandling 1
-      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
-      | 01.10.2023 | 31.10.2023 | UTBETALING         |           |
-      | 01.11.2023 |            | OPPHØR             |           |
-
-    Så forvent at følgende begrunnelser er gyldige for behandling 1
-      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser           | Ugyldige begrunnelser |
-      | 01.10.2023 | 31.10.2023 | UTBETALING         |                                |                                |                       |
-      | 01.11.2023 |            | OPPHØR             |                                |                                |                       |
-      | 01.11.2023 |            | OPPHØR             | EØS_FORORDNINGEN               | OPPHØR_SELVSTENDIG_RETT_OPPHØR |                       |
 
     Og når disse begrunnelsene er valgt for behandling 1
       | Fra dato   | Til dato | Standardbegrunnelser | Eøsbegrunnelser                | Fritekster |

--- a/src/test/resources/cucumber/sekundærland/opphør.feature
+++ b/src/test/resources/cucumber/sekundærland/opphør.feature
@@ -1,0 +1,75 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Sekundærland - opphør
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Behandlingskategori |
+      | 1            | 2        |                     | INNVILGET_OG_OPPHØRT | SØKNAD           | EØS                 |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 16.08.1988  |
+      | 1            | 2       | BARN       | 15.09.2022  |
+
+  Scenario: Plassholdertekst for scenario - FLj664h0b2
+    Og følgende dagens dato 18.01.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                  | Utdypende vilkår                    | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | MEDLEMSKAP                              |                                     | 16.08.1988 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | BOSATT_I_RIKET                          | OMFATTET_AV_NORSK_LOVGIVNING_UTLAND | 16.08.1988 | 15.11.2023 | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 1       | LOVLIG_OPPHOLD                          |                                     | 16.08.1988 |            | OPPFYLT  | Nei                  |                      |                  |
+
+      | 2       | BOSATT_I_RIKET                          | BARN_BOR_I_EØS                      | 15.09.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BOR_MED_SØKER,MEDLEMSKAP_ANNEN_FORELDER |                                     | 15.09.2022 |            | OPPFYLT  | Nei                  |                      | EØS_FORORDNINGEN |
+      | 2       | BARNEHAGEPLASS                          |                                     | 15.09.2022 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BARNETS_ALDER                           |                                     | 15.09.2023 | 15.09.2024 | OPPFYLT  | Nei                  |                      |                  |
+
+    Og følgende kompetanser for behandling 1
+      | AktørId | Fra dato   | Til dato   | Resultat              | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.10.2023 | 31.10.2023 | NORGE_ER_SEKUNDÆRLAND | ARBEIDER         | INAKTIV                   | NO                    | PL                             | PL                  |
+
+    Og følgende utenlandske periodebeløp for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 01.10.2023 | 31.10.2023 | 1000  | PLN         | MÅNEDLIG  | PL              |
+
+    Og følgende valutakurser for behandling 1
+      | AktørId | Fra dato   | Til dato   | Valutakursdato | Valuta kode | Kurs         |
+      | 2       | 01.10.2023 | 31.10.2023 | 2023-10-24     | PLN         | 2.6496751064 |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.10.2023 | 31.10.2023 | 4851  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   | 4851                     |
+
+    Og vedtaksperioder er laget for behandling 1
+
+    Så forvent følgende vedtaksperioder på behandling 1
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.10.2023 | 31.10.2023 | UTBETALING         |           |
+      | 01.11.2023 |            | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 1
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser           | Ugyldige begrunnelser |
+      | 01.10.2023 | 31.10.2023 | UTBETALING         |                                |                                |                       |
+      | 01.11.2023 |            | OPPHØR             |                                |                                |                       |
+      | 01.11.2023 |            | OPPHØR             | EØS_FORORDNINGEN               | OPPHØR_SELVSTENDIG_RETT_OPPHØR |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 1
+      | Fra dato   | Til dato | Standardbegrunnelser | Eøsbegrunnelser                | Fritekster |
+      | 01.11.2023 |          |                      | OPPHØR_SELVSTENDIG_RETT_OPPHØR |            |
+
+    Så forvent følgende brevperioder for behandling 1
+      | Brevperiodetype | Fra dato         | Til dato | Beløp | Antall barn med utbetaling | Barnas fødselsdager | Du eller institusjonen |
+      | OPPHOR          | 1. november 2023 |          | 0     | 0                          |                     | Du                     |
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.11.2023 til -
+      | Begrunnelse                    | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | OPPHØR_SELVSTENDIG_RETT_OPPHØR | EØS  | 15.09.22             | 1           | NB      | arbeider         | inaktiv                   | Norge                 | Polen                          | Polen               |

--- a/src/test/resources/cucumber/sekundærland/opphør.feature
+++ b/src/test/resources/cucumber/sekundærland/opphør.feature
@@ -17,7 +17,7 @@ Egenskap: Sekundærland - opphør
       | 1            | 1       | SØKER      | 16.08.1988  |
       | 1            | 2       | BARN       | 15.09.2022  |
 
-  Scenario: Plassholdertekst for scenario - FLj664h0b2
+  Scenario: Skal få riktige begrunnelser ved opphør
     Og følgende dagens dato 18.01.2024
 
     Og følgende vilkårresultater for behandling 1


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17809

Leses enklest commit for commit. 

Når vi henter inn dataene fra kompetansene til begrunnelsene bruker vi alle kompetansene i hele behandlingen. 

Endrer så vi kun henter inn kompetansene som er samtidig som vedtaksperioden ved utbetaling og kompetansene som avsluttes perioden før ved opphør. 

Oppdaterer også cucumberoppsettet for å støtte eøs sekundærland. 