### PR TITLE
Fix: Vedtakssiden viser ikke vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -74,7 +74,6 @@ class VedtaksperiodeService(
     private val refusjonEøsRepository: RefusjonEøsRepository,
     private val kompetanseService: KompetanseService,
 ) {
-
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,
         fritekster: List<String>,
@@ -138,7 +137,7 @@ class VedtaksperiodeService(
 
     fun skalHaÅrligKontroll(vedtak: Vedtak): Boolean {
         return vedtak.behandling.kategori == BehandlingKategori.EØS &&
-                hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
+            hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
     }
 
     private fun validerEndretUtbetalingsbegrunnelse(
@@ -232,8 +231,8 @@ class VedtaksperiodeService(
     ) = utbetalingsperioder.filter { utbetalingsperiode ->
         avslagsperioder.none { avslagsperiode ->
             avslagsperiode.fom == utbetalingsperiode.fom &&
-                    avslagsperiode.tom == utbetalingsperiode.tom &&
-                    avslagsperiode.begrunnelser.isNotEmpty()
+                avslagsperiode.tom == utbetalingsperiode.tom &&
+                avslagsperiode.begrunnelser.isNotEmpty()
         }
     }
 
@@ -421,16 +420,16 @@ class VedtaksperiodeService(
 
                 utvidetVedtaksperiodeMedBegrunnelser.copy(
                     gyldigeBegrunnelser =
-                    BegrunnelserForPeriodeContext(
-                        utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
-                        sanityBegrunnelser = sanityBegrunnelser,
-                        personopplysningGrunnlag = persongrunnlag,
-                        personResultater = vilkårsvurdering.personResultater.toList(),
-                        endretUtbetalingsandeler = endreteUtbetalinger,
-                        erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
-                        kompetanser = utfylteKompetanser,
-                        andelerTilkjentYtelse = andeler,
-                    ).hentGyldigeBegrunnelserForVedtaksperiode(),
+                        BegrunnelserForPeriodeContext(
+                            utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
+                            sanityBegrunnelser = sanityBegrunnelser,
+                            personopplysningGrunnlag = persongrunnlag,
+                            personResultater = vilkårsvurdering.personResultater.toList(),
+                            endretUtbetalingsandeler = endreteUtbetalinger,
+                            erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
+                            kompetanser = utfylteKompetanser,
+                            andelerTilkjentYtelse = andeler,
+                        ).hentGyldigeBegrunnelserForVedtaksperiode(),
                 )
             }
     }
@@ -469,8 +468,9 @@ class VedtaksperiodeService(
             andelerTilkjentYtelseOgEndreteUtbetalingerService
                 .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
 
-        val vilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandling.id)
-            ?: throw Feil("Fant ikke vilkårsvurdering på behandling $behandling")
+        val vilkårsvurdering =
+            vilkårsvurderingRepository.finnAktivForBehandling(behandling.id)
+                ?: throw Feil("Fant ikke vilkårsvurdering på behandling $behandling")
 
         return mapTilOpphørsperioder(
             forrigePersonopplysningGrunnlag = forrigePersonopplysningGrunnlag,
@@ -652,12 +652,12 @@ class VedtaksperiodeService(
         val avslagsperioderMedTomPeriode =
             if (avslagsperioder.none { it.fom == null && it.tom == null }) {
                 avslagsperioder +
-                        VedtaksperiodeMedBegrunnelser(
-                            vedtak = vedtak,
-                            fom = null,
-                            tom = null,
-                            type = Vedtaksperiodetype.AVSLAG,
-                        )
+                    VedtaksperiodeMedBegrunnelser(
+                        vedtak = vedtak,
+                        fom = null,
+                        tom = null,
+                        type = Vedtaksperiodetype.AVSLAG,
+                    )
             } else {
                 avslagsperioder
             }
@@ -695,5 +695,4 @@ class VedtaksperiodeService(
             .filterNot { it == TIDENES_ENDE }
             .minOfOrNull { it }?.førsteDagIInneværendeMåned() ?: TIDENES_ENDE
     }
-
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -3,13 +3,17 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode
 import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.common.tidslinje.outerJoin
 import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.filtrerIkkeNull
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioderIkkeNull
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilSeparateTidslinjerForBarna
 import no.nav.familie.ks.sak.common.util.NullablePeriode
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
 import no.nav.familie.ks.sak.common.util.erSenereEnnInneværendeMåned
+import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.storForbokstav
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
@@ -47,6 +51,7 @@ import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.IBegrunnelse
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilVedtaksbegrunnelse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
@@ -69,6 +74,7 @@ class VedtaksperiodeService(
     private val refusjonEøsRepository: RefusjonEøsRepository,
     private val kompetanseService: KompetanseService,
 ) {
+
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,
         fritekster: List<String>,
@@ -132,7 +138,7 @@ class VedtaksperiodeService(
 
     fun skalHaÅrligKontroll(vedtak: Vedtak): Boolean {
         return vedtak.behandling.kategori == BehandlingKategori.EØS &&
-            hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
+                hentPersisterteVedtaksperioder(vedtak).any { it.tom?.erSenereEnnInneværendeMåned() != false }
     }
 
     private fun validerEndretUtbetalingsbegrunnelse(
@@ -226,8 +232,8 @@ class VedtaksperiodeService(
     ) = utbetalingsperioder.filter { utbetalingsperiode ->
         avslagsperioder.none { avslagsperiode ->
             avslagsperiode.fom == utbetalingsperiode.fom &&
-                avslagsperiode.tom == utbetalingsperiode.tom &&
-                avslagsperiode.begrunnelser.isNotEmpty()
+                    avslagsperiode.tom == utbetalingsperiode.tom &&
+                    avslagsperiode.begrunnelser.isNotEmpty()
         }
     }
 
@@ -415,16 +421,16 @@ class VedtaksperiodeService(
 
                 utvidetVedtaksperiodeMedBegrunnelser.copy(
                     gyldigeBegrunnelser =
-                        BegrunnelserForPeriodeContext(
-                            utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
-                            sanityBegrunnelser = sanityBegrunnelser,
-                            personopplysningGrunnlag = persongrunnlag,
-                            personResultater = vilkårsvurdering.personResultater.toList(),
-                            endretUtbetalingsandeler = endreteUtbetalinger,
-                            erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
-                            kompetanser = utfylteKompetanser,
-                            andelerTilkjentYtelse = andeler,
-                        ).hentGyldigeBegrunnelserForVedtaksperiode(),
+                    BegrunnelserForPeriodeContext(
+                        utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
+                        sanityBegrunnelser = sanityBegrunnelser,
+                        personopplysningGrunnlag = persongrunnlag,
+                        personResultater = vilkårsvurdering.personResultater.toList(),
+                        endretUtbetalingsandeler = endreteUtbetalinger,
+                        erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
+                        kompetanser = utfylteKompetanser,
+                        andelerTilkjentYtelse = andeler,
+                    ).hentGyldigeBegrunnelserForVedtaksperiode(),
                 )
             }
     }
@@ -463,7 +469,8 @@ class VedtaksperiodeService(
             andelerTilkjentYtelseOgEndreteUtbetalingerService
                 .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
 
-        val vilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandling.id) ?: throw Feil("Fant ikke vilkårsvurdering på behandling $behandling")
+        val vilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandling.id)
+            ?: throw Feil("Fant ikke vilkårsvurdering på behandling $behandling")
 
         return mapTilOpphørsperioder(
             forrigePersonopplysningGrunnlag = forrigePersonopplysningGrunnlag,
@@ -495,9 +502,13 @@ class VedtaksperiodeService(
                 forrigeAndelerTilkjentYtelse = andelerTilkjentYtelseForForrigeBehandling,
             ) ?: TIDENES_ENDE
 
-        // TODO EØS
+        val kompetansePerioder = kompetanseService.hentKompetanser(behandling.behandlingId)
+        val kompetansePerioderForrigeBehandling = kompetanseService.hentKompetanser(sisteVedtattBehandling.behandlingId)
 
-        return førsteEndringstidspunktFraAndelTilkjentYtelse
+        val førsteEndringstidspunktIKompetansePerioder =
+            kompetansePerioder.finnFørsteEndringstidspunkt(kompetansePerioderForrigeBehandling)
+
+        return minOf(førsteEndringstidspunktFraAndelTilkjentYtelse, førsteEndringstidspunktIKompetansePerioder)
     }
 
     private fun hentAvslagsperioderMedBegrunnelser(vedtak: Vedtak): List<VedtaksperiodeMedBegrunnelser> {
@@ -641,12 +652,12 @@ class VedtaksperiodeService(
         val avslagsperioderMedTomPeriode =
             if (avslagsperioder.none { it.fom == null && it.tom == null }) {
                 avslagsperioder +
-                    VedtaksperiodeMedBegrunnelser(
-                        vedtak = vedtak,
-                        fom = null,
-                        tom = null,
-                        type = Vedtaksperiodetype.AVSLAG,
-                    )
+                        VedtaksperiodeMedBegrunnelser(
+                            vedtak = vedtak,
+                            fom = null,
+                            tom = null,
+                            type = Vedtaksperiodetype.AVSLAG,
+                        )
             } else {
                 avslagsperioder
             }
@@ -666,4 +677,23 @@ class VedtaksperiodeService(
             }
         }.toList()
     }
+
+    private fun Iterable<Kompetanse>.finnFørsteEndringstidspunkt(kompetansePerioderForrigeBehandling: Iterable<Kompetanse>): LocalDate {
+        val separateTidslinjerForBarna = this.tilSeparateTidslinjerForBarna()
+        val separateTidslinjerForBarnaForrigeBehandling = kompetansePerioderForrigeBehandling.tilSeparateTidslinjerForBarna()
+
+        return separateTidslinjerForBarna.outerJoin(separateTidslinjerForBarnaForrigeBehandling) { nyKompetanse, forrigeKompetanse ->
+            when {
+                nyKompetanse == forrigeKompetanse -> null
+                nyKompetanse == null -> forrigeKompetanse
+                forrigeKompetanse == null -> nyKompetanse
+                nyKompetanse != forrigeKompetanse -> nyKompetanse
+                else -> null
+            }
+        }.values
+            .map { it.filtrerIkkeNull().startsTidspunkt }
+            .filterNot { it == TIDENES_ENDE }
+            .minOfOrNull { it }?.førsteDagIInneværendeMåned() ?: TIDENES_ENDE
+    }
+
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -61,7 +61,6 @@ import org.hamcrest.CoreMatchers.`is` as Is
 
 @ExtendWith(MockKExtension::class)
 internal class VedtaksperiodeServiceTest {
-
     @MockK
     private lateinit var behandlingRepository: BehandlingRepository
 
@@ -224,9 +223,9 @@ internal class VedtaksperiodeServiceTest {
             )
 
         every { vedtaksperiodeHentOgPersisterService.hentVedtaksperioderFor(1) } returns
-                listOf(
-                    gammelVedtaksperiodeMedBegrunnelse,
-                )
+            listOf(
+                gammelVedtaksperiodeMedBegrunnelse,
+            )
         every { vedtaksperiodeHentOgPersisterService.lagre(capture(vedtaksperiodeMedBegrunnelseSlot)) } returnsArgument 0
 
         vedtaksperiodeService.kopierOverVedtaksperioder(gammelVedtak, nyttVedtak)
@@ -325,10 +324,10 @@ internal class VedtaksperiodeServiceTest {
         every {
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
         } returns
-                listOf(
-                    AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse1, emptyList()),
-                    AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse2, emptyList()),
-                )
+            listOf(
+                AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse1, emptyList()),
+                AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse2, emptyList()),
+            )
 
         val revurdering = lagBehandling()
         val andelTilkjentYtelseForRevurdering1 =
@@ -354,10 +353,10 @@ internal class VedtaksperiodeServiceTest {
                 revurdering.id,
             )
         } returns
-                listOf(
-                    AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelseForRevurdering1, emptyList()),
-                    AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelseForRevurdering2, emptyList()),
-                )
+            listOf(
+                AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelseForRevurdering1, emptyList()),
+                AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelseForRevurdering2, emptyList()),
+            )
 
         // endring i beløp på revurdering for periode2
         assertEquals(
@@ -373,20 +372,20 @@ internal class VedtaksperiodeServiceTest {
     fun `finnEndringstidspunktForBehandling finner endringstidspunkt fra kompetanseperiode`() {
         val kompetanseFom = YearMonth.now().minusMonths(3)
         every { kompetanseService.hentKompetanser(behandling.behandlingId) } returns
-                listOf(
-                    Kompetanse(
-                        fom = kompetanseFom,
-                        tom = null,
-                        barnAktører = setOf(randomAktør()),
-                        søkersAktivitet = KompetanseAktivitet.I_ARBEID,
-                        annenForeldersAktivitet = KompetanseAktivitet.MOTTAR_UFØRETRYGD,
-                        annenForeldersAktivitetsland = "NO",
-                        søkersAktivitetsland = "DK",
-                        barnetsBostedsland = "DK",
-                        resultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
-                        erAnnenForelderOmfattetAvNorskLovgivning = true
-                    )
-                )
+            listOf(
+                Kompetanse(
+                    fom = kompetanseFom,
+                    tom = null,
+                    barnAktører = setOf(randomAktør()),
+                    søkersAktivitet = KompetanseAktivitet.I_ARBEID,
+                    annenForeldersAktivitet = KompetanseAktivitet.MOTTAR_UFØRETRYGD,
+                    annenForeldersAktivitetsland = "NO",
+                    søkersAktivitetsland = "DK",
+                    barnetsBostedsland = "DK",
+                    resultat = KompetanseResultat.NORGE_ER_SEKUNDÆRLAND,
+                    erAnnenForelderOmfattetAvNorskLovgivning = true,
+                ),
+            )
         every {
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
         } returns listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(), emptyList()))
@@ -544,23 +543,23 @@ internal class VedtaksperiodeServiceTest {
         )
 
         every { refusjonEøsRepository.finnRefusjonEøsForBehandling(any()) } returns
-                listOf(
-                    RefusjonEøs(
-                        behandlingId = 1L,
-                        fom = LocalDate.of(2020, 1, 1),
-                        tom = LocalDate.of(2022, 1, 1),
-                        refusjonsbeløp = 200,
-                        land = "NO",
-                        refusjonAvklart = true,
-                    ),
-                )
+            listOf(
+                RefusjonEøs(
+                    behandlingId = 1L,
+                    fom = LocalDate.of(2020, 1, 1),
+                    tom = LocalDate.of(2022, 1, 1),
+                    refusjonsbeløp = 200,
+                    land = "NO",
+                    refusjonAvklart = true,
+                ),
+            )
 
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = true)
 
         assertThat(perioder?.size, Is(1))
         assertThat(
             perioder?.single(),
-            Is("Fra januar 2020 til januar 2022 blir etterbetaling på 200 kroner per måned utbetalt til myndighetene i Norge.")
+            Is("Fra januar 2020 til januar 2022 blir etterbetaling på 200 kroner per måned utbetalt til myndighetene i Norge."),
         )
     }
 
@@ -581,23 +580,23 @@ internal class VedtaksperiodeServiceTest {
         )
 
         every { refusjonEøsRepository.finnRefusjonEøsForBehandling(any()) } returns
-                listOf(
-                    RefusjonEøs(
-                        behandlingId = 1L,
-                        fom = LocalDate.of(2020, 1, 1),
-                        tom = LocalDate.of(2022, 1, 1),
-                        refusjonsbeløp = 200,
-                        land = "NO",
-                        refusjonAvklart = false,
-                    ),
-                )
+            listOf(
+                RefusjonEøs(
+                    behandlingId = 1L,
+                    fom = LocalDate.of(2020, 1, 1),
+                    tom = LocalDate.of(2022, 1, 1),
+                    refusjonsbeløp = 200,
+                    land = "NO",
+                    refusjonAvklart = false,
+                ),
+            )
 
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = false)
 
         assertThat(perioder?.size, Is(1))
         assertThat(
             perioder?.single(),
-            Is(("Fra januar 2020 til januar 2022 blir ikke etterbetaling på 200 kroner per måned utbetalt nå siden det er utbetalt barnetrygd i Norge."))
+            Is(("Fra januar 2020 til januar 2022 blir ikke etterbetaling på 200 kroner per måned utbetalt nå siden det er utbetalt barnetrygd i Norge.")),
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -557,10 +557,7 @@ internal class VedtaksperiodeServiceTest {
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = true)
 
         assertThat(perioder?.size, Is(1))
-        assertThat(
-            perioder?.single(),
-            Is("Fra januar 2020 til januar 2022 blir etterbetaling på 200 kroner per måned utbetalt til myndighetene i Norge."),
-        )
+        assertThat(perioder?.single(), Is("Fra januar 2020 til januar 2022 blir etterbetaling på 200 kroner per måned utbetalt til myndighetene i Norge."))
     }
 
     @Test
@@ -594,9 +591,6 @@ internal class VedtaksperiodeServiceTest {
         val perioder = vedtaksperiodeService.beskrivPerioderMedRefusjonEøs(behandling = behandling, avklart = false)
 
         assertThat(perioder?.size, Is(1))
-        assertThat(
-            perioder?.single(),
-            Is(("Fra januar 2020 til januar 2022 blir ikke etterbetaling på 200 kroner per måned utbetalt nå siden det er utbetalt barnetrygd i Norge.")),
-        )
+        assertThat(perioder?.single(), Is(("Fra januar 2020 til januar 2022 blir ikke etterbetaling på 200 kroner per måned utbetalt nå siden det er utbetalt barnetrygd i Norge.")))
     }
 }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18215)

Har lagt til logikken for å finne endringstidspunkt fra kompetanseperioder, som ikke ble med over fra ba-sak til å begynne med pga. EØS var nedprioritert.


![image](https://github.com/navikt/familie-ks-sak/assets/47184872/02100bff-23e3-4a4b-9986-1c468628cb50)
