### PR TITLE
Stopp saksbehandler fra å lage fremtidig opphør hvis toggle er av

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -17,6 +17,8 @@ import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.NullablePeriode
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig.Companion.LOV_ENDRING_7_MND_NYE_BEHANDLINGER
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -70,6 +72,9 @@ class VilkårsvurderingStegTest {
     @MockK
     private lateinit var kompetanseService: KompetanseService
 
+    @MockK
+    private lateinit var unleashNextMedContextService: UnleashNextMedContextService
+
     @InjectMockKs
     private lateinit var vilkårsvurderingSteg: VilkårsvurderingSteg
 
@@ -108,6 +113,7 @@ class VilkårsvurderingStegTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandling(any(), any(), any(), any()) } just runs
+        every { unleashNextMedContextService.isEnabled(LOV_ENDRING_7_MND_NYE_BEHANDLINGER) } returns true
     }
 
     @Test


### PR DESCRIPTION
Trukket ut fra denne for å ikke legge press på at den må ut i prod mandag morgen: https://github.com/navikt/familie-ks-sak/pull/724

Når toggle er av ønsker vi å stoppe saksbehandler fra å legge inn fremtidig opphør fordi dette vil generere andeler som ikke stemmer med det nye regelverket. Ønsker at de heller venter med sakene til vi er klare for å skru på toggle.

Avklart med Birgitte