### PR TITLE
Flytter sjekken om man skal gjøre identhendelsen til tasken

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdentHendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdentHendelseTask.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.personident
 
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -24,7 +25,13 @@ class IdentHendelseTask(
     override fun doTask(task: Task) {
         logger.info("Kjører task for håndtering av identhendelse.")
         val personIdent = objectMapper.readValue(task.payload, PersonIdent::class.java)
-        personidentService.håndterNyIdent(personIdent)
+        if (personidentService.identSkalLeggesTil(personIdent)) {
+            logger.info("Skal håndtere ny ident")
+            secureLogger.info("Skal håndtere ny ident ${personIdent.ident}")
+            personidentService.håndterNyIdent(personIdent)
+        } else {
+            logger.info("Ident er ikke knyttet til noen av aktørene våre, ignorerer hendelse.")
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdenthendelseV2Consumer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdenthendelseV2Consumer.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.personident
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.ks.sak.config.KafkaConfig.Companion.PDL_AKTOR_V2_TOPIC
 import no.nav.familie.log.mdc.MDCConstants
+import no.nav.familie.prosessering.internal.TaskService
 import no.nav.person.pdl.aktor.v2.Aktor
 import no.nav.person.pdl.aktor.v2.Type
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -19,7 +20,7 @@ import java.util.UUID
 @Service
 @Profile("!integrasjonstest & !dev-postgres-preprod")
 class IdenthendelseV2Consumer(
-    val personidentService: PersonidentService,
+    val taskService: TaskService,
 ) {
     @KafkaListener(
         id = "familie-ks-sak-aktorv2",
@@ -55,7 +56,7 @@ class IdenthendelseV2Consumer(
                 aktør?.identifikatorer?.singleOrNull { ident ->
                     ident.type == Type.FOLKEREGISTERIDENT && ident.gjeldende
                 }?.also { folkeregisterident ->
-                    personidentService.opprettTaskForIdentHendelse(PersonIdent(folkeregisterident.idnummer))
+                    taskService.save(IdentHendelseTask.opprettTask(PersonIdent(folkeregisterident.idnummer)))
                 }
             } else {
                 SECURE_LOGGER.info("Ignorerer å lage task på ident-hendelse fordi aktør $aktørIdPåHendelse ikke lenger er en gyldig aktør")

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.integrasjon.pdl.PdlClient
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlIdent
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.hentAktivAktørId
-import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,7 +15,6 @@ class PersonidentService(
     private val personidentRepository: PersonidentRepository,
     private val aktørRepository: AktørRepository,
     private val pdlClient: PdlClient,
-    private val taskService: TaskService,
 ) {
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
@@ -116,16 +114,6 @@ class PersonidentService(
         personIdent: String,
         historikk: Boolean,
     ): List<PdlIdent> = pdlClient.hentIdenter(personIdent, historikk)
-
-    fun opprettTaskForIdentHendelse(nyIdent: PersonIdent) {
-        if (identSkalLeggesTil(nyIdent)) {
-            logger.info("Oppretter task for senere håndterering av ny ident")
-            secureLogger.info("Oppretter task for senere håndterering av ny ident ${nyIdent.ident}")
-            taskService.save(IdentHendelseTask.opprettTask(nyIdent))
-        } else {
-            logger.info("Ident er ikke knyttet til noen av aktørene våre, ignorerer hendelse.")
-        }
-    }
 
     fun identSkalLeggesTil(nyIdent: PersonIdent): Boolean {
         val identerFraPdl = hentIdenter(nyIdent.ident, true)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdentHendelseTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdentHendelseTaskTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.personident
 
+import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -22,6 +23,7 @@ internal class IdentHendelseTaskTest {
     @Test
     fun `Task skal kalle videre på håndtering av ny ident`() {
         val nyPersonIdent = PersonIdent("123")
+        every { personidentService.identSkalLeggesTil(nyPersonIdent) } returns true
         val task = IdentHendelseTask.opprettTask(nyPersonIdent)
         assertEquals(nyPersonIdent, objectMapper.readValue(task.payload, PersonIdent::class.java))
         assertEquals("123", task.metadata["nyPersonIdent"])

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentServiceTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.kontrakter.felles.PersonIdent
@@ -213,7 +212,6 @@ class PersonidentServiceTest {
                     personidentRepository,
                     aktørRepository,
                     pdlClient,
-                    mockk(),
                 )
 
             val aktør = personidentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomSkalLeggesTil))
@@ -249,7 +247,6 @@ class PersonidentServiceTest {
                     personidentRepository,
                     aktørRepository,
                     pdlClient,
-                    mockk(),
                 )
 
             val aktør = personidentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomFinnes))
@@ -289,7 +286,6 @@ class PersonidentServiceTest {
                     personidentRepository,
                     aktørRepository,
                     pdlClient,
-                    mockk(),
                 )
 
             val feil = assertThrows<Feil> { personidentService.håndterNyIdent(nyIdent = PersonIdent(aktivFnrIdent2)) }
@@ -324,7 +320,6 @@ class PersonidentServiceTest {
                     personidentRepository,
                     aktørRepository,
                     pdlClient,
-                    mockk(),
                 )
 
             val aktør = personidentService.håndterNyIdent(nyIdent = PersonIdent(aktivFnrIdent2))


### PR DESCRIPTION
Dette fordi man ikke skal stoppe lesing av topicen bare fordi en hendelse ikke lar seg gjennomføre f.eks. ved at den ikke finnes i PDL
