### PR TITLE
Fjerner valg for refusjon fra UDI for korriger etterbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetaling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetaling.kt
@@ -51,7 +51,6 @@ fun KorrigertEtterbetalingRequestDto.tilKorrigertEtterbetaling(behandling: Behan
 
 enum class KorrigertEtterbetalingÅrsak(val visningsnavn: String) {
     FEIL_TIDLIGERE_UTBETALT_BELØP("Feil i tidligere utbetalt beløp"),
-    REFUSJON_FRA_UDI("Refusjon fra UDI"),
     REFUSJON_FRA_ANDRE_MYNDIGHETER("Refusjon fra andre myndigheter"),
     MOTREGNING("Motregning"),
 }


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17926

Sletter valget for refusjon fra UDI for korriger etterbetaling, som ikke skal være mulig å velge i KS. 

~Før merge må jeg sjekke at databasen ikke har noen entries med denne verdien:)~ ingen innslag i databasen!