### PR TITLE
Oppdag fremtidig opphør basert på korrekt siste utbetalingsmåned

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Opphørsperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Opphørsperiode.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilForskjøvetTomMånedForSisteUtbetalingsperiodePgaFremtidigOpphør
 import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilVedtaksbegrunnelse
@@ -118,7 +119,8 @@ private fun finnOpphørsperiodeEtterSisteUtbetalingsperiode(
     val erFramtidigOpphørPgaBarnehageplass =
         vilkårsvurdering.personResultater.any {
             it.vilkårResultater.any {
-                it.vilkårType == Vilkår.BARNEHAGEPLASS && it.søkerHarMeldtFraOmBarnehageplass == true && it.periodeTom?.toYearMonth() == sisteUtbetalingsperiodeTom
+                it.vilkårType == Vilkår.BARNEHAGEPLASS && it.søkerHarMeldtFraOmBarnehageplass == true &&
+                    it.periodeTom?.tilForskjøvetTomMånedForSisteUtbetalingsperiodePgaFremtidigOpphør() == sisteUtbetalingsperiodeTom
             }
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvBarnehageplass.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvBarnehageplass.kt
@@ -5,10 +5,7 @@ import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombiner
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioderIkkeNull
-import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
-import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
-import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
-import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.common.util.*
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.beregning.domene.hentProsentForAntallTimer
 import java.math.BigDecimal
@@ -130,6 +127,8 @@ private fun LocalDate?.tilForskøvetTomBasertPåGraderingsforskjell(graderingsfo
             -> tomDato.plusDays(1).minusMonths(1).sisteDagIMåned()
         }
     }
+
+fun LocalDate?.tilForskjøvetTomMånedForSisteUtbetalingsperiodePgaFremtidigOpphør() = this?.tilForskøvetTomBasertPåGraderingsforskjell(Graderingsforskjell.ReduksjonGårTilIngenUtbetaling)?.toYearMonth()
 
 private fun LocalDate?.tilForskøvetFomBasertPåGraderingsforskjell(graderingsforskjellMellomDenneOgForrigePeriode: Graderingsforskjell) =
     this?.let { fomDato ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvBarnehageplass.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvBarnehageplass.kt
@@ -5,7 +5,11 @@ import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombiner
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioderIkkeNull
-import no.nav.familie.ks.sak.common.util.*
+import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
+import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
+import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
+import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.beregning.domene.hentProsentForAntallTimer
 import java.math.BigDecimal

--- a/src/test/resources/cucumber/fremtidig-opphør.feature
+++ b/src/test/resources/cucumber/fremtidig-opphør.feature
@@ -45,3 +45,61 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.08.2024 til -
       | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Avtale tidspunkt delt bosted | Søkers rett til utvidet |
       | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |               |         | 0     |                  | august 2024                          |                              |                         |
+
+  Scenario: Barnehageplass fra måneden før barnet fyller to år
+    Og følgende dagens dato 06.02.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 23.08.1988 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+
+      | 2       | BARNEHAGEPLASS                                         |                  | 11.09.2022 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                  | Ja                                    |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 11.09.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 2       | BARNETS_ALDER                                          |                  | 11.09.2023 | 11.09.2024 | OPPFYLT  | Nei                  |                      |                  |                                       |
+
+    Og andeler er beregnet for behandling 1
+
+    Og vedtaksperioder er laget for behandling 1
+
+    Så forvent følgende vedtaksperioder på behandling 1
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.10.2023 | 31.07.2024 | UTBETALING         |           |
+      | 01.08.2024 |            | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 1
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                   | Ugyldige begrunnelser |
+      | 01.10.2023 | 31.07.2024 | UTBETALING         |                                |                                        |                       |
+      | 01.08.2024 |            | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.08.2024 til -
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Avtale tidspunkt delt bosted | Søkers rett til utvidet |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |               |         | 0     |                  | august 2024                          |                              |                         |
+
+  Scenario: Barnehageplass fra midten av en måned
+    Og følgende dagens dato 06.02.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 23.08.1988 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+
+      | 2       | BARNEHAGEPLASS                                         |                  | 11.09.2022 | 15.07.2024 | OPPFYLT  | Nei                  |                      |                  | Ja                                    |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 11.09.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 2       | BARNETS_ALDER                                          |                  | 11.09.2023 | 11.09.2024 | OPPFYLT  | Nei                  |                      |                  |                                       |
+
+    Og andeler er beregnet for behandling 1
+
+    Og vedtaksperioder er laget for behandling 1
+
+    Så forvent følgende vedtaksperioder på behandling 1
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.10.2023 | 30.06.2024 | UTBETALING         |           |
+      | 01.07.2024 |            | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 1
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                   | Ugyldige begrunnelser |
+      | 01.10.2023 | 30.06.2024 | UTBETALING         |                                |                                        |                       |
+      | 01.07.2024 |            | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
+
+    Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.07.2024 til -
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Avtale tidspunkt delt bosted | Søkers rett til utvidet |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |               |         | 0     |                  | juli 2024                            |                              |                         |


### PR DESCRIPTION
Følger opp #598 
Favro: NAV-17924

Når vi evaluerer hvorvidt barnehagevilkåret skal føre til at vi lager en opphørsperiode, må vi bruke samme logikk for å utlede siste utbetalingsperiode som vi gjør når vi utleder andel tilkjent ytelse

Legger til et testscenario der vilkåret er satt med tom midt i måneden, i tillegg til eksisterende testscenario der tom er siste dag i måneden. Disse scenarioene vil gi ulik tom-måned for siste utbetalingsperiode