### PR TITLE
Bug/cucumbertester legger til forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -126,7 +126,7 @@ fun hentTekstForBehandlinger(
       | ${it.id} | 1 |           | ${it.resultat} | ${it.opprettetÅrsak}  | ${it.kategori} |"""
         } ?: ""
     }
-      | ${behandling.id} | 2 | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak}  | ${behandling.kategori} |"""
+      | ${behandling.id} | 1 | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak}  | ${behandling.kategori} |"""
 
 fun hentTekstForPersongrunnlag(
     persongrunnlag: PersonopplysningGrunnlag,

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -469,7 +469,7 @@ fun hentBrevBegrunnelseTekster(
         """
 
     Så forvent følgende brevbegrunnelser for behandling $behandlingId i periode ${vedtaksperiode.fom?.tilddMMyyyy() ?: "-"} til ${vedtaksperiode.tom?.tilddMMyyyy() ?: "-"}
-        | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Gjelder søker  | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for| Avtale tidspunkt delt bosted | Søkers rett til utvidet |""" +
+        | Begrunnelse | Type | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | """ +
             vedtaksperiode.begrunnelser.map { it.nasjonalEllerFellesBegrunnelse }.joinToString("") {
                 """
         | $it | STANDARD |               |                      |             |                                      |         |       |                  |                         |                               |"""
@@ -485,10 +485,10 @@ fun hentEØSBrevBegrunnelseTekster(
         """
 
     Så forvent følgende brevbegrunnelser for behandling $behandlingId i periode ${vedtaksperiode.fom?.tilddMMyyyy() ?: "-"} til ${vedtaksperiode.tom?.tilddMMyyyy() ?: "-"}
-        | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland | """ +
+        | Begrunnelse | Type | Gjelder søker | Barnas fødselsdatoer | Antall barn | Annen forelders aktivitet | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitet | Søkers aktivitetsland | Målform |""" +
             vedtaksperiode.eøsBegrunnelser.map { it.begrunnelse }.joinToString("") {
                 """
-        | $it | EØS | | | | | | | | |"""
+        | $it | EØS |               |                      |             |                                      |         |       |                  |                         |                               |"""
             }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -120,13 +120,13 @@ fun hentTekstForBehandlinger(
     """
 
     Og følgende behandlinger
-      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak  | Behandlingskategori |${
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak  | Behandlingskategori | Behandlingsstatus | ${
         forrigeBehandling?.let {
             """ 
-      | ${it.id} | 1 |           | ${it.resultat} | ${it.opprettetÅrsak}  | ${it.kategori} |"""
+      | ${it.id} | 1 |           | ${it.resultat} | ${it.opprettetÅrsak}  | ${it.kategori} | ${it.status} |"""
         } ?: ""
     }
-      | ${behandling.id} | 1 | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak}  | ${behandling.kategori} |"""
+      | ${behandling.id} | 1 | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak}  | ${behandling.kategori} | ${behandling.status} |"""
 
 fun hentTekstForPersongrunnlag(
     persongrunnlag: PersonopplysningGrunnlag,

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -31,7 +31,6 @@ import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -236,7 +235,7 @@ fun lagBehandling(
     type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     opprettetÅrsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
     kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
-    resultat: Behandlingsresultat = Behandlingsresultat.IKKE_VURDERT
+    resultat: Behandlingsresultat = Behandlingsresultat.IKKE_VURDERT,
 ): Behandling =
     Behandling(
         id = nesteBehandlingId(),
@@ -246,7 +245,6 @@ fun lagBehandling(
         kategori = kategori,
         resultat = resultat,
     ).initBehandlingStegTilstand()
-
 
 fun lagBehandlingStegTilstand(
     behandling: Behandling,
@@ -272,11 +270,11 @@ fun lagArbeidsfordelingPåBehandling(behandlingId: Long): ArbeidsfordelingPåBeh
 fun lagRegistrerSøknadDto() =
     RegistrerSøknadDto(
         søknad =
-        SøknadDto(
-            søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = randomFnr()),
-            barnaMedOpplysninger = listOf(BarnMedOpplysningerDto(ident = randomFnr())),
-            endringAvOpplysningerBegrunnelse = "",
-        ),
+            SøknadDto(
+                søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = randomFnr()),
+                barnaMedOpplysninger = listOf(BarnMedOpplysningerDto(ident = randomFnr())),
+                endringAvOpplysningerBegrunnelse = "",
+            ),
         bekreftEndringerViaFrontend = true,
     )
 
@@ -305,16 +303,16 @@ fun lagBostedsadresse(): Bostedsadresse =
     Bostedsadresse(
         gyldigFraOgMed = LocalDate.of(2015, 1, 1),
         vegadresse =
-        Vegadresse(
-            matrikkelId = 1234,
-            husnummer = "3",
-            husbokstav = null,
-            bruksenhetsnummer = null,
-            adressenavn = "OTTO SVERDRUPS VEG",
-            kommunenummer = "1560",
-            postnummer = "6650",
-            tilleggsnavn = null,
-        ),
+            Vegadresse(
+                matrikkelId = 1234,
+                husnummer = "3",
+                husbokstav = null,
+                bruksenhetsnummer = null,
+                adressenavn = "OTTO SVERDRUPS VEG",
+                kommunenummer = "1560",
+                postnummer = "6650",
+                tilleggsnavn = null,
+            ),
     )
 
 fun lagSivilstand(): Sivilstand = Sivilstand(type = SIVILSTAND.UGIFT, gyldigFraOgMed = LocalDate.of(2004, 12, 2))
@@ -448,23 +446,23 @@ fun lagVilkårsvurderingMedSøkersVilkår(
                 utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
             ),
         ) +
-                if (regelverk == Regelverk.EØS_FORORDNINGEN) {
-                    setOf(
-                        VilkårResultat(
-                            personResultat = personResultat,
-                            vilkårType = Vilkår.LOVLIG_OPPHOLD,
-                            resultat = resultat,
-                            periodeFom = søkerPeriodeFom,
-                            periodeTom = søkerPeriodeTom,
-                            begrunnelse = "",
-                            behandlingId = behandling.id,
-                            vurderesEtter = regelverk,
-                            utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
-                        ),
-                    )
-                } else {
-                    emptySet()
-                },
+            if (regelverk == Regelverk.EØS_FORORDNINGEN) {
+                setOf(
+                    VilkårResultat(
+                        personResultat = personResultat,
+                        vilkårType = Vilkår.LOVLIG_OPPHOLD,
+                        resultat = resultat,
+                        periodeFom = søkerPeriodeFom,
+                        periodeTom = søkerPeriodeTom,
+                        begrunnelse = "",
+                        behandlingId = behandling.id,
+                        vurderesEtter = regelverk,
+                        utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
+                    ),
+                )
+            } else {
+                emptySet()
+            },
     )
 
     personResultat.andreVurderinger.add(
@@ -687,12 +685,12 @@ fun lagPersonResultat(
                     begrunnelse = "",
                     behandlingId = vilkårsvurdering.behandling.id,
                     utdypendeVilkårsvurderinger =
-                    listOfNotNull(
-                        when {
-                            erDeltBosted && it == Vilkår.BOR_MED_SØKER -> UtdypendeVilkårsvurdering.DELT_BOSTED
-                            else -> null
-                        },
-                    ),
+                        listOfNotNull(
+                            when {
+                                erDeltBosted && it == Vilkår.BOR_MED_SØKER -> UtdypendeVilkårsvurdering.DELT_BOSTED
+                                else -> null
+                            },
+                        ),
                 )
             }.toSet(),
         )
@@ -769,9 +767,9 @@ fun lagØkonomiSimuleringPostering(
     posteringType: PosteringType = PosteringType.YTELSE,
 ) = ØkonomiSimuleringPostering(
     økonomiSimuleringMottaker =
-    lagØkonomiSimuleringMottaker(
-        behandling = behandling,
-    ),
+        lagØkonomiSimuleringMottaker(
+            behandling = behandling,
+        ),
     fagOmrådeKode = FagOmrådeKode.KONTANTSTØTTE,
     fom = fom,
     tom = tom,
@@ -874,13 +872,13 @@ fun lagVilkårsvurderingOppfylt(
                     VilkårResultat(
                         personResultat = personResultat,
                         periodeFom =
-                        if (person.type == PersonType.SØKER) {
-                            person.fødselsdato
-                        } else {
-                            person.fødselsdato.plusYears(
-                                1,
-                            )
-                        },
+                            if (person.type == PersonType.SØKER) {
+                                person.fødselsdato
+                            } else {
+                                person.fødselsdato.plusYears(
+                                    1,
+                                )
+                            },
                         periodeTom = if (person.type == PersonType.SØKER) null else person.fødselsdato.plusYears(2),
                         vilkårType = it,
                         resultat = Resultat.OPPFYLT,

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -236,8 +236,7 @@ fun lagBehandling(
     type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
     opprettetÅrsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
     kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
-    resultat: Behandlingsresultat = Behandlingsresultat.IKKE_VURDERT,
-    status: BehandlingStatus = BehandlingStatus.UTREDES
+    resultat: Behandlingsresultat = Behandlingsresultat.IKKE_VURDERT
 ): Behandling =
     Behandling(
         id = nesteBehandlingId(),
@@ -246,18 +245,7 @@ fun lagBehandling(
         opprettetÅrsak = opprettetÅrsak,
         kategori = kategori,
         resultat = resultat,
-        status = status,
     ).initBehandlingStegTilstand()
-        .apply {
-            if (status == BehandlingStatus.AVSLUTTET) {
-                this.behandlingStegTilstand.add(
-                    BehandlingStegTilstand(
-                        behandling = this,
-                        behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING
-                    )
-                )
-            }
-        }
 
 
 fun lagBehandlingStegTilstand(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
@@ -127,8 +127,8 @@ fun parseValgfriBoolean(
     }
 
     return when (verdi.uppercase()) {
-        "JA" -> true
-        "NEI" -> false
+        "JA", "TRUE" -> true
+        "NEI", "FALSE" -> false
         else -> null
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/DomeneparserUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/DomeneparserUtil.kt
@@ -17,6 +17,7 @@ enum class Domenebegrep(override val nøkkel: String) : Domenenøkkel {
     ENDRET_MIGRERINGSDATO("Endret migreringsdato"),
     BEHANDLINGSÅRSAK("Behandlingsårsak"),
     BEHANDLINGSRESULTAT("Behandlingsresultat"),
+    BEHANDLINGSSTATUS("Behandlingsstatus"),
     SKAL_BEHANLDES_AUTOMATISK("Skal behandles automatisk"),
     SØKNADSTIDSPUNKT("Søknadstidspunkt"),
     BEHANDLINGSKATEGORI("Behandlingskategori"),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -73,7 +73,7 @@ fun parseNasjonalEllerFellesBegrunnelse(rad: Tabellrad): BegrunnelseDtoMedData {
                 BrevPeriodeParser.DomenebegrepBrevBegrunnelse.SØKNADSTIDSPUNKT,
                 rad,
             ) ?: "",
-        antallTimerBarnehageplass = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_TIMER_BARNEHAGEPLASS, rad) ?: 0.toString(),
+        antallTimerBarnehageplass = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_TIMER_BARNEHAGEPLASS, rad) ?: "0",
         sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
         gjelderAndreForelder = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_ANDRE_FORELDER, rad) ?: true,
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseDto
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.domene.SøknadGrunnlag
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
@@ -433,7 +434,7 @@ class StepDefinition {
     fun mockVedtaksperiodeService(): VedtaksperiodeService {
         val behandlingRepository = mockk<BehandlingRepository>()
         every { behandlingRepository.finnIverksatteBehandlinger(any<Long>()) } answers {
-            behandlinger.values.filter { behandling -> behandling.fagsak.id == firstArg<Long>() }
+            behandlinger.values.filter { behandling -> behandling.fagsak.id == firstArg<Long>() && behandling.status == BehandlingStatus.AVSLUTTET }
         }
         every { behandlingRepository.finnBehandlinger(any<Long>()) } answers {
             behandlinger.values.filter { behandling -> behandling.fagsak.id == firstArg<Long>() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.tilfeldigPerson
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
@@ -93,12 +94,14 @@ fun lagVedtakListe(
             val behandlingKategori =
                 parseValgfriEnum<BehandlingKategori>(Domenebegrep.BEHANDLINGSKATEGORI, rad)
                     ?: BehandlingKategori.NASJONAL
+            val status = parseValgfriEnum<BehandlingStatus>(Domenebegrep.BEHANDLINGSSTATUS, rad)
 
             lagBehandling(
                 fagsak = fagsak,
                 opprettetÅrsak = behandlingÅrsak ?: BehandlingÅrsak.SØKNAD,
                 resultat = behandlingResultat ?: Behandlingsresultat.IKKE_VURDERT,
                 kategori = behandlingKategori,
+                status = status ?: BehandlingStatus.UTREDES,
             ).copy(id = behandlingId)
         }.associateBy { it.id },
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -86,7 +86,6 @@ fun lagVedtakListe(
     behandlingTilForrigeBehandling: MutableMap<Long, Long?>,
     fagsaker: Map<Long, Fagsak>,
 ): List<Vedtak> {
-
     behandlinger.putAll(
         dataTable.asMaps().map { rad ->
             val behandlingId = parseLong(Domenebegrep.BEHANDLING_ID, rad)
@@ -99,12 +98,13 @@ fun lagVedtakListe(
                     ?: BehandlingKategori.NASJONAL
             val status = parseValgfriEnum<BehandlingStatus>(Domenebegrep.BEHANDLINGSSTATUS, rad)
 
-            val behandling = lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = behandlingÅrsak ?: BehandlingÅrsak.SØKNAD,
-                resultat = behandlingResultat ?: Behandlingsresultat.IKKE_VURDERT,
-                kategori = behandlingKategori,
-            ).copy(id = behandlingId)
+            val behandling =
+                lagBehandling(
+                    fagsak = fagsak,
+                    opprettetÅrsak = behandlingÅrsak ?: BehandlingÅrsak.SØKNAD,
+                    resultat = behandlingResultat ?: Behandlingsresultat.IKKE_VURDERT,
+                    kategori = behandlingKategori,
+                ).copy(id = behandlingId)
             behandling.apply {
                 this.status = status ?: BehandlingStatus.UTREDES
 
@@ -112,8 +112,8 @@ fun lagVedtakListe(
                     this.behandlingStegTilstand.add(
                         BehandlingStegTilstand(
                             behandling = this,
-                            behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING
-                        )
+                            behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING,
+                        ),
                     )
                 }
             }
@@ -194,17 +194,17 @@ private fun lagVilkårResultater(
             personResultat = personResultat,
             vilkårType = vilkår,
             resultat =
-            parseEnum<Resultat>(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.RESULTAT,
-                rad,
-            ),
+                parseEnum<Resultat>(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.RESULTAT,
+                    rad,
+                ),
             periodeFom = parseValgfriDato(Domenebegrep.FRA_DATO, rad),
             periodeTom = parseValgfriDato(Domenebegrep.TIL_DATO, rad),
             erEksplisittAvslagPåSøknad =
-            parseValgfriBoolean(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.ER_EKSPLISITT_AVSLAG,
-                rad,
-            ),
+                parseValgfriBoolean(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.ER_EKSPLISITT_AVSLAG,
+                    rad,
+                ),
             begrunnelse = "",
             utdypendeVilkårsvurderinger = utdypendeVilkårsvurderingFor,
             vurderesEtter = vurderesEtter,
@@ -243,42 +243,42 @@ fun lagKompetanser(
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             barnAktører =
-            personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
-                .filter { aktørerForKompetanse.contains(it.aktør.aktørId) }
-                .map { it.aktør }
-                .toSet(),
+                personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
+                    .filter { aktørerForKompetanse.contains(it.aktør.aktørId) }
+                    .map { it.aktør }
+                    .toSet(),
             søkersAktivitet =
-            parseValgfriEnum<KompetanseAktivitet>(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITET,
-                rad,
-            )
-                ?: KompetanseAktivitet.ARBEIDER,
+                parseValgfriEnum<KompetanseAktivitet>(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITET,
+                    rad,
+                )
+                    ?: KompetanseAktivitet.ARBEIDER,
             annenForeldersAktivitet =
-            parseValgfriEnum<KompetanseAktivitet>(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITET,
-                rad,
-            )
-                ?: KompetanseAktivitet.I_ARBEID,
+                parseValgfriEnum<KompetanseAktivitet>(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITET,
+                    rad,
+                )
+                    ?: KompetanseAktivitet.I_ARBEID,
             søkersAktivitetsland =
-            parseValgfriString(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITETSLAND,
-                rad,
-            )?.also { validerErLandkode(it) } ?: "PL",
+                parseValgfriString(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITETSLAND,
+                    rad,
+                )?.also { validerErLandkode(it) } ?: "PL",
             annenForeldersAktivitetsland =
-            parseValgfriString(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITETSLAND,
-                rad,
-            )?.also { validerErLandkode(it) } ?: "NO",
+                parseValgfriString(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITETSLAND,
+                    rad,
+                )?.also { validerErLandkode(it) } ?: "NO",
             barnetsBostedsland =
-            parseValgfriString(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.BARNETS_BOSTEDSLAND,
-                rad,
-            )?.also { validerErLandkode(it) } ?: "NO",
+                parseValgfriString(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.BARNETS_BOSTEDSLAND,
+                    rad,
+                )?.also { validerErLandkode(it) } ?: "NO",
             resultat =
-            parseEnum<KompetanseResultat>(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.RESULTAT,
-                rad,
-            ),
+                parseEnum<KompetanseResultat>(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.RESULTAT,
+                    rad,
+                ),
         ).also { it.behandlingId = behandlingId }
     }.groupBy { it.behandlingId }
         .toMutableMap()
@@ -295,16 +295,16 @@ fun lagValutakurs(
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             barnAktører =
-            personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
-                .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
-                .map { it.aktør }
-                .toSet(),
+                personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
+                    .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
+                    .map { it.aktør }
+                    .toSet(),
             valutakursdato = parseValgfriDato(VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VALUTAKURSDATO, rad),
             valutakode =
-            parseValgfriString(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VALUTA_KODE,
-                rad,
-            ),
+                parseValgfriString(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VALUTA_KODE,
+                    rad,
+                ),
             kurs = parseBigDecimal(VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.KURS, rad),
         ).also { it.behandlingId = behandlingId }
     }
@@ -321,16 +321,16 @@ fun lagUtenlandskperiodeBeløp(
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             barnAktører =
-            personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
-                .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
-                .map { it.aktør }
-                .toSet(),
+                personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
+                    .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
+                    .map { it.aktør }
+                    .toSet(),
             beløp = parseBigDecimal(VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.BELØP, rad),
             valutakode =
-            parseValgfriString(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.VALUTA_KODE,
-                rad,
-            ),
+                parseValgfriString(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.VALUTA_KODE,
+                    rad,
+                ),
             intervall = parseValgfriEnum<Intervall>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.INTERVALL, rad),
             utbetalingsland = parseValgfriString(VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.UTBETALINGSLAND, rad),
         ).let {
@@ -358,20 +358,20 @@ fun lagEndredeUtbetalinger(
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             person = persongrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer.find { aktørId == it.aktør.aktørId },
             prosent =
-            parseValgfriLong(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
-                rad,
-            )?.toBigDecimal() ?: BigDecimal.valueOf(100),
+                parseValgfriLong(
+                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
+                    rad,
+                )?.toBigDecimal() ?: BigDecimal.valueOf(100),
             årsak =
-            parseValgfriEnum<Årsak>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.ÅRSAK, rad)
-                ?: Årsak.ALLEREDE_UTBETALT,
+                parseValgfriEnum<Årsak>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.ÅRSAK, rad)
+                    ?: Årsak.ALLEREDE_UTBETALT,
             søknadstidspunkt = parseValgfriDato(Domenebegrep.SØKNADSTIDSPUNKT, rad) ?: LocalDate.now(),
             begrunnelse = "Fordi at...",
             avtaletidspunktDeltBosted =
-            parseValgfriDato(
-                BrevPeriodeParser.DomenebegrepBrevBegrunnelse.AVTALETIDSPUNKT_DELT_BOSTED,
-                rad,
-            ),
+                parseValgfriDato(
+                    BrevPeriodeParser.DomenebegrepBrevBegrunnelse.AVTALETIDSPUNKT_DELT_BOSTED,
+                    rad,
+                ),
         )
     }.groupBy { it.behandlingId }
         .toMutableMap()
@@ -381,24 +381,24 @@ fun lagPersonGrunnlag(dataTable: DataTable): Map<Long, PersonopplysningGrunnlag>
         val behandlingsIder = parseList(Domenebegrep.BEHANDLING_ID, rad)
         behandlingsIder.map { id ->
             id to
-                    tilfeldigPerson(
-                        personType =
+                tilfeldigPerson(
+                    personType =
                         parseEnum(
                             VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.PERSON_TYPE,
                             rad,
                         ),
-                        fødselsdato =
+                    fødselsdato =
                         parseDato(
                             VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.FØDSELSDATO,
                             rad,
                         ),
-                        aktør = randomAktør().copy(aktørId = VedtaksperiodeMedBegrunnelserParser.parseAktørId(rad)),
-                    ).also { person ->
-                        parseValgfriDato(
-                            VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.DØDSFALLDATO,
-                            rad,
-                        )?.let { person.dødsfall = lagDødsfall(person = person, dødsfallDato = it) }
-                    }
+                    aktør = randomAktør().copy(aktørId = VedtaksperiodeMedBegrunnelserParser.parseAktørId(rad)),
+                ).also { person ->
+                    parseValgfriDato(
+                        VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.DØDSFALLDATO,
+                        rad,
+                    )?.let { person.dødsfall = lagDødsfall(person = person, dødsfallDato = it) }
+                }
         }
     }.flatten()
         .groupBy({ it.first }, { it.second })
@@ -425,30 +425,30 @@ fun lagAndelerTilkjentYtelse(
         aktør = personGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer.find { aktørId == it.aktør.aktørId }!!.aktør,
         kalkulertUtbetalingsbeløp = beløp,
         ytelseType =
-        parseValgfriEnum<YtelseType>(
-            VedtaksperiodeMedBegrunnelserParser.DomenebegrepAndelTilkjentYtelse.YTELSE_TYPE,
-            rad,
-        ) ?: YtelseType.ORDINÆR_KONTANTSTØTTE,
+            parseValgfriEnum<YtelseType>(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepAndelTilkjentYtelse.YTELSE_TYPE,
+                rad,
+            ) ?: YtelseType.ORDINÆR_KONTANTSTØTTE,
         prosent =
-        parseValgfriLong(
-            VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
-            rad,
-        )?.toBigDecimal() ?: BigDecimal(100),
+            parseValgfriLong(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
+                rad,
+            )?.toBigDecimal() ?: BigDecimal(100),
         sats =
-        parseValgfriInt(
-            VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.SATS,
-            rad,
-        ) ?: beløp,
+            parseValgfriInt(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.SATS,
+                rad,
+            ) ?: beløp,
         nasjonaltPeriodebeløp =
-        parseValgfriInt(
-            VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.NASJONALT_PERIODEBELØP,
-            rad,
-        ) ?: beløp,
+            parseValgfriInt(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.NASJONALT_PERIODEBELØP,
+                rad,
+            ) ?: beløp,
         differanseberegnetPeriodebeløp =
-        parseValgfriInt(
-            VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.DIFFERANSEBEREGNET_BELØP,
-            rad,
-        ),
+            parseValgfriInt(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.DIFFERANSEBEREGNET_BELØP,
+                rad,
+            ),
     )
 }
 
@@ -479,7 +479,7 @@ fun leggBegrunnelserIVedtaksperiodene(
                 vedtaksperioder.find { it.fom == fom && it.tom == tom }
                     ?: throw Feil(
                         "Ingen vedtaksperioder med Fom=$fom og Tom=$tom. " +
-                                "Vedtaksperiodene var ${vedtaksperioder.map { "\n${it.fom?.tilddMMyyyy()} til ${it.tom?.tilddMMyyyy()}" }}",
+                            "Vedtaksperiodene var ${vedtaksperioder.map { "\n${it.fom?.tilddMMyyyy()} til ${it.tom?.tilddMMyyyy()}" }}",
                     )
 
             val nasjonaleOgFellesBegrunnelser =
@@ -513,8 +513,8 @@ fun leggBegrunnelserIVedtaksperiodene(
         vedtaksperioder.filter { vedtaksperiodeUtenBegrunnelse ->
             vedtaksperioderSomHarFåttBegrunnelser.none {
                 it.fom == vedtaksperiodeUtenBegrunnelse.fom &&
-                        it.tom == vedtaksperiodeUtenBegrunnelse.tom &&
-                        it.type == vedtaksperiodeUtenBegrunnelse.type
+                    it.tom == vedtaksperiodeUtenBegrunnelse.tom &&
+                    it.type == vedtaksperiodeUtenBegrunnelse.type
             }
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -33,8 +33,10 @@ import no.nav.familie.ks.sak.data.tilfeldigPerson
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.EØSBegrunnelseDB
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.NasjonalEllerFellesBegrunnelseDB
@@ -84,6 +86,7 @@ fun lagVedtakListe(
     behandlingTilForrigeBehandling: MutableMap<Long, Long?>,
     fagsaker: Map<Long, Fagsak>,
 ): List<Vedtak> {
+
     behandlinger.putAll(
         dataTable.asMaps().map { rad ->
             val behandlingId = parseLong(Domenebegrep.BEHANDLING_ID, rad)
@@ -96,13 +99,24 @@ fun lagVedtakListe(
                     ?: BehandlingKategori.NASJONAL
             val status = parseValgfriEnum<BehandlingStatus>(Domenebegrep.BEHANDLINGSSTATUS, rad)
 
-            lagBehandling(
+            val behandling = lagBehandling(
                 fagsak = fagsak,
                 opprettetÅrsak = behandlingÅrsak ?: BehandlingÅrsak.SØKNAD,
                 resultat = behandlingResultat ?: Behandlingsresultat.IKKE_VURDERT,
                 kategori = behandlingKategori,
-                status = status ?: BehandlingStatus.UTREDES,
             ).copy(id = behandlingId)
+            behandling.apply {
+                this.status = status ?: BehandlingStatus.UTREDES
+
+                if (status == BehandlingStatus.AVSLUTTET) {
+                    this.behandlingStegTilstand.add(
+                        BehandlingStegTilstand(
+                            behandling = this,
+                            behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING
+                        )
+                    )
+                }
+            }
         }.associateBy { it.id },
     )
     behandlingTilForrigeBehandling.putAll(
@@ -180,17 +194,17 @@ private fun lagVilkårResultater(
             personResultat = personResultat,
             vilkårType = vilkår,
             resultat =
-                parseEnum<Resultat>(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.RESULTAT,
-                    rad,
-                ),
+            parseEnum<Resultat>(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.RESULTAT,
+                rad,
+            ),
             periodeFom = parseValgfriDato(Domenebegrep.FRA_DATO, rad),
             periodeTom = parseValgfriDato(Domenebegrep.TIL_DATO, rad),
             erEksplisittAvslagPåSøknad =
-                parseValgfriBoolean(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.ER_EKSPLISITT_AVSLAG,
-                    rad,
-                ),
+            parseValgfriBoolean(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.ER_EKSPLISITT_AVSLAG,
+                rad,
+            ),
             begrunnelse = "",
             utdypendeVilkårsvurderinger = utdypendeVilkårsvurderingFor,
             vurderesEtter = vurderesEtter,
@@ -229,42 +243,42 @@ fun lagKompetanser(
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             barnAktører =
-                personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
-                    .filter { aktørerForKompetanse.contains(it.aktør.aktørId) }
-                    .map { it.aktør }
-                    .toSet(),
+            personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
+                .filter { aktørerForKompetanse.contains(it.aktør.aktørId) }
+                .map { it.aktør }
+                .toSet(),
             søkersAktivitet =
-                parseValgfriEnum<KompetanseAktivitet>(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITET,
-                    rad,
-                )
-                    ?: KompetanseAktivitet.ARBEIDER,
+            parseValgfriEnum<KompetanseAktivitet>(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITET,
+                rad,
+            )
+                ?: KompetanseAktivitet.ARBEIDER,
             annenForeldersAktivitet =
-                parseValgfriEnum<KompetanseAktivitet>(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITET,
-                    rad,
-                )
-                    ?: KompetanseAktivitet.I_ARBEID,
+            parseValgfriEnum<KompetanseAktivitet>(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITET,
+                rad,
+            )
+                ?: KompetanseAktivitet.I_ARBEID,
             søkersAktivitetsland =
-                parseValgfriString(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITETSLAND,
-                    rad,
-                )?.also { validerErLandkode(it) } ?: "PL",
+            parseValgfriString(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.SØKERS_AKTIVITETSLAND,
+                rad,
+            )?.also { validerErLandkode(it) } ?: "PL",
             annenForeldersAktivitetsland =
-                parseValgfriString(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITETSLAND,
-                    rad,
-                )?.also { validerErLandkode(it) } ?: "NO",
+            parseValgfriString(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ANNEN_FORELDERS_AKTIVITETSLAND,
+                rad,
+            )?.also { validerErLandkode(it) } ?: "NO",
             barnetsBostedsland =
-                parseValgfriString(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.BARNETS_BOSTEDSLAND,
-                    rad,
-                )?.also { validerErLandkode(it) } ?: "NO",
+            parseValgfriString(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.BARNETS_BOSTEDSLAND,
+                rad,
+            )?.also { validerErLandkode(it) } ?: "NO",
             resultat =
-                parseEnum<KompetanseResultat>(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.RESULTAT,
-                    rad,
-                ),
+            parseEnum<KompetanseResultat>(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.RESULTAT,
+                rad,
+            ),
         ).also { it.behandlingId = behandlingId }
     }.groupBy { it.behandlingId }
         .toMutableMap()
@@ -281,16 +295,16 @@ fun lagValutakurs(
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             barnAktører =
-                personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
-                    .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
-                    .map { it.aktør }
-                    .toSet(),
+            personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
+                .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
+                .map { it.aktør }
+                .toSet(),
             valutakursdato = parseValgfriDato(VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VALUTAKURSDATO, rad),
             valutakode =
-                parseValgfriString(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VALUTA_KODE,
-                    rad,
-                ),
+            parseValgfriString(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.VALUTA_KODE,
+                rad,
+            ),
             kurs = parseBigDecimal(VedtaksperiodeMedBegrunnelserParser.DomenebegrepValutakurs.KURS, rad),
         ).also { it.behandlingId = behandlingId }
     }
@@ -307,16 +321,16 @@ fun lagUtenlandskperiodeBeløp(
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             barnAktører =
-                personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
-                    .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
-                    .map { it.aktør }
-                    .toSet(),
+            personopplysningGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer
+                .filter { aktørerForValutakurs.contains(it.aktør.aktørId) }
+                .map { it.aktør }
+                .toSet(),
             beløp = parseBigDecimal(VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.BELØP, rad),
             valutakode =
-                parseValgfriString(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.VALUTA_KODE,
-                    rad,
-                ),
+            parseValgfriString(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.VALUTA_KODE,
+                rad,
+            ),
             intervall = parseValgfriEnum<Intervall>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.INTERVALL, rad),
             utbetalingsland = parseValgfriString(VedtaksperiodeMedBegrunnelserParser.DomenebegrepUtenlandskPeriodebeløp.UTBETALINGSLAND, rad),
         ).let {
@@ -344,20 +358,20 @@ fun lagEndredeUtbetalinger(
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
             person = persongrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer.find { aktørId == it.aktør.aktørId },
             prosent =
-                parseValgfriLong(
-                    VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
-                    rad,
-                )?.toBigDecimal() ?: BigDecimal.valueOf(100),
+            parseValgfriLong(
+                VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
+                rad,
+            )?.toBigDecimal() ?: BigDecimal.valueOf(100),
             årsak =
-                parseValgfriEnum<Årsak>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.ÅRSAK, rad)
-                    ?: Årsak.ALLEREDE_UTBETALT,
+            parseValgfriEnum<Årsak>(VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.ÅRSAK, rad)
+                ?: Årsak.ALLEREDE_UTBETALT,
             søknadstidspunkt = parseValgfriDato(Domenebegrep.SØKNADSTIDSPUNKT, rad) ?: LocalDate.now(),
             begrunnelse = "Fordi at...",
             avtaletidspunktDeltBosted =
-                parseValgfriDato(
-                    BrevPeriodeParser.DomenebegrepBrevBegrunnelse.AVTALETIDSPUNKT_DELT_BOSTED,
-                    rad,
-                ),
+            parseValgfriDato(
+                BrevPeriodeParser.DomenebegrepBrevBegrunnelse.AVTALETIDSPUNKT_DELT_BOSTED,
+                rad,
+            ),
         )
     }.groupBy { it.behandlingId }
         .toMutableMap()
@@ -367,24 +381,24 @@ fun lagPersonGrunnlag(dataTable: DataTable): Map<Long, PersonopplysningGrunnlag>
         val behandlingsIder = parseList(Domenebegrep.BEHANDLING_ID, rad)
         behandlingsIder.map { id ->
             id to
-                tilfeldigPerson(
-                    personType =
+                    tilfeldigPerson(
+                        personType =
                         parseEnum(
                             VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.PERSON_TYPE,
                             rad,
                         ),
-                    fødselsdato =
+                        fødselsdato =
                         parseDato(
                             VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.FØDSELSDATO,
                             rad,
                         ),
-                    aktør = randomAktør().copy(aktørId = VedtaksperiodeMedBegrunnelserParser.parseAktørId(rad)),
-                ).also { person ->
-                    parseValgfriDato(
-                        VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.DØDSFALLDATO,
-                        rad,
-                    )?.let { person.dødsfall = lagDødsfall(person = person, dødsfallDato = it) }
-                }
+                        aktør = randomAktør().copy(aktørId = VedtaksperiodeMedBegrunnelserParser.parseAktørId(rad)),
+                    ).also { person ->
+                        parseValgfriDato(
+                            VedtaksperiodeMedBegrunnelserParser.DomenebegrepPersongrunnlag.DØDSFALLDATO,
+                            rad,
+                        )?.let { person.dødsfall = lagDødsfall(person = person, dødsfallDato = it) }
+                    }
         }
     }.flatten()
         .groupBy({ it.first }, { it.second })
@@ -411,30 +425,30 @@ fun lagAndelerTilkjentYtelse(
         aktør = personGrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer.find { aktørId == it.aktør.aktørId }!!.aktør,
         kalkulertUtbetalingsbeløp = beløp,
         ytelseType =
-            parseValgfriEnum<YtelseType>(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepAndelTilkjentYtelse.YTELSE_TYPE,
-                rad,
-            ) ?: YtelseType.ORDINÆR_KONTANTSTØTTE,
+        parseValgfriEnum<YtelseType>(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepAndelTilkjentYtelse.YTELSE_TYPE,
+            rad,
+        ) ?: YtelseType.ORDINÆR_KONTANTSTØTTE,
         prosent =
-            parseValgfriLong(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
-                rad,
-            )?.toBigDecimal() ?: BigDecimal(100),
+        parseValgfriLong(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,
+            rad,
+        )?.toBigDecimal() ?: BigDecimal(100),
         sats =
-            parseValgfriInt(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.SATS,
-                rad,
-            ) ?: beløp,
+        parseValgfriInt(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.SATS,
+            rad,
+        ) ?: beløp,
         nasjonaltPeriodebeløp =
-            parseValgfriInt(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.NASJONALT_PERIODEBELØP,
-                rad,
-            ) ?: beløp,
+        parseValgfriInt(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.NASJONALT_PERIODEBELØP,
+            rad,
+        ) ?: beløp,
         differanseberegnetPeriodebeløp =
-            parseValgfriInt(
-                VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.DIFFERANSEBEREGNET_BELØP,
-                rad,
-            ),
+        parseValgfriInt(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.DIFFERANSEBEREGNET_BELØP,
+            rad,
+        ),
     )
 }
 
@@ -465,7 +479,7 @@ fun leggBegrunnelserIVedtaksperiodene(
                 vedtaksperioder.find { it.fom == fom && it.tom == tom }
                     ?: throw Feil(
                         "Ingen vedtaksperioder med Fom=$fom og Tom=$tom. " +
-                            "Vedtaksperiodene var ${vedtaksperioder.map { "\n${it.fom?.tilddMMyyyy()} til ${it.tom?.tilddMMyyyy()}" }}",
+                                "Vedtaksperiodene var ${vedtaksperioder.map { "\n${it.fom?.tilddMMyyyy()} til ${it.tom?.tilddMMyyyy()}" }}",
                     )
 
             val nasjonaleOgFellesBegrunnelser =
@@ -499,8 +513,8 @@ fun leggBegrunnelserIVedtaksperiodene(
         vedtaksperioder.filter { vedtaksperiodeUtenBegrunnelse ->
             vedtaksperioderSomHarFåttBegrunnelser.none {
                 it.fom == vedtaksperiodeUtenBegrunnelse.fom &&
-                    it.tom == vedtaksperiodeUtenBegrunnelse.tom &&
-                    it.type == vedtaksperiodeUtenBegrunnelse.type
+                        it.tom == vedtaksperiodeUtenBegrunnelse.tom &&
+                        it.type == vedtaksperiodeUtenBegrunnelse.type
             }
         }
 


### PR DESCRIPTION
For cucumbertestene i forrige behandling har vi hittil ikke lagt inn forrige behandling riktig. Det fører til at man ikke får vedtaksperioder når man leter etter opphørte perioder. 

Har lagt til et ekstra felt, Behandlingsstatus. Dersom feltet settes til avsluttet mocker vi finnIverksatteBehandlinger() til å returnere forrige behanling og legger til et AVSLUTT_BEHANDLING - behandlingssteg på oppdraget slik at vi greier å finne forrige iverksatte behandling i hentOpphørsperioder(). 