### PR TITLE
Regelverksendring 2024 - kopiering av vilkårsvurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -42,7 +42,7 @@ class VilkårsvurderingService(
     ): Vilkårsvurdering {
         logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} oppretter vilkårsvurdering for behandling ${behandling.id}")
 
-        val behandlingSkalFølgeNyeLovendringer2024 =
+        val erToggleForLovendringAugust2024På =
             unleashService.isEnabled(FeatureToggleConfig.LOV_ENDRING_7_MND_NYE_BEHANDLINGER)
 
         val aktivVilkårsvurdering = finnAktivVilkårsvurdering(behandling.id)
@@ -51,12 +51,18 @@ class VilkårsvurderingService(
         val personopplysningGrunnlag =
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
 
-        val initiellVilkårsvurdering = genererInitiellVilkårsvurdering(behandling, vilkårsvurderingFraForrigeBehandling, personopplysningGrunnlag, behandlingSkalFølgeNyeLovendringer2024)
+        val initiellVilkårsvurdering =
+            genererInitiellVilkårsvurdering(
+                behandling,
+                vilkårsvurderingFraForrigeBehandling,
+                personopplysningGrunnlag,
+                erToggleForLovendringAugust2024På,
+            )
 
         vilkårsvurderingFraForrigeBehandling?.let {
             initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
                 vilkårsvurderingForrigeBehandling = it,
-                behandlingSkalFølgeNyeLovendringer2024 = behandlingSkalFølgeNyeLovendringer2024,
+                erToggleForLovendringAugust2024På = erToggleForLovendringAugust2024På,
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -56,6 +56,7 @@ class VilkårsvurderingService(
         vilkårsvurderingFraForrigeBehandling?.let {
             initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
                 vilkårsvurderingForrigeBehandling = it,
+                behandlingSkalFølgeNyeLovendringer2024 = behandlingSkalFølgeNyeLovendringer2024,
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -493,7 +493,7 @@ fun Vilkårsvurdering.oppdaterMedDødsdatoer(personopplysningGrunnlag: Personopp
 
 fun Vilkårsvurdering.kopierResultaterFraForrigeBehandling(
     vilkårsvurderingForrigeBehandling: Vilkårsvurdering,
-    behandlingSkalFølgeNyeLovendringer2024: Boolean,
+    erToggleForLovendringAugust2024På: Boolean,
 ) {
     personResultater.forEach { initieltPersonResultat ->
         val personResultatForrigeBehandling =
@@ -510,7 +510,7 @@ fun Vilkårsvurdering.kopierResultaterFraForrigeBehandling(
                         kunForGodkjenteVilkår = behandling.type != BehandlingType.FØRSTEGANGSBEHANDLING,
                         vilkårResultaterFraForrigeBehandling = personResultatForrigeBehandling.vilkårResultater,
                         nyttPersonResultat = initieltPersonResultat,
-                        behandlingSkalFølgeNyeLovendringer2024 = behandlingSkalFølgeNyeLovendringer2024,
+                        erToggleForLovendringAugust2024På = erToggleForLovendringAugust2024På,
                     )
             }
 
@@ -522,7 +522,7 @@ private fun Collection<VilkårResultat>.overskrivMedVilkårResultaterFraForrigeB
     vilkårResultaterFraForrigeBehandling: Collection<VilkårResultat>,
     nyttPersonResultat: PersonResultat,
     kunForGodkjenteVilkår: Boolean,
-    behandlingSkalFølgeNyeLovendringer2024: Boolean,
+    erToggleForLovendringAugust2024På: Boolean,
 ): List<VilkårResultat> {
     val vilkårForPerson = nyttPersonResultat.vilkårResultater.map { it.vilkårType }.toSet()
 
@@ -535,7 +535,7 @@ private fun Collection<VilkårResultat>.overskrivMedVilkårResultaterFraForrigeB
                 .map { it.kopier(personResultat = nyttPersonResultat) }
 
         val vilkårResultaterForrigeBehandlingSomViØnskerÅTaMed: List<VilkårResultat> =
-            if (behandlingSkalFølgeNyeLovendringer2024) {
+            if (erToggleForLovendringAugust2024På) {
                 when (vilkårType) {
                     Vilkår.BARNEHAGEPLASS -> {
                     /* *

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -481,7 +481,7 @@ class StepDefinition {
         vilkårsvurdering[behandlingId] =
             vilkårsvurderingService.opprettVilkårsvurdering(
                 behandling = behandling,
-                forrigeBehandlingSomErVedtatt = null,
+                forrigeBehandlingSomErVedtatt = behandlingTilForrigeBehandling[behandlingId]?.let { behandlinger[it] },
             )
     }
 
@@ -513,6 +513,7 @@ class StepDefinition {
                     ".*begrunnelse",
                     ".*regelsett",
                     ".*personResultat",
+                    ".*behandlingId",
                 )
                 .isEqualTo(forventetVilkårResultat.sortedWith(comparator))
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -45,7 +45,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-            behandlingSkalFølgeNyeLovendringer2024 = true,
+            erToggleForLovendringAugust2024På = true,
         )
 
         val søkerVilkårResultater =
@@ -97,7 +97,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-            behandlingSkalFølgeNyeLovendringer2024 = true,
+            erToggleForLovendringAugust2024På = true,
         )
 
         val søkerVilkårResultater =
@@ -164,7 +164,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-            behandlingSkalFølgeNyeLovendringer2024 = true,
+            erToggleForLovendringAugust2024På = true,
         )
         Assertions.assertEquals(1, initiellVilkårsvurdering.personResultater.size)
     }
@@ -209,7 +209,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-            behandlingSkalFølgeNyeLovendringer2024 = true,
+            erToggleForLovendringAugust2024På = true,
         )
 
         val nyInitBosattIRiketVilkår =
@@ -242,7 +242,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurderingUtenAndreVurderinger.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-            behandlingSkalFølgeNyeLovendringer2024 = true,
+            erToggleForLovendringAugust2024På = true,
         )
 
         val nyInitInnholderOpplysningspliktVilkår =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -20,8 +20,6 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 import org.hamcrest.CoreMatchers.`is` as Is
 
@@ -47,6 +45,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
+            behandlingSkalFølgeNyeLovendringer2024 = true,
         )
 
         val søkerVilkårResultater =
@@ -98,6 +97,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
+            behandlingSkalFølgeNyeLovendringer2024 = true,
         )
 
         val søkerVilkårResultater =
@@ -164,6 +164,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
+            behandlingSkalFølgeNyeLovendringer2024 = true,
         )
         Assertions.assertEquals(1, initiellVilkårsvurdering.personResultater.size)
     }
@@ -208,6 +209,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
+            behandlingSkalFølgeNyeLovendringer2024 = true,
         )
 
         val nyInitBosattIRiketVilkår =
@@ -217,82 +219,6 @@ class OppdaterVilkårsvurderingTest {
 
         Assertions.assertTrue(nyInitBosattIRiketVilkår.isNotEmpty())
         Assertions.assertTrue(nyInitBosattIRiketVilkår.single().resultat == Resultat.IKKE_VURDERT)
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = BehandlingType::class, names = ["FØRSTEGANGSBEHANDLING", "REVURDERING"])
-    fun `kopierResultaterFraForrigeBehandling skal kun ta med oppfylte og ikke aktuelle perioder såsant det ikke er ny førstegangsbehandling`(
-        behandlingType: BehandlingType,
-    ) {
-        val søkerAktørId = randomAktør()
-        val forrigeBehandling = lagBehandling()
-
-        val nyBehandling = lagBehandling(type = behandlingType)
-
-        val initiellVilkårsvurdering =
-            lagVilkårsvurderingOppfylt(
-                behandling = nyBehandling,
-                personer =
-                    listOf(
-                        lagPerson(personType = PersonType.SØKER, aktør = søkerAktørId),
-                        lagPerson(personType = PersonType.BARN, aktør = randomAktør()),
-                    ),
-                regelsett = VilkårRegelsett.LOV_AUGUST_2021,
-            )
-        val aktivMedBosattIRiketDelvisIkkeOppfylt = Vilkårsvurdering(behandling = forrigeBehandling)
-        val personResultat =
-            PersonResultat(
-                vilkårsvurdering = aktivMedBosattIRiketDelvisIkkeOppfylt,
-                aktør = søkerAktørId,
-            )
-        val bosattIRiketVilkårResultater =
-            setOf(
-                lagVilkårResultat(
-                    vilkårType = Vilkår.BOSATT_I_RIKET,
-                    personResultat = personResultat,
-                    resultat = Resultat.IKKE_OPPFYLT,
-                    periodeFom = LocalDate.now().minusYears(2),
-                    periodeTom = LocalDate.now().minusYears(1),
-                    regelsett = VilkårRegelsett.LOV_AUGUST_2021,
-                ),
-                lagVilkårResultat(
-                    vilkårType = Vilkår.BOSATT_I_RIKET,
-                    personResultat = personResultat,
-                    resultat = Resultat.OPPFYLT,
-                    periodeFom = LocalDate.now(),
-                    periodeTom = LocalDate.now().plusYears(1),
-                    regelsett = VilkårRegelsett.LOV_AUGUST_2021,
-                ),
-                lagVilkårResultat(
-                    vilkårType = Vilkår.BOSATT_I_RIKET,
-                    personResultat = personResultat,
-                    resultat = Resultat.IKKE_AKTUELT,
-                    periodeFom = LocalDate.now().plusYears(2),
-                    periodeTom = LocalDate.now().plusYears(3),
-                    regelsett = VilkårRegelsett.LOV_AUGUST_2021,
-                ),
-            )
-        personResultat.setSortedVilkårResultater(bosattIRiketVilkårResultater)
-        aktivMedBosattIRiketDelvisIkkeOppfylt.personResultater = setOf(personResultat)
-
-        initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
-            vilkårsvurderingForrigeBehandling = aktivMedBosattIRiketDelvisIkkeOppfylt,
-        )
-
-        val nyInitBosattIRiketVilkår =
-            initiellVilkårsvurdering.personResultater.find {
-                it.aktør == søkerAktørId
-            }?.vilkårResultater?.filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
-                ?: emptyList()
-
-        Assertions.assertTrue(nyInitBosattIRiketVilkår.isNotEmpty())
-        val erKunOppfylteOgIkkeAktuellePerioder =
-            nyInitBosattIRiketVilkår.all { it.resultat == Resultat.OPPFYLT || it.resultat == Resultat.IKKE_AKTUELT }
-
-        when (behandlingType != BehandlingType.FØRSTEGANGSBEHANDLING) {
-            true -> Assertions.assertTrue(erKunOppfylteOgIkkeAktuellePerioder)
-            false -> Assertions.assertFalse(erKunOppfylteOgIkkeAktuellePerioder)
-        }
     }
 
     @Test
@@ -316,6 +242,7 @@ class OppdaterVilkårsvurderingTest {
 
         initiellVilkårsvurderingUtenAndreVurderinger.kopierResultaterFraForrigeBehandling(
             vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
+            behandlingSkalFølgeNyeLovendringer2024 = true,
         )
 
         val nyInitInnholderOpplysningspliktVilkår =

--- a/src/test/resources/cucumber/lovendring2024/kopiering_av_vilkårsvurdering.feature
+++ b/src/test/resources/cucumber/lovendring2024/kopiering_av_vilkårsvurdering.feature
@@ -1,0 +1,115 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: opprettVilkårsvurdering - tester for kopiering av vilkårresultater fra forrige behandling
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | SØKNAD           | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 15.04.1989  |
+      | 1            | 2       | BARN       | 17.01.2023  |
+      | 1            | 3       | BARN       | 17.12.2022  |
+      | 2            | 1       | SØKER      | 15.04.1989  |
+      | 2            | 2       | BARN       | 17.01.2023  |
+      | 2            | 3       | BARN       | 17.12.2022  |
+
+  Scenario: Barnets aldervilkår skal splittes etter regelverksendring ved revurdering
+    Og følgende dagens dato 27.06.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Fra dato   | Til dato   | Resultat | Vurderes etter   | Antall timer |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              | 15.04.1989 |            | OPPFYLT  | NASJONALE_REGLER |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET | 17.01.2023 |            | OPPFYLT  | NASJONALE_REGLER |              |
+      | 2       | BARNEHAGEPLASS                                         | 17.01.2023 |            | OPPFYLT  |                  | 40           |
+      | 2       | BARNETS_ALDER                                          | 17.01.2024 | 17.01.2025 | OPPFYLT  |                  |              |
+
+    Når vi oppretter vilkårresultater for behandling 2
+
+    Så forvent følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                                                 | Fra dato   | Til dato   | Resultat | Vurderes etter   | Antall timer | Er automatisk vurdert |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              | 15.04.1989 |            | OPPFYLT  | NASJONALE_REGLER |              |                       |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET | 17.01.2023 |            | OPPFYLT  | NASJONALE_REGLER |              |                       |
+      | 2       | BARNEHAGEPLASS                                         | 17.01.2023 |            | OPPFYLT  |                  | 40           |                       |
+      | 2       | BARNETS_ALDER                                          | 17.01.2024 | 31.07.2024 | OPPFYLT  |                  |              | Ja                    |
+      | 2       | BARNETS_ALDER                                          | 01.08.2024 | 17.08.2024 | OPPFYLT  |                  |              | Ja                    |
+
+  Scenario: Ved revurdering av adopsjonsak, skal barnets aldervilkår skal splittes på regelendringsdato, men datoer skal ikke endres
+    Og følgende dagens dato 27.06.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Vurderes etter   | Antall timer |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              |                  | 15.04.1989 |            | OPPFYLT  | NASJONALE_REGLER |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.01.2023 |            | OPPFYLT  | NASJONALE_REGLER |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 17.01.2023 |            | OPPFYLT  |                  |              |
+      | 2       | BARNETS_ALDER                                          | ADOPSJON         | 17.01.2024 | 17.01.2025 | OPPFYLT  |                  |              |
+
+    Når vi oppretter vilkårresultater for behandling 2
+
+    Så forvent følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Vurderes etter   | Antall timer |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              |                  | 15.04.1989 |            | OPPFYLT  | NASJONALE_REGLER |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.01.2023 |            | OPPFYLT  | NASJONALE_REGLER |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 17.01.2023 |            | OPPFYLT  |                  |              |
+      | 2       | BARNETS_ALDER                                          | ADOPSJON         | 17.01.2024 | 31.07.2024 | OPPFYLT  |                  |              |
+      | 2       | BARNETS_ALDER                                          | ADOPSJON         | 01.08.2024 | 17.01.2025 | OPPFYLT  |                  |              |
+
+  Scenario: Ved kopiering av vilkårresultater skal avslag og opphør for barnehageplassvilkåret beholdes fra forrige behanlding
+    Og følgende dagens dato 27.06.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser             | Vurderes etter   | Antall timer |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              | 15.04.1989 |            | OPPFYLT      | Nei                  |                                  | NASJONALE_REGLER |              |
+
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET | 17.12.2022 |            | OPPFYLT      | Nei                  |                                  | NASJONALE_REGLER |              |
+      | 3       | BARNEHAGEPLASS                                         | 17.12.2022 | 16.02.2023 | IKKE_OPPFYLT | Nei                  |                                  |                  | 40           |
+      | 3       | BARNEHAGEPLASS                                         | 17.02.2023 | 31.04.2024 | IKKE_OPPFYLT | Ja                   | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE |                  | 40           |
+      | 3       | BARNETS_ALDER                                          | 17.12.2023 | 17.12.2024 | OPPFYLT      | Nei                  |                                  |                  |              |
+      | 3       | BARNEHAGEPLASS                                         | 01.05.2024 |            | OPPFYLT      | Nei                  |                                  |                  |              |
+
+    Når vi oppretter vilkårresultater for behandling 2
+
+    Så forvent følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                                                 | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Antall timer | Er automatisk vurdert |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              | 15.04.1989 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER |              |                       |
+
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET | 17.12.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER |              |                       |
+      | 3       | BARNEHAGEPLASS                                         | 17.12.2022 | 16.02.2023 | IKKE_OPPFYLT | Nei                  |                      |                  | 40           |                       |
+      | 3       | BARNEHAGEPLASS                                         | 17.02.2023 | 31.04.2024 | IKKE_OPPFYLT | Ja                   |                      |                  | 40           |                       |
+      | 3       | BARNETS_ALDER                                          | 17.12.2023 | 31.07.2024 | OPPFYLT      |                      |                      |                  |              | Ja                    |
+      | 3       | BARNEHAGEPLASS                                         | 01.05.2024 |            | OPPFYLT      | Nei                  |                      |                  |              |                       |
+
+  Scenario: Ved kopiering av vilkårresultater skal avslag og opphør fjernes for andre vilkår enn barnehageplassvilkåret
+    Og følgende dagens dato 27.06.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Vurderes etter   | Søker har meldt fra om barnehageplass |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              |                  | 15.04.1989 |            | OPPFYLT      | Nei                  | NASJONALE_REGLER | Nei                                   |
+
+      | 3       | BARNEHAGEPLASS                                         |                  | 17.12.2022 |            | OPPFYLT      | Nei                  | NASJONALE_REGLER | Nei                                   |
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.12.2022 | 16.02.2023 | IKKE_OPPFYLT | Nei                  |                  | Nei                                   |
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.02.2023 | 31.04.2024 | IKKE_OPPFYLT | Ja                   |                  | Nei                                   |
+      | 3       | BARNETS_ALDER                                          |                  | 17.12.2023 | 17.12.2024 | OPPFYLT      | Nei                  |                  | Nei                                   |
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.12.2022 |            | OPPFYLT      | Nei                  |                  | Nei                                   |
+
+    Når vi oppretter vilkårresultater for behandling 2
+
+    Så forvent følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Vurderes etter   | Søker har meldt fra om barnehageplass | Er automatisk vurdert |
+      | 1       | MEDLEMSKAP,BOSATT_I_RIKET                              |                  | 15.04.1989 |            | OPPFYLT  | Nei                  | NASJONALE_REGLER | Nei                                   |                       |
+
+      | 3       | BARNEHAGEPLASS                                         |                  | 17.12.2022 |            | OPPFYLT  | Nei                  | NASJONALE_REGLER | Nei                                   |                       |
+      | 3       | BARNETS_ALDER                                          |                  | 17.12.2023 | 31.07.2024 | OPPFYLT  |                      |                  |                                       | Ja                    |
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.12.2022 |            | OPPFYLT  | Nei                  |                  | Nei                                   |                       |


### PR DESCRIPTION
# Endre kopiering av aldersvilkåret og barnehagevilkåret
## Barnehagevilkåret
Tidligere favro-oppgave: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20596
Tidligere PR: https://github.com/navikt/familie-ks-sak/pull/673

I koden som originalt kopierte fra ba-sak sletter vi alltid opphør- og avslagsvilkår fra forrige behandling når vi kopierer til neste behandling. Dette blir feil for barnehagevilkåret fordi det er "ikke oppfylt" når man har full barnehageplass og det kreves at man fyller inn alle periodene. Derfor endret vi i https://github.com/navikt/familie-ks-sak/pull/673 til å kopiere opphørene og avslagene for alle vilkår.

Slik det er nå gjør vi det bare for førstegangsbehandlinger. Altså for første barn eller når kontantstøtten avsluttes før neste søknad. Dette må egentlig også gjøres for revurderinger, i tillegg er det nok å kun gjøre det for barnehagevilkåret. I kontantstøtte er nesten alle behandlinger førstegangsbehandlinger, så tror det er derfor dette ikke har truffet oss enda. 

Endrer så vi kun kopierer avslag og opphør for barnehagevilkåret og at det skjer på revurderinger også. 

## Aldersvilkåret
Favro-oppgave: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21687

Etter regelverksendringen august 2024 er det nye perioder som gjelder for aldersvilkåret. 

Endrer så vilkårsresultatene for aldersvilkåret oppdateres til å følge de nye reglene når vi kopierer vilkårene fra tidligere behandlinger