### PR TITLE
Fjern fritekster fra vedtaksperiode dersom den ikke lenger støtter fritekst

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -103,6 +103,8 @@ class VedtaksperiodeService(
         val persongrunnlag =
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id)
 
+        val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
+
         vedtaksperiodeMedBegrunnelser.settBegrunnelser(
             begrunnelserFraFrontend.map {
                 it.tilVedtaksbegrunnelse(vedtaksperiodeMedBegrunnelser)
@@ -123,6 +125,10 @@ class VedtaksperiodeService(
                     .finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
 
             validerEndretUtbetalingsbegrunnelse(vedtaksperiodeMedBegrunnelser, andelerTilkjentYtelse, persongrunnlag)
+        }
+
+        if (!vedtaksperiodeMedBegrunnelser.støtterFritekst(sanityBegrunnelser)) {
+            vedtaksperiodeMedBegrunnelser.fritekster.clear()
         }
 
         vedtaksperiodeHentOgPersisterService.lagre(vedtaksperiodeMedBegrunnelser)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -144,6 +144,7 @@ internal class VedtaksperiodeServiceTest {
 
         val mocketPersonOpplysningGrunnlag = mockk<PersonopplysningGrunnlag>()
 
+        every { sanityService.hentSanityBegrunnelser() } returns emptyList()
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) } returns mocketPersonOpplysningGrunnlag
         every { vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(any()) } returns vedtaksperiodeMedBegrunnelse
 
@@ -175,6 +176,7 @@ internal class VedtaksperiodeServiceTest {
 
         val mocketPersonOpplysningGrunnlag = mockk<PersonopplysningGrunnlag>()
 
+        every { sanityService.hentSanityBegrunnelser() } returns emptyList()
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) } returns mocketPersonOpplysningGrunnlag
         every { vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(any()) } returns vedtaksperiodeMedBegrunnelse
         every { vedtaksperiodeHentOgPersisterService.lagre(vedtaksperiodeMedBegrunnelse) } returns vedtaksperiodeMedBegrunnelse


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20535

I sanity er det mulig å krysse av for at en begrunnelse skal kunne begrunnes med fritekst.
Når man velger en slik begrunnelse i vedtaksperioden så åpner det opp for mulighet for å legge inn fritekst.
Men dersom man fjerner begrunnelsen, så forsvinner ikke friteksten, og man kan plutselig ha en kombinasjon av begrunnelse som ikke støtter fritekst + fritekst.

Jeg tenker at vi derfor må slette alle fritekster dersom vedtaksperioden ikke lenger støtter fritekst.