### PR TITLE
Feil ved saksbehandling i samme måned som vilkår er oppfylt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -124,7 +124,7 @@ class KompetanseService(
         this.mapValues { (_, tidslinjer) ->
             tidslinjer.filtrer { it?.regelverk == Regelverk.EØS_FORORDNINGEN }
                 .filtrerIkkeNull()
-                .forlengTomdatoTilUendeligOmTomErSenereEnn(LocalDate.now())
+                .forlengTomdatoTilUendeligOmTomErSenereEnn(LocalDate.now().plusMonths(1))
         }
 
     private fun <T> Tidslinje<T>.forlengTomdatoTilUendeligOmTomErSenereEnn(nå: LocalDate): Tidslinje<T & Any> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -126,14 +126,14 @@ class KompetanseService(
         this.mapValues { (_, tidslinjer) ->
             tidslinjer.filtrer { it?.regelverk == Regelverk.EØS_FORORDNINGEN }
                 .filtrerIkkeNull()
-                .forlengTomdatoTilUendeligOmTomErSenereEnn(LocalDate.now().førsteDagINesteMåned())
+                .forlengTomdatoTilUendeligOmTomErSenereEnn(førsteDagINesteMåned = LocalDate.now().førsteDagINesteMåned())
         }
 
-    private fun <T> Tidslinje<T>.forlengTomdatoTilUendeligOmTomErSenereEnn(nå: LocalDate): Tidslinje<T & Any> {
+    private fun <T> Tidslinje<T>.forlengTomdatoTilUendeligOmTomErSenereEnn(førsteDagINesteMåned: LocalDate): Tidslinje<T & Any> {
         val tom = this.tilPerioderIkkeNull().mapNotNull { it.tom }.maxOrNull()
-        return if (tom != null && tom > nå) {
+        return if (tom != null && tom > førsteDagINesteMåned) {
             this.tilPerioderIkkeNull()
-                .filter { it.fom != null && it.fom <= nå }
+                .filter { it.fom != null && it.fom <= førsteDagINesteMåned }
                 .replaceLast { Periode(verdi = it.verdi, fom = it.fom, tom = null) }
                 .tilTidslinje()
         } else {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.eøs.kompetanse
 import no.nav.familie.ks.sak.api.dto.KompetanseDto
 import no.nav.familie.ks.sak.api.dto.tilKompetanse
 import no.nav.familie.ks.sak.common.BehandlingId
+import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.tidslinje.Periode
 import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
 import no.nav.familie.ks.sak.common.tidslinje.leftJoin
@@ -14,6 +15,7 @@ import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioderIkkeNull
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilSeparateTidslinjerForBarna
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilSkjemaer
+import no.nav.familie.ks.sak.common.util.førsteDagINesteMåned
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ks.sak.kjerne.eøs.felles.EøsSkjemaService
 import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
@@ -124,7 +126,7 @@ class KompetanseService(
         this.mapValues { (_, tidslinjer) ->
             tidslinjer.filtrer { it?.regelverk == Regelverk.EØS_FORORDNINGEN }
                 .filtrerIkkeNull()
-                .forlengTomdatoTilUendeligOmTomErSenereEnn(LocalDate.now().plusMonths(1))
+                .forlengTomdatoTilUendeligOmTomErSenereEnn(LocalDate.now().førsteDagINesteMåned())
         }
 
     private fun <T> Tidslinje<T>.forlengTomdatoTilUendeligOmTomErSenereEnn(nå: LocalDate): Tidslinje<T & Any> {
@@ -139,5 +141,10 @@ class KompetanseService(
         }
     }
 
-    fun <T> List<T>.replaceLast(replacer: (T) -> T) = this.take(this.size - 1) + replacer(this.last())
+    fun <T> List<T>.replaceLast(replacer: (T) -> T): List<T> {
+        if (this.isEmpty()) {
+            throw Feil("Kan ikke modifisere på siste element i en tom liste")
+        }
+        return this.take(this.size - 1) + replacer(this.last())
+    }
 }


### PR DESCRIPTION
Favro: [NAV-20786](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20786)

Dersom man forsøker å gå videre fra vilkårsvurderingen til behandlingsresultat og vilkårene er oppfylte fra en dato i inneværende måned kastes en feil. Feilen stammer fra at vi har kopiert over kode fra ba-sak, og er relatert til forskjellene i hvordan vi forskyver tidslinjer i ks-sak vs ba-sak.

Sørger her for at vi bruker `LocalDate.now().førsteDagINesteMåned()` fremfor `LocalDate.now()` når vi skal finne ut om vi skal forlenge siste periode til uendelig eller ikke, slik at datoen vi sammenligner med samsvarer med forskyvningen av vilkår.