### PR TITLE
Generer lovlig opphold hvis forrige revurdering hadde eøs spesifikke vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -39,15 +39,16 @@ class VilkårsvurderingService(
         logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} oppretter vilkårsvurdering for behandling ${behandling.id}")
 
         val aktivVilkårsvurdering = finnAktivVilkårsvurdering(behandling.id)
+        val vilkårsvurderingFraForrigeBehandling = forrigeBehandlingSomErVedtatt?.let { hentAktivVilkårsvurderingForBehandling(forrigeBehandlingSomErVedtatt.id) }
 
         val personopplysningGrunnlag =
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
 
-        val initiellVilkårsvurdering = genererInitiellVilkårsvurdering(behandling, personopplysningGrunnlag)
+        val initiellVilkårsvurdering = genererInitiellVilkårsvurdering(behandling, vilkårsvurderingFraForrigeBehandling, personopplysningGrunnlag)
 
-        if (forrigeBehandlingSomErVedtatt != null) {
+        vilkårsvurderingFraForrigeBehandling?.let {
             initiellVilkårsvurdering.kopierOverOppfylteOgIkkeAktuelleResultaterFraForrigeBehandling(
-                vilkårsvurderingForrigeBehandling = hentAktivVilkårsvurderingForBehandling(forrigeBehandlingSomErVedtatt.id),
+                vilkårsvurderingForrigeBehandling = it,
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -320,13 +320,18 @@ private fun VilkårResultat.validerVilkårBarnetsAlder(
 
 fun genererInitiellVilkårsvurdering(
     behandling: Behandling,
+    forrigeVilkårsvurdering: Vilkårsvurdering?,
     personopplysningGrunnlag: PersonopplysningGrunnlag,
 ): Vilkårsvurdering {
     return Vilkårsvurdering(behandling = behandling).apply {
         personResultater =
             personopplysningGrunnlag.personer.map { person ->
                 val personResultat = PersonResultat(vilkårsvurdering = this, aktør = person.aktør)
-                val skalHenteEøsSpesifikkeVilkår = behandling.kategori == BehandlingKategori.EØS
+
+                val forrigeBehandlingHaddeEøsSpesifikkeVilkår = forrigeVilkårsvurdering?.personResultater?.flatMap { it.vilkårResultater }?.any { it.vilkårType.eøsSpesifikt } ?: false
+                val behandlingKategoriErEøs = behandling.kategori == BehandlingKategori.EØS
+
+                val skalHenteEøsSpesifikkeVilkår = behandlingKategoriErEøs || forrigeBehandlingHaddeEøsSpesifikkeVilkår
 
                 val vilkårForPerson = Vilkår.hentVilkårFor(person.type, skalHenteEøsSpesifikkeVilkår)
 

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -853,7 +853,7 @@ fun lagVilkårsvurderingOppfylt(
     personer: Collection<Person>,
     behandling: Behandling = lagBehandling(),
     erEksplisittAvslagPåSøknad: Boolean = false,
-    eøsSpesifikkeVilkår: Boolean = false,
+    skalOppretteEøsSpesifikkeVilkår: Boolean = false,
 ): Vilkårsvurdering {
     val vilkårsvurdering =
         Vilkårsvurdering(
@@ -869,7 +869,7 @@ fun lagVilkårsvurderingOppfylt(
                 )
 
             personResultat.setSortedVilkårResultater(
-                Vilkår.hentVilkårFor(person.type, eøsSpesifikkeVilkår).map {
+                Vilkår.hentVilkårFor(person.type, skalOppretteEøsSpesifikkeVilkår).map {
                     VilkårResultat(
                         personResultat = personResultat,
                         periodeFom =

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -853,6 +853,7 @@ fun lagVilkårsvurderingOppfylt(
     personer: Collection<Person>,
     behandling: Behandling = lagBehandling(),
     erEksplisittAvslagPåSøknad: Boolean = false,
+    eøsSpesifikkeVilkår: Boolean = false,
 ): Vilkårsvurdering {
     val vilkårsvurdering =
         Vilkårsvurdering(
@@ -868,7 +869,7 @@ fun lagVilkårsvurderingOppfylt(
                 )
 
             personResultat.setSortedVilkårResultater(
-                Vilkår.hentVilkårFor(person.type).map {
+                Vilkår.hentVilkårFor(person.type, eøsSpesifikkeVilkår).map {
                     VilkårResultat(
                         personResultat = personResultat,
                         periodeFom =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -321,7 +321,7 @@ class OppdaterVilkårsvurderingTest {
                 søkerPersonIdent = søkerFnr,
             )
 
-        val forrigeVilkårsvurdering = lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag.søker), eøsSpesifikkeVilkår = true)
+        val forrigeVilkårsvurdering = lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag.søker), skalOppretteEøsSpesifikkeVilkår = true)
 
         val initiellVilkårsvurdering =
             genererInitiellVilkårsvurdering(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -34,7 +34,7 @@ class OppdaterVilkårsvurderingTest {
         val vilkårsvurderingForrigeBehandling =
             lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag.søker, persongrunnlag.barna.single()))
         val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(behandling = mockk(relaxed = true), personopplysningGrunnlag = persongrunnlag)
+            genererInitiellVilkårsvurdering(behandling = mockk(relaxed = true), forrigeVilkårsvurdering = null, personopplysningGrunnlag = persongrunnlag)
 
         initiellVilkårsvurdering.kopierOverOppfylteOgIkkeAktuelleResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
@@ -80,7 +80,7 @@ class OppdaterVilkårsvurderingTest {
                 barnasIdenter = listOf(barnPersonIdent),
             )
         val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(behandling = mockk(relaxed = true), personopplysningGrunnlag = persongrunnlag2)
+            genererInitiellVilkårsvurdering(behandling = mockk(relaxed = true), forrigeVilkårsvurdering = null, personopplysningGrunnlag = persongrunnlag2)
 
         initiellVilkårsvurdering.kopierOverOppfylteOgIkkeAktuelleResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
@@ -102,7 +102,7 @@ class OppdaterVilkårsvurderingTest {
         }
 
         val initiellVilkårsvurderingUendret =
-            genererInitiellVilkårsvurdering(behandling = mockk(relaxed = true), personopplysningGrunnlag = persongrunnlag2)
+            genererInitiellVilkårsvurdering(behandling = mockk(relaxed = true), forrigeVilkårsvurdering = null, personopplysningGrunnlag = persongrunnlag2)
         val barnVilkårResultaterUendret =
             initiellVilkårsvurderingUendret.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
 
@@ -123,6 +123,7 @@ class OppdaterVilkårsvurderingTest {
         val initiellVilkårsvurdering =
             genererInitiellVilkårsvurdering(
                 behandling = mockk(relaxed = true),
+                forrigeVilkårsvurdering = null,
                 personopplysningGrunnlag = persongrunnlagRevurdering,
             )
 
@@ -160,6 +161,7 @@ class OppdaterVilkårsvurderingTest {
         val initiellVilkårsvurdering =
             genererInitiellVilkårsvurdering(
                 behandling = nyBehandling,
+                forrigeVilkårsvurdering = null,
                 personopplysningGrunnlag = persongrunnlag,
             )
         val vilkårsvurderingForrigeBehandling = Vilkårsvurdering(behandling = forrigeBehandling)
@@ -299,6 +301,32 @@ class OppdaterVilkårsvurderingTest {
         val initiellVilkårsvurdering =
             genererInitiellVilkårsvurdering(
                 behandling = nyBehandling,
+                forrigeVilkårsvurdering = null,
+                personopplysningGrunnlag = persongrunnlag,
+            )
+
+        val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
+
+        assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering, Is(true))
+    }
+
+    @Test
+    fun `genererInitiellVilkårsvurdering skal generere eøs spesifikke vilkår dersom forrige behandling hadde eøs spesifikke vilkår selvom kategori nå er nasjonal`() {
+        val søkerFnr = randomFnr()
+        val nyBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
+
+        val persongrunnlag =
+            lagPersonopplysningGrunnlag(
+                behandlingId = nyBehandling.id,
+                søkerPersonIdent = søkerFnr,
+            )
+
+        val forrigeVilkårsvurdering = lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag.søker), eøsSpesifikkeVilkår = true)
+
+        val initiellVilkårsvurdering =
+            genererInitiellVilkårsvurdering(
+                behandling = nyBehandling,
+                forrigeVilkårsvurdering = forrigeVilkårsvurdering,
                 personopplysningGrunnlag = persongrunnlag,
             )
 
@@ -320,6 +348,7 @@ class OppdaterVilkårsvurderingTest {
         val initiellVilkårsvurdering =
             genererInitiellVilkårsvurdering(
                 behandling = nyBehandling,
+                forrigeVilkårsvurdering = null,
                 personopplysningGrunnlag = persongrunnlag,
             )
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18469

Lovlig Opphold er et vilkår som er "EØS"-spesifikk.
Den skal bare opprettes hvis behandlingskategori er EØS eller at man har behandlingskategori som er nasjonal, men noe vilkår vurdert etter eøs regelverk.  Har man en nasjonal behandling, men så fjerner man alle perioder vurdert etter EØS, skal lovlig opphold forsvinne.

Denne logikken fungerte ikke helt bra dersom man først hadde en EØS Behandling m/ lovlig opphold, og deretter lagde en nasjonal revurdering. Da ønsket man fortsatt lovlig opphold, siden den fantes i den forrige behandlingen.

Vi ser derfor nå på forrige behandling sin vilkårsvurdering, og dersom det eksisterer noe eøs spesifikke vilkår, så generer vi dem også ved opprettelse av behandlingen.