### PR TITLE
Tasker med statusFraOppdrag feiler når det ikke er noen utbetalingsperioder.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
@@ -13,6 +13,8 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.ks.sak.common.tidslinje.Periode
 import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
 import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
@@ -75,3 +77,9 @@ fun TilkjentYtelse.tilTidslinjeMedAndeler(): Tidslinje<Collection<AndelTilkjentY
         }
     return tidslinjer.slåSammen()
 }
+
+fun TilkjentYtelse.utbetalingsoppdrag(): Utbetalingsoppdrag? =
+    objectMapper.readValue(this.utbetalingsoppdrag, Utbetalingsoppdrag::class.java)
+
+fun TilkjentYtelse.skalIverksettesMotOppdrag(): Boolean =
+    this.utbetalingsoppdrag()?.utbetalingsperiode?.isNotEmpty() ?: false


### PR DESCRIPTION
Dette kan skje når man iverksetter et oppdrag som det ikke er endringer i. Et eksempel på dette er når man gjør fremtidig opphør. IverksettMotOppdrag kjøres da, men selve oppdraget blir ikke postet fordi oppdraget mangler perioder

Kopiert over kode fra ba-sak