### PR TITLE
Tillat manglende barnehageplassperiode dersom siste periode har framtidig opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -212,26 +212,30 @@ class VilkårsvurderingSteg(
                     it.vilkårType == Vilkår.BARNEHAGEPLASS
                 }
 
-            val minFraOgMedDatoIBarnehageplassVilkårResultater =
+            val startDatoBarnehageplassVilkår =
                 barnehageplassVilkårResultater.sortedBy { it.periodeFom }.first().periodeFom
                     ?: error("Mangler fom dato")
-            val maksTilOmMedDatoIBarnehageplassVilkårResultater =
-                barnehageplassVilkårResultater.sortedWith(compareBy(nullsLast()) { it.periodeTom }).last().periodeTom
+            val sisteBarnehageplassVilkårresultat = barnehageplassVilkårResultater.sortedWith(compareBy(nullsLast()) { it.periodeTom }).last()
+
+            val sluttDatoBarnehageplassVilkår =
+                sisteBarnehageplassVilkårresultat.periodeTom
                     ?: TIDENES_ENDE
+            val sisteBarnehageplassVilkårresultatHarFramtidigOpphør =
+                sisteBarnehageplassVilkårresultat.søkerHarMeldtFraOmBarnehageplass == true
 
             val barnetsAlderVilkårResultater =
                 personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.BARNETS_ALDER }
 
-            val minFraOgMedDatoIBarnetsAlderVilkårResultater =
+            val startDatoBarnetsAlderVilkår =
                 barnetsAlderVilkårResultater.sortedBy { it.periodeFom }.first().periodeFom
                     ?: person.fødselsdato.plusYears(1)
 
-            val maksTilOmMedDatoIBarnetsAlderVilkårResultater =
+            val sluttDatoBarnetsAlderVilkår =
                 barnetsAlderVilkårResultater.sortedBy { it.periodeTom }.last().periodeTom
                     ?: person.fødselsdato.plusYears(2)
 
-            if (minFraOgMedDatoIBarnehageplassVilkårResultater.isAfter(minFraOgMedDatoIBarnetsAlderVilkårResultater) ||
-                maksTilOmMedDatoIBarnehageplassVilkårResultater.isBefore(maksTilOmMedDatoIBarnetsAlderVilkårResultater)
+            if (startDatoBarnehageplassVilkår.isAfter(startDatoBarnetsAlderVilkår) ||
+                (!sisteBarnehageplassVilkårresultatHarFramtidigOpphør && sluttDatoBarnehageplassVilkår.isBefore(sluttDatoBarnetsAlderVilkår))
             ) {
                 throw FunksjonellFeil(
                     "Det mangler vurdering på vilkåret ${Vilkår.BARNEHAGEPLASS.beskrivelse}. " +
@@ -239,7 +243,7 @@ class VilkårsvurderingSteg(
                 )
             }
             if (barnehageplassVilkårResultater.any {
-                    it.periodeFom?.isAfter(maksTilOmMedDatoIBarnetsAlderVilkårResultater) == true
+                    it.periodeFom?.isAfter(sluttDatoBarnetsAlderVilkår) == true
                 }
             ) {
                 throw FunksjonellFeil(


### PR DESCRIPTION
Backend til denne frontend-PR-en: https://github.com/navikt/familie-ks-sak-frontend/pull/559
Favro: NAV-17924

Dersom SB har lagt inn et vilkårsresultat på barnehagevilkåret med fremtidig opphør pga fremtidig barnehageplass, skal vi akseptere at det ikke er lagt inn påfølgende vilkårsresultater som dekker perioden der barnets alder oppfyller aldersvilkåret. Dersom et slikt fremtidig opphør ikke er lagt inn, krever vi som tidligere at barnehagevilkåret må være vurdert i hele perioden der barnets alder oppfyller aldersvilkåret 

Endrer også eksisterende variabelnavn i valideringsfunksjonen i et forsøk på å forbedre lesbarheten