### PR TITLE
Hvis fom eller tom er skudd år i barnets alder vilkår, er det lov med 367 dager

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.tidslinje.IkkeNullbarPeriode
 import no.nav.familie.ks.sak.common.tidslinje.Periode
 import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
-import no.nav.familie.ks.sak.common.tidslinje.diffIDager
 import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioderIkkeNull
@@ -300,16 +299,13 @@ private fun VilkårResultat.validerVilkårBarnetsAlder(
     periode: IkkeNullbarPeriode<Long>,
     barn: Person,
 ): String? {
-    val fomEllerTomErSkuddår = periode.fom.isLeapYear || periode.tom.isLeapYear
-    val maksAntallDagerVedAdopsjon = if (fomEllerTomErSkuddår) 367 else 366
-
     return when {
         this.erAdopsjonOppfylt() &&
             periode.tom.isAfter(barn.fødselsdato.plusYears(6).withMonth(Month.AUGUST.value).sisteDagIMåned()) ->
             "Du kan ikke sette en t.o.m dato som er etter august året barnet fyller 6 år."
 
-        // Ved adopsjon skal det være lov å ha en differanse på 1 år + 1 eller 2 dager avhengig om det er skuddår slik at man får 11 måned med kontantstøtte.
-        this.erAdopsjonOppfylt() && periode.fom.diffIDager(periode.tom) > maksAntallDagerVedAdopsjon ->
+        // Ved adopsjon skal det være lov å ha en differanse på 1 år slik at man får 11 måned med kontantstøtte.
+        this.erAdopsjonOppfylt() && periode.fom.plusYears(1) < periode.tom ->
             "Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 1 år."
 
         !this.erAdopsjonOppfylt() && !periode.fom.isEqual(barn.fødselsdato.plusYears(1)) ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -298,8 +298,8 @@ private fun VilkårResultat.lagOgValiderPeriodeFraVilkår(): IkkeNullbarPeriode<
 private fun VilkårResultat.validerVilkårBarnetsAlder(
     periode: IkkeNullbarPeriode<Long>,
     barn: Person,
-): String? {
-    return when {
+): String? =
+    when {
         this.erAdopsjonOppfylt() &&
             periode.tom.isAfter(barn.fødselsdato.plusYears(6).withMonth(Month.AUGUST.value).sisteDagIMåned()) ->
             "Du kan ikke sette en t.o.m dato som er etter august året barnet fyller 6 år."
@@ -316,7 +316,6 @@ private fun VilkårResultat.validerVilkårBarnetsAlder(
 
         else -> null
     }
-}
 
 fun genererInitiellVilkårsvurdering(
     behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -299,14 +299,17 @@ private fun VilkårResultat.lagOgValiderPeriodeFraVilkår(): IkkeNullbarPeriode<
 private fun VilkårResultat.validerVilkårBarnetsAlder(
     periode: IkkeNullbarPeriode<Long>,
     barn: Person,
-): String? =
-    when {
+): String? {
+    val fomEllerTomErSkuddår = periode.fom.isLeapYear || periode.tom.isLeapYear
+    val maksAntallDagerVedAdopsjon = if (fomEllerTomErSkuddår) 367 else 366
+
+    return when {
         this.erAdopsjonOppfylt() &&
             periode.tom.isAfter(barn.fødselsdato.plusYears(6).withMonth(Month.AUGUST.value).sisteDagIMåned()) ->
             "Du kan ikke sette en t.o.m dato som er etter august året barnet fyller 6 år."
 
-        // Ved adopsjon skal det være lov å ha en differanse på 1 år + 1 dag slik at man får 11 måned med kontantstøtte.
-        this.erAdopsjonOppfylt() && periode.fom.diffIDager(periode.tom) > 366 ->
+        // Ved adopsjon skal det være lov å ha en differanse på 1 år + 1 eller 2 dager avhengig om det er skuddår slik at man får 11 måned med kontantstøtte.
+        this.erAdopsjonOppfylt() && periode.fom.diffIDager(periode.tom) > maksAntallDagerVedAdopsjon ->
             "Differansen mellom f.o.m datoen og t.o.m datoen kan ikke være mer enn 1 år."
 
         !this.erAdopsjonOppfylt() && !periode.fom.isEqual(barn.fødselsdato.plusYears(1)) ->
@@ -317,6 +320,7 @@ private fun VilkårResultat.validerVilkårBarnetsAlder(
 
         else -> null
     }
+}
 
 fun genererInitiellVilkårsvurdering(
     behandling: Behandling,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18781

Vi har en feil i prod nå siden vi sjekker om barnets alder er max 366 dager.
Dette må økes til 367 dager ved skuddår.