### PR TITLE
Splitt aldersvilkåret ved generering av vilkår 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
@@ -17,6 +17,8 @@ val TIDENES_ENDE = LocalDate.MAX
 val MAX_MÅNED = LocalDate.MAX.toYearMonth()
 val MIN_MÅNED = LocalDate.MIN.toYearMonth()
 
+val DATO_LOVENDRING_2024 = LocalDate.of(2024, Month.AUGUST, 1)
+
 fun LocalDate.tilddMMyy() = this.format(DateTimeFormatter.ofPattern("ddMMyy", nbLocale))
 
 fun LocalDate.tilyyyyMMdd() = this.format(DateTimeFormatter.ofPattern("yyyy-MM-dd", nbLocale))

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtils.kt
@@ -1,0 +1,63 @@
+import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
+import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårRegelsett
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
+import java.time.LocalDate
+
+fun lagAutomatiskGenererteVilkårForBarnetsAlder(
+    personResultat: PersonResultat,
+    behandling: Behandling,
+    fødselsdato: LocalDate,
+): List<VilkårResultat> {
+    val periodeFomBarnetsAlderLov2024 = fødselsdato.plusMonths(13)
+    val periodeTomBarnetsAlderLov2024 = fødselsdato.plusMonths(19)
+
+    val periodeFomBarnetsAlderLov2021 = fødselsdato.plusYears(1)
+    val periodeTomBarnetsAlderLov2021 = fødselsdato.plusYears(2)
+
+    val erTruffetAvRegelverk2021 = periodeFomBarnetsAlderLov2021.isBefore(DATO_LOVENDRING_2024)
+    val erTruffetAvRegelverk2024 = periodeTomBarnetsAlderLov2024.erSammeEllerEtter(DATO_LOVENDRING_2024)
+
+    val vilkårResultatEtterRegelverk2021 =
+        if (erTruffetAvRegelverk2021) {
+            VilkårResultat(
+                personResultat = personResultat,
+                erAutomatiskVurdert = true,
+                resultat = Resultat.OPPFYLT,
+                vilkårType = Vilkår.BARNETS_ALDER,
+                begrunnelse = "Vurdert og satt automatisk",
+                behandlingId = behandling.id,
+                periodeFom = periodeFomBarnetsAlderLov2021,
+                periodeTom = minOf(periodeTomBarnetsAlderLov2021, DATO_LOVENDRING_2024.minusDays(1)),
+                regelsett = VilkårRegelsett.LOV_AUGUST_2021,
+            )
+        } else {
+            null
+        }
+
+    val vilkårResultatEtterRegelverk2024 =
+        if (erTruffetAvRegelverk2024) {
+            VilkårResultat(
+                personResultat = personResultat,
+                erAutomatiskVurdert = true,
+                resultat = Resultat.OPPFYLT,
+                vilkårType = Vilkår.BARNETS_ALDER,
+                begrunnelse = "Vurdert og satt automatisk",
+                behandlingId = behandling.id,
+                periodeFom = maxOf(periodeFomBarnetsAlderLov2024, DATO_LOVENDRING_2024),
+                periodeTom = periodeTomBarnetsAlderLov2024,
+                regelsett = VilkårRegelsett.LOV_AUGUST_2024,
+            )
+        } else {
+            null
+        }
+
+    return listOfNotNull(
+        vilkårResultatEtterRegelverk2021,
+        vilkårResultatEtterRegelverk2024,
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ks.sak.api.dto.EndreVilkårResultatDto
 import no.nav.familie.ks.sak.api.dto.NyttVilkårDto
 import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.common.util.erFørsteAugust2024EllerSenere
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
@@ -27,7 +26,6 @@ import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 class VilkårsvurderingService(
@@ -44,7 +42,8 @@ class VilkårsvurderingService(
     ): Vilkårsvurdering {
         logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} oppretter vilkårsvurdering for behandling ${behandling.id}")
 
-        val behandlingSkalFølgeNyeLovendringer2024 = unleashService.isEnabled(FeatureToggleConfig.LOV_ENDRING_7_MND_NYE_BEHANDLINGER) || LocalDate.now().erFørsteAugust2024EllerSenere()
+        val behandlingSkalFølgeNyeLovendringer2024 =
+            unleashService.isEnabled(FeatureToggleConfig.LOV_ENDRING_7_MND_NYE_BEHANDLINGER)
 
         val aktivVilkårsvurdering = finnAktivVilkårsvurdering(behandling.id)
         val vilkårsvurderingFraForrigeBehandling = forrigeBehandlingSomErVedtatt?.let { hentAktivVilkårsvurderingForBehandling(forrigeBehandlingSomErVedtatt.id) }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -384,18 +384,6 @@ fun genererInitiellVilkårsvurdering(
                                         fødselsdato = person.fødselsdato,
                                     )
                                 } else {
-                                    val periodeFomForBarnetsAlder =
-                                        when (regelsett) {
-                                            VilkårRegelsett.LOV_AUGUST_2021 -> person.fødselsdato.plusYears(1)
-                                            VilkårRegelsett.LOV_AUGUST_2024 -> person.fødselsdato.plusMonths(13)
-                                        }
-
-                                    val periodeTomForBarnetsAlder =
-                                        when (regelsett) {
-                                            VilkårRegelsett.LOV_AUGUST_2021 -> person.fødselsdato.plusYears(2)
-                                            VilkårRegelsett.LOV_AUGUST_2024 -> person.fødselsdato.plusMonths(19)
-                                        }
-
                                     listOf(
                                         VilkårResultat(
                                             personResultat = personResultat,
@@ -404,8 +392,8 @@ fun genererInitiellVilkårsvurdering(
                                             vilkårType = vilkår,
                                             begrunnelse = "Vurdert og satt automatisk",
                                             behandlingId = behandling.id,
-                                            periodeFom = periodeFomForBarnetsAlder,
-                                            periodeTom = periodeTomForBarnetsAlder,
+                                            periodeFom = person.fødselsdato.plusYears(1),
+                                            periodeTom = person.fødselsdato.plusYears(2),
                                             regelsett = regelsett,
                                         ),
                                     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårResultat.kt
@@ -160,7 +160,7 @@ class VilkårResultat(
     )
 
     override fun toString(): String {
-        return """ VilkårResultat(id=$id,vilkårType=$vilkårType,periodeFom=$periodeFom,periodeTom=$periodeTom,resultat=$resultat,evalueringÅrsaker=$evalueringÅrsaker") """
+        return """ VilkårResultat(id=$id,vilkårType=$vilkårType,periodeFom=$periodeFom,periodeTom=$periodeTom,resultat=$resultat,evalueringÅrsaker=$evalueringÅrsaker",erAutomatiskVurdert=$erAutomatiskVurdert) """
     }
 
     companion object {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BasisDomeneParser.kt
@@ -149,6 +149,16 @@ fun parseDato(dato: String): LocalDate {
     }
 }
 
+fun parseValgfriDato(dato: String?): LocalDate? {
+    return if (dato == null) {
+        null
+    } else if (dato.contains(".")) {
+        LocalDate.parse(dato, norskDatoFormatter)
+    } else {
+        LocalDate.parse(dato, isoDatoFormatter)
+    }
+}
+
 fun parseValgfriDato(
     domenebegrep: String,
     rad: Map<String, String?>,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/DomeneparserUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/DomeneparserUtil.kt
@@ -20,6 +20,10 @@ enum class Domenebegrep(override val nøkkel: String) : Domenenøkkel {
     BEHANDLINGSKATEGORI("Behandlingskategori"),
 }
 
+enum class DomenebegrepAndelTilkjentYtelse(override val nøkkel: String) : Domenenøkkel {
+    ER_AUTOMATISK_VURDERT("Er automatisk vurdert"),
+}
+
 object DomeneparserUtil {
     fun DataTable.groupByBehandlingId(): Map<Long, List<Map<String, String>>> =
         this.asMaps().groupBy { rad -> parseLong(Domenebegrep.BEHANDLING_ID, rad) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.tilKalkulertMånedligBeløp
 import no.nav.familie.ks.sak.common.domeneparser.BrevPeriodeParser
 import no.nav.familie.ks.sak.common.domeneparser.Domenebegrep
+import no.nav.familie.ks.sak.common.domeneparser.DomenebegrepAndelTilkjentYtelse
 import no.nav.familie.ks.sak.common.domeneparser.VedtaksperiodeMedBegrunnelserParser
 import no.nav.familie.ks.sak.common.domeneparser.parseBigDecimal
 import no.nav.familie.ks.sak.common.domeneparser.parseDato
@@ -176,7 +177,7 @@ private fun lagVilkårResultater(
         parseValgfriEnum<Regelverk>(
             VedtaksperiodeMedBegrunnelserParser.DomenebegrepVedtaksperiodeMedBegrunnelser.VURDERES_ETTER,
             rad,
-        ) ?: Regelverk.NASJONALE_REGLER
+        )
 
     val søkerHarMeldtFraOmBarnehageplass =
         parseValgfriBoolean(
@@ -221,6 +222,8 @@ private fun lagVilkårResultater(
             søkerHarMeldtFraOmBarnehageplass = søkerHarMeldtFraOmBarnehageplass,
             antallTimer = antallTimer,
             regelsett = regelsett,
+            erAutomatiskVurdert =
+                parseValgfriBoolean(DomenebegrepAndelTilkjentYtelse.ER_AUTOMATISK_VURDERT, rad) ?: false,
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -1,0 +1,138 @@
+package no.nav.familie.ks.sak.cucumber.mocking
+
+import io.mockk.mockk
+import no.nav.familie.ba.sak.cucumber.mock.mockEndretUtbetalingAndelRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockFagsakRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockKompetanseRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockLoggService
+import no.nav.familie.ba.sak.cucumber.mock.mockPersonopplysningGrunnlagRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockTaskService
+import no.nav.familie.ba.sak.cucumber.mock.mockTilkjentYtelseRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockUtenlandskPeriodebeløpRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockValutakursRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockVedtakRepository
+import no.nav.familie.ks.sak.common.util.LocalDateProvider
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
+import no.nav.familie.ks.sak.integrasjon.pdl.PdlClient
+import no.nav.familie.ks.sak.integrasjon.pdl.PersonOpplysningerService
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
+import no.nav.familie.ks.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterTilkjentYtelseService
+import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentRepository
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonRepository
+import no.nav.familie.ks.sak.kjerne.tilbakekreving.TilbakekrevingsbehandlingHentService
+import java.time.LocalDate
+
+class CucumberMock(stepDefinition: StepDefinition) {
+    val mockedDateProvider = MockedDateProvider(stepDefinition.dagensDato)
+
+    val vilkårsvurderingRepositoryMock = mockVilkårsvurderingRepository(stepDefinition)
+    val andelTilkjentYtelseRepositoryMock = mockAndelTilkjentYtelseRepository(stepDefinition)
+    val valutakursRepositoryMock = mockValutakursRepository(stepDefinition)
+    val kompetanseRepositoryMock = mockKompetanseRepository(stepDefinition)
+    val utenlandskPeriodebeløpRepositoryMock = mockUtenlandskPeriodebeløpRepository(stepDefinition)
+    val tilkjentYtelseRepositoryMock = mockTilkjentYtelseRepository(stepDefinition)
+    val personopplysningGrunnlagRepositoryMock = mockPersonopplysningGrunnlagRepository(stepDefinition)
+    val endretUtbetalingAndelRepositoryMock = mockEndretUtbetalingAndelRepository(stepDefinition)
+    val fagsakRepositoryMock = mockFagsakRepository(stepDefinition)
+    val vedtakRepositoryMock = mockVedtakRepository(stepDefinition)
+    val taskServiceMock = mockTaskService()
+    val loggServiceMock = mockLoggService()
+
+    val personService = mockk<PersonService>()
+    val personopplysningerServiceMock = mockk<PersonOpplysningerService>()
+    val aktørRepositoryMock = mockk<AktørRepository>()
+    val pdlClientMock = mockk<PdlClient>()
+    val personidentRepositoryMock = mockk<PersonidentRepository>()
+    val behandlingRepositoryMock = mockk<BehandlingRepository>()
+    val integrasjonServiceMock = mockk<IntegrasjonService>()
+    val personRepository = mockk<PersonRepository>()
+    val tilbakekrevingsbehandlingHentService = mockk<TilbakekrevingsbehandlingHentService>()
+    val arbeidsfordelingServiceMock = mockk<ArbeidsfordelingService>()
+    val unleashNextMedContextServiceMock = mockUnleashNextMedContextService()
+
+    val tilpassDifferanseberegningEtterTilkjentYtelseService =
+        TilpassDifferanseberegningEtterTilkjentYtelseService(
+            valutakursRepository = valutakursRepositoryMock,
+            utenlandskPeriodebeløpRepository = utenlandskPeriodebeløpRepositoryMock,
+            tilkjentYtelseRepository = tilkjentYtelseRepositoryMock,
+        )
+
+    val andelerTilkjentYtelseOgEndreteUtbetalingerService =
+        AndelerTilkjentYtelseOgEndreteUtbetalingerService(
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
+            endretUtbetalingAndelRepository = endretUtbetalingAndelRepositoryMock,
+            vilkårsvurderingRepository = vilkårsvurderingRepositoryMock,
+        )
+
+    val personidentService =
+        PersonidentService(
+            personidentRepository = personidentRepositoryMock,
+            aktørRepository = aktørRepositoryMock,
+            pdlClient = pdlClientMock,
+            taskService = taskServiceMock,
+        )
+
+    val fagsakService =
+        FagsakService(
+            personidentService = personidentService,
+            integrasjonService = integrasjonServiceMock,
+            personopplysningerService = personopplysningerServiceMock,
+            personopplysningGrunnlagRepository = personopplysningGrunnlagRepositoryMock,
+            fagsakRepository = fagsakRepositoryMock,
+            personRepository = personRepository,
+            behandlingRepository = behandlingRepositoryMock,
+            andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            taskService = taskServiceMock,
+            tilbakekrevingsbehandlingHentService = tilbakekrevingsbehandlingHentService,
+            vedtakRepository = vedtakRepositoryMock,
+            andelerTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
+            localDateProvider = mockedDateProvider,
+        )
+
+    val beregningService =
+        BeregningService(
+            tilkjentYtelseRepository = tilkjentYtelseRepositoryMock,
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
+            personopplysningGrunnlagRepository = personopplysningGrunnlagRepositoryMock,
+            behandlingRepository = behandlingRepositoryMock,
+            andelerTilkjentYtelseOgEndreteUtbetalingerService = andelerTilkjentYtelseOgEndreteUtbetalingerService,
+            fagsakService = fagsakService,
+            tilkjentYtelseEndretAbonnenter = listOf(tilpassDifferanseberegningEtterTilkjentYtelseService),
+        )
+
+    val personopplysningGrunnlagService =
+        PersonopplysningGrunnlagService(
+            personopplysningGrunnlagRepository = personopplysningGrunnlagRepositoryMock,
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
+            beregningService = beregningService,
+            personService = personService,
+            arbeidsfordelingService = arbeidsfordelingServiceMock,
+            personidentService = personidentService,
+            loggService = loggServiceMock,
+        )
+
+    val vilkårsvurderingService =
+        VilkårsvurderingService(
+            vilkårsvurderingRepository = vilkårsvurderingRepositoryMock,
+            personopplysningGrunnlagService = personopplysningGrunnlagService,
+            sanityService = mockk(),
+            personidentService = personidentService,
+            unleashService = unleashNextMedContextServiceMock,
+        )
+}
+
+class MockedDateProvider(
+    val mockedDate: LocalDate,
+) : LocalDateProvider {
+    override fun now(): LocalDate = this.mockedDate
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockAndelTilkjentYtelseRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockAndelTilkjentYtelseRepository.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.ks.sak.cucumber.mocking
+
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+
+fun mockAndelTilkjentYtelseRepository(stepDefinition: StepDefinition): AndelTilkjentYtelseRepository {
+    val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+
+    return andelTilkjentYtelseRepository
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockEndretUtbetalingAndelRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockEndretUtbetalingAndelRepository.kt
@@ -1,0 +1,15 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
+
+fun mockEndretUtbetalingAndelRepository(stepDefinition: StepDefinition): EndretUtbetalingAndelRepository {
+    val endretUtbetalingAndelRepository = mockk<EndretUtbetalingAndelRepository>()
+    every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        stepDefinition.endredeUtbetalinger[behandlingId] ?: emptyList()
+    }
+    return endretUtbetalingAndelRepository
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockFagsakRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockFagsakRepository.kt
@@ -1,0 +1,15 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+
+fun mockFagsakRepository(stepDefinition: StepDefinition): FagsakRepository {
+    val fagsakRepository = mockk<FagsakRepository>()
+    every { fagsakRepository.finnFagsak(any()) } answers {
+        val id = firstArg<Long>()
+        stepDefinition.fagsaker.values.single { it.id == id }
+    }
+    return fagsakRepository
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompetanseRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompetanseRepository.kt
@@ -1,0 +1,31 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseRepository
+
+fun mockKompetanseRepository(stepDefinition: StepDefinition): KompetanseRepository {
+    val kompetanseRepository = mockk<KompetanseRepository>()
+    every { kompetanseRepository.findByBehandlingId(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        stepDefinition.kompetanser[behandlingId] ?: emptyList()
+    }
+    every { kompetanseRepository.deleteAll(any<Iterable<Kompetanse>>()) } answers {
+        val kompetanser = firstArg<Iterable<Kompetanse>>()
+        kompetanser.forEach {
+            stepDefinition.kompetanser[it.behandlingId] =
+                stepDefinition.kompetanser[it.behandlingId]?.filter { kompetanse -> kompetanse != it } ?: emptyList()
+        }
+    }
+    every { kompetanseRepository.saveAll(any<Iterable<Kompetanse>>()) } answers {
+        val kompetanser = firstArg<Iterable<Kompetanse>>()
+        kompetanser.forEach {
+            stepDefinition.kompetanser[it.behandlingId] =
+                (stepDefinition.kompetanser[it.behandlingId] ?: emptyList()) + it
+        }
+        kompetanser.toMutableList()
+    }
+    return kompetanseRepository
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockLoggService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockLoggService.kt
@@ -1,0 +1,32 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.kjerne.logg.LoggService
+import no.nav.familie.ks.sak.kjerne.logg.LoggType
+import no.nav.familie.ks.sak.kjerne.logg.domene.Logg
+import java.time.LocalDateTime
+
+fun mockLoggService(): LoggService {
+    val loggService = mockk<LoggService>()
+    every { loggService.opprettBeslutningOmVedtakLogg(any(), any(), any()) } just runs
+    every { loggService.opprettBehandlingLogg(any()) } just runs
+    every { loggService.opprettSettPåMaskinellVent(any(), any()) } just runs
+    every { loggService.opprettVilkårsvurderingLogg(any(), any(), any()) } just runs
+    every { loggService.opprettTattAvMaskinellVent(any()) } just runs
+    every { loggService.hentLoggForBehandling(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        listOf(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.BEHANDLING_OPPRETTET,
+                rolle = BehandlerRolle.SYSTEM,
+                tekst = "",
+            ).copy(opprettetTidspunkt = LocalDateTime.now().minusDays(1)),
+        )
+    }
+    return loggService
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPersonopplysningGrunnlagRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPersonopplysningGrunnlagRepository.kt
@@ -1,0 +1,17 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
+
+fun mockPersonopplysningGrunnlagRepository(stepDefinition: StepDefinition): PersonopplysningGrunnlagRepository {
+    val personopplysningGrunnlagRepository = mockk<PersonopplysningGrunnlagRepository>()
+
+    every { personopplysningGrunnlagRepository.findByBehandlingAndAktiv(any()) } answers {
+        val behandlingsId = firstArg<Long>()
+        stepDefinition.persongrunnlag[behandlingsId]
+            ?: error("Fant ikke personopplysninggrunnlag for behandling $behandlingsId")
+    }
+    return personopplysningGrunnlagRepository
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTaskService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTaskService.kt
@@ -1,0 +1,11 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.prosessering.internal.TaskService
+
+fun mockTaskService(): TaskService {
+    val taskService = mockk<TaskService>()
+    every { taskService.save(any()) } answers { firstArg() }
+    return taskService
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTilkjentYtelseRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTilkjentYtelseRepository.kt
@@ -1,0 +1,46 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import java.time.LocalDate
+
+fun mockTilkjentYtelseRepository(stepDefinition: StepDefinition): TilkjentYtelseRepository {
+    val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
+    every { tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        stepDefinition.andelerTilkjentYtelse[behandlingId]!!.tilTilkjentYtelse(stepDefinition)
+    }
+    every { tilkjentYtelseRepository.hentOptionalTilkjentYtelseForBehandling(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        stepDefinition.andelerTilkjentYtelse[behandlingId]?.tilTilkjentYtelse(stepDefinition)
+    }
+    every { tilkjentYtelseRepository.slettTilkjentYtelseForBehandling(any()) } answers {
+        val behandling = firstArg<Behandling>()
+        stepDefinition.andelerTilkjentYtelse[behandling.id] = emptyList()
+    }
+    every { tilkjentYtelseRepository.save(any()) } answers {
+        val tilkjentYtelse = firstArg<TilkjentYtelse>()
+        stepDefinition.andelerTilkjentYtelse[tilkjentYtelse.behandling.id] =
+            tilkjentYtelse.andelerTilkjentYtelse.toList()
+
+        tilkjentYtelse
+    }
+    return tilkjentYtelseRepository
+}
+
+fun Collection<AndelTilkjentYtelse>.tilTilkjentYtelse(stepDefinition: StepDefinition): TilkjentYtelse {
+    val behandlingId = this.map { it.behandlingId }.toSet().single()
+    val behandling = stepDefinition.behandlinger[behandlingId]!!
+
+    return TilkjentYtelse(
+        andelerTilkjentYtelse = this.toMutableSet(),
+        behandling = behandling,
+        endretDato = LocalDate.now(),
+        opprettetDato = LocalDate.now(),
+    )
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUnleashService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUnleashService.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ks.sak.cucumber.mocking
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.unleash.UnleashService
+
+fun mockUnleashNextMedContextService(): UnleashNextMedContextService {
+    val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
+    every { unleashNextMedContextService.isEnabled(any()) } returns true
+    return unleashNextMedContextService
+}
+
+fun mockUnleashService(): UnleashService {
+    val unleashService = mockk<UnleashService>()
+    every { unleashService.isEnabled(any()) } returns true
+    every { unleashService.isEnabled(any(), defaultValue = any()) } returns true
+    return unleashService
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUtenlandskPeriodebeløpRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUtenlandskPeriodebeløpRepository.kt
@@ -1,0 +1,32 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpRepository
+import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
+
+fun mockUtenlandskPeriodebeløpRepository(stepDefinition: StepDefinition): UtenlandskPeriodebeløpRepository {
+    val utenlandskPeriodebeløpRepository = mockk<UtenlandskPeriodebeløpRepository>()
+    every { utenlandskPeriodebeløpRepository.findByBehandlingId(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        stepDefinition.utenlandskPeriodebeløp[behandlingId] ?: emptyList()
+    }
+    every { utenlandskPeriodebeløpRepository.deleteAll(any<Iterable<UtenlandskPeriodebeløp>>()) } answers {
+        val utenlandskPeriodebeløp = firstArg<Iterable<UtenlandskPeriodebeløp>>()
+        utenlandskPeriodebeløp.forEach {
+            stepDefinition.utenlandskPeriodebeløp[it.behandlingId] =
+                stepDefinition.utenlandskPeriodebeløp[it.behandlingId]?.filter { utenlandskPeriodebeløp -> utenlandskPeriodebeløp != it }
+                    ?: emptyList()
+        }
+    }
+    every { utenlandskPeriodebeløpRepository.saveAll(any<Iterable<UtenlandskPeriodebeløp>>()) } answers {
+        val utenlandskPeriodebeløp = firstArg<Iterable<UtenlandskPeriodebeløp>>()
+        utenlandskPeriodebeløp.forEach {
+            stepDefinition.utenlandskPeriodebeløp[it.behandlingId] =
+                (stepDefinition.utenlandskPeriodebeløp[it.behandlingId] ?: emptyList()) + it
+        }
+        utenlandskPeriodebeløp.toList()
+    }
+    return utenlandskPeriodebeløpRepository
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockValutakursRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockValutakursRepository.kt
@@ -1,0 +1,32 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.ValutakursRepository
+import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.domene.Valutakurs
+
+fun mockValutakursRepository(stepDefinition: StepDefinition): ValutakursRepository {
+    val valutakursRepository = mockk<ValutakursRepository>()
+    every { valutakursRepository.findByBehandlingId(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        stepDefinition.valutakurs[behandlingId] ?: emptyList()
+    }
+    every { valutakursRepository.deleteAll(any<Iterable<Valutakurs>>()) } answers {
+        val valutakurser = firstArg<Iterable<Valutakurs>>()
+        valutakurser.forEach {
+            stepDefinition.valutakurs[it.behandlingId] =
+                stepDefinition.valutakurs[it.behandlingId]?.filter { valutakurs -> valutakurs != it } ?: emptyList()
+        }
+    }
+    every { valutakursRepository.saveAll(any<Iterable<Valutakurs>>()) } answers {
+        val valutakurser = firstArg<Iterable<Valutakurs>>()
+        valutakurser.forEach {
+            stepDefinition.valutakurs[it.behandlingId] =
+                (stepDefinition.valutakurs[it.behandlingId] ?: emptyList()) + it
+        }
+        valutakurser.toList()
+    }
+
+    return valutakursRepository
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockVedtakRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockVedtakRepository.kt
@@ -1,0 +1,60 @@
+﻿package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.data.lagVedtak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
+
+fun mockVedtakRepository(stepDefinition: StepDefinition): VedtakRepository {
+    val vedtakRepository = mockk<VedtakRepository>()
+    every { vedtakRepository.findByBehandlingAndAktiv(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        opprettEllerHentVedtak(stepDefinition, behandlingId)
+    }
+    every { vedtakRepository.getReferenceById(any()) } answers {
+        val vedtakId = firstArg<Long>()
+        stepDefinition.vedtakslister.first { it.id == vedtakId }
+    }
+    every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } answers {
+        val behandlingId = firstArg<Long>()
+        opprettEllerHentVedtak(stepDefinition, behandlingId)
+    }
+    every { vedtakRepository.save(any()) } answers {
+        val oppdatertVedtak = firstArg<Vedtak>()
+        lagreVedtak(stepDefinition, oppdatertVedtak)
+    }
+    every { vedtakRepository.saveAndFlush(any()) } answers {
+        val oppdatertVedtak = firstArg<Vedtak>()
+        lagreVedtak(stepDefinition, oppdatertVedtak)
+    }
+    return vedtakRepository
+}
+
+private fun lagreVedtak(
+    stepDefinition: StepDefinition,
+    oppdatertVedtak: Vedtak,
+): Vedtak {
+    stepDefinition.vedtakslister =
+        stepDefinition.vedtakslister.map { if (it.id == oppdatertVedtak.id) oppdatertVedtak else it }.toMutableList()
+    if (oppdatertVedtak.id !in stepDefinition.vedtakslister.map { it.id }) {
+        stepDefinition.vedtakslister.add(oppdatertVedtak)
+    }
+    return oppdatertVedtak
+}
+
+private fun opprettEllerHentVedtak(
+    stepDefinition: StepDefinition,
+    behandlingId: Long,
+): Vedtak {
+    val vedtakForBehandling =
+        stepDefinition.vedtakslister.find { it.behandling.id == behandlingId }
+            ?: lagVedtak(stepDefinition.behandlinger[behandlingId]!!)
+
+    if (vedtakForBehandling !in stepDefinition.vedtakslister) {
+        stepDefinition.vedtakslister.add(vedtakForBehandling)
+    }
+
+    return vedtakForBehandling
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockVilkårsvurderingRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockVilkårsvurderingRepository.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.ks.sak.cucumber.mocking
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårsvurderingRepository
+
+fun mockVilkårsvurderingRepository(stepDefinition: StepDefinition): VilkårsvurderingRepository {
+    val vilkårsvurderingRepository = mockk<VilkårsvurderingRepository>()
+
+    every { vilkårsvurderingRepository.save(any()) } answers {
+        val vilkårsvurdering = firstArg<Vilkårsvurdering>()
+
+        stepDefinition.vilkårsvurdering[vilkårsvurdering.behandling.id] = vilkårsvurdering
+
+        vilkårsvurdering
+    }
+
+    every { vilkårsvurderingRepository.finnAktivForBehandling(any()) } answers {
+        val behandlingId = firstArg<Long>()
+
+        stepDefinition.vilkårsvurdering[behandlingId]
+    }
+
+    return vilkårsvurderingRepository
+}

--- a/src/test/resources/cucumber/lovendring2024/barnets_alder.feature
+++ b/src/test/resources/cucumber/lovendring2024/barnets_alder.feature
@@ -53,3 +53,90 @@ Egenskap: Barnets alder
       | 2       | BARNEHAGEPLASS                                         |                  | 15.02.2024 |            | OPPFYLT      | LOV_AUGUST_2024 |                  | Nei                   |
       | 2       | BARNETS_ALDER                                          |                  | 15.01.2024 | 31.07.2024 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
       | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 15.08.2024 | OPPFYLT      | LOV_AUGUST_2024 |                  | Ja                    |
+
+  Scenario: Ved opprettelse av ny behandling av barn født 1. okt 2022 skal aldersvilkåret være oppfylt f.o.m. 1 oktober 2023 til 31 juli 2024
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 01.10.2022  |
+
+    Når vi oppretter vilkårresultater for behandling 1
+
+    Så forvent følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Regelsett       | Vurderes etter   | Er automatisk vurdert |
+      | 1       | BOSATT_I_RIKET                                         |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 1       | MEDLEMSKAP                                             |                  | 19.06.1993 |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 2       | BARNEHAGEPLASS                                         |                  | 01.11.2023 |            | OPPFYLT      | LOV_AUGUST_2024 |                  | Nei                   |
+      | 2       | BARNETS_ALDER                                          |                  | 01.10.2023 | 31.07.2024 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
+
+  Scenario: Ved opprettelse av ny behandling av barn født 1. des 2022 skal aldersvilkåret være oppfylt f.o.m. 1 des 2023 til 31 juli 2024
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 01.12.2022  |
+
+    Når vi oppretter vilkårresultater for behandling 1
+
+    Så forvent følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Regelsett       | Vurderes etter   | Er automatisk vurdert |
+      | 1       | BOSATT_I_RIKET                                         |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 1       | MEDLEMSKAP                                             |                  | 19.06.1993 |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 2       | BARNEHAGEPLASS                                         |                  | 01.01.2024 |            | OPPFYLT      | LOV_AUGUST_2024 |                  | Nei                   |
+      | 2       | BARNETS_ALDER                                          |                  | 01.12.2023 | 31.07.2024 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
+
+  Scenario: Ved opprettelse av ny behandling av barn født 15. feb 2023 skal aldersvilkåret være oppfylt fom 15 februar 2024 til 31 juli 2024 og fom 1 august 2024 til 15 september 2024
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 15.02.2023  |
+
+    Når vi oppretter vilkårresultater for behandling 1
+
+    Så forvent følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Regelsett       | Vurderes etter   | Er automatisk vurdert |
+      | 1       | BOSATT_I_RIKET                                         |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 1       | MEDLEMSKAP                                             |                  | 19.06.1993 |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 2       | BARNEHAGEPLASS                                         |                  | 15.03.2024 |            | OPPFYLT      | LOV_AUGUST_2024 |                  | Nei                   |
+      | 2       | BARNETS_ALDER                                          |                  | 15.02.2024 | 31.07.2024 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
+      | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 15.09.2024 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
+
+  Scenario: Ved opprettelse av ny behandling av barn født 15. juli 2023 skal aldersvilkåret være oppfylt fom 15 juli 2024 til 31 juli 2024 og fom 15 august 2024 til 15 februar 2025
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 15.07.2023  |
+
+    Når vi oppretter vilkårresultater for behandling 1
+
+    Så forvent følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Regelsett       | Vurderes etter   | Er automatisk vurdert |
+      | 1       | BOSATT_I_RIKET                                         |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 1       | MEDLEMSKAP                                             |                  | 19.06.1993 |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 2       | BARNEHAGEPLASS                                         |                  | 15.08.2024 |            | OPPFYLT      | LOV_AUGUST_2024 |                  | Nei                   |
+      | 2       | BARNETS_ALDER                                          |                  | 15.07.2024 | 31.07.2024 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
+      | 2       | BARNETS_ALDER                                          |                  | 15.08.2024 | 15.02.2025 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
+
+  Scenario: Ved opprettelse av ny behandling av barn født 15. august 2023 skal aldersvilkåret være oppfylt fom 15.september 2024 til tom 15. mars 2025
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 15.08.2023  |
+
+    Når vi oppretter vilkårresultater for behandling 1
+
+    Så forvent følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Regelsett       | Vurderes etter   | Er automatisk vurdert |
+      | 1       | BOSATT_I_RIKET                                         |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 1       | MEDLEMSKAP                                             |                  | 19.06.1993 |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 2       | BARNEHAGEPLASS                                         |                  | 15.09.2024 |            | OPPFYLT      | LOV_AUGUST_2024 |                  | Nei                   |
+      | 2       | BARNETS_ALDER                                          |                  | 15.09.2024 | 15.03.2025 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |

--- a/src/test/resources/cucumber/lovendring2024/barnets_alder.feature
+++ b/src/test/resources/cucumber/lovendring2024/barnets_alder.feature
@@ -35,3 +35,21 @@ Egenskap: Barnets alder
     Så forvent følgende andeler tilkjent ytelse for behandling 1
       | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
       | 2       | 01.06.2024 | 31.12.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 |
+
+  Scenario: For barn født 15. januar 2023 skal aldersvilkår splittes i agust 2024
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 15.01.2023  |
+
+    Når vi oppretter vilkårresultater for behandling 1
+
+    Så forvent følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Regelsett       | Vurderes etter   | Er automatisk vurdert |
+      | 1       | BOSATT_I_RIKET                                         |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 1       | MEDLEMSKAP                                             |                  | 19.06.1993 |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  |            |            | IKKE_VURDERT | LOV_AUGUST_2024 | NASJONALE_REGLER | Nei                   |
+      | 2       | BARNEHAGEPLASS                                         |                  | 15.02.2024 |            | OPPFYLT      | LOV_AUGUST_2024 |                  | Nei                   |
+      | 2       | BARNETS_ALDER                                          |                  | 15.01.2024 | 31.07.2024 | OPPFYLT      | LOV_AUGUST_2021 |                  | Ja                    |
+      | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 15.08.2024 | OPPFYLT      | LOV_AUGUST_2024 |                  | Ja                    |

--- a/src/test/resources/cucumber/lovendring2024/barnets_alder.feature
+++ b/src/test/resources/cucumber/lovendring2024/barnets_alder.feature
@@ -36,7 +36,7 @@ Egenskap: Barnets alder
       | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
       | 2       | 01.06.2024 | 31.12.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 |
 
-  Scenario: For barn født 15. januar 2023 skal aldersvilkår splittes i agust 2024
+  Scenario: For barn født 15. januar 2023 skal aldersvilkår splittes i august 2024
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1       | SØKER      | 19.06.1988  |


### PR DESCRIPTION
### Vil på det varmeste anbefale å leste dette commit for commit

# Hvorfor
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21687)

Siden vi har en lovendring som endrer hvordan vi tolker fra og med datoen og til og med datoen for aldersvilkåret i tillegg til  varigheten til vilkåret, ønsker vi en at det alltid skal være en splitt på aldersvilkåret i august 2024 når de blir generert i starten av en behandling. 

Fra favrokortet:
> Prop. 43 L (2023-2024) Endringer i kontantstøtteloven og folketrygdloven (justering av kontantstøtteperioden og forlenging av foreldrepengeperioden ved 80 prosent dekning)

> I dag utbetales kontantstøtten i maksimalt 11 måneder - fra og med måneden etter at barnet fyller 1 år og til og med måneden før barnet fyller 2 år. Fra 1. august 2024 avkortes stønadsperioden slik at kontantstøtten maksimalt kan utbetales i 7 måneder -  fra og med måneden barnet fyller 13 måneder til og med den måneden barnet fyller 19 måneder. 

> Endringen gjelder også adopterte barn som vil kunne motta kontantstøtten i maksimalt 7 måneder.

# Hva
Lager en splitt på aldersvilkåret i august 2024 og følger gamle regler før splitten og nye regler etter splitten.

NB: Tar ikke høyde for revurderinger i denne PRen

