### PR TITLE
Lagt til feed køene til kafka-manager

### DIFF
--- a/.deploy/nais/kafka-manager/dev/familie-baks-kafka-manager.yml
+++ b/.deploy/nais/kafka-manager/dev/familie-baks-kafka-manager.yml
@@ -97,6 +97,18 @@ spec:
               "location": "AIVEN",
               "keyDeserializerType": "STRING",
               "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-feed-barnetrygd-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-feed-kontantstotte-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
             }
           ]
         }

--- a/.deploy/nais/kafka-manager/prod/familie-baks-kafka-manager.yml
+++ b/.deploy/nais/kafka-manager/prod/familie-baks-kafka-manager.yml
@@ -97,6 +97,18 @@ spec:
               "location": "AIVEN",
               "keyDeserializerType": "STRING",
               "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-feed-barnetrygd-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
+            },
+            {
+              "name": "teamfamilie.aapen-feed-kontantstotte-v1",
+              "location": "AIVEN",
+              "keyDeserializerType": "STRING",
+              "valueDeserializerType": "STRING"
             }
           ]
         }


### PR DESCRIPTION
Flytter over fra baks-infotrygd-feed sin egen kafka-manager, og slettet den andre appen. Slik at man slipper å endre så mange kafka-managere når de oppdateres