### PR TITLE
Se på andelene til forrige behandling som har utbetalingsoppdrag når vi vurderer om vi skal iverksette vedtak eller ikke

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -212,7 +212,7 @@ class StegService(
 
     private fun hentNesteStegOgOpprettTaskEtterBeslutteVedtak(behandling: Behandling): BehandlingSteg {
         return when {
-            behandling.erTekniskEndring() -> if (behandling.resultat.kanIkkeSendesTilOppdrag()) AVSLUTT_BEHANDLING else IVERKSETT_MOT_OPPDRAG
+            behandling.erTekniskEndring() -> if (!erEndringIUtbetaling(behandling)) AVSLUTT_BEHANDLING else IVERKSETT_MOT_OPPDRAG
             !erEndringIUtbetaling(behandling) -> {
                 opprettJournalførVedtaksbrevTaskPåBehandling(behandling)
                 JOURNALFØR_VEDTAKSBREV

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -1,10 +1,13 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
+import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
 import no.nav.familie.ks.sak.api.dto.BesluttVedtakDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
@@ -16,7 +19,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg.JOURNALFØR_V
 import no.nav.familie.ks.sak.kjerne.behandling.steg.iverksettmotoppdrag.IverksettMotOppdragTask
 import no.nav.familie.ks.sak.kjerne.behandling.steg.journalførvedtaksbrev.JournalførVedtaksbrevTask
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
-import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.SendOpprettTilbakekrevingsbehandlingRequestTask
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.TilbakekrevingRepository
@@ -37,7 +40,8 @@ class StegService(
     private val sakStatistikkService: SakStatistikkService,
     private val taskService: TaskService,
     private val loggService: LoggService,
-    private val beregningService: BeregningService,
+    private val behandlingService: BehandlingService,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
 ) {
     @Transactional
     fun utførSteg(
@@ -207,16 +211,27 @@ class StegService(
     }
 
     private fun hentNesteStegOgOpprettTaskEtterBeslutteVedtak(behandling: Behandling): BehandlingSteg {
-        val erEndringIUtbetaling = !beregningService.erEndringIUtbetaling(behandling)
         return when {
-            behandling.erTekniskEndring() && erEndringIUtbetaling -> AVSLUTT_BEHANDLING
-            erEndringIUtbetaling -> {
+            behandling.erTekniskEndring() -> if (!erEndringIUtbetaling(behandling)) AVSLUTT_BEHANDLING else IVERKSETT_MOT_OPPDRAG
+            !erEndringIUtbetaling(behandling) -> {
                 opprettJournalførVedtaksbrevTaskPåBehandling(behandling)
                 JOURNALFØR_VEDTAKSBREV
             }
 
             else -> IVERKSETT_MOT_OPPDRAG
         }
+    }
+
+    private fun erEndringIUtbetaling(behandling: Behandling): Boolean {
+        val forrigeBehandling = behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
+        val andelerForrigeBehandling =
+            forrigeBehandling?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
+                ?: emptyList()
+
+        val andelerBehandling = behandling.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
+
+        return lagEndringIUtbetalingTidslinje(andelerBehandling, andelerForrigeBehandling)
+            .tilPerioder().any { it.verdi == true }
     }
 
     private fun utførStegAutomatisk(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -187,7 +187,7 @@ class StegService(
         behandlingStegDto: BehandlingStegDto?,
     ): BehandlingSteg {
         val nesteGyldigeStadier =
-            BehandlingSteg.values().filter {
+            BehandlingSteg.entries.filter {
                 it.sekvens > behandledeSteg.sekvens &&
                     behandling.opprettetÅrsak in it.gyldigForÅrsaker &&
                     behandling.resultat in it.gyldigForResultater

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -1,13 +1,10 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
-import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
 import no.nav.familie.ks.sak.api.dto.BesluttVedtakDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
-import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
@@ -19,7 +16,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg.JOURNALFØR_V
 import no.nav.familie.ks.sak.kjerne.behandling.steg.iverksettmotoppdrag.IverksettMotOppdragTask
 import no.nav.familie.ks.sak.kjerne.behandling.steg.journalførvedtaksbrev.JournalførVedtaksbrevTask
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
-import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.SendOpprettTilbakekrevingsbehandlingRequestTask
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.TilbakekrevingRepository
@@ -40,8 +37,7 @@ class StegService(
     private val sakStatistikkService: SakStatistikkService,
     private val taskService: TaskService,
     private val loggService: LoggService,
-    private val behandlingService: BehandlingService,
-    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    private val beregningService: BeregningService,
 ) {
     @Transactional
     fun utførSteg(
@@ -211,27 +207,16 @@ class StegService(
     }
 
     private fun hentNesteStegOgOpprettTaskEtterBeslutteVedtak(behandling: Behandling): BehandlingSteg {
+        val erEndringIUtbetaling = !beregningService.erEndringIUtbetaling(behandling)
         return when {
-            behandling.erTekniskEndring() -> if (!erEndringIUtbetaling(behandling)) AVSLUTT_BEHANDLING else IVERKSETT_MOT_OPPDRAG
-            !erEndringIUtbetaling(behandling) -> {
+            behandling.erTekniskEndring() && erEndringIUtbetaling -> AVSLUTT_BEHANDLING
+            erEndringIUtbetaling -> {
                 opprettJournalførVedtaksbrevTaskPåBehandling(behandling)
                 JOURNALFØR_VEDTAKSBREV
             }
 
             else -> IVERKSETT_MOT_OPPDRAG
         }
-    }
-
-    private fun erEndringIUtbetaling(behandling: Behandling): Boolean {
-        val forrigeBehandling = behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
-        val andelerForrigeBehandling =
-            forrigeBehandling?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
-                ?: emptyList()
-
-        val andelerBehandling = behandling.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
-
-        return lagEndringIUtbetalingTidslinje(andelerBehandling, andelerForrigeBehandling)
-            .tilPerioder().any { it.verdi == true }
     }
 
     private fun utførStegAutomatisk(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -1,9 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
-import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje
-import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
@@ -31,7 +28,6 @@ class BeregningService(
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val fagsakService: FagsakService,
     private val tilkjentYtelseEndretAbonnenter: List<TilkjentYtelseEndretAbonnent> = emptyList(),
-    private val behandlingService: BehandlingService,
 ) {
     /**
      * Henter alle barn på behandlingen som har minst en periode med tilkjentytelse.
@@ -172,18 +168,6 @@ class BeregningService(
         ).filter { it.erAndelSomSkalSendesTilOppdrag() }
 
     fun slettTilkjentYtelseForBehandling(behandling: Behandling) = tilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling)
-
-    fun erEndringIUtbetaling(behandling: Behandling): Boolean {
-        val forrigeBehandling = behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
-        val andelerForrigeBehandling =
-            forrigeBehandling?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
-                ?: emptyList()
-
-        val andelerBehandling = behandling.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
-
-        return lagEndringIUtbetalingTidslinje(andelerBehandling, andelerForrigeBehandling)
-            .tilPerioder().any { it.verdi == true }
-    }
 }
 
 interface TilkjentYtelseEndretAbonnent {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -1,6 +1,9 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
+import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
@@ -28,6 +31,7 @@ class BeregningService(
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val fagsakService: FagsakService,
     private val tilkjentYtelseEndretAbonnenter: List<TilkjentYtelseEndretAbonnent> = emptyList(),
+    private val behandlingService: BehandlingService,
 ) {
     /**
      * Henter alle barn på behandlingen som har minst en periode med tilkjentytelse.
@@ -168,6 +172,18 @@ class BeregningService(
         ).filter { it.erAndelSomSkalSendesTilOppdrag() }
 
     fun slettTilkjentYtelseForBehandling(behandling: Behandling) = tilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling)
+
+    fun erEndringIUtbetaling(behandling: Behandling): Boolean {
+        val forrigeBehandling = behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id)
+        val andelerForrigeBehandling =
+            forrigeBehandling?.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
+                ?: emptyList()
+
+        val andelerBehandling = behandling.let { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(it.id) }
+
+        return lagEndringIUtbetalingTidslinje(andelerBehandling, andelerForrigeBehandling)
+            .tilPerioder().any { it.verdi == true }
+    }
 }
 
 interface TilkjentYtelseEndretAbonnent {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.ba.sak.kjerne.forrigebehandling
+
+import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
+import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombiner
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.tilPeriode
+
+object EndringIUtbetalingUtil {
+    internal fun lagEndringIUtbetalingTidslinje(
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
+        forrigeAndeler: List<AndelTilkjentYtelse>,
+    ): Tidslinje<Boolean> {
+        val allePersonerMedAndeler = (nåværendeAndeler.map { it.aktør } + forrigeAndeler.map { it.aktør }).distinct()
+
+        val endringstidslinjePerPersonOgType =
+            allePersonerMedAndeler.flatMap { aktør ->
+                val ytelseTyperForPerson = (nåværendeAndeler.map { it.type } + forrigeAndeler.map { it.type }).distinct()
+
+                ytelseTyperForPerson.map { ytelseType ->
+                    lagEndringIUtbetalingForPersonOgTypeTidslinje(
+                        nåværendeAndeler = nåværendeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
+                        forrigeAndeler = forrigeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
+                    )
+                }
+            }
+
+        return endringstidslinjePerPersonOgType.kombiner { finnesMinstEnEndringIPeriode(it) }
+    }
+
+    private fun finnesMinstEnEndringIPeriode(
+        endringer: Iterable<Boolean>,
+    ): Boolean = endringer.any { it }
+
+    // Det regnes ikke ut som en endring dersom
+    // 1. Vi har fått nye andeler som har 0 i utbetalingsbeløp
+    // 2. Vi har mistet andeler som har hatt 0 i utbetalingsbeløp
+    // 3. Vi har lik utbetalingsbeløp mellom nåværende og forrige andeler
+    private fun lagEndringIUtbetalingForPersonOgTypeTidslinje(
+        nåværendeAndeler: List<AndelTilkjentYtelse>,
+        forrigeAndeler: List<AndelTilkjentYtelse>,
+    ): Tidslinje<Boolean> {
+        val nåværendeTidslinje = nåværendeAndeler.map { it.tilPeriode() }.tilTidslinje()
+        val forrigeTidslinje = forrigeAndeler.map { it.tilPeriode() }.tilTidslinje()
+
+        val endringIBeløpTidslinje =
+            nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
+                val nåværendeBeløp = nåværende?.kalkulertUtbetalingsbeløp ?: 0
+                val forrigeBeløp = forrige?.kalkulertUtbetalingsbeløp ?: 0
+
+                nåværendeBeløp != forrigeBeløp
+            }
+
+        return endringIBeløpTidslinje
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceUnitTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceUnitTest.kt
@@ -311,7 +311,7 @@ class StegServiceUnitTest {
     }
 
     @Test
-    fun `skal ikke iverksette hvis det er første iverksettelse og det ikke er andeler på behandlingen`() {
+    fun `skal ikke iverksette hvis det mangler andeler på behandlingen`() {
         // Arrange
         every { behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns null
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id) } returns emptyList()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceUnitTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceUnitTest.kt
@@ -311,7 +311,7 @@ class StegServiceUnitTest {
     }
 
     @Test
-    fun `skal ikke iverksette hvis det mangler andeler på behandlingen`() {
+    fun `skal ikke iverksette hvis det er første iverksettelse og det ikke er andeler på behandlingen`() {
         // Arrange
         every { behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns null
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id) } returns emptyList()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagBehandlingStegTilstand
@@ -54,6 +55,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakReposito
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakStatus
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.Tilbakekreving
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.TilbakekrevingRepository
@@ -109,6 +111,9 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var tilbakekrevingRepository: TilbakekrevingRepository
+
+    @Autowired
+    private lateinit var andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository
 
     @BeforeEach
     fun setup() {
@@ -303,6 +308,15 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         behandling.status = BehandlingStatus.FATTER_VEDTAK
         lagreBehandling(behandling)
         vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now()))
+
+        lagTilkjentYtelse("")
+        val andelTilkjentYtelse =
+            lagAndelTilkjentYtelse(
+                tilkjentYtelse = tilkjentYtelse,
+                kalkulertUtbetalingsbeløp = 1000,
+                behandling = behandling,
+            )
+        andelTilkjentYtelseRepository.saveAndFlush(andelTilkjentYtelse)
 
         val beslutteVedtakDto = BesluttVedtakDto(beslutning = Beslutning.GODKJENT, begrunnelse = "Godkjent")
         assertDoesNotThrow { stegService.utførSteg(behandling.id, BESLUTTE_VEDTAK, beslutteVedtakDto) }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -532,6 +532,15 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         val tekniskEndringBehandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING))
         lagreArbeidsfordeling(lagArbeidsfordelingPåBehandling(behandlingId = tekniskEndringBehandling.id))
 
+        lagTilkjentYtelse("")
+        val andelTilkjentYtelse =
+            lagAndelTilkjentYtelse(
+                tilkjentYtelse = tilkjentYtelse,
+                kalkulertUtbetalingsbeløp = 1000,
+                behandling = tekniskEndringBehandling,
+            )
+        andelTilkjentYtelseRepository.saveAndFlush(andelTilkjentYtelse)
+
         tekniskEndringBehandling.resultat = Behandlingsresultat.ENDRET_UTBETALING
         tekniskEndringBehandling.status = BehandlingStatus.FATTER_VEDTAK
         tekniskEndringBehandling.behandlingStegTilstand.clear()


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20982)

Vi har en feil i produksjon en bruker i produksjon har fått innvilget 1 ekstra måned med kontantstøtte, men denne endringen har ikke blitt iverksatt mot økonomi etter at behandlingen ble vedtatt.

Grunnen til dette er fordi:
1. Man fikk feil behandlingsresultat (FORTSATT_INNVILGET)
2. Dersom behandlingsresultatet er satt til fortsatt innvilget, vil man ikke iverksette mot økonomi uavhengig av endringer i tilkjent ytelse.

Vi har derfor endret på logikken slik at så lenge det er forskjell mellom nåværende behandling og sist iverksatte behandling, så ønsker vi å iverksette det mot økonomi uavhengig av behandlingsresultat. Vi har også fikset feilen i en tidligere PR som førte til feil behandlingsresultat (man skulle egentlig ha fått innvilget og opphørt)