### PR TITLE
Bug/cucumbertest feiler pga nådato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/util/LocalDateProvider.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/util/LocalDateProvider.kt
@@ -1,0 +1,13 @@
+package no.nav.familie.ks.sak.common.util
+
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+interface LocalDateProvider {
+    fun now(): LocalDate
+}
+
+@Service
+class RealDateProvider : LocalDateProvider {
+    override fun now() = LocalDate.now()
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -25,6 +25,7 @@ object BehandlingsresultatOpphørUtils {
         forrigeEndretAndeler: List<EndretUtbetalingAndel>,
         nåværendePersonResultaterPåBarn: List<PersonResultat>,
         forrigePersonResultaterPåBarn: List<PersonResultat>,
+        nåMåned: YearMonth,
     ): Opphørsresultat {
         val meldtOmBarnehagePlassPåAlleBarn = nåværendePersonResultaterPåBarn.harMeldtOmBarnehagePlassPåAlleBarn()
         val meldtOmBarnehagePlassPåAlleBarnIForrigeVilkårsvurdering = forrigePersonResultaterPåBarn.harMeldtOmBarnehagePlassPåAlleBarn()
@@ -45,7 +46,7 @@ object BehandlingsresultatOpphørUtils {
         val forrigeBehandlingOpphørsdato =
             forrigeAndeler.utledOpphørsdatoForForrigeBehandling(forrigeEndretAndeler = forrigeEndretAndeler)
 
-        val nesteMåned = YearMonth.now().plusMonths(1)
+        val nesteMåned = nåMåned.plusMonths(1)
 
         return when {
             // Rekkefølgen av sjekkene er viktig for å komme fram til riktig opphørsresultat.

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -5,8 +5,10 @@ import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.util.LocalDateProvider
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.convertDataClassToJson
+import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
@@ -42,6 +44,7 @@ class BehandlingsresultatService(
     private val andelerTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
     private val kompetanseService: KompetanseService,
+    private val localDateProvider: LocalDateProvider,
 ) {
     @Deprecated("Erstattes av ny behandlingsresultat logikk og kan fjernes sammen med relevant kode når featuretoggle slettes.")
     fun utledBehandlingsresultat(behandling: Behandling): Behandlingsresultat {
@@ -218,6 +221,7 @@ class BehandlingsresultatService(
                     personerFremstiltKravFor = personerFremstiltKravFor,
                     personerIBehandling = personerIBehandling,
                     personerIForrigeBehandling = personerIForrigeBehandling,
+                    nåDato = localDateProvider.now(),
                 )
             } else {
                 Endringsresultat.INGEN_ENDRING
@@ -232,6 +236,7 @@ class BehandlingsresultatService(
                 forrigeEndretAndeler = forrigeEndretUtbetalingAndeler,
                 nåværendePersonResultaterPåBarn = nåværendePersonResultat.filter { !it.erSøkersResultater() },
                 forrigePersonResultaterPåBarn = forrigePersonResultat.filter { !it.erSøkersResultater() },
+                nåMåned = localDateProvider.now().toYearMonth(),
             )
 
         // KOMBINER

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -493,7 +493,7 @@ class StepDefinition {
         val personidentService = mockk<PersonidentService>()
         every { personidentService.hentAktør(any()) } answers {
             val personId = firstArg<String>()
-            persongrunnlag[1]?.personer?.single { it.id.toString() == personId }?.aktør ?: throw Feil("Fant ingen aktør")
+            persongrunnlag.flatMap { it.value.personer }.first { it.id.toString() == personId }.aktør
         }
 
         val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ks.sak.common.domeneparser.VedtaksperiodeMedBegrunnelserPa
 import no.nav.familie.ks.sak.common.domeneparser.parseDato
 import no.nav.familie.ks.sak.common.domeneparser.parseLong
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.util.LocalDateProvider
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.tilddMMyyyy
 import no.nav.familie.ks.sak.cucumber.BrevBegrunnelseParser.mapBegrunnelser
@@ -43,6 +44,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbe
 import no.nav.familie.ks.sak.kjerne.beregning.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseUtils
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.tilAndelerTilkjentYtelseMedEndreteUtbetalinger
 import no.nav.familie.ks.sak.kjerne.beregning.tilEndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.brev.BrevPeriodeContext
@@ -50,6 +52,7 @@ import no.nav.familie.ks.sak.kjerne.brev.LANDKODER
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDtoMedData
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelserForPeriodeContext
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.brevperioder.BrevPeriodeDto
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.eøs.differanseberegning.beregnDifferanse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
@@ -59,8 +62,10 @@ import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
 import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.domene.Valutakurs
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import org.assertj.core.api.Assertions.assertThat
 import java.time.LocalDate
@@ -237,7 +242,7 @@ class StepDefinition {
     ) {
         val behandling = behandlinger[behandlingId]!!
 
-        val behandlingsresultat = mockBehandlingsresultatService().utledBehandlingsresultat(behandling)
+        val behandlingsresultat = mockBehandlingsresultatService().utledBehandlingsresultatNy(behandlingId)
 
         behandlinger[behandlingId] = behandling.copy(resultat = behandlingsresultat)
     }
@@ -461,6 +466,12 @@ class StepDefinition {
 
     fun mockBehandlingsresultatService(): BehandlingsresultatService {
         val behandlingService = mockk<BehandlingService>()
+
+        every { behandlingService.hentBehandling(any()) } answers {
+            val behandlingId = firstArg<Long>()
+            behandlinger[behandlingId] ?: throw Feil("Ingen behandling med id: $behandlingId")
+        }
+
         every { behandlingService.hentSisteBehandlingSomErVedtatt(any()) } answers {
             val fagsakId = firstArg<Long>()
             behandlinger.values.filter { behandling -> behandling.fagsak.id == fagsakId && behandling.status == BehandlingStatus.AVSLUTTET }
@@ -468,25 +479,55 @@ class StepDefinition {
         }
 
         val søknadGrunnlagService = mockk<SøknadGrunnlagService>()
+
+        every { søknadGrunnlagService.hentAktiv(any()) } answers {
+            val behandlingId = firstArg<Long>()
+            lagSøknadGrunnlag(behandlingId) ?: throw Feil("Kunne ikke lage søknadGrunnlag")
+        }
+
         every { søknadGrunnlagService.finnAktiv(any()) } answers {
             val behandlingId = firstArg<Long>()
             lagSøknadGrunnlag(behandlingId)
         }
-        every { søknadGrunnlagService.hentAktiv(any()) } answers {
-            val behandlingId = firstArg<Long>()
-            lagSøknadGrunnlag(behandlingId) ?: throw Feil("Behandling $behandlingId er ikke en søknad")
+
+        val personidentService = mockk<PersonidentService>()
+        every { personidentService.hentAktør(any()) } answers {
+            val personId = firstArg<String>()
+            persongrunnlag[1]?.personer?.single { it.id.toString() == personId }?.aktør ?: throw Feil("Fant ingen aktør")
         }
+
+        val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(any()) } answers {
+            val behandlingId = firstArg<Long>()
+            andelerTilkjentYtelse[behandlingId] ?: emptyList()
+        }
+
+        val endretUtbetalingAndelService = mockk<EndretUtbetalingAndelService>()
+        every { endretUtbetalingAndelService.hentEndredeUtbetalingAndeler(any()) } answers {
+            val behandlingId = firstArg<Long>()
+            endredeUtbetalinger[behandlingId] ?: emptyList()
+        }
+
+        val kompetanseService = mockk<KompetanseService>()
+        every { kompetanseService.hentKompetanser(any()) } answers {
+            val behandlingId = firstArg<BehandlingId>()
+            kompetanser[behandlingId.id] ?: emptyList()
+        }
+
+        val localDateProvider = mockk<LocalDateProvider>()
+        every { localDateProvider.now() } returns dagensDato
 
         return BehandlingsresultatService(
             behandlingService = behandlingService,
             andelerTilkjentYtelseOgEndreteUtbetalingerService = mockAndelerTilkjentYtelseOgEndreteUtbetalingerService(),
             vilkårsvurderingService = mockVilkårsvurderingService(),
             søknadGrunnlagService = søknadGrunnlagService,
-            personidentService = mockk(),
+            personidentService = personidentService,
             personopplysningGrunnlagService = mockPersonopplysningGrunnlagService(),
-            andelerTilkjentYtelseRepository = mockk(),
-            endretUtbetalingAndelService = mockk(),
-            kompetanseService = mockk(),
+            andelerTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            endretUtbetalingAndelService = endretUtbetalingAndelService,
+            kompetanseService = kompetanseService,
+            localDateProvider = localDateProvider,
         )
     }
 
@@ -498,7 +539,7 @@ class StepDefinition {
         val søknadDtoString =
             objectMapper.writeValueAsString(
                 SøknadDto(
-                    barnaMedOpplysninger = uregistrerteBarn[behandlingId] ?: emptyList(),
+                    barnaMedOpplysninger = lagRegistrertebarn(behandlingId) + (uregistrerteBarn[behandlingId] ?: emptyList()),
                     endringAvOpplysningerBegrunnelse = "",
                     søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = "", målform = målform),
                 ),
@@ -521,12 +562,25 @@ class StepDefinition {
             vilkårsvurdering[behandlingId]
         }
         val søknadGrunnlagService = mockk<SøknadGrunnlagService>()
+        every { søknadGrunnlagService.finnAktiv(any<Long>()) } answers {
+            val behandlingId = firstArg<Long>()
+            val søknadDtoString =
+                objectMapper.writeValueAsString(
+                    SøknadDto(
+                        barnaMedOpplysninger = lagRegistrertebarn(behandlingId) + (uregistrerteBarn[behandlingId] ?: emptyList()),
+                        endringAvOpplysningerBegrunnelse = "",
+                        søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = "", målform = målform),
+                    ),
+                )
+            SøknadGrunnlag(behandlingId = behandlingId, søknad = søknadDtoString)
+        }
+
         every { søknadGrunnlagService.hentAktiv(any<Long>()) } answers {
             val behandlingId = firstArg<Long>()
             val søknadDtoString =
                 objectMapper.writeValueAsString(
                     SøknadDto(
-                        barnaMedOpplysninger = uregistrerteBarn[behandlingId] ?: emptyList(),
+                        barnaMedOpplysninger = lagRegistrertebarn(behandlingId) + (uregistrerteBarn[behandlingId] ?: emptyList()),
                         endringAvOpplysningerBegrunnelse = "",
                         søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = "", målform = målform),
                     ),
@@ -562,6 +616,17 @@ class StepDefinition {
             refusjonEøsRepository = mockk(),
             kompetanseService = kompetanseService,
         )
+    }
+
+    private fun lagRegistrertebarn(behandlingId: Long): List<BarnMedOpplysningerDto> {
+        return persongrunnlag[behandlingId]?.personer
+            ?.filter { it.type == PersonType.BARN }
+            ?.map { person ->
+                BarnMedOpplysningerDto(
+                    ident = person.id.toString(),
+                    fødselsdato = person.fødselsdato,
+                )
+            } ?: emptyList()
     }
 
     private fun mockPersonopplysningGrunnlagService(): PersonopplysningGrunnlagService {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -59,6 +59,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 personerIBehandling = emptySet(),
                 personerIForrigeBehandling = emptySet(),
+                nåDato = LocalDate.now(),
             )
 
         assertThat(endringsresultat, Is(Endringsresultat.INGEN_ENDRING))
@@ -89,6 +90,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 personerIBehandling = setOf(person),
                 personerIForrigeBehandling = setOf(person),
+                nåDato = LocalDate.now(),
             )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -179,6 +181,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 personerIBehandling = setOf(barn),
                 personerIForrigeBehandling = setOf(barn),
+                nåDato = LocalDate.now(),
             )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -222,6 +225,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 personerIBehandling = setOf(barnPerson),
                 personerIForrigeBehandling = setOf(barnPerson),
+                nåDato = LocalDate.now(),
             )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -254,6 +258,7 @@ class BehandlingsresultatEndringUtilsTest {
                 nåværendeEndretAndeler = listOf(forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)),
                 personerIBehandling = setOf(barn),
                 personerIForrigeBehandling = setOf(barn),
+                nåDato = LocalDate.now(),
             )
 
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
@@ -293,6 +298,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeAndelerForPerson = forrigeAndeler,
                 opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                 erFremstiltKravForPerson = false,
+                nåDato = LocalDate.now(),
             )
 
         assertEquals(false, erEndringIBeløp)
@@ -351,6 +357,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = erFremstiltKravForPerson,
+                        nåDato = LocalDate.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -419,6 +426,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = erFremstiltKravForPerson,
+                        nåDato = LocalDate.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -477,6 +485,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = false,
+                        nåDato = LocalDate.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -539,6 +548,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = erFremstiltKravForPerson,
+                        nåDato = LocalDate.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -604,6 +614,7 @@ class BehandlingsresultatEndringUtilsTest {
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør },
                         opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                         erFremstiltKravForPerson = false,
+                        nåDato = LocalDate.now(),
                     )
 
                 erEndringIBeløpForPerson
@@ -664,6 +675,7 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == barn1Aktør },
                 opphørstidspunktForBehandling = opphørstidspunktForBehandling!!,
                 erFremstiltKravForPerson = false,
+                nåDato = LocalDate.now(),
             )
 
         assertEquals(false, erEndringIBeløp)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -95,6 +95,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = emptyList(),
                 forrigePersonResultaterPåBarn = emptyList(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
@@ -145,6 +146,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = emptyList(),
                 forrigePersonResultaterPåBarn = emptyList(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
@@ -195,6 +197,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = emptyList(),
                 forrigePersonResultaterPåBarn = emptyList(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
@@ -222,6 +225,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = emptyList(),
                 forrigePersonResultaterPåBarn = emptyList(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
@@ -272,6 +276,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = emptyList(),
                 forrigePersonResultaterPåBarn = emptyList(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.FORTSATT_OPPHØRT, opphørsresultat)
@@ -322,6 +327,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = emptyList(),
                 forrigePersonResultaterPåBarn = emptyList(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
@@ -613,6 +619,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = listOf(personResultatBarn1, personResultatBarn2),
                 forrigePersonResultaterPåBarn = listOf(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
@@ -671,6 +678,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = listOf(personResultatBarn1, personResultatBarn2),
                 forrigePersonResultaterPåBarn = listOf(personResultatBarn1, personResultatBarn2),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.FORTSATT_OPPHØRT, opphørsresultat)
@@ -729,6 +737,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 forrigeEndretAndeler = emptyList(),
                 nåværendePersonResultaterPåBarn = listOf(personResultatBarn1, personResultatBarn2),
                 forrigePersonResultaterPåBarn = listOf(),
+                nåMåned = YearMonth.now(),
             )
 
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.common.util.LocalDateProvider
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -36,6 +37,9 @@ import org.hamcrest.CoreMatchers.`is` as Is
 
 @ExtendWith(MockKExtension::class)
 class BehandlingsresultatServiceTest {
+    @MockK
+    private lateinit var localDateProvider: LocalDateProvider
+
     @MockK
     private lateinit var behandlingService: BehandlingService
 

--- a/src/test/resources/cucumber/fortsatt-innvilget.feature
+++ b/src/test/resources/cucumber/fortsatt-innvilget.feature
@@ -1,7 +1,6 @@
 # language: no
 # encoding: UTF-8
 
-@Disabled
 Egenskap: Fortsatt innvilget
 
   Bakgrunn:


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20256)

Cucumbertest feilet siden vi har kommet i en ny måned. 
Lagt til Localdateprovider slik at vi kan mocke ut en nåDato for testing.

Har også tatt i bruk utledBehandlingsresultatNy(), det krevde en del ekstra logikk og mocking i stepDefinition. 