### PR TITLE
Bug/ikke aktuelt vilkår skal ikke påvirke vilkårresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -338,7 +338,7 @@ class BegrunnelserForPeriodeContext(
                         .singleOrNull()
                         ?.verdi
                         ?.takeIf { vilkårResultater ->
-                            val erAlleVilkårOppfylt = vilkårResultater.all { it.erOppfylt() }
+                            val erAlleVilkårOppfylt = vilkårResultater.all { it.erOppfylt() || it.erIkkeAktuelt() }
                             val erVilkårResultatSomOpphørerRettFørPeriode =
                                 vilkårResultater.any { it.erOppfylt() && it.periodeTom?.toYearMonth() == vedtaksperiode.fom.toYearMonth() }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -73,7 +73,7 @@ fun parseNasjonalEllerFellesBegrunnelse(rad: Tabellrad): BegrunnelseDtoMedData {
                 BrevPeriodeParser.DomenebegrepBrevBegrunnelse.SØKNADSTIDSPUNKT,
                 rad,
             ) ?: "",
-        antallTimerBarnehageplass = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_TIMER_BARNEHAGEPLASS, rad) ?: "0",
+        antallTimerBarnehageplass = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_TIMER_BARNEHAGEPLASS, rad) ?: "",
         sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
         gjelderAndreForelder = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_ANDRE_FORELDER, rad) ?: false,
     )

--- a/src/test/resources/cucumber/fremtidig-opphør.feature
+++ b/src/test/resources/cucumber/fremtidig-opphør.feature
@@ -45,8 +45,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 01.08.2024 |            | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.08.2024 til -
-      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Avtale tidspunkt delt bosted | Søkers rett til utvidet | Gjelder andre forelder |
-      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |               |         | 0     |                  | august 2024                          |                              |                         | true                   |
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |         | 0     | august 2024                          | true                   | 0                           |
 
   Scenario: Barnehageplass fra måneden før barnet fyller to år
     Og følgende dagens dato 06.02.2024
@@ -76,8 +76,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 01.08.2024 |            | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.08.2024 til -
-      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Avtale tidspunkt delt bosted | Søkers rett til utvidet | Gjelder andre forelder |
-      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |               |         | 0     |                  | august 2024                          |                              |                         | true                   |
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |         | 0     |                  | august 2024                          | true                   | 0                           |
 
   Scenario: Barnehageplass fra midten av en måned
     Og følgende dagens dato 06.02.2024
@@ -107,8 +107,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 01.07.2024 |            | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.07.2024 til -
-      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for | Avtale tidspunkt delt bosted | Søkers rett til utvidet | Gjelder andre forelder |
-      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |               |         | 0     |                  | juli 2024                            |                              |                         | true                   |
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.09.22             | 1           |         | 0     | juli 2024                            | true                   | 0                           |
 
   Scenario: Revurdering. Eneste endring er framtidig opphør framtidig opphør på barnehageplass. Skal gi behandlingsresultat opphør.
     Gitt følgende fagsaker

--- a/src/test/resources/cucumber/opphør-første-periode.feature
+++ b/src/test/resources/cucumber/opphør-første-periode.feature
@@ -48,16 +48,7 @@ Egenskap: Opphør første periode
 
     Og andeler er beregnet for behandling 2
 
-    Så forvent følgende andeler tilkjent ytelse for behandling 2
-      | AktørId | Fra dato | Til dato | Beløp | Ytelse type | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
-
-
     Og vedtaksperioder er laget for behandling 2
-
-    Så forvent følgende vedtaksperioder på behandling 2
-      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
-      | 01.09.2023 | 31.07.2024 | OPPHØR             |           |
-
 
     Så forvent at følgende begrunnelser er gyldige for behandling 2
       | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                                                                                                             | Ugyldige begrunnelser |
@@ -69,8 +60,57 @@ Egenskap: Opphør første periode
 
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2023 til 31.07.2024
-      | Begrunnelse                          | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder |
-      | OPPHØR_VURDERING_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   |
-      | OPPHØR_IKKE_BOSATT_I_NORGE           | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   |
-      | OPPHØR_FLYTTET_FRA_NORGE             | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   |
-      | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   |
+      | Begrunnelse                          | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
+      | OPPHØR_VURDERING_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
+      | OPPHØR_IKKE_BOSATT_I_NORGE           | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
+      | OPPHØR_FLYTTET_FRA_NORGE             | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
+      | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
+
+
+  Scenario: Når det er opphør første periode men ikke på barn ønsker vi at barnet ikke flettes inn
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 14.01.2004  |
+      | 1            | 2       | BARN       | 15.11.2022  |
+      | 2            | 1       | SØKER      | 14.01.2004  |
+      | 2            | 2       | BARN       | 15.11.2022  |
+
+    Og følgende dagens dato 13.03.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass |
+      | 1       | BOSATT_I_RIKET               |                  | 14.01.2004 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+      | 1       | MEDLEMSKAP                   |                  | 14.01.2009 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 15.11.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+      | 2       | BARNEHAGEPLASS               |                  | 15.11.2022 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |
+      | 2       | BARNETS_ALDER                |                  | 15.11.2023 | 15.11.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass |
+      | 1       | BOSATT_I_RIKET               |                  | 14.01.2004 | 15.12.2023 | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+      | 1       | MEDLEMSKAP                   |                  | 14.01.2009 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+      | 2       | BARNEHAGEPLASS               |                  | 15.11.2022 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 15.11.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |
+      | 2       | BARNETS_ALDER                |                  | 15.11.2023 | 15.11.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |
+
+    Og andeler er beregnet for behandling 1
+    Og andeler er beregnet for behandling 2
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                 | Ugyldige begrunnelser |
+      | 01.12.2023 | 31.10.2024 | OPPHØR             |                                | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser                 | Eøsbegrunnelser | Fritekster |
+      | 01.12.2023 | 31.10.2024 | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.12.2023 til 31.10.2024
+      | Begrunnelse                          | Type     | Gjelder søker | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Gjelder andre forelder | Antall timer barnehageplass |
+      | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | Ja            | 0           | desember 2023                        | 0     | false                  |                             |


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18059)

Hadde en bug der et ikke-aktuelt vilkår førte til at vi fikk en opphørsperiode når vi ikke burde få det. Det førte igjen til at vi flettet inn barnet i begrunnelser når vi ikke ønsker det. 