### PR TITLE
gradle/gradle-build-action erstattes med gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
+++ b/.github/workflows/build-and-deploy-krise-rett-i-prod.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Bygg med gradle
         env:

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Bygg med gradle
         env:
@@ -44,7 +44,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Bygg med gradle
         env:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Kjør ktlint
         env:
@@ -55,7 +55,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Kjør enhetstester
         env:
@@ -82,7 +82,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Kjør integrasjonstester
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,7 +66,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
 
     - name: Bygg med gradle
       env:


### PR DESCRIPTION
Bytter ut deprikert action ```gradle/gradle-build-action``` med ```gradle/actions/setup-gradle```

https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle

