### PR TITLE
Fiks behandlingsresultat ved framtidig opphør i revurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -123,13 +123,13 @@ fun hentTekstForBehandlinger(
     """
 
     Og følgende behandlinger
-      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak  | Behandlingskategori | Behandlingsstatus | ${
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak  | Behandlingskategori | Behandlingsstatus | ${
         forrigeBehandling?.let {
             """ 
-      | ${it.id} | 1 |           | ${it.resultat} | ${it.opprettetÅrsak}  | ${it.kategori} | ${it.status} |"""
+      | ${it.id} | 1 |           | ${it.opprettetÅrsak}  | ${it.kategori} | ${it.status} |"""
         } ?: ""
     }
-      | ${behandling.id} | 1 | ${forrigeBehandling?.id ?: ""} |${behandling.resultat} | ${behandling.opprettetÅrsak}  | ${behandling.kategori} | ${behandling.status} |"""
+      | ${behandling.id} | 1 | ${forrigeBehandling?.id ?: ""} | ${behandling.opprettetÅrsak}  | ${behandling.kategori} | ${behandling.status} |"""
 
 fun hentTekstForPersongrunnlag(
     persongrunnlag: PersonopplysningGrunnlag,

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -159,7 +159,7 @@ fun hentTekstForVilkårresultater(
     return """
         
     Og følgende vilkårresultater for behandling $behandlingId
-      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter |""" +
+      | AktørId | Vilkår | Utdypende vilkår | Fra dato | Til dato | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter | Søker har meldt fra om barnehageplass |""" +
         tilVilkårResultatRader(personResultater)
 }
 
@@ -175,6 +175,7 @@ data class VilkårResultatRad(
     val erEksplisittAvslagPåSøknad: Boolean?,
     val standardbegrunnelser: List<IBegrunnelse>,
     val vurderesEtter: Regelverk?,
+    val søkerHarMeldtFraOmBarnehageplass: Boolean?,
 )
 
 private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
@@ -191,6 +192,7 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     it.erEksplisittAvslagPåSøknad,
                     it.begrunnelser,
                     it.vurderesEtter,
+                    it.søkerHarMeldtFraOmBarnehageplass,
                 )
             }.toList().joinToString("") { (vilkårResultatRad, vilkårResultater) ->
                 "\n | ${vilkårResultatRad.aktørId} " +
@@ -202,6 +204,7 @@ private fun tilVilkårResultatRader(personResultater: List<PersonResultat>?) =
                     "| ${if (vilkårResultatRad.erEksplisittAvslagPåSøknad == true) "Ja" else "Nei"} " +
                     "| ${vilkårResultatRad.standardbegrunnelser.joinToString(",")}" +
                     "| ${vilkårResultatRad.vurderesEtter ?: ""} " +
+                    "| ${if (vilkårResultatRad.søkerHarMeldtFraOmBarnehageplass == true) "Ja" else "Nei"} " +
                     "| "
             }
     } ?: ""

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
 import no.nav.familie.ks.sak.common.util.tilddMMyyyy
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
@@ -75,6 +76,8 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
             hentTekstForValutakurs(valutakurser, behandling.id) +
 
             hentTekstForTilkjentYtelse(andeler, persongrunnlag, forrigeBehandling?.id, behandling.id) +
+            hentTekstForBehandlingsresultat(behandling.id, behandling.resultat) +
+
             hentTekstForVedtaksperioder(behandling.id, vedtaksperioder) +
 
             hentTekstForGyligeBegrunnelserForVedtaksperiodene(vedtaksperioder, behandling.id) +
@@ -216,6 +219,15 @@ fun hentTekstForTilkjentYtelse(
     Så forvent følgende andeler tilkjent ytelse for behandling $behandlingId
       | AktørId | Fra dato | Til dato | Beløp | Ytelse type | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp | """ +
         hentAndelRader(andeler, persongrunnlag)
+
+fun hentTekstForBehandlingsresultat(
+    behandlingId: Long,
+    behandlingsresultat: Behandlingsresultat,
+) =
+    """
+    Og når behandlingsresultatet er utledet for behandling $behandlingId
+    Så forvent at behandlingsresultatet er $behandlingsresultat på behandling $behandlingId
+    """
 
 private fun hentAndelRader(
     andeler: List<AndelTilkjentYtelse>?,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatPerson.kt
@@ -15,6 +15,7 @@ data class BehandlingsresultatPerson(
     val eksplisittAvslag: Boolean = false,
     val forrigeAndeler: List<BehandlingsresultatAndelTilkjentYtelse> = emptyList(),
     val andeler: List<BehandlingsresultatAndelTilkjentYtelse>,
+    val erDetFramtidigOpphørPåBarnehagevilkåret: Boolean,
 ) {
     /**
      * Utleder krav for personer framstilt nå og/eller tidligere.
@@ -28,6 +29,7 @@ data class BehandlingsresultatPerson(
             aktør = aktør,
             ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
             kravOpprinnelse = utledKravOpprinnelser(),
+            erDetFramtidigOpphørPåBarnehagevilkåret = erDetFramtidigOpphørPåBarnehagevilkåret,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -128,11 +128,20 @@ class BehandlingsresultatService(
     private fun erDetFramtidigOpphørPåBarnehagevilkåret(personresultat: PersonResultat): Boolean {
         val oppfylteVilkårsresultater = personresultat.vilkårResultater.filter { it.resultat == Resultat.OPPFYLT }
         val vilkårResultaterForBarnehagevilkår =
-            oppfylteVilkårsresultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS && it.søkerHarMeldtFraOmBarnehageplass == true }
+            oppfylteVilkårsresultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS }
         val vilkårResultaterForBarnetsAlder = oppfylteVilkårsresultater.filter { it.vilkårType == Vilkår.BARNETS_ALDER }
 
-        return vilkårResultaterForBarnehagevilkår.maxOf { it.periodeTom ?: TIDENES_ENDE } <
-            vilkårResultaterForBarnetsAlder.maxOf { it.periodeTom ?: TIDENES_ENDE }
+        val tidBarnehagevilkåretAvsluttesPgaBarnehageplass =
+            vilkårResultaterForBarnehagevilkår.filter { it.søkerHarMeldtFraOmBarnehageplass == true }
+                .maxOfOrNull { it.periodeTom ?: TIDENES_ENDE }
+
+        val tidAlderVilkåretAvsluttes = vilkårResultaterForBarnetsAlder.maxOf { it.periodeTom ?: TIDENES_ENDE }
+
+        return if (tidBarnehagevilkåretAvsluttesPgaBarnehageplass == null) {
+            false
+        } else {
+            tidBarnehagevilkåretAvsluttesPgaBarnehageplass < tidAlderVilkåretAvsluttes
+        }
     }
 
     private fun hentBarna(behandling: Behandling): List<Aktør> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -3,12 +3,16 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.convertDataClassToJson
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
@@ -97,9 +101,9 @@ class BehandlingsresultatService(
         vilkårsvurdering: Vilkårsvurdering,
     ) = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
         .personer.filter { it.type == PersonType.BARN }.map {
-            val harEksplisittAvslagIVilkårsvurderingen =
+            val personresultat =
                 vilkårsvurdering.personResultater.find { personResultat -> personResultat.aktør == it.aktør }
-                    ?.harEksplisittAvslag() ?: false
+            val harEksplisittAvslagIVilkårsvurderingen = personresultat?.harEksplisittAvslag() ?: false
 
             val harEksplisittAvslagIEndreteUtbetalinger =
                 andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(
@@ -108,14 +112,28 @@ class BehandlingsresultatService(
                     endretUtbetalingAndel.erEksplisittAvslagPåSøknad == true && endretUtbetalingAndel.person?.aktør == it.aktør
                 }
 
+            val erDetFramtidigOpphørPåBarnehagevilkåret =
+                personresultat?.let { erDetFramtidigOpphørPåBarnehagevilkåret(personresultat) } ?: false
+
             BehandlingsresultatUtils.utledBehandlingsresultatDataForPerson(
                 person = it,
                 personerFremstiltKravFor = personerFremslitKravFor,
                 andelerMedEndringer = andelerMedEndringer,
                 forrigeAndelerMedEndringer = forrigeAndelerMedEndringer,
                 erEksplisittAvslag = harEksplisittAvslagIVilkårsvurderingen || harEksplisittAvslagIEndreteUtbetalinger,
+                erDetFramtidigOpphørPåBarnehagevilkåret = erDetFramtidigOpphørPåBarnehagevilkåret,
             )
         }
+
+    private fun erDetFramtidigOpphørPåBarnehagevilkåret(personresultat: PersonResultat): Boolean {
+        val oppfylteVilkårsresultater = personresultat.vilkårResultater.filter { it.resultat == Resultat.OPPFYLT }
+        val vilkårResultaterForBarnehagevilkår =
+            oppfylteVilkårsresultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS && it.søkerHarMeldtFraOmBarnehageplass == true }
+        val vilkårResultaterForBarnetsAlder = oppfylteVilkårsresultater.filter { it.vilkårType == Vilkår.BARNETS_ALDER }
+
+        return vilkårResultaterForBarnehagevilkår.maxOf { it.periodeTom ?: TIDENES_ENDE } <
+            vilkårResultaterForBarnetsAlder.maxOf { it.periodeTom ?: TIDENES_ENDE }
+    }
 
     private fun hentBarna(behandling: Behandling): List<Aktør> {
         // Søknad kan ha flere barn som er inkludert i søknaden og folkeregistert, men ikke i behandling

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -72,6 +72,7 @@ object BehandlingsresultatUtils {
         andelerMedEndringer: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
         forrigeAndelerMedEndringer: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
         erEksplisittAvslag: Boolean,
+        erDetFramtidigOpphørPåBarnehagevilkåret: Boolean,
     ): BehandlingsresultatPerson {
         val aktør = person.aktør
 
@@ -97,6 +98,7 @@ object BehandlingsresultatUtils {
                         )
                     },
             eksplisittAvslag = erEksplisittAvslag,
+            erDetFramtidigOpphørPåBarnehagevilkåret = erDetFramtidigOpphørPåBarnehagevilkåret,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePerson.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePerson.kt
@@ -19,6 +19,7 @@ data class YtelsePerson(
     val kravOpprinnelse: List<KravOpprinnelse>,
     val resultater: Set<YtelsePersonResultat> = emptySet(),
     val ytelseSlutt: YearMonth? = null,
+    val erDetFramtidigOpphørPåBarnehagevilkåret: Boolean,
 ) {
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -97,7 +97,7 @@ class StepDefinition {
 
     /**
      * Mulige felter:
-     * | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Behandlingsstatus |
+     * | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingsstatus |
      */
     @Og("følgende behandlinger")
     fun `følgende behandling`(dataTable: DataTable) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -22,9 +22,12 @@ import no.nav.familie.ks.sak.common.util.tilddMMyyyy
 import no.nav.familie.ks.sak.cucumber.BrevBegrunnelseParser.mapBegrunnelser
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseDto
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat.BehandlingsresultatService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.domene.SøknadGrunnlag
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
@@ -227,6 +230,26 @@ class StepDefinition {
         assertThat(beregnetTilkjentYtelse)
             .usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*endretTidspunkt", ".*opprettetTidspunkt", ".*kildeBehandlingId", ".*tilkjentYtelse")
             .isEqualTo(forventedeAndeler)
+    }
+
+    @Og("når behandlingsresultatet er utledet for behandling {}")
+    fun `når behandlingsresultatet er utledet for behehandling`(
+        behandlingId: Long,
+    ) {
+        val behandling = behandlinger[behandlingId]!!
+
+        val behandlingsresultat = mockBehandlingsresultatService().utledBehandlingsresultat(behandling)
+
+        behandlinger[behandlingId] = behandling.copy(resultat = behandlingsresultat)
+    }
+
+    @Så("forvent at behandlingsresultatet er {} på behandling {}")
+    fun `forvent følgende behanlingsresultat på behandling`(
+        forventetBehandlingsresultat: Behandlingsresultat,
+        behandlingId: Long,
+    ) {
+        val faktiskResultat = behandlinger[behandlingId]!!.resultat
+        assertThat(faktiskResultat).isEqualTo(forventetBehandlingsresultat)
     }
 
     /**

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtilsTest.kt
@@ -76,11 +76,13 @@ internal class YtelsePersonUtilsTest {
     private fun lagYtelsePerson(
         resultater: Set<YtelsePersonResultat>,
         ytelseSlutt: YearMonth? = YearMonth.now().plusMonths(3),
+        erDetFramtidigOpphørPåBarnehagevilkåret: Boolean = false,
     ) = YtelsePerson(
         aktør = randomAktør(),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
         kravOpprinnelse = listOf(KravOpprinnelse.INNEVÆRENDE),
         resultater = resultater,
         ytelseSlutt = ytelseSlutt,
+        erDetFramtidigOpphørPåBarnehagevilkåret = erDetFramtidigOpphørPåBarnehagevilkåret,
     )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/YtelsePersonUtilsTest.kt
@@ -39,26 +39,6 @@ internal class YtelsePersonUtilsTest {
     }
 
     @Test
-    fun `validerYtelsePersoner skal kaste feil når ytelse slutter etter inneværende måned ved OPPHØR`() {
-        val exception =
-            assertThrows<Feil> {
-                YtelsePersonUtils.validerYtelsePersoner(
-                    listOf(
-                        lagYtelsePerson(setOf(YtelsePersonResultat.INNVILGET)),
-                        lagYtelsePerson(
-                            resultater = setOf(YtelsePersonResultat.OPPHØRT),
-                            ytelseSlutt = YearMonth.now().plusMonths(4),
-                        ),
-                    ),
-                )
-            }
-        assertEquals(
-            "Minst én ytelseperson har fått opphør som resultat og ytelseSlutt etter inneværende måned",
-            exception.message,
-        )
-    }
-
-    @Test
     fun `validerYtelsePersoner skal ikke kaste feil ved INNVILGET og OPPHØRT`() {
         assertDoesNotThrow {
             YtelsePersonUtils.validerYtelsePersoner(

--- a/src/test/resources/cucumber/automatisk-behandling.feature
+++ b/src/test/resources/cucumber/automatisk-behandling.feature
@@ -9,8 +9,8 @@ Egenskap: Vedtaksperioder
       | 1        |
 
     Og følgende behandlinger
-      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Behandlingskategori |
-      | 1            | 2        |                     | INNVILGET_OG_OPPHØRT | SØKNAD           | EØS                 |
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori |
+      | 1            | 2        |                     | SØKNAD           | EØS                 |
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
@@ -38,6 +38,8 @@ Egenskap: Vedtaksperioder
     Og følgende kompetanser for behandling 1
       | AktørId | Fra dato   | Til dato | Resultat            | BehandlingId | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
       | 2       | 01.03.2023 |          | NORGE_ER_PRIMÆRLAND | 1            | ARBEIDER         | I_ARBEID                  | NO                    | NO                             | NO                  |
+
+    Og når behandlingsresultatet er utledet for behandling 1
 
     Og vedtaksperioder er laget for behandling 1
 

--- a/src/test/resources/cucumber/fortsatt-innvilget.feature
+++ b/src/test/resources/cucumber/fortsatt-innvilget.feature
@@ -9,9 +9,9 @@ Egenskap: Fortsatt innvilget
       | 1        |
 
     Og følgende behandlinger
-      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Behandlingskategori |
-      | 1            | 1        |                     | ENDRET_UTBETALING   | SØKNAD           | NASJONAL            |
-      | 2            | 2        | 1                   | FORTSATT_INNVILGET  | NYE_OPPLYSNINGER | NASJONAL            |
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | NYE_OPPLYSNINGER | NASJONAL            | UTREDES           |
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
@@ -35,22 +35,30 @@ Egenskap: Fortsatt innvilget
 
     Og følgende vilkårresultater for behandling 2
       | AktørId | Vilkår                                   | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
-      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                |                  | 11.04.1987 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                |                  | 11.04.1987 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
 
+      | 2       | BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 07.05.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
       | 2       | BOR_MED_SØKER                            |                  | 07.05.2022 | 31.12.2023 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
-      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOSATT_I_RIKET |                  | 07.05.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
       | 2       | BARNEHAGEPLASS                           |                  | 07.05.2022 |            | OPPFYLT  | Nei                  |                      |                  |
       | 2       | BARNETS_ALDER                            |                  | 07.05.2023 | 07.05.2024 | OPPFYLT  | Nei                  |                      |                  |
       | 2       | BOR_MED_SØKER                            | DELT_BOSTED      | 01.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
 
     Og andeler er beregnet for behandling 1
-
     Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp |
+      | 2       | 01.06.2023 | 31.01.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |
+      | 2       | 01.02.2024 | 30.04.2024 | 3750  | ORDINÆR_KONTANTSTØTTE | 50      | 7500 | 3750                   |
 
     Så forvent følgende andeler tilkjent ytelse for behandling 2
       | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp |
       | 2       | 01.06.2023 | 31.01.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |
       | 2       | 01.02.2024 | 30.04.2024 | 3750  | ORDINÆR_KONTANTSTØTTE | 50      | 7500 | 3750                   |
+
+    #Og når behandlingsresultatet er utledet for behandling 1
+    Og når behandlingsresultatet er utledet for behandling 2
+    Så forvent at behandlingsresultatet er FORTSATT_INNVILGET på behandling 2
 
     Og vedtaksperioder er laget for behandling 2
 

--- a/src/test/resources/cucumber/fortsatt-innvilget.feature
+++ b/src/test/resources/cucumber/fortsatt-innvilget.feature
@@ -56,7 +56,6 @@ Egenskap: Fortsatt innvilget
       | 2       | 01.06.2023 | 31.01.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |
       | 2       | 01.02.2024 | 30.04.2024 | 3750  | ORDINÆR_KONTANTSTØTTE | 50      | 7500 | 3750                   |
 
-    #Og når behandlingsresultatet er utledet for behandling 1
     Og når behandlingsresultatet er utledet for behandling 2
     Så forvent at behandlingsresultatet er FORTSATT_INNVILGET på behandling 2
 

--- a/src/test/resources/cucumber/fremtidig-opphør.feature
+++ b/src/test/resources/cucumber/fremtidig-opphør.feature
@@ -9,8 +9,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 1        |
 
     Og følgende behandlinger
-      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Behandlingskategori |
-      | 1            | 2        |                     | INNVILGET           | SØKNAD           | NASJONAL            |
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori |
+      | 1            | 2        |                     | SØKNAD           | NASJONAL            |
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
@@ -29,6 +29,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 2       | BARNETS_ALDER                                          |                  | 11.09.2023 | 11.09.2024 | OPPFYLT  | Nei                  |                      |                  |                                       |
 
     Og andeler er beregnet for behandling 1
+
+    Og når behandlingsresultatet er utledet for behandling 1
 
     Og vedtaksperioder er laget for behandling 1
 
@@ -58,6 +60,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 2       | BARNETS_ALDER                                          |                  | 11.09.2023 | 11.09.2024 | OPPFYLT  | Nei                  |                      |                  |                                       |
 
     Og andeler er beregnet for behandling 1
+
+    Og når behandlingsresultatet er utledet for behandling 1
 
     Og vedtaksperioder er laget for behandling 1
 
@@ -87,6 +91,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 2       | BARNETS_ALDER                                          |                  | 11.09.2023 | 11.09.2024 | OPPFYLT  | Nei                  |                      |                  |                                       |
 
     Og andeler er beregnet for behandling 1
+
+    Og når behandlingsresultatet er utledet for behandling 1
 
     Og vedtaksperioder er laget for behandling 1
 

--- a/src/test/resources/cucumber/fremtidig-opphør.feature
+++ b/src/test/resources/cucumber/fremtidig-opphør.feature
@@ -109,3 +109,58 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.07.2024 til -
       | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Avtale tidspunkt delt bosted | Søkers rett til utvidet |
       | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |               |         | 0     |                  | juli 2024                            |                              |                         |
+
+  Scenario: Revurdering. Eneste endring er framtidig opphør framtidig opphør på barnehageplass. Skal gi behandlingsresultat opphør.
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | INNVILGET           | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | FORTSATT_INNVILGET  | NYE_OPPLYSNINGER | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 15.11.1988  |
+      | 1            | 2       | BARN       | 28.09.2022  |
+      | 2            | 1       | SØKER      | 15.11.1988  |
+      | 2            | 2       | BARN       | 28.09.2022  |
+
+    Og følgende dagens dato 20.02.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                        | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass |
+      | 1       | BOSATT_I_RIKET                |                  | 15.10.1988 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 1       | MEDLEMSKAP                    |                  | 15.11.1993 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER     |                  | 15.12.1980 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 2       | BOSATT_I_RIKET, BOR_MED_SØKER |                  | 28.09.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 2       | BARNEHAGEPLASS                |                  | 28.09.2022 |            | OPPFYLT  | Nei                  |                      |                  |                                       |
+      | 2       | BARNETS_ALDER                 |                  | 28.09.2023 | 28.09.2024 | OPPFYLT  | Nei                  |                      |                  |                                       |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                        | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass |
+      | 1       | BOSATT_I_RIKET                |                  | 15.10.1988 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 1       | MEDLEMSKAP                    |                  | 15.11.1993 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER     |                  | 15.12.1980 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 2       | BOSATT_I_RIKET, BOR_MED_SØKER |                  | 28.09.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |                                       |
+      | 2       | BARNEHAGEPLASS                |                  | 28.09.2022 | 31.05.2024 | OPPFYLT  | Nei                  |                      |                  | Ja                                    |
+      | 2       | BARNETS_ALDER                 |                  | 28.09.2023 | 28.09.2024 | OPPFYLT  | Nei                  |                      |                  |                                       |
+
+    Og andeler er beregnet for behandling 1
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.10.2023 | 31.05.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og når behandlingsresultatet er utledet for behandling 2
+    Så forvent at behandlingsresultatet er OPPHØRT på behandling 2
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
+      | 01.06.2024 |          | OPPHØR             |           |

--- a/src/test/resources/cucumber/sekundærland/innvilgelse.feature
+++ b/src/test/resources/cucumber/sekundærland/innvilgelse.feature
@@ -9,8 +9,8 @@ Egenskap: Sekundærland - innvilgelse
       | 1        |
 
     Og følgende behandlinger
-      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat | Behandlingsårsak | Behandlingskategori |
-      | 1            | 1        |                     | INNVILGET           | SØKNAD           | EØS                 |
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori |
+      | 1            | 1        |                     | SØKNAD           | EØS                 |
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
@@ -43,6 +43,8 @@ Egenskap: Sekundærland - innvilgelse
       | 2       | 01.10.2023 | 30.11.2023 | 2023-10-24     | PLN         | 2.6496751064 |
 
     Og andeler er beregnet for behandling 1
+
+    Og når behandlingsresultatet er utledet for behandling 1
 
     Og vedtaksperioder er laget for behandling 1
 

--- a/src/test/resources/cucumber/sekundærland/opphør.feature
+++ b/src/test/resources/cucumber/sekundærland/opphør.feature
@@ -9,8 +9,8 @@ Egenskap: Sekundærland - opphør
       | 1        |
 
     Og følgende behandlinger
-      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsresultat  | Behandlingsårsak | Behandlingskategori |
-      | 1            | 2        |                     | INNVILGET_OG_OPPHØRT | SØKNAD           | EØS                 |
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori |
+      | 1            | 2        |                     | SØKNAD           | EØS                 |
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
@@ -44,6 +44,8 @@ Egenskap: Sekundærland - opphør
       | 2       | 01.10.2023 | 31.10.2023 | 2023-10-24     | PLN         | 2.6496751064 |
 
     Og andeler er beregnet for behandling 1
+
+    Og når behandlingsresultatet er utledet for behandling 1
 
     Og vedtaksperioder er laget for behandling 1
 


### PR DESCRIPTION
Hører til denne saken: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18244

**PRen leses lettest commit for commit**

Når det eneste vi gjør i en revurdering er å opphøre fram i tid blir behandlingsresultatet fortsatt innvilget og vi lager ikke opphørsperioden.

Endrer så behandlingsresultatet blir opphør også ved fremtidig opphør. 

Hele løypa er testa i preprod og vedtaksperioden blir opprettet som forventet med riktig begrunnelse.
![image](https://github.com/navikt/familie-ks-sak/assets/17828446/1f2fefa7-36aa-47f6-bf72-d890733480ab)
