### PR TITLE
Fix: Eøs-avslagsbegrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -98,7 +98,7 @@ data class VedtaksperiodeMedBegrunnelser(
         }
 
     fun harFriteksterUtenStandardbegrunnelser(): Boolean =
-        (type == Vedtaksperiodetype.OPPHØR || type == Vedtaksperiodetype.AVSLAG) && fritekster.isNotEmpty() && begrunnelser.isEmpty()
+        fritekster.isNotEmpty() && begrunnelser.isEmpty() && eøsBegrunnelser.isEmpty()
 
     fun harFriteksterOgStandardbegrunnelser(): Boolean = fritekster.isNotEmpty() && begrunnelser.isNotEmpty()
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -437,9 +437,10 @@ class BrevPeriodeContext(
                 val begrunnelseGjelderOpphørFraForrigeBehandling = sanityBegrunnelse.begrunnelseGjelderOpphørFraForrigeBehandling()
 
                 if (relevanteKompetanser.isEmpty() && (begrunnelse.begrunnelseType.erAvslagEllerEøsAvslag() || begrunnelse.begrunnelseType == BegrunnelseType.EØS_OPPHØR)) {
+                    val barnIBegrunnelse = personerGjeldendeForBegrunnelse.filter { it.type == PersonType.BARN }
                     val barnasFødselsdagerForAvslagOgOpphør =
                         hentBarnasFødselsdagerForAvslagOgOpphør(
-                            barnIBegrunnelse = personerGjeldendeForBegrunnelse.filter { it.type == PersonType.BARN },
+                            barnIBegrunnelse = barnIBegrunnelse,
                             barnPåBehandling = persongrunnlag.barna,
                             uregistrerteBarn = uregistrerteBarn,
                             gjelderSøker = gjelderSøker,
@@ -451,7 +452,7 @@ class BrevPeriodeContext(
                             apiNavn = begrunnelse.sanityApiNavn,
                             sanityBegrunnelseType = sanityBegrunnelse.type,
                             barnasFodselsdatoer = barnasFødselsdagerForAvslagOgOpphør.tilBrevTekst(),
-                            antallBarn = barnasFødselsdagerForAvslagOgOpphør.size,
+                            antallBarn = barnIBegrunnelse.size,
                             maalform = persongrunnlag.søker.målform.tilSanityFormat(),
                             gjelderSoker = gjelderSøker,
                         ),


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17932

To små feil meldt inn på denne oppgaven 👆

- Fikser så EØS begrunnelse også sees på når man skal se om vedtaksperiode har fritekst uten standardbegrunnelse
- Antall barn som skal sendes med for begrunnelse skal alltid være antall barn i begrunnelsen, og ikke alle barna i behandlingen for avslag