### PR TITLE
Renamer ks-kafka-manager til baks-kafka-manager og flytter over ba-køer

### DIFF
--- a/.deploy/nais/kafka-manager/dev/familie-baks-kafka-manager.yml
+++ b/.deploy/nais/kafka-manager/dev/familie-baks-kafka-manager.yml
@@ -1,15 +1,15 @@
 kind: Application
 apiVersion: nais.io/v1alpha1
 metadata:
-  name: familie-ks-kafka-manager
+  name: familie-baks-kafka-manager
   namespace: teamfamilie
   labels:
     team: teamfamilie
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2023.12.13-06.32-bd9f953 # See https://github.com/navikt/kafka-manager/packages
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2024.02.06-12.20-dabf3e1 # See https://github.com/navikt/kafka-manager/actions
   port: 8080
   ingresses:
-    - https://familie-ks-kafka-manager.intern.dev.nav.no
+    - https://familie-baks-kafka-manager.intern.dev.nav.no
   prometheus:
     enabled: true
     path: /internal/prometheus
@@ -64,6 +64,36 @@ spec:
             },
             {
               "name": "alf.aapen-altinn-barnehageliste-mottatt",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-barnetrygd-vedtak-v2",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-familie-ba-sak-opphoer-barnetrygd",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-barnetrygd-saksstatistikk-sak-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-barnetrygd-saksstatistikk-behandling-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-familie-ba-sak-identer-med-barnetrygd",
               "location": "AIVEN",
               "keyDeserializerType": "STRING",
               "valueDeserializerType": "STRING"

--- a/.deploy/nais/kafka-manager/prod/familie-baks-kafka-manager.yml
+++ b/.deploy/nais/kafka-manager/prod/familie-baks-kafka-manager.yml
@@ -1,15 +1,15 @@
 kind: Application
 apiVersion: nais.io/v1alpha1
 metadata:
-  name: familie-ks-kafka-manager
+  name: familie-baks-kafka-manager
   namespace: teamfamilie
   labels:
     team: teamfamilie
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2023.12.13-06.32-bd9f953 # See https://github.com/navikt/kafka-manager/packages
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2024.02.06-12.20-dabf3e1 # See https://github.com/navikt/kafka-manager/actions
   port: 8080
   ingresses:
-    - https://familie-ks-kafka-manager.intern.nav.no
+    - https://familie-baks-kafka-manager.intern.nav.no
   prometheus:
     enabled: true
     path: /internal/prometheus
@@ -64,6 +64,36 @@ spec:
             },
             {
               "name": "alf.aapen-altinn-barnehageliste-mottatt",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-barnetrygd-vedtak-v2",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-familie-ba-sak-opphoer-barnetrygd",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-barnetrygd-saksstatistikk-sak-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-barnetrygd-saksstatistikk-behandling-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-familie-ba-sak-identer-med-barnetrygd",
               "location": "AIVEN",
               "keyDeserializerType": "STRING",
               "valueDeserializerType": "STRING"

--- a/.deploy/nais/kafka/dev/dvh_sakstatistikk_behandling_topic.yaml
+++ b/.deploy/nais/kafka/dev/dvh_sakstatistikk_behandling_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: dv-familie
       application: dvh-fambt-konsumer

--- a/.deploy/nais/kafka/dev/dvh_sakstatistikk_sak_topic.yaml
+++ b/.deploy/nais/kafka/dev/dvh_sakstatistikk_sak_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: dv-familie
       application: dvh-fambt-konsumer

--- a/.deploy/nais/kafka/dev/dvh_sakstatistikk_siste_tilstand_behandling_topic.yaml
+++ b/.deploy/nais/kafka/dev/dvh_sakstatistikk_siste_tilstand_behandling_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: dv-familie
       application: dvh-fambt-konsumer

--- a/.deploy/nais/kafka/dev/dvh_vedtak_topic.yaml
+++ b/.deploy/nais/kafka/dev/dvh_vedtak_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: teamfamilie
       application: familie-ef-personhendelse

--- a/.deploy/nais/kafka/prod/dvh_sakstatistikk_behandling_topic.yaml
+++ b/.deploy/nais/kafka/prod/dvh_sakstatistikk_behandling_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: dv-familie
       application: dvh-fambt-konsumer

--- a/.deploy/nais/kafka/prod/dvh_sakstatistikk_sak_topic.yaml
+++ b/.deploy/nais/kafka/prod/dvh_sakstatistikk_sak_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: dv-familie
       application: dvh-fambt-konsumer

--- a/.deploy/nais/kafka/prod/dvh_sakstatistikk_siste_tilstand_behandling_topic.yaml
+++ b/.deploy/nais/kafka/prod/dvh_sakstatistikk_siste_tilstand_behandling_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: dv-familie
       application: dvh-fambt-konsumer

--- a/.deploy/nais/kafka/prod/dvh_vedtak_topic.yaml
+++ b/.deploy/nais/kafka/prod/dvh_vedtak_topic.yaml
@@ -19,7 +19,7 @@ spec:
       application: familie-ks-sak #owner
       access: write   # readwrite
     - team: teamfamilie
-      application: familie-ks-kafka-manager
+      application: familie-baks-kafka-manager
       access: read
     - team: teamfamilie
       application: familie-ef-personhendelse

--- a/.github/workflows/deploy-kafka-manager.yml
+++ b/.github/workflows/deploy-kafka-manager.yml
@@ -1,4 +1,4 @@
-name: Deploy familie-ks-kafka-manager
+name: Deploy familie-baks-kafka-manager
 
 on:
   workflow_dispatch:
@@ -9,15 +9,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Deploy familie-ks-kafka-manager til dev
+      - name: Deploy familie-baks-kafka-manager til dev
         uses: nais/deploy/actions/deploy@v2
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
-          RESOURCE: .deploy/nais/kafka-manager/dev/familie-ks-kafka-manager.yml
-      - name: Deploy familie-ks-kafka-manager til prod
+          RESOURCE: .deploy/nais/kafka-manager/dev/familie-baks-kafka-manager.yml
+      - name: Deploy familie-baks-kafka-manager til prod
         uses: nais/deploy/actions/deploy@v2
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
-          RESOURCE: .deploy/nais/kafka-manager/prod/familie-ks-kafka-manager.yml
+          RESOURCE: .deploy/nais/kafka-manager/prod/familie-baks-kafka-manager.yml

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ under actions på GitHub, finn byggejobben du vil gå tilbake til, og kopier tag
 
 ### Monitorering av kafka køer
 
-Det er satt opp en tjeneste familie-ks-kafka-manager som er et verktøy for å monitorere
+Det er satt opp en tjeneste familie-baks-kafka-manager som er et verktøy for å monitorere
 kafka meldinger i preprod og prod.
 
-* Preprod: https://familie-ks-kafka-manager.intern.dev.nav.no
-* Prod: https://familie-ks-kafka-manager.intern.nav.no
+* Preprod: https://familie-baks-kafka-manager.intern.dev.nav.no
+* Prod: https://familie-baks-kafka-manager.intern.nav.no
 
 ## Kontaktinformasjon
 


### PR DESCRIPTION
familie-ba-kafka-manager er i ba-statistikk. Flytter de over hit og lager felles app for baks