### PR TITLE
Feil andel generering fix

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkår.kt
@@ -106,10 +106,6 @@ fun forskyvVilkårResultater(
                                 it.vilkårResultat.periodeTom?.plusDays(1)?.sisteDagIMåned()
                             }
 
-                            it.slutterPåSisteDagIMåneden -> { // Hvis perioden slutter siste dag i måned, får man kontantstøtte i denne måneden
-                                it.vilkårResultat.periodeTom?.sisteDagIMåned()
-                            }
-
                             else -> it.vilkårResultat.periodeTom?.minusMonths(1)?.sisteDagIMåned()
                         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkårTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/ForskyvVilkårTest.kt
@@ -94,7 +94,7 @@ class ForskyvVilkårTest {
     }
 
     @Test
-    fun `forskyvVilkårResultater skal lage opphold i vilkår som ikke ligger back to back i månedsskifte`() {
+    fun `forskyvVilkårResultater skal bare lage opphold i vilkår som varer lengre enn en hel måned`() {
         val vilkårResultat1 =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNETS_ALDER,
@@ -111,10 +111,7 @@ class ForskyvVilkårTest {
         val forskjøvedeVilkårResultater =
             forskyvVilkårResultater(Vilkår.BARNETS_ALDER, listOf(vilkårResultat1, vilkårResultat2))
 
-        Assertions.assertEquals(2, forskjøvedeVilkårResultater.size)
-
-        Assertions.assertEquals(september.atDay(1), forskjøvedeVilkårResultater.first().fom)
-        Assertions.assertEquals(september.atEndOfMonth(), forskjøvedeVilkårResultater.first().tom)
+        Assertions.assertEquals(1, forskjøvedeVilkårResultater.size)
 
         Assertions.assertEquals(november.atDay(1), forskjøvedeVilkårResultater.last().fom)
         Assertions.assertEquals(november.atEndOfMonth(), forskjøvedeVilkårResultater.last().tom)


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18719

![andelfeil](https://github.com/navikt/familie-ks-sak/assets/110383605/d33cbc80-dc4e-4c50-88fb-81092bc8ff1d)


Vi har en bug i kontantstøtte der dersom man har delt opp to vilkår, og sluttresultatet er at den ender siste dag i en måned, så vil man få andel for den perioden.Men dersom den ikke er splittet opp, så får man ikke andel.

Har avklart med Birgitte og Anna at det som er riktig her er at man skal ikke få andel for måned dersom perioden slutter siste dag i måned (uansett splitt eller ei)

barnehagevilkåret har andre regler som ikke blir påvirket av endringene her.