### PR TITLE
Tar i bruk ny utbetalingsgenerator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     val prosesseringVersion = "2.20240214140223_83c31de"
     val restAssuredVersion = "5.4.0"
     val kotlinxVersion = "1.7.3"
+    val utbetalingsgeneratorVersion = "1.0_20240208132236_bce5777"
 
     // ---------- Spring ---------- \\
     implementation("org.springframework.boot:spring-boot-starter")
@@ -106,6 +107,8 @@ dependencies {
     implementation("no.nav.familie.felles:leader:$navFellesVersion")
     implementation("no.nav.familie.felles:http-client:$navFellesVersion")
     implementation("no.nav.familie.felles:modell:$navFellesVersion")
+    implementation("no.nav.familie.felles:familie-utbetalingsgenerator:$utbetalingsgeneratorVersion")
+
     implementation("no.nav.familie.felles:util:$navFellesVersion")
     implementation("no.nav.familie.felles:valutakurs-klient:$navFellesVersion")
     implementation("no.nav.familie.kontrakter:felles:$fellesKontrakterVersion")

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -6,5 +6,6 @@ class FeatureToggleConfig {
         const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
         const val TEKNISK_ENDRING = "familie-ks-sak.behandling.teknisk-endring"
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ks-sak.behandling.korreksjon-vedtaksbrev"
+        const val BRUK_NY_UTBETALINGSGENERATOR = "familie-ks-sak.bruk-ny-utbetalingsgenerator"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -1,6 +1,13 @@
 package no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag
 
+import no.nav.familie.felles.utbetalingsgenerator.Utbetalingsgenerator
+import no.nav.familie.felles.utbetalingsgenerator.domain.AndelDataLongId
+import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
+import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
+import no.nav.familie.felles.utbetalingsgenerator.domain.Fagsystem
+import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppdrag.Opphør
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import no.nav.familie.ks.sak.integrasjon.økonomi.UtbetalingsperiodeMal
@@ -17,12 +24,58 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import org.springframework.stereotype.Component
+import java.time.LocalDate
 import java.time.YearMonth
 
 const val FAGSYSTEM = "KS"
 
 @Component
 class UtbetalingsoppdragGenerator {
+    fun lagUtbetalingsoppdrag(
+        saksbehandlerId: String,
+        vedtak: Vedtak,
+        forrigeTilkjentYtelse: TilkjentYtelse?,
+        nyTilkjentYtelse: TilkjentYtelse,
+        sisteAndelPerKjede: Map<IdentOgType, AndelTilkjentYtelse>,
+        erSimulering: Boolean,
+    ): BeregnetUtbetalingsoppdragLongId {
+        return Utbetalingsgenerator().lagUtbetalingsoppdrag(
+            behandlingsinformasjon =
+                Behandlingsinformasjon(
+                    saksbehandlerId = saksbehandlerId,
+                    behandlingId = vedtak.behandling.id.toString(),
+                    eksternBehandlingId = vedtak.behandling.id,
+                    eksternFagsakId = vedtak.behandling.fagsak.id,
+                    fagsystem = FagsystemKS.KONTANTSTØTTE,
+                    personIdent = vedtak.behandling.fagsak.aktør.aktivFødselsnummer(),
+                    vedtaksdato = vedtak.vedtaksdato?.toLocalDate() ?: LocalDate.now(),
+                    opphørAlleKjederFra = null,
+                    utbetalesTil = vedtak.behandling.fagsak.aktør.aktivFødselsnummer(),
+                    // Ved simulering når migreringsdato er endret, skal vi opphøre fra den nye datoen og ikke fra første utbetaling per kjede.
+                    opphørKjederFraFørsteUtbetaling = erSimulering,
+                ),
+            forrigeAndeler = forrigeTilkjentYtelse?.tilAndelData() ?: emptyList(),
+            nyeAndeler = nyTilkjentYtelse.tilAndelData(),
+            sisteAndelPerKjede = sisteAndelPerKjede.mapValues { it.value.tilAndelDataLongId() },
+        )
+    }
+
+    private fun TilkjentYtelse.tilAndelData(): List<AndelDataLongId> =
+        this.andelerTilkjentYtelse.map { it.tilAndelDataLongId() }
+
+    private fun AndelTilkjentYtelse.tilAndelDataLongId(): AndelDataLongId =
+        AndelDataLongId(
+            id = id,
+            fom = periode.fom,
+            tom = periode.tom,
+            beløp = kalkulertUtbetalingsbeløp,
+            personIdent = aktør.aktivFødselsnummer(),
+            type = type.tilYtelseType(),
+            periodeId = periodeOffset,
+            forrigePeriodeId = forrigePeriodeOffset,
+            kildeBehandlingId = kildeBehandlingId,
+        )
+
     /**
      * Lager utbetalingsoppdrag med kjedede perioder av andeler.
      * Ved opphør sendes kun siste utbetalingsperiode (med opphørsdato).
@@ -258,6 +311,52 @@ class AndelTilkjentYtelseForIverksetting(
         ): List<AndelTilkjentYtelseForUtbetalingsoppdrag> = andelerTilkjentYtelse.map { AndelTilkjentYtelseForIverksetting(it) }
     }
 }
+
+enum class YtelsetypeKS(
+    override val klassifisering: String,
+    override val satsType: no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode.SatsType = no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode.SatsType.MND,
+) : no.nav.familie.felles.utbetalingsgenerator.domain.Ytelsestype {
+    ORDINÆR_KONTANTSTØTTE("KS"),
+}
+
+enum class FagsystemKS(
+    override val kode: String,
+    override val gyldigeSatstyper: Set<YtelsetypeKS>,
+) : Fagsystem {
+    KONTANTSTØTTE(
+        "KS",
+        setOf(YtelsetypeKS.ORDINÆR_KONTANTSTØTTE),
+    ),
+}
+
+fun no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.tilRestUtbetalingsoppdrag(): Utbetalingsoppdrag =
+    Utbetalingsoppdrag(
+        kodeEndring = Utbetalingsoppdrag.KodeEndring.valueOf(this.kodeEndring.name),
+        fagSystem = this.fagSystem,
+        saksnummer = this.saksnummer,
+        aktoer = this.aktoer,
+        saksbehandlerId = this.saksbehandlerId,
+        avstemmingTidspunkt = this.avstemmingTidspunkt,
+        utbetalingsperiode = this.utbetalingsperiode.map { it.tilRestUtbetalingsperiode() },
+        gOmregning = this.gOmregning,
+    )
+
+fun no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode.tilRestUtbetalingsperiode(): Utbetalingsperiode =
+    Utbetalingsperiode(
+        erEndringPåEksisterendePeriode = this.erEndringPåEksisterendePeriode,
+        opphør = this.opphør?.let { Opphør(it.opphørDatoFom) },
+        periodeId = this.periodeId,
+        forrigePeriodeId = this.forrigePeriodeId,
+        datoForVedtak = this.datoForVedtak,
+        klassifisering = this.klassifisering,
+        vedtakdatoFom = this.vedtakdatoFom,
+        vedtakdatoTom = this.vedtakdatoTom,
+        sats = this.sats,
+        satsType = Utbetalingsperiode.SatsType.valueOf(this.satsType.name),
+        utbetalesTil = this.utbetalesTil,
+        behandlingId = this.behandlingId,
+        utbetalingsgrad = this.utbetalingsgrad,
+    )
 
 class AndelTilkjentYtelseForSimulering(
     andelTilkjentYtelse: AndelTilkjentYtelse,

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -54,13 +54,13 @@ class UtbetalingsoppdragGenerator {
                     // Ved simulering når migreringsdato er endret, skal vi opphøre fra den nye datoen og ikke fra første utbetaling per kjede.
                     opphørKjederFraFørsteUtbetaling = erSimulering,
                 ),
-            forrigeAndeler = forrigeTilkjentYtelse?.tilAndelData() ?: emptyList(),
-            nyeAndeler = nyTilkjentYtelse.tilAndelData(),
+            forrigeAndeler = forrigeTilkjentYtelse?.tilAndelDataLongId() ?: emptyList(),
+            nyeAndeler = nyTilkjentYtelse.tilAndelDataLongId(),
             sisteAndelPerKjede = sisteAndelPerKjede.mapValues { it.value.tilAndelDataLongId() },
         )
     }
 
-    private fun TilkjentYtelse.tilAndelData(): List<AndelDataLongId> =
+    private fun TilkjentYtelse.tilAndelDataLongId(): List<AndelDataLongId> =
         this.andelerTilkjentYtelse.map { it.tilAndelDataLongId() }
 
     private fun AndelTilkjentYtelse.tilAndelDataLongId(): AndelDataLongId =

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -85,6 +85,7 @@ class UtbetalingsoppdragGenerator {
      * @param[forrigeTilkjentYtelseMedAndeler] forrige tilkjentYtelse
      * @return oppdatert TilkjentYtelse som inneholder generert utbetalingsoppdrag
      */
+    @Deprecated("Gammel utbetalingsgenerator")
     fun lagTilkjentYtelseMedUtbetalingsoppdrag(
         vedtakMedTilkjentYtelse: VedtakMedTilkjentYtelse,
         andelTilkjentYtelseForUtbetalingsoppdragFactory: AndelTilkjentYtelseForUtbetalingsoppdragFactory,

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -1,21 +1,32 @@
 package no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag
 
 import io.micrometer.core.instrument.Metrics
+import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
+import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
+import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 class UtbetalingsoppdragService(
@@ -24,6 +35,8 @@ class UtbetalingsoppdragService(
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val utbetalingsoppdragGenerator: UtbetalingsoppdragGenerator,
     private val behandlingService: BehandlingService,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
 ) {
     private val sammeOppdragSendtKonflikt = Metrics.counter("familie.ks.sak.samme.oppdrag.sendt.konflikt")
 
@@ -52,6 +65,24 @@ class UtbetalingsoppdragService(
         return tilkjentYtelse
     }
 
+    fun oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
+        vedtak: Vedtak,
+        saksbehandlerId: String,
+    ): Utbetalingsoppdrag {
+        val oppdatertBehandling = vedtak.behandling
+
+        val utbetalingsoppdrag =
+            genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak,
+                saksbehandlerId,
+            ).utbetalingsoppdrag.tilRestUtbetalingsoppdrag()
+
+        tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(behandlingId = vedtak.behandling.id)
+
+        iverksettOppdrag(utbetalingsoppdrag, oppdatertBehandling.id)
+        return utbetalingsoppdrag
+    }
+
     private fun iverksettOppdrag(
         utbetalingsoppdrag: Utbetalingsoppdrag,
         behandlingId: Long,
@@ -76,6 +107,50 @@ class UtbetalingsoppdragService(
     }
 
     fun hentStatus(oppdragId: OppdragId): OppdragStatus = oppdragKlient.hentStatus(oppdragId)
+
+    @Transactional
+    fun genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+        vedtak: Vedtak,
+        saksbehandlerId: String,
+        erSimulering: Boolean = false,
+    ): BeregnetUtbetalingsoppdragLongId {
+        val forrigeTilkjentYtelse = hentForrigeTilkjentYtelse(vedtak.behandling)
+        val nyTilkjentYtelse = tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(behandlingId = vedtak.behandling.id)
+
+        val sisteAndelPerKjede = hentSisteAndelTilkjentYtelse(vedtak.behandling.fagsak)
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
+                saksbehandlerId = saksbehandlerId,
+                vedtak = vedtak,
+                forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+                nyTilkjentYtelse = nyTilkjentYtelse,
+                sisteAndelPerKjede = sisteAndelPerKjede,
+                erSimulering = erSimulering,
+            )
+
+        if (!erSimulering) {
+            oppdaterTilkjentYtelse(nyTilkjentYtelse, beregnetUtbetalingsoppdrag)
+        }
+
+        return beregnetUtbetalingsoppdrag
+    }
+
+    private fun oppdaterTilkjentYtelse(
+        tilkjentYtelse: TilkjentYtelse,
+        beregnetUtbetalingsoppdrag: BeregnetUtbetalingsoppdragLongId,
+    ) {
+        secureLogger.info("Oppdaterer TilkjentYtelse med utbetalingsoppdrag og offsets på andeler for behandling ${tilkjentYtelse.behandling.id}")
+
+        oppdaterTilkjentYtelseMedUtbetalingsoppdrag(
+            tilkjentYtelse = tilkjentYtelse,
+            utbetalingsoppdrag = beregnetUtbetalingsoppdrag.utbetalingsoppdrag,
+        )
+        oppdaterAndelerMedPeriodeOffset(
+            tilkjentYtelse = tilkjentYtelse,
+            andelerMedPeriodeId = beregnetUtbetalingsoppdrag.andeler,
+        )
+        tilkjentYtelseRepository.save(tilkjentYtelse)
+    }
 
     @Transactional
     fun genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
@@ -117,7 +192,72 @@ class UtbetalingsoppdragService(
         )
     }
 
+    private fun hentForrigeTilkjentYtelse(behandling: Behandling): TilkjentYtelse? =
+        behandlingService.hentSisteBehandlingSomErIverksatt(fagsakId = behandling.fagsak.id)
+            ?.let { tilkjentYtelseRepository.finnByBehandlingAndHasUtbetalingsoppdrag(behandlingId = it.id) }
+
+    private fun hentSisteAndelTilkjentYtelse(fagsak: Fagsak) =
+        andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(fagsakId = fagsak.id)
+            .associateBy { IdentOgType(it.aktør.aktivFødselsnummer(), it.type.tilYtelseType()) }
+
+    private fun utledOpphør(
+        utbetalingsoppdrag: no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag,
+        behandling: Behandling,
+    ): Opphør {
+        val erRentOpphør =
+            utbetalingsoppdrag.utbetalingsperiode.isNotEmpty() && utbetalingsoppdrag.utbetalingsperiode.all { it.opphør != null }
+        var opphørsdato: LocalDate? = null
+        if (erRentOpphør) {
+            opphørsdato = utbetalingsoppdrag.utbetalingsperiode.minOf { it.opphør!!.opphørDatoFom }
+        }
+
+        if (behandling.type == BehandlingType.REVURDERING) {
+            val opphørPåRevurdering = utbetalingsoppdrag.utbetalingsperiode.filter { it.opphør != null }
+            if (opphørPåRevurdering.isNotEmpty()) {
+                opphørsdato = opphørPåRevurdering.maxOfOrNull { it.opphør!!.opphørDatoFom }
+            }
+        }
+        return Opphør(erRentOpphør = erRentOpphør, opphørsdato = opphørsdato)
+    }
+
+    private fun oppdaterTilkjentYtelseMedUtbetalingsoppdrag(
+        tilkjentYtelse: TilkjentYtelse,
+        utbetalingsoppdrag: no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag,
+    ) {
+        val opphør = utledOpphør(utbetalingsoppdrag, tilkjentYtelse.behandling)
+
+        tilkjentYtelse.utbetalingsoppdrag = objectMapper.writeValueAsString(utbetalingsoppdrag)
+        tilkjentYtelse.stønadTom = tilkjentYtelse.andelerTilkjentYtelse.maxOfOrNull { it.stønadTom }
+        tilkjentYtelse.stønadFom =
+            if (opphør.erRentOpphør) null else tilkjentYtelse.andelerTilkjentYtelse.minOfOrNull { it.stønadFom }
+        tilkjentYtelse.endretDato = LocalDate.now()
+        tilkjentYtelse.opphørFom = opphør.opphørsdato?.toYearMonth()
+    }
+
+    private fun oppdaterAndelerMedPeriodeOffset(
+        tilkjentYtelse: TilkjentYtelse,
+        andelerMedPeriodeId: List<AndelMedPeriodeIdLongId>,
+    ) {
+        val andelerPåId = andelerMedPeriodeId.associateBy { it.id }
+        val andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse
+        val andelerSomSkalSendesTilOppdrag = andelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() }
+        if (andelerMedPeriodeId.size != andelerSomSkalSendesTilOppdrag.size) {
+            error("Antallet andeler med oppdatert periodeOffset, forrigePeriodeOffset og kildeBehandlingId fra ny generator skal være likt antallet andeler med kalkulertUtbetalingsbeløp != 0. Generator gir ${andelerMedPeriodeId.size} andeler men det er ${andelerSomSkalSendesTilOppdrag.size} andeler med kalkulertUtbetalingsbeløp != 0")
+        }
+        andelerSomSkalSendesTilOppdrag.forEach { andel ->
+            val andelMedOffset =
+                andelerPåId[andel.id]
+                    ?: error("Feil ved oppdaterig av offset på andeler. Finner ikke andel med id ${andel.id} blandt andelene med oppdatert offset fra ny generator. Ny generator returnerer andeler med ider [${andelerPåId.values.map { it.id }}]")
+            andel.periodeOffset = andelMedOffset.periodeId
+            andel.forrigePeriodeOffset = andelMedOffset.forrigePeriodeId
+            andel.kildeBehandlingId = andelMedOffset.kildeBehandlingId
+        }
+    }
+
+    data class Opphør(val erRentOpphør: Boolean, val opphørsdato: LocalDate?)
+
     companion object {
         val logger = LoggerFactory.getLogger(UtbetalingsoppdragService::class.java)
+        val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -6,8 +6,6 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppd
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.objectMapper
-import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
-import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
@@ -40,6 +38,7 @@ class UtbetalingsoppdragService(
 ) {
     private val sammeOppdragSendtKonflikt = Metrics.counter("familie.ks.sak.samme.oppdrag.sendt.konflikt")
 
+    @Deprecated("Bruker gammel utbetalingsgenerator")
     fun oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
         vedtak: Vedtak,
         saksbehandlerId: String,
@@ -106,8 +105,6 @@ class UtbetalingsoppdragService(
         }
     }
 
-    fun hentStatus(oppdragId: OppdragId): OppdragStatus = oppdragKlient.hentStatus(oppdragId)
-
     @Transactional
     fun genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
         vedtak: Vedtak,
@@ -152,6 +149,7 @@ class UtbetalingsoppdragService(
         tilkjentYtelseRepository.save(tilkjentYtelse)
     }
 
+    @Deprecated("Gammel utbetalingsgenerator")
     @Transactional
     fun genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
         vedtak: Vedtak,

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.internal.vedtak.begrunnelser
+package no.nav.familie.ks.sak.internal
 
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/TestVerktøyService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/TestVerktøyService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.internal
 
-import no.nav.familie.ba.sak.internal.vedtak.begrunnelser.lagBrevTest
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.brev.mottaker.BrevmottakerService
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.tilEndretUtbetalingAndelResponsDto
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseRepository
@@ -70,6 +71,7 @@ class BehandlingService(
     private val refusjonEøsService: RefusjonEøsService,
     private val korrigertEtterbetalingRepository: KorrigertEtterbetalingRepository,
     private val brevmottakerService: BrevmottakerService,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
 ) {
     fun hentBehandling(behandlingId: Long): Behandling = behandlingRepository.hentBehandling(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -27,7 +27,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
-import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.brev.mottaker.BrevmottakerService
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.tilEndretUtbetalingAndelResponsDto
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseRepository
@@ -71,7 +70,6 @@ class BehandlingService(
     private val refusjonEøsService: RefusjonEøsService,
     private val korrigertEtterbetalingRepository: KorrigertEtterbetalingRepository,
     private val brevmottakerService: BrevmottakerService,
-    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
 ) {
     fun hentBehandling(behandlingId: Long): Behandling = behandlingRepository.hentBehandling(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/IverksettMotOppdragSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/IverksettMotOppdragSteg.kt
@@ -49,7 +49,7 @@ class IverksettMotOppdragSteg(
 
         val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
 
-        if (unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR)) {
+        if (unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR, mapOf("fagsakId" to behandling.fagsak.id.toString()))) {
             utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
                 vedtak = vedtak,
                 saksbehandlerId = (behandlingStegDto as IverksettMotOppdragDto).saksbehandlerId,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringService.kt
@@ -98,7 +98,7 @@ class SimuleringService(
 
         val utbetalingsoppdrag =
             when {
-                unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR) ->
+                unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR, mapOf("fagsakId" to vedtak.behandling.fagsak.id.toString())) ->
                     utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
                         vedtak = vedtak,
                         saksbehandlerId = SikkerhetContext.hentSaksbehandler(),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -163,7 +163,6 @@ fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp():
     }
 
 enum class YtelseType(val klassifisering: String) {
-    // TODO verdien må avklares med økonomi
     ORDINÆR_KONTANTSTØTTE("KS"),
     ;
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -20,6 +20,7 @@ import jakarta.persistence.Table
 import no.nav.familie.ks.sak.common.entitet.BaseEntitet
 import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.YearMonthConverter
+import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.YtelsetypeKS
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import java.math.BigDecimal
@@ -162,5 +163,12 @@ fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp():
     }
 
 enum class YtelseType(val klassifisering: String) {
-    ORDINÆR_KONTANTSTØTTE("KS"), // TODO verdien må avklares med økonomi
+    // TODO verdien må avklares med økonomi
+    ORDINÆR_KONTANTSTØTTE("KS"),
+    ;
+
+    fun tilYtelseType(): YtelsetypeKS =
+        when (this) {
+            ORDINÆR_KONTANTSTØTTE -> YtelsetypeKS.ORDINÆR_KONTANTSTØTTE
+        }
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ks.sak.data
 
 import io.mockk.mockk
 import no.nav.commons.foedselsnummer.testutils.FoedselsnummerGenerator
+import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
+import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.Opphør
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
@@ -55,6 +57,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.SatsType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
@@ -342,7 +345,9 @@ fun lagAndelTilkjentYtelse(
     prosent: BigDecimal = BigDecimal(100),
     nasjonaltPeriodebeløp: Int = sats,
     differanseberegnetPeriodebeløp: Int? = null,
+    id: Long = 0L,
 ) = AndelTilkjentYtelse(
+    id = id,
     behandlingId = behandling.id,
     tilkjentYtelse = tilkjentYtelse ?: lagInitieltTilkjentYtelse(behandling),
     aktør = aktør ?: behandling.fagsak.aktør,
@@ -711,6 +716,37 @@ fun lagPersonResultat(
     }
     return personResultat
 }
+
+fun lagBeregnetUtbetalingsoppdrag(
+    vedtak: Vedtak,
+    utbetlingsperioder: List<no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode> = emptyList(),
+) =
+    BeregnetUtbetalingsoppdragLongId(
+        no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag(
+            aktoer = "",
+            fagSystem = "KS",
+            saksnummer = "1234",
+            kodeEndring = no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.KodeEndring.NY,
+            saksbehandlerId = "123abc",
+            utbetalingsperiode = utbetlingsperioder,
+        ),
+        listOf(AndelMedPeriodeIdLongId(id = 0L, periodeId = 0L, forrigePeriodeId = null, kildeBehandlingId = vedtak.behandling.id)),
+    )
+
+fun lagUtbetalingsperiode(vedtak: Vedtak) =
+    no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode(
+        erEndringPåEksisterendePeriode = false,
+        periodeId = 0L,
+        forrigePeriodeId = null,
+        datoForVedtak = LocalDate.now(),
+        klassifisering = "KS",
+        vedtakdatoFom = LocalDate.now().minusMonths(5),
+        vedtakdatoTom = LocalDate.now(),
+        sats = maksBeløp().toBigDecimal(),
+        satsType = no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode.SatsType.MND,
+        behandlingId = vedtak.behandling.id,
+        utbetalesTil = "",
+    )
 
 fun lagTilkjentYtelse(
     utbetalingsoppdrag: Utbetalingsoppdrag,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.common.domeneparser
 
-import no.nav.familie.ba.sak.cucumber.domeneparser.ÅrMånedEllerDato
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/ÅrMånedEllerDato.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/ÅrMånedEllerDato.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.cucumber.domeneparser
+package no.nav.familie.ks.sak.common.domeneparser
 
 import java.time.LocalDate
 import java.time.YearMonth

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/OppdragParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/OppdragParser.kt
@@ -1,0 +1,196 @@
+package no.nav.familie.ks.sak.cucumber
+
+import io.cucumber.datatable.DataTable
+import no.nav.familie.felles.utbetalingsgenerator.domain.AndelDataLongId
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.ks.sak.common.domeneparser.Domenebegrep
+import no.nav.familie.ks.sak.common.domeneparser.Domenenøkkel
+import no.nav.familie.ks.sak.common.domeneparser.DomeneparserUtil.groupByBehandlingId
+import no.nav.familie.ks.sak.common.domeneparser.parseBoolean
+import no.nav.familie.ks.sak.common.domeneparser.parseEnum
+import no.nav.familie.ks.sak.common.domeneparser.parseInt
+import no.nav.familie.ks.sak.common.domeneparser.parseLong
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriBoolean
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriEnum
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriInt
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriLong
+import no.nav.familie.ks.sak.common.domeneparser.parseValgfriÅrMåned
+import no.nav.familie.ks.sak.common.domeneparser.parseÅrMåned
+import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
+import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.YtelsetypeKS
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personident.Personident
+import org.assertj.core.api.Assertions
+import java.time.LocalDate
+
+object OppdragParser {
+    fun mapTilkjentYtelse(
+        dataTable: DataTable,
+        behandlinger: Map<Long, Behandling>,
+        tilkjentYtelseId: Long = 0,
+    ): List<TilkjentYtelse> {
+        var index = 0
+        var tilkjentYtelseIdIterator = tilkjentYtelseId
+        return dataTable.groupByBehandlingId().map { (behandlingId, rader) ->
+
+            val behandling = behandlinger.getValue(behandlingId)
+            val andeler = parseAndelder(behandling, rader, index)
+            index += andeler.size
+
+            val tilkjentYtelse =
+                TilkjentYtelse(
+                    id = tilkjentYtelseIdIterator++,
+                    behandling = behandling,
+                    stønadFom = null,
+                    stønadTom = null,
+                    opphørFom = null,
+                    opprettetDato = LocalDate.now(),
+                    endretDato = LocalDate.now(),
+                    utbetalingsoppdrag = null,
+                    andelerTilkjentYtelse = andeler,
+                )
+            andeler.forEach { it.tilkjentYtelse = tilkjentYtelse }
+
+            tilkjentYtelse
+        }
+    }
+
+    private fun parseAndelder(
+        behandling: Behandling,
+        rader: List<Map<String, String>>,
+        forrigeAndelId: Int,
+    ): MutableSet<AndelTilkjentYtelse> {
+        val erUtenAndeler = (parseValgfriBoolean(DomenebegrepTilkjentYtelse.UTEN_ANDELER, rader.first()) ?: false)
+        var andelId = forrigeAndelId
+        return if (erUtenAndeler) {
+            emptySet<AndelTilkjentYtelse>().toMutableSet()
+        } else {
+            rader.map { mapAndelTilkjentYtelse(it, behandling, andelId++) }.toMutableSet()
+        }
+    }
+
+    fun mapForventetUtbetalingsoppdrag(
+        dataTable: DataTable,
+    ): List<ForventetUtbetalingsoppdrag> {
+        return dataTable.groupByBehandlingId().map { (behandlingId, rader) ->
+            val rad = rader.first()
+            validerAlleKodeEndringerLike(rader)
+            ForventetUtbetalingsoppdrag(
+                behandlingId = behandlingId,
+                kodeEndring = parseEnum(DomenebegrepUtbetalingsoppdrag.KODE_ENDRING, rad),
+                utbetalingsperiode = rader.map { mapForventetUtbetalingsperiode(it) },
+            )
+        }
+    }
+
+    fun mapForventetBeståendeAndeler(dataTable: DataTable): List<AndelDataLongId> {
+        return dataTable.asMaps().map { rad ->
+            AndelDataLongId(
+                id = parseLong(Domenebegrep.ID, rad),
+                fom = parseÅrMåned(Domenebegrep.FRA_DATO, rad),
+                tom = parseÅrMåned(Domenebegrep.TIL_DATO, rad),
+                beløp = parseInt(DomenebegrepTilkjentYtelse.BELØP, rad),
+                personIdent = lagFødselsnummer("1"),
+                type = YtelsetypeKS.ORDINÆR_KONTANTSTØTTE,
+                periodeId = parseValgfriLong(DomenebegrepUtbetalingsoppdrag.PERIODE_ID, rad),
+                forrigePeriodeId = parseValgfriLong(DomenebegrepUtbetalingsoppdrag.FORRIGE_PERIODE_ID, rad),
+                kildeBehandlingId = parseValgfriLong(DomenebegrepTilkjentYtelse.KILDEBEHANDLING_ID, rad),
+            )
+        }
+    }
+
+    private fun mapForventetUtbetalingsperiode(it: Map<String, String>) =
+        ForventetUtbetalingsperiode(
+            erEndringPåEksisterendePeriode = parseBoolean(DomenebegrepUtbetalingsoppdrag.ER_ENDRING, it),
+            periodeId = parseLong(DomenebegrepUtbetalingsoppdrag.PERIODE_ID, it),
+            forrigePeriodeId = parseValgfriLong(DomenebegrepUtbetalingsoppdrag.FORRIGE_PERIODE_ID, it),
+            sats = parseInt(DomenebegrepUtbetalingsoppdrag.BELØP, it),
+            ytelse =
+                parseValgfriEnum<YtelseType>(DomenebegrepUtbetalingsoppdrag.YTELSE_TYPE, it)
+                    ?: YtelseType.ORDINÆR_KONTANTSTØTTE,
+            fom = parseÅrMåned(Domenebegrep.FRA_DATO, it).atDay(1),
+            tom = parseÅrMåned(Domenebegrep.TIL_DATO, it).atEndOfMonth(),
+            opphør = parseValgfriÅrMåned(DomenebegrepUtbetalingsoppdrag.OPPHØRSDATO, it)?.atDay(1),
+            kildebehandlingId = parseValgfriLong(DomenebegrepTilkjentYtelse.KILDEBEHANDLING_ID, it),
+        )
+
+    private fun validerAlleKodeEndringerLike(rader: List<Map<String, String>>) {
+        rader.map { parseEnum<Utbetalingsoppdrag.KodeEndring>(DomenebegrepUtbetalingsoppdrag.KODE_ENDRING, it) }
+            .zipWithNext().forEach {
+                Assertions.assertThat(it.first).isEqualTo(it.second)
+                    .withFailMessage("Alle kodeendringer for en og samme oppdrag må være lik ${it.first} -> ${it.second}")
+            }
+    }
+
+    private fun mapAndelTilkjentYtelse(
+        rad: Map<String, String>,
+        behandling: Behandling,
+        andelId: Int,
+    ): AndelTilkjentYtelse {
+        val ytelseType =
+            parseValgfriEnum(DomenebegrepTilkjentYtelse.YTELSE_TYPE, rad) ?: YtelseType.ORDINÆR_KONTANTSTØTTE
+        return lagAndelTilkjentYtelse(
+            fom = parseÅrMåned(Domenebegrep.FRA_DATO, rad),
+            tom = parseÅrMåned(Domenebegrep.TIL_DATO, rad),
+            ytelseType = ytelseType,
+            beløp = parseInt(DomenebegrepTilkjentYtelse.BELØP, rad),
+            behandling = behandling,
+            tilkjentYtelse = null,
+            kildeBehandlingId = parseValgfriLong(DomenebegrepTilkjentYtelse.KILDEBEHANDLING_ID, rad),
+            aktør = parseAktør(rad),
+            periodeIdOffset = parseValgfriLong(DomenebegrepUtbetalingsoppdrag.PERIODE_ID, rad),
+            forrigeperiodeIdOffset = parseValgfriLong(DomenebegrepUtbetalingsoppdrag.FORRIGE_PERIODE_ID, rad),
+        ).copy(id = parseValgfriLong(Domenebegrep.ID, rad) ?: andelId.toLong())
+    }
+
+    private fun parseAktør(rad: Map<String, String>): Aktør {
+        val id = (parseValgfriInt(DomenebegrepTilkjentYtelse.IDENT, rad) ?: 1).toString()
+        val aktørId = id.padStart(13, '0')
+        val fødselsnummer = lagFødselsnummer(id)
+        return Aktør(aktørId).also {
+            it.personidenter.add(Personident(fødselsnummer, it))
+        }
+    }
+
+    private fun lagFødselsnummer(id: String) = id.padStart(11, '0')
+}
+
+enum class DomenebegrepTilkjentYtelse(override val nøkkel: String) : Domenenøkkel {
+    YTELSE_TYPE("Ytelse"),
+    UTEN_ANDELER("Uten andeler"),
+    BELØP("Beløp"),
+    KILDEBEHANDLING_ID("Kildebehandling"),
+    IDENT("Ident"),
+}
+
+enum class DomenebegrepUtbetalingsoppdrag(override val nøkkel: String) : Domenenøkkel {
+    KODE_ENDRING("Kode endring"),
+    ER_ENDRING("Er endring"),
+    PERIODE_ID("Periode id"),
+    FORRIGE_PERIODE_ID("Forrige periode id"),
+    BELØP("Beløp"),
+    YTELSE_TYPE("Ytelse"),
+    OPPHØRSDATO("Opphørsdato"),
+}
+
+data class ForventetUtbetalingsoppdrag(
+    val behandlingId: Long,
+    val kodeEndring: Utbetalingsoppdrag.KodeEndring,
+    val utbetalingsperiode: List<ForventetUtbetalingsperiode>,
+)
+
+data class ForventetUtbetalingsperiode(
+    val erEndringPåEksisterendePeriode: Boolean,
+    val periodeId: Long,
+    val forrigePeriodeId: Long?,
+    val sats: Int,
+    val ytelse: YtelseType,
+    val fom: LocalDate,
+    val tom: LocalDate,
+    val opphør: LocalDate?,
+    val kildebehandlingId: Long?,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/OppdragSteg.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/OppdragSteg.kt
@@ -1,0 +1,221 @@
+package no.nav.familie.ks.sak.cucumber
+
+import io.cucumber.datatable.DataTable
+import io.cucumber.java.no.Gitt
+import io.cucumber.java.no.Når
+import io.cucumber.java.no.Så
+import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
+import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.ks.sak.common.domeneparser.DomeneparserUtil.groupByBehandlingId
+import no.nav.familie.ks.sak.cucumber.OppdragParser.mapTilkjentYtelse
+import no.nav.familie.ks.sak.cucumber.ValideringUtil.assertSjekkBehandlingIder
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.lagVedtak
+import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.UtbetalingsoppdragGenerator
+import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.tilRestUtbetalingsoppdrag
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import org.assertj.core.api.Assertions.assertThat
+import org.slf4j.LoggerFactory
+
+@Suppress("ktlint:standard:function-naming")
+class OppdragSteg {
+    private val utbetalingsoppdragGenerator = UtbetalingsoppdragGenerator()
+    private var behandlinger = mapOf<Long, Behandling>()
+    private var tilkjenteYtelser = listOf<TilkjentYtelse>()
+    private var tilkjenteYtelserNy = listOf<TilkjentYtelse>()
+    private var beregnetUtbetalingsoppdrag = mutableMapOf<Long, BeregnetUtbetalingsoppdragLongId>()
+    private var beregnetUtbetalingsoppdragSimulering = mutableMapOf<Long, BeregnetUtbetalingsoppdragLongId>()
+    private var kastedeFeil = mutableMapOf<Long, Exception>()
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Gitt("følgende tilkjente ytelser")
+    fun følgendeTilkjenteYtelser(dataTable: DataTable) {
+        genererBehandlinger(dataTable)
+        tilkjenteYtelser = mapTilkjentYtelse(dataTable, behandlinger)
+        tilkjenteYtelserNy = mapTilkjentYtelse(dataTable, behandlinger, tilkjenteYtelser.size.toLong())
+        if (tilkjenteYtelser.flatMap { it.andelerTilkjentYtelse }.any { it.kildeBehandlingId != null }) {
+            error("Kildebehandling skal ikke settes på input, denne settes fra utbetalingsgeneratorn")
+        }
+    }
+
+    @Når("beregner utbetalingsoppdrag")
+    fun `beregner utbetalingsoppdrag`() {
+        tilkjenteYtelserNy.fold(emptyList<TilkjentYtelse>()) { acc, tilkjentYtelse ->
+            val behandlingId = tilkjentYtelse.behandling.id
+            try {
+                genererUtbetalingsoppdragForSimuleringNy(behandlingId, acc, tilkjentYtelse)
+                beregnetUtbetalingsoppdrag[behandlingId] = beregnUtbetalingsoppdrag(acc, tilkjentYtelse)
+                oppdaterTilkjentYtelseMedUtbetalingsoppdrag(
+                    beregnetUtbetalingsoppdrag[behandlingId]!!,
+                    tilkjentYtelse,
+                )
+            } catch (e: Exception) {
+                logger.error("Feilet beregning av oppdrag for behandling=$behandlingId")
+                kastedeFeil[behandlingId] = e
+            }
+            acc + tilkjentYtelse
+        }
+    }
+
+    private fun genererUtbetalingsoppdragForSimuleringNy(
+        behandlingId: Long,
+        tilkjenteYtelser: List<TilkjentYtelse>,
+        tilkjentYtelse: TilkjentYtelse,
+    ) {
+        try {
+            beregnetUtbetalingsoppdragSimulering[behandlingId] =
+                beregnUtbetalingsoppdrag(tilkjenteYtelser, tilkjentYtelse, erSimulering = true)
+        } catch (e: Exception) {
+            logger.error("Feilet beregning av oppdrag ved simulering for behandling=$behandlingId")
+            kastedeFeil[behandlingId] = e
+        }
+    }
+
+    private fun oppdaterTilkjentYtelseMedUtbetalingsoppdrag(
+        beregnetUtbetalingsoppdragLongId: BeregnetUtbetalingsoppdragLongId,
+        tilkjentYtelse: TilkjentYtelse,
+    ) {
+        tilkjentYtelse.andelerTilkjentYtelse.forEach { andel ->
+            val andelMedOppdatertOffset = beregnetUtbetalingsoppdragLongId.andeler.find { it.id == andel.id }
+            if (andelMedOppdatertOffset != null) {
+                andel.periodeOffset = andelMedOppdatertOffset.periodeId
+                andel.forrigePeriodeOffset = andelMedOppdatertOffset.forrigePeriodeId
+                andel.kildeBehandlingId = andelMedOppdatertOffset.kildeBehandlingId
+            }
+        }
+    }
+
+    private fun beregnUtbetalingsoppdrag(
+        acc: List<TilkjentYtelse>,
+        tilkjentYtelse: TilkjentYtelse,
+        erSimulering: Boolean = false,
+    ): BeregnetUtbetalingsoppdragLongId {
+        val forrigeTilkjentYtelse = acc.lastOrNull()
+
+        val vedtak = lagVedtak(behandling = tilkjentYtelse.behandling)
+        val sisteAndelPerIdent = sisteAndelPerIdent(acc)
+        return utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
+            saksbehandlerId = "saksbehandlerId",
+            vedtak = vedtak,
+            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+            sisteAndelPerKjede = sisteAndelPerIdent,
+            nyTilkjentYtelse = tilkjentYtelse,
+            erSimulering = erSimulering,
+        )
+    }
+
+    @Så("forvent at en exception kastes for behandling {long}")
+    fun `forvent at en exception kastes for behandling`(behandlingId: Long) {
+        assertThat(kastedeFeil).isNotEmpty
+        assertThat(kastedeFeil[behandlingId]).isNotNull
+    }
+
+    @Så("forvent følgende utbetalingsoppdrag")
+    fun `forvent følgende utbetalingsoppdrag`(dataTable: DataTable) {
+        validerForventetUtbetalingsoppdrag(
+            dataTable,
+            beregnetUtbetalingsoppdrag.mapValues { it.value.utbetalingsoppdrag.tilRestUtbetalingsoppdrag() }
+                .toMutableMap(),
+        )
+        assertSjekkBehandlingIder(
+            dataTable,
+            beregnetUtbetalingsoppdrag.mapValues { it.value.utbetalingsoppdrag.tilRestUtbetalingsoppdrag() }
+                .toMutableMap(),
+        )
+    }
+
+    @Så("forvent følgende simulering")
+    fun `forvent følgende simulering`(dataTable: DataTable) {
+        validerForventetUtbetalingsoppdrag(
+            dataTable,
+            beregnetUtbetalingsoppdragSimulering.mapValues { it.value.utbetalingsoppdrag.tilRestUtbetalingsoppdrag() }
+                .toMutableMap(),
+        )
+        assertSjekkBehandlingIder(
+            dataTable,
+            beregnetUtbetalingsoppdragSimulering.mapValues { it.value.utbetalingsoppdrag.tilRestUtbetalingsoppdrag() }
+                .toMutableMap(),
+        )
+    }
+
+    private fun validerForventetUtbetalingsoppdrag(
+        dataTable: DataTable,
+        beregnetUtbetalingsoppdrag: MutableMap<Long, Utbetalingsoppdrag>,
+    ) {
+        val forventedeUtbetalingsoppdrag =
+            OppdragParser.mapForventetUtbetalingsoppdrag(
+                dataTable,
+            )
+        forventedeUtbetalingsoppdrag.forEach { forventetUtbetalingsoppdrag ->
+            val behandlingId = forventetUtbetalingsoppdrag.behandlingId
+            val utbetalingsoppdrag =
+                beregnetUtbetalingsoppdrag[behandlingId]
+                    ?: error("Mangler utbetalingsoppdrag for $behandlingId")
+            try {
+                assertUtbetalingsoppdrag(forventetUtbetalingsoppdrag, utbetalingsoppdrag)
+            } catch (e: Throwable) {
+                logger.error("Feilet validering av behandling $behandlingId")
+                throw e
+            }
+        }
+    }
+
+    private fun genererBehandlinger(dataTable: DataTable) {
+        val fagsak = lagFagsak()
+        behandlinger =
+            dataTable.groupByBehandlingId()
+                .map { lagBehandling(fagsak = fagsak).copy(id = it.key) }
+                .associateBy { it.id }
+    }
+
+    private fun sisteAndelPerIdent(tilkjenteYtelser: List<TilkjentYtelse>): Map<IdentOgType, AndelTilkjentYtelse> {
+        return tilkjenteYtelser.flatMap { it.andelerTilkjentYtelse }
+            .groupBy { IdentOgType(it.aktør.aktivFødselsnummer(), it.type.tilYtelseType()) }
+            .mapValues { it.value.maxBy { it.periodeOffset ?: 0 } }
+    }
+
+    private fun assertUtbetalingsoppdrag(
+        forventetUtbetalingsoppdrag: ForventetUtbetalingsoppdrag,
+        utbetalingsoppdrag: Utbetalingsoppdrag,
+        medUtbetalingsperiode: Boolean = true,
+    ) {
+        assertThat(utbetalingsoppdrag.kodeEndring).isEqualTo(forventetUtbetalingsoppdrag.kodeEndring)
+        assertThat(utbetalingsoppdrag.utbetalingsperiode).hasSize(forventetUtbetalingsoppdrag.utbetalingsperiode.size)
+        if (medUtbetalingsperiode) {
+            forventetUtbetalingsoppdrag.utbetalingsperiode.forEachIndexed { index, forventetUtbetalingsperiode ->
+                val utbetalingsperiode = utbetalingsoppdrag.utbetalingsperiode[index]
+                try {
+                    assertUtbetalingsperiode(utbetalingsperiode, forventetUtbetalingsperiode)
+                } catch (e: Throwable) {
+                    logger.error("Feilet validering av rad $index for oppdrag=${forventetUtbetalingsoppdrag.behandlingId}")
+                    throw e
+                }
+            }
+        }
+    }
+}
+
+private fun assertUtbetalingsperiode(
+    utbetalingsperiode: Utbetalingsperiode,
+    forventetUtbetalingsperiode: ForventetUtbetalingsperiode,
+) {
+    assertThat(utbetalingsperiode.erEndringPåEksisterendePeriode)
+        .isEqualTo(forventetUtbetalingsperiode.erEndringPåEksisterendePeriode)
+    assertThat(utbetalingsperiode.klassifisering).isEqualTo(forventetUtbetalingsperiode.ytelse.klassifisering)
+    assertThat(utbetalingsperiode.periodeId).isEqualTo(forventetUtbetalingsperiode.periodeId)
+    assertThat(utbetalingsperiode.forrigePeriodeId).isEqualTo(forventetUtbetalingsperiode.forrigePeriodeId)
+    assertThat(utbetalingsperiode.sats.toInt()).isEqualTo(forventetUtbetalingsperiode.sats)
+    assertThat(utbetalingsperiode.satsType).isEqualTo(Utbetalingsperiode.SatsType.MND)
+    assertThat(utbetalingsperiode.vedtakdatoFom).isEqualTo(forventetUtbetalingsperiode.fom)
+    assertThat(utbetalingsperiode.vedtakdatoTom).isEqualTo(forventetUtbetalingsperiode.tom)
+    assertThat(utbetalingsperiode.opphør?.opphørDatoFom).isEqualTo(forventetUtbetalingsperiode.opphør)
+    forventetUtbetalingsperiode.kildebehandlingId?.let {
+        assertThat(utbetalingsperiode.behandlingId).isEqualTo(forventetUtbetalingsperiode.kildebehandlingId)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/ValideringUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/ValideringUtil.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ks.sak.cucumber
+
+import io.cucumber.datatable.DataTable
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.ks.sak.common.domeneparser.Domenebegrep
+import no.nav.familie.ks.sak.common.domeneparser.parseLong
+
+object ValideringUtil {
+    fun assertSjekkBehandlingIder(
+        dataTable: DataTable,
+        utbetalingsoppdrag: Map<Long, Utbetalingsoppdrag>,
+    ) {
+        val eksisterendeBehandlingId =
+            utbetalingsoppdrag.filter {
+                it.value.utbetalingsperiode.isNotEmpty()
+            }.keys
+        val forventedeBehandlingId = dataTable.asMaps().map { parseLong(Domenebegrep.BEHANDLING_ID, it) }.toSet()
+        val ukontrollerteBehandlingId = eksisterendeBehandlingId.filterNot { forventedeBehandlingId.contains(it) }
+        if (ukontrollerteBehandlingId.isNotEmpty() &&
+            erUkontrollerteUtbetalingsoppdragTomme(
+                ukontrollerteBehandlingId,
+                utbetalingsoppdrag,
+            )
+        ) {
+            error("Har ikke kontrollert behandlingene:$ukontrollerteBehandlingId")
+        }
+    }
+
+    private fun erUkontrollerteUtbetalingsoppdragTomme(
+        ukontrollerteBehandlingId: List<Long>,
+        utbetalingsoppdrag: Map<Long, Utbetalingsoppdrag>,
+    ): Boolean =
+        utbetalingsoppdrag
+            .filterKeys {
+                ukontrollerteBehandlingId.contains(it)
+            }
+            .any { it.value.utbetalingsperiode.isNotEmpty() }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
+import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
@@ -30,6 +31,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 internal class UtbetalingsperiodeServiceTest {
     @MockK
     private lateinit var oppdragKlient: OppdragKlient
+
+    @MockK
+    private lateinit var beregningService: BeregningService
 
     @MockK
     private lateinit var tilkjentYtelseValideringService: TilkjentYtelseValideringService

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag
 
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
@@ -7,25 +8,27 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
+import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagBeregnetUtbetalingsoppdrag
-import no.nav.familie.ks.sak.data.lagFagsak
-import no.nav.familie.ks.sak.data.lagTilkjentYtelse
-import no.nav.familie.ks.sak.data.lagUtbetalingsoppdrag
-import no.nav.familie.ks.sak.data.lagUtbetalingsperiode
+import no.nav.familie.ks.sak.data.lagInitiellTilkjentYtelse
+import no.nav.familie.ks.sak.data.lagVedtak
+import no.nav.familie.ks.sak.data.tilfeldigPerson
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
-import org.junit.jupiter.api.BeforeEach
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.YearMonth
 
 @ExtendWith(MockKExtension::class)
 internal class UtbetalingsperiodeServiceTest {
@@ -39,9 +42,6 @@ internal class UtbetalingsperiodeServiceTest {
     private lateinit var tilkjentYtelseValideringService: TilkjentYtelseValideringService
 
     @MockK
-    private lateinit var utbetalingsoppdragGenerator: UtbetalingsoppdragGenerator
-
-    @MockK
     private lateinit var behandlingService: BehandlingService
 
     @MockK
@@ -51,61 +51,637 @@ internal class UtbetalingsperiodeServiceTest {
     private lateinit var andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository
 
     @InjectMockKs
+    private lateinit var utbetalingsoppdragGenerator: UtbetalingsoppdragGenerator
+
+    @InjectMockKs
     private lateinit var utbetalingsoppdragService: UtbetalingsoppdragService
-
-    private val fagsak = lagFagsak()
-
-    private val behandling = lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
-
-    private val vedtak = Vedtak(behandling = behandling)
-
-    @BeforeEach
-    fun beforeEach() {
-        every { behandlingService.hentSisteBehandlingSomErIverksatt(any()) } returns null
-        every { tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(any()) } just runs
-        every { oppdragKlient.iverksettOppdrag(any()) } returns ""
-        every { tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(any()) } returns lagTilkjentYtelse(utbetalingsoppdrag = lagUtbetalingsoppdrag(emptyList()), behandling = behandling).also { it.andelerTilkjentYtelse.addAll(mutableListOf(lagAndelTilkjentYtelse())) }
-        every { tilkjentYtelseRepository.save(any()) } returns mockk()
-        every { tilkjentYtelseRepository.finnByBehandlingAndHasUtbetalingsoppdrag(any()) } returns mockk()
-        every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(any()) } returns emptyList()
-    }
 
     @Test
     fun `oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett - skal ikke iverksette mot oppdrag hvis det ikke finnes utbetalingsperioder`() {
-        every {
-            utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            )
-        } returns
-            lagBeregnetUtbetalingsoppdrag(vedtak, utbetlingsperioder = emptyList())
-        utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
-            vedtak,
-            "",
+        every { tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(any()) } just runs
+        every { oppdragKlient.iverksettOppdrag(any()) } returns ""
+
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            emptySet(),
         )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+        )
+
+        utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
+            vedtak = vedtak,
+            "abc123",
+        )
+
         verify(exactly = 0) { oppdragKlient.iverksettOppdrag(any()) }
     }
 
     @Test
     fun `oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett - skal iverksette mot oppdrag hvis det finnes utbetalingsperioder`() {
-        every {
-            utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-            )
-        } returns lagBeregnetUtbetalingsoppdrag(vedtak, utbetlingsperioder = listOf(lagUtbetalingsperiode(vedtak)))
-        utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
-            vedtak,
-            "",
+        every { tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(any()) } just runs
+        every { oppdragKlient.iverksettOppdrag(any()) } returns ""
+
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 350,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2023, 6),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                ),
+            ),
         )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+        )
+
+        utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
+            vedtak = vedtak,
+            "abc123",
+        )
+
         verify(exactly = 1) { oppdragKlient.iverksettOppdrag(any()) }
+    }
+
+    @Test
+    fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset når det ikke finnes en forrige behandling`() {
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 350,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2023, 6),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                ),
+            ),
+        )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+        )
+
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak = vedtak,
+                "abc123",
+            )
+
+        val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
+
+        verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
+
+        validerBeregnetUtbetalingsoppdragOgAndeler(
+            beregnetUtbetalingsoppdrag = beregnetUtbetalingsoppdrag,
+            andelerTilkjentYtelse = lagredeAndeler,
+            forventetAntallAndeler = 3,
+            forventetAntallUtbetalingsperioder = 3,
+            forventedeOffsets =
+                listOf(
+                    Pair(0L, null),
+                    Pair(1L, 0L),
+                    Pair(2L, 1L),
+                ),
+        )
+    }
+
+    @Test
+    fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset når det finnes en forrige behandling`() {
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 4,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 300,
+                    person = person,
+                ),
+            ),
+        )
+
+        val forrigeBehandling = lagBehandling()
+        val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(forrigeBehandling)
+        forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = person,
+                    periodeIdOffset = 0,
+                    forrigeperiodeIdOffset = null,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 350,
+                    person = person,
+                    periodeIdOffset = 1,
+                    forrigeperiodeIdOffset = 0,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2023, 6),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                    periodeIdOffset = 2,
+                    forrigeperiodeIdOffset = 1,
+                ),
+            ),
+        )
+
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+        )
+
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak = vedtak,
+                "abc123",
+            )
+
+        val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
+
+        verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
+
+        validerBeregnetUtbetalingsoppdragOgAndeler(
+            beregnetUtbetalingsoppdrag = beregnetUtbetalingsoppdrag,
+            andelerTilkjentYtelse = lagredeAndeler,
+            forventetAntallAndeler = 1,
+            forventetAntallUtbetalingsperioder = 1,
+            forventedeOffsets =
+                listOf(
+                    Pair(3L, 2L),
+                ),
+        )
+    }
+
+    @Test
+    fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset for 2 personer`() {
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        val barn = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 350,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2023, 6),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 4,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = barn,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 5,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 350,
+                    person = barn,
+                ),
+            ),
+        )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+        )
+
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak = vedtak,
+                "abc123",
+            )
+
+        val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
+
+        verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
+
+        validerBeregnetUtbetalingsoppdragOgAndeler(
+            beregnetUtbetalingsoppdrag = beregnetUtbetalingsoppdrag,
+            andelerTilkjentYtelse = lagredeAndeler,
+            forventetAntallAndeler = 5,
+            forventetAntallUtbetalingsperioder = 5,
+            forventedeOffsets =
+                listOf(
+                    Pair(0L, null),
+                    Pair(1L, 0L),
+                    Pair(2L, 1L),
+                    Pair(3L, null),
+                    Pair(4L, 3L),
+                ),
+        )
+    }
+
+    @Test
+    fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset for 2 personer og tidligere behandling`() {
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        val barn = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 6,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 7,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 350,
+                    person = barn,
+                ),
+            ),
+        )
+
+        val forrigeBehandling = lagBehandling()
+        val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(forrigeBehandling)
+        forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = person,
+                    periodeIdOffset = 0L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 350,
+                    person = person,
+                    periodeIdOffset = 1L,
+                    forrigeperiodeIdOffset = 0L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2023, 6),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                    periodeIdOffset = 2L,
+                    forrigeperiodeIdOffset = 1L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 4,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = barn,
+                    periodeIdOffset = 3L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 5,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 350,
+                    person = barn,
+                    periodeIdOffset = 4L,
+                    forrigeperiodeIdOffset = 3L,
+                ),
+            ),
+        )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+        )
+
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak = vedtak,
+                "abc123",
+            )
+
+        val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
+
+        verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
+
+        validerBeregnetUtbetalingsoppdragOgAndeler(
+            beregnetUtbetalingsoppdrag = beregnetUtbetalingsoppdrag,
+            andelerTilkjentYtelse = lagredeAndeler,
+            forventetAntallAndeler = 2,
+            forventetAntallUtbetalingsperioder = 2,
+            forventedeOffsets =
+                listOf(
+                    Pair(5L, 2L),
+                    Pair(6L, 4L),
+                ),
+        )
+    }
+
+    @Test
+    fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag for simulering med en eksisterende kjede og en ny kjede`() {
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        val barn = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 6,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 7,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 350,
+                    person = barn,
+                ),
+            ),
+        )
+
+        val forrigeBehandling = lagBehandling()
+        val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(forrigeBehandling)
+        forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 3),
+                    beløp = 250,
+                    person = person,
+                    periodeIdOffset = 0L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2023, 4),
+                    tom = YearMonth.of(2023, 5),
+                    beløp = 350,
+                    person = person,
+                    periodeIdOffset = 1L,
+                    forrigeperiodeIdOffset = 0L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2023, 6),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                    periodeIdOffset = 2L,
+                    forrigeperiodeIdOffset = 1L,
+                ),
+            ),
+        )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+        )
+
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak = vedtak,
+                saksbehandlerId = "abc123",
+                erSimulering = true,
+            )
+
+        verify(exactly = 0) { tilkjentYtelseRepository.save(any()) }
+
+        validerBeregnetUtbetalingsoppdragOgAndeler(
+            beregnetUtbetalingsoppdrag = beregnetUtbetalingsoppdrag,
+            andelerTilkjentYtelse = emptySet(),
+            forventetAntallAndeler = 2,
+            forventetAntallUtbetalingsperioder = 3,
+            forventedeOffsets =
+                listOf(
+                    Pair(3L, 2L),
+                    Pair(4L, null),
+                ),
+        )
+    }
+
+    @Test
+    fun `genererUtbetalingsoppdrag - revurdering hvor 0-utbetaling går til betaling skal ikke opprette noe opphør ved simulering`() {
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        val barn = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 4,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 350,
+                    person = barn,
+                ),
+            ),
+        )
+
+        val forrigeBehandling = lagBehandling()
+        val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(forrigeBehandling)
+        forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 0,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2023, 1),
+                    tom = YearMonth.of(2023, 8),
+                    beløp = 0,
+                    person = barn,
+                ),
+            ),
+        )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+        )
+
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak = vedtak,
+                saksbehandlerId = "abc123",
+                erSimulering = true,
+            )
+
+        verify(exactly = 0) { tilkjentYtelseRepository.save(any()) }
+
+        validerBeregnetUtbetalingsoppdragOgAndeler(
+            beregnetUtbetalingsoppdrag = beregnetUtbetalingsoppdrag,
+            andelerTilkjentYtelse = emptySet(),
+            forventetAntallAndeler = 2,
+            forventetAntallUtbetalingsperioder = 2,
+            forventedeOffsets =
+                listOf(
+                    Pair(0L, null),
+                    Pair(1L, null),
+                ),
+        )
+    }
+
+    private fun validerBeregnetUtbetalingsoppdragOgAndeler(
+        beregnetUtbetalingsoppdrag: BeregnetUtbetalingsoppdragLongId,
+        andelerTilkjentYtelse: Set<AndelTilkjentYtelse>,
+        forventedeOffsets: List<Pair<Long?, Long?>>,
+        forventetAntallAndeler: Int,
+        forventetAntallUtbetalingsperioder: Int,
+    ) {
+        assertThat(beregnetUtbetalingsoppdrag.utbetalingsoppdrag).isNotNull
+        assertThat(beregnetUtbetalingsoppdrag.utbetalingsoppdrag.utbetalingsperiode.size).isEqualTo(
+            forventetAntallUtbetalingsperioder,
+        )
+
+        assertThat(beregnetUtbetalingsoppdrag.andeler).isNotEmpty
+        assertThat(beregnetUtbetalingsoppdrag.andeler.size).isEqualTo(forventetAntallAndeler)
+
+        if (andelerTilkjentYtelse.isNotEmpty()) {
+            assertThat(andelerTilkjentYtelse.size).isEqualTo(forventetAntallAndeler)
+            assertThat(
+                andelerTilkjentYtelse.map {
+                    Pair(
+                        it.periodeOffset,
+                        it.forrigePeriodeOffset,
+                    )
+                },
+            ).isEqualTo(
+                forventedeOffsets,
+            )
+        } else {
+            assertThat(
+                beregnetUtbetalingsoppdrag.andeler.map {
+                    Pair(
+                        it.periodeId,
+                        it.forrigePeriodeId,
+                    )
+                },
+            ).isEqualTo(
+                forventedeOffsets,
+            )
+        }
+    }
+
+    private fun setUpMocks(
+        behandling: Behandling,
+        tilkjentYtelse: TilkjentYtelse,
+        tilkjentYtelseSlot: CapturingSlot<TilkjentYtelse>,
+        forrigeTilkjentYtelse: TilkjentYtelse? = null,
+    ) {
+        if (forrigeTilkjentYtelse == null) {
+            every { behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns null
+            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(behandling.fagsak.id) } returns emptyList()
+        } else {
+            every { behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns forrigeTilkjentYtelse.behandling
+
+            every { tilkjentYtelseRepository.finnByBehandlingAndHasUtbetalingsoppdrag(forrigeTilkjentYtelse.behandling.id) } returns forrigeTilkjentYtelse
+
+            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(behandling.fagsak.id) } returns
+                forrigeTilkjentYtelse.andelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() }
+                    .groupBy { it.aktør.aktivFødselsnummer() }
+                    .mapValues { it.value.maxBy { it.periodeOffset!! } }.values.toList()
+        }
+
+        every { tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(behandling.id) } returns tilkjentYtelse
+
+        every { behandlingService.hentBehandlingerPåFagsak(behandling.fagsak.id) } returns listOf(behandling)
+
+        every { tilkjentYtelseRepository.save(capture(tilkjentYtelseSlot)) } returns mockk()
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/IverksettMotOppdragStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/IverksettMotOppdragStegTest.kt
@@ -10,6 +10,7 @@ import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ks.sak.api.dto.IverksettMotOppdragDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.FeatureToggleConfig
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.UtbetalingsoppdragService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
@@ -20,6 +21,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.prosessering.internal.TaskService
+import no.nav.familie.unleash.UnleashService
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -45,6 +47,9 @@ class IverksettMotOppdragStegTest {
 
     @MockK
     private lateinit var taskService: TaskService
+
+    @MockK
+    private lateinit var unleashService: UnleashService
 
     @InjectMockKs
     private lateinit var iverksettMotOppdragSteg: IverksettMotOppdragSteg
@@ -109,10 +114,11 @@ class IverksettMotOppdragStegTest {
         every { totrinnskontrollService.hentAktivForBehandling(any()) } returns mocketTotrinnskontroll
         every { vedtakService.hentAktivVedtakForBehandling(any()) } returns mockk()
         every {
-            utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(any(), any(), any())
+            utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(any(), any())
         } returns mockk()
         every { behandlingService.hentSisteBehandlingSomErVedtatt(any()) } returns null
         every { taskService.save(any()) } returns mockk()
+        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR) } returns true
 
         iverksettMotOppdragSteg.utførSteg(200, iverksettMotOppdragDto)
 
@@ -125,7 +131,7 @@ class IverksettMotOppdragStegTest {
         verify(exactly = 1) { totrinnskontrollService.hentAktivForBehandling(any()) }
         verify(exactly = 1) { vedtakService.hentAktivVedtakForBehandling(any()) }
         verify(exactly = 1) {
-            utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(any(), any(), any())
+            utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(any(), any())
         }
         verify(exactly = 1) { taskService.save(any()) }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/IverksettMotOppdragStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/IverksettMotOppdragStegTest.kt
@@ -118,7 +118,7 @@ class IverksettMotOppdragStegTest {
         } returns mockk()
         every { behandlingService.hentSisteBehandlingSomErVedtatt(any()) } returns null
         every { taskService.save(any()) } returns mockk()
-        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR, mapOf("fagsakId" to mocketBehandling.fagsak.id.toString())) } returns true
 
         iverksettMotOppdragSteg.utførSteg(200, iverksettMotOppdragDto)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
@@ -31,7 +31,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakReposito
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -64,11 +63,6 @@ class SimuleringServiceTest {
     @InjectMockKs
     private lateinit var simuleringService: SimuleringService
 
-    @BeforeEach
-    fun beforeEach() {
-        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR) } returns true
-    }
-
     @ParameterizedTest
     @EnumSource(value = BehandlingStatus::class, names = ["IVERKSETTER_VEDTAK", "AVSLUTTET"])
     fun `oppdaterSimuleringPåBehandlingVedBehov - skal returnere eksisterende simulering dersom behandlingstatus er IVERKSETTER_VEDTAK eller AVSLUTTET`(
@@ -94,6 +88,7 @@ class SimuleringServiceTest {
 
         every { behandlingRepository.hentBehandling(behandling.id) } returns behandling
         every { øknomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns eksisterendeSimulering
+        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR, mapOf("fagsakId" to behandling.fagsak.id.toString())) } returns true
 
         val simulering = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId = behandling.id)
 
@@ -137,6 +132,7 @@ class SimuleringServiceTest {
 
         every { behandlingRepository.hentBehandling(behandling.id) } returns behandling
         every { øknomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns eksisterendeSimulering
+        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR, mapOf("fagsakId" to behandling.fagsak.id.toString())) } returns true
 
         val simulering = simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId = behandling.id)
 
@@ -195,6 +191,7 @@ class SimuleringServiceTest {
         every { oppdragKlient.hentSimulering(any()) } returns DetaljertSimuleringResultat(simuleringMottaker = nySimulering)
         every { øknomiSimuleringMottakerRepository.deleteByBehandlingId(any()) } just runs
         every { øknomiSimuleringMottakerRepository.saveAll(any<List<ØkonomiSimuleringMottaker>>()) } returns mockk()
+        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR, mapOf("fagsakId" to behandling.fagsak.id.toString())) } returns true
 
         simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId = behandling.id)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
@@ -11,11 +11,12 @@ import io.mockk.verify
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
 import no.nav.familie.kontrakter.felles.simulering.MottakerType
 import no.nav.familie.kontrakter.felles.simulering.SimuleringMottaker
+import no.nav.familie.ks.sak.config.FeatureToggleConfig
 import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagBeregnetUtbetalingsoppdrag
 import no.nav.familie.ks.sak.data.lagSimulertPostering
-import no.nav.familie.ks.sak.data.lagTilkjentYtelse
-import no.nav.familie.ks.sak.data.lagUtbetalingsoppdrag
 import no.nav.familie.ks.sak.data.lagUtbetalingsperiode
+import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.data.lagØkonomiSimuleringMottaker
 import no.nav.familie.ks.sak.data.lagØkonomiSimuleringPostering
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
@@ -28,7 +29,9 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.domene.ØkonomiSi
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
+import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -55,8 +58,16 @@ class SimuleringServiceTest {
     @MockK
     private lateinit var behandlingRepository: BehandlingRepository
 
+    @MockK
+    private lateinit var unleashService: UnleashService
+
     @InjectMockKs
     private lateinit var simuleringService: SimuleringService
+
+    @BeforeEach
+    fun beforeEach() {
+        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_UTBETALINGSGENERATOR) } returns true
+    }
 
     @ParameterizedTest
     @EnumSource(value = BehandlingStatus::class, names = ["IVERKSETTER_VEDTAK", "AVSLUTTET"])
@@ -175,16 +186,12 @@ class SimuleringServiceTest {
         every { beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = behandling) } returns false
         every {
             utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
-                any(),
-                any(),
-                any(),
-                any(),
+                vedtak = any(),
+                saksbehandlerId = any(),
+                erSimulering = any(),
             )
         } returns
-            lagTilkjentYtelse(
-                utbetalingsoppdrag = lagUtbetalingsoppdrag(listOf(lagUtbetalingsperiode())),
-                behandling = behandling,
-            )
+            lagBeregnetUtbetalingsoppdrag(vedtak = lagVedtak(behandling), listOf(lagUtbetalingsperiode(vedtak = lagVedtak(behandling))))
         every { oppdragKlient.hentSimulering(any()) } returns DetaljertSimuleringResultat(simuleringMottaker = nySimulering)
         every { øknomiSimuleringMottakerRepository.deleteByBehandlingId(any()) } just runs
         every { øknomiSimuleringMottakerRepository.saveAll(any<List<ØkonomiSimuleringMottaker>>()) } returns mockk()

--- a/src/test/resources/cucumber/oppdrag/0beløp.feature
+++ b/src/test/resources/cucumber/oppdrag/0beløp.feature
@@ -1,0 +1,85 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Utbetalingsoppdrag: Håndtering av 0-beløp
+
+
+  Scenario: Endrer en tidligere periode til 0-utbetaling
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 04.2021  | 700   |
+      | 2            | 03.2021  | 03.2021  | 0     |
+      | 2            | 04.2021  | 04.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  |
+
+      | 2            | 04.2021  | 04.2021  | 03.2021     | 700   | ENDR         | Ja         | 1          | 0                  |
+      | 2            | 04.2021  | 04.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  |
+
+  Scenario: Splitter en periode til 2 perioder der en av de får 0-beløp
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 04.2021  | 700   |
+      | 1            | 05.2021  | 06.2021  | 800   |
+
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 04.2021  | 0     |
+      | 2            | 05.2021  | 06.2021  | 800   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 04.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 05.2021  | 06.2021  |             | 800   | NY           | Nei        | 1          | 0                  |
+
+      | 2            | 05.2021  | 06.2021  | 04.2021     | 800   | ENDR         | Ja         | 1          | 0                  |
+      | 2            | 05.2021  | 06.2021  |             | 800   | ENDR         | Nei        | 2          | 1                  |
+
+  Scenario: 0 beløp før forrige periode skal opphøra bak i tiden, for å kunne opphøre bak i tiden til når infotrygd eide dataen
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+
+      | 2            | 02.2021  | 02.2021  | 0     |
+      | 2            | 03.2021  | 03.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+
+      | 2            | 03.2021  | 03.2021  | 02.2021     | 700   | ENDR         | Ja         | 0          |                    |
+      | 2            | 03.2021  | 03.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  |
+
+  Scenario: 0-beløp beholdes, og får en ny andel
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 04.2021  | 0     |
+      | 1            | 05.2021  | 05.2021  | 800   |
+
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 04.2021  | 0     |
+      | 2            | 05.2021  | 05.2021  | 800   |
+      | 2            | 06.2021  | 06.2021  | 900   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 05.2021  | 05.2021  |             | 800   | NY           | Nei        | 1          | 0                  |
+
+      | 2            | 06.2021  | 06.2021  |             | 900   | ENDR         | Nei        | 2          | 1                  |

--- a/src/test/resources/cucumber/oppdrag/flerePersoner.feature
+++ b/src/test/resources/cucumber/oppdrag/flerePersoner.feature
@@ -1,0 +1,40 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Utbetalingsoppdrag: Vedtak med flere identer
+
+
+  Scenario: Vedtak med to perioder på ulike identer
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp | Ident |
+      | 1            | 03.2021  | 03.2021  | 700   | 1     |
+      | 1            | 03.2021  | 03.2021  | 700   | 2     |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 1          |                    | 1               |
+
+
+  Scenario: Revurderer og legger til en periode på en av personene
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp | Ident |
+      | 1            | 03.2021  | 03.2021  | 700   | 1     |
+      | 1            | 03.2021  | 03.2021  | 700   | 2     |
+
+      | 2            | 03.2021  | 03.2021  | 700   | 1     |
+      | 2            | 04.2021  | 04.2021  | 800   | 1     |
+      | 2            | 03.2021  | 03.2021  | 700   | 2     |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 1          |                    | 1               |
+      | 2            | 04.2021  | 04.2021  |             | 800   | ENDR         | Nei        | 2          | 0                  | 2               |
+

--- a/src/test/resources/cucumber/oppdrag/oppdrag.feature
+++ b/src/test/resources/cucumber/oppdrag/oppdrag.feature
@@ -1,0 +1,127 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Utbetalingsoppdrag: Vedtak for førstegangsbehandling
+
+
+  Scenario: Vedtak med en periode
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+
+  Scenario: Revurdering uten endring av andeler
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 04.2021  | 700   |
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 04.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  |
+
+
+  Scenario: Vedtak med to perioder
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 05.2021  | 800   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 05.2021  |             | 800   | NY           | Nei        | 1          | 0                  |
+
+
+  Scenario: Revurdering som legger til en periode, simulering skal opphøre fra start for å kunne vise all historikk
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 04.2021  | 800   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 04.2021  | 04.2021  |             | 800   | ENDR         | Nei        | 1          | 0                  |
+
+
+    Så forvent følgende simulering
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 700   | ENDR         | Ja         | 0          |                    |
+      | 2            | 03.2021  | 03.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  |
+      | 2            | 04.2021  | 04.2021  |             | 800   | ENDR         | Nei        | 2          | 1                  |
+
+  Scenario: 2 revurderinger som legger til en periode
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 04.2021  | 800   |
+
+      | 3            | 03.2021  | 03.2021  | 700   |
+      | 3            | 04.2021  | 04.2021  | 800   |
+      | 3            | 05.2021  | 05.2021  | 900   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 2            | 04.2021  | 04.2021  |             | 800   | ENDR         | Nei        | 1          | 0                  | 2               |
+      | 3            | 05.2021  | 05.2021  |             | 900   | ENDR         | Nei        | 2          | 1                  | 3               |
+
+  Scenario: Endrer beløp fra april
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 06.2021  | 700   |
+
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 06.2021  | 800   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 06.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 04.2021  | 06.2021  |             | 800   | ENDR         | Nei        | 1          | 0                  |
+
+
+  Scenario: Endrer beløp fra start
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 06.2021  | 700   |
+
+      | 2            | 03.2021  | 03.2021  | 800   |
+      | 2            | 04.2021  | 06.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 06.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 03.2021  | 03.2021  |             | 800   | ENDR         | Nei        | 1          | 0                  |
+      | 2            | 04.2021  | 06.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  |

--- a/src/test/resources/cucumber/oppdrag/opphoer.feature
+++ b/src/test/resources/cucumber/oppdrag/opphoer.feature
@@ -1,0 +1,163 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Utbetalingsoppdrag: Opphør
+
+
+  Scenario: Opphør en periode
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Uten andeler | Fra dato | Til dato | Beløp |
+      | 1            |              | 03.2021  | 03.2021  | 700   |
+      | 2            | Ja           |          |          |       |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 700   | ENDR         | Ja         | 0          |                    |
+
+  Scenario: Iverksetter på nytt etter opphør
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Uten andeler | Fra dato | Til dato | Beløp |
+      | 1            |              | 03.2021  | 03.2021  | 700   |
+      | 2            | Ja           |          |          |       |
+      | 3            |              | 03.2021  | 03.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 700   | ENDR         | Ja         | 0          |                    |
+      | 3            | 03.2021  | 03.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  |
+
+  Scenario: Opphør en av 2 perioder
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 04.2021  | 800   |
+      | 2            | 03.2021  | 03.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 04.2021  |             | 800   | NY           | Nei        | 1          | 0                  |
+      | 2            | 04.2021  | 04.2021  | 04.2021     | 800   | ENDR         | Ja         | 1          | 0                  |
+
+  Scenario: Opphører en lang periode
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 06.2021  | 700   |
+      | 2            | 03.2021  | 04.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 06.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 03.2021  | 06.2021  | 05.2021     | 700   | ENDR         | Ja         | 0          |                    |
+
+  Scenario: Opphør en tidligere periode da vi kun har med den andre av 2 perioder
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 04.2021  | 700   |
+      | 2            | 04.2021  | 04.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |                 |
+      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  |                 |
+
+      | 2            | 04.2021  | 04.2021  | 03.2021     | 700   | ENDR         | Ja         | 1          | 0                  |                 |
+      | 2            | 04.2021  | 04.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  |                 |
+
+  Scenario: Endrer en tidligere periode til 0-utbetaling
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 04.2021  | 700   |
+      | 2            | 03.2021  | 03.2021  | 0     |
+      | 2            | 04.2021  | 04.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  |
+
+      | 2            | 04.2021  | 04.2021  | 03.2021     | 700   | ENDR         | Ja         | 1          | 0                  |
+      | 2            | 04.2021  | 04.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  |
+
+
+  Scenario: 2 opphør etter hverendre på ulike perioder
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 04.2021  | 800   |
+      | 1            | 05.2021  | 05.2021  | 900   |
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 04.2021  | 800   |
+      | 3            | 03.2021  | 03.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 04.2021  |             | 800   | NY           | Nei        | 1          | 0                  |
+      | 1            | 05.2021  | 05.2021  |             | 900   | NY           | Nei        | 2          | 1                  |
+
+      | 2            | 05.2021  | 05.2021  | 05.2021     | 900   | ENDR         | Ja         | 2          | 1                  |
+
+      | 3            | 05.2021  | 05.2021  | 04.2021     | 900   | ENDR         | Ja         | 2          | 1                  |
+
+
+  Scenario: Opphør mellom 2 andeler
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 08.2021  | 700   |
+      | 2            | 03.2021  | 04.2021  | 700   |
+      | 2            | 07.2021  | 08.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 08.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 2            | 03.2021  | 08.2021  | 05.2021     | 700   | ENDR         | Ja         | 0          |                    |
+      | 2            | 07.2021  | 08.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  |
+
+  Scenario: Avkorter en periode, som man sen opphører. Her må opphøret ha peiling på siste andelen med riktig tom
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 1            | 04.2021  | 08.2021  | 700   |
+      | 2            | 03.2021  | 03.2021  | 700   |
+      | 2            | 04.2021  | 05.2021  | 700   |
+      | 3            | 03.2021  | 03.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 08.2021  |             | 700   | NY           | Nei        | 1          | 0                  |
+      | 2            | 04.2021  | 08.2021  | 06.2021     | 700   | ENDR         | Ja         | 1          | 0                  |
+      | 3            | 04.2021  | 08.2021  | 04.2021     | 700   | ENDR         | Ja         | 1          | 0                  |
+


### PR DESCRIPTION
Favro: [NAV-17939](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17939)

Kopierer over ny utbetalingsgenerator fra `ba-sak` og gjør nødvendige tilpasninger for ks. 

Bruk av ny utbetalingsgenerator er foreløpig lagt bak en [feature toggle](https://teamfamilie-unleash-web.nav.cloud.nais.io/projects/default/features/familie-ks-sak.bruk-ny-utbetalingsgenerator). Planen er at vi alltid bruker ny utbetalingsgenerator i dev og at vi kun bruker den i et utvalg av fagsaker i prod frem til vi er klare for å rulle den ut til alle.