### PR TITLE
Reduser cpu i preprod

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -109,7 +109,7 @@ spec:
       memory: 2048Mi
     requests:
       memory: 1024Mi
-      cpu: 500m
+      cpu: 50m
   ingresses:
     - https://familie-ks-sak.intern.dev.nav.no
     - https://familie-kontantstotte-sak.intern.dev.nav.no


### PR DESCRIPTION
oppfølger av https://github.com/navikt/familie-ba-sak/pull/4391

I følge [dokumenteringen til Nais](https://doc.nais.io/explanation/good-practices/?h=cp#set-reasonable-resource-requests-and-limits) skal man sette cpu-requests til hva applikasjonen bruker ved normal last. Ved å se på historisk data kan det se ut som dette ligger på mye mindre enn det vi ber om i dag i preprod, se [nais console](https://console.nav.cloud.nais.io/team/teamfamilie/dev-gcp/app/familie-ks-sak/utilization?from=2023-10-17&to=2024-02-29) og bilde under. Endrer derfor cpu-request til 10% av det vi har i dag.

<img width="1467" alt="image" src="https://github.com/navikt/familie-ks-sak/assets/17828446/e4e51160-005f-4ab3-967f-f946aeb9f8df">
