### PR TITLE
Ignorer barnets alder ved generering av vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -4,11 +4,13 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.tidslinje.Periode
 import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
 import no.nav.familie.ks.sak.common.tidslinje.filtrerIkkeNull
+import no.nav.familie.ks.sak.common.tidslinje.mapVerdi
 import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.filtrer
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombiner
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.slåSammen
+import no.nav.familie.ks.sak.common.tidslinje.utvidelser.slåSammenLikePerioder
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioderIkkeNull
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
@@ -104,7 +106,10 @@ data class SplittkriterierForVilkår(
 
 private fun Map<Aktør, Tidslinje<List<VilkårResultat>>>.tilSplittkriterierForVilkårTidslinje(): Tidslinje<Map<Aktør, List<SplittkriterierForVilkår>>> =
     this.map { (aktør, vilkårsvurderingTidslinje) ->
-        vilkårsvurderingTidslinje.tilPerioder().filtrerIkkeNull().map { vilkårResultater ->
+        val vilkårsvurderingTidslinjeUtenBarnetsAlder =
+            vilkårsvurderingTidslinje.mapVerdi { it?.filter { vilkårResultat -> vilkårResultat.vilkårType != Vilkår.BARNETS_ALDER } }.slåSammenLikePerioder()
+
+        vilkårsvurderingTidslinjeUtenBarnetsAlder.tilPerioder().filtrerIkkeNull().map { vilkårResultater ->
             Periode(
                 verdi = Pair(aktør, vilkårResultater.verdi.map { SplittkriterierForVilkår(it) }),
                 fom = vilkårResultater.fom,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -92,22 +92,22 @@ data class SplittkriterierForVilkår(
     val regelverk: Regelverk?,
     val utdypendeVilkårsvurderinger: Set<UtdypendeVilkårsvurdering>,
 ) {
-    constructor(vilkårResultat: VilkårResultat) :
-        this(
-            vilkårType = vilkårResultat.vilkårType,
-            resultat = vilkårResultat.resultat,
-            periodeFom = vilkårResultat.periodeFom,
-            periodeTom = vilkårResultat.periodeTom,
-            erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
-            regelverk = vilkårResultat.vurderesEtter,
-            utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger.toSet(),
-        )
+    constructor(vilkårResultat: VilkårResultat) : this(
+        vilkårType = vilkårResultat.vilkårType,
+        resultat = vilkårResultat.resultat,
+        periodeFom = vilkårResultat.periodeFom,
+        periodeTom = vilkårResultat.periodeTom,
+        erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
+        regelverk = vilkårResultat.vurderesEtter,
+        utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger.toSet(),
+    )
 }
 
 private fun Map<Aktør, Tidslinje<List<VilkårResultat>>>.tilSplittkriterierForVilkårTidslinje(): Tidslinje<Map<Aktør, List<SplittkriterierForVilkår>>> =
     this.map { (aktør, vilkårsvurderingTidslinje) ->
-        val vilkårsvurderingTidslinjeUtenBarnetsAlder =
-            vilkårsvurderingTidslinje.mapVerdi { it?.filter { vilkårResultat -> vilkårResultat.vilkårType != Vilkår.BARNETS_ALDER } }.slåSammenLikePerioder()
+        // Vi ønsker ikke å splitte opp vedtaksperiodene på grunn av splitt i barnets alder grunnet lovendringen i 2024 august.
+        // Vurder å sjekke om personen er truffet av lovendringen i 2021 og 2024 først dersom det oppstår problemer
+        val vilkårsvurderingTidslinjeUtenBarnetsAlder = vilkårsvurderingTidslinje.mapVerdi { it?.filter { vilkårResultat -> vilkårResultat.vilkårType != Vilkår.BARNETS_ALDER } }.slåSammenLikePerioder()
 
         vilkårsvurderingTidslinjeUtenBarnetsAlder.tilPerioder().filtrerIkkeNull().map { vilkårResultater ->
             Periode(
@@ -127,16 +127,15 @@ data class SplittkriterierForKompetanse(
     val resultat: KompetanseResultat? = null,
     val erAnnenForelderOmfattetAvNorskLovgivning: Boolean? = false,
 ) {
-    constructor(kompetanse: Kompetanse) :
-        this(
-            søkersAktivitet = kompetanse.søkersAktivitet,
-            annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
-            annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland,
-            søkersAktivitetsland = kompetanse.søkersAktivitetsland,
-            barnetsBostedsland = kompetanse.barnetsBostedsland,
-            resultat = kompetanse.resultat,
-            erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
-        )
+    constructor(kompetanse: Kompetanse) : this(
+        søkersAktivitet = kompetanse.søkersAktivitet,
+        annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
+        annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland,
+        søkersAktivitetsland = kompetanse.søkersAktivitetsland,
+        barnetsBostedsland = kompetanse.barnetsBostedsland,
+        resultat = kompetanse.resultat,
+        erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
+    )
 }
 
 private fun List<Kompetanse>.tilSplittkriterierForKompetanseTidslinje(): Tidslinje<Map<Aktør, SplittkriterierForKompetanse>> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -42,7 +42,7 @@ fun hentPerioderMedUtbetaling(
     forskjøvetVilkårResultatTidslinjeMap: Map<Aktør, Tidslinje<List<VilkårResultat>>>,
     kompetanser: List<Kompetanse>,
 ): List<VedtaksperiodeMedBegrunnelser> {
-    val splittkriterierForVedtaksperiodeTidslinje = forskjøvetVilkårResultatTidslinjeMap.tilSplittkriterierForVilkårTidslinje()
+    val splittkriterierForVilkårResultatTidslinje = forskjøvetVilkårResultatTidslinjeMap.tilSplittkriterierForVilkårTidslinje()
     val splittkriterierForKompetanseTidslinjer = kompetanser.tilSplittkriterierForKompetanseTidslinje()
 
     val andeltilkjentYtelserSplittetPåKriterier =
@@ -50,7 +50,7 @@ fun hentPerioderMedUtbetaling(
             .tilTidslinjerPerPerson().values
             .slåSammen()
             .filtrer { !it.isNullOrEmpty() }
-            .kombinerMed(splittkriterierForVedtaksperiodeTidslinje, splittkriterierForKompetanseTidslinjer) {
+            .kombinerMed(splittkriterierForVilkårResultatTidslinje, splittkriterierForKompetanseTidslinjer) {
                     andelerTilkjentYtelseIPeriode,
                     splittkriterierVilkår,
                     splittKriterierKompetanse,
@@ -91,15 +91,15 @@ data class SplittkriterierForVilkår(
     val utdypendeVilkårsvurderinger: Set<UtdypendeVilkårsvurdering>,
 ) {
     constructor(vilkårResultat: VilkårResultat) :
-        this(
-            vilkårType = vilkårResultat.vilkårType,
-            resultat = vilkårResultat.resultat,
-            periodeFom = vilkårResultat.periodeFom,
-            periodeTom = vilkårResultat.periodeTom,
-            erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
-            regelverk = vilkårResultat.vurderesEtter,
-            utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger.toSet(),
-        )
+            this(
+                vilkårType = vilkårResultat.vilkårType,
+                resultat = vilkårResultat.resultat,
+                periodeFom = vilkårResultat.periodeFom,
+                periodeTom = vilkårResultat.periodeTom,
+                erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
+                regelverk = vilkårResultat.vurderesEtter,
+                utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger.toSet(),
+            )
 }
 
 private fun Map<Aktør, Tidslinje<List<VilkårResultat>>>.tilSplittkriterierForVilkårTidslinje(): Tidslinje<Map<Aktør, List<SplittkriterierForVilkår>>> =
@@ -123,15 +123,15 @@ data class SplittkriterierForKompetanse(
     val erAnnenForelderOmfattetAvNorskLovgivning: Boolean? = false,
 ) {
     constructor(kompetanse: Kompetanse) :
-        this(
-            søkersAktivitet = kompetanse.søkersAktivitet,
-            annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
-            annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland,
-            søkersAktivitetsland = kompetanse.søkersAktivitetsland,
-            barnetsBostedsland = kompetanse.barnetsBostedsland,
-            resultat = kompetanse.resultat,
-            erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
-        )
+            this(
+                søkersAktivitet = kompetanse.søkersAktivitet,
+                annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
+                annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland,
+                søkersAktivitetsland = kompetanse.søkersAktivitetsland,
+                barnetsBostedsland = kompetanse.barnetsBostedsland,
+                resultat = kompetanse.resultat,
+                erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
+            )
 }
 
 private fun List<Kompetanse>.tilSplittkriterierForKompetanseTidslinje(): Tidslinje<Map<Aktør, SplittkriterierForKompetanse>> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -93,15 +93,15 @@ data class SplittkriterierForVilkår(
     val utdypendeVilkårsvurderinger: Set<UtdypendeVilkårsvurdering>,
 ) {
     constructor(vilkårResultat: VilkårResultat) :
-            this(
-                vilkårType = vilkårResultat.vilkårType,
-                resultat = vilkårResultat.resultat,
-                periodeFom = vilkårResultat.periodeFom,
-                periodeTom = vilkårResultat.periodeTom,
-                erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
-                regelverk = vilkårResultat.vurderesEtter,
-                utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger.toSet(),
-            )
+        this(
+            vilkårType = vilkårResultat.vilkårType,
+            resultat = vilkårResultat.resultat,
+            periodeFom = vilkårResultat.periodeFom,
+            periodeTom = vilkårResultat.periodeTom,
+            erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
+            regelverk = vilkårResultat.vurderesEtter,
+            utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger.toSet(),
+        )
 }
 
 private fun Map<Aktør, Tidslinje<List<VilkårResultat>>>.tilSplittkriterierForVilkårTidslinje(): Tidslinje<Map<Aktør, List<SplittkriterierForVilkår>>> =
@@ -128,15 +128,15 @@ data class SplittkriterierForKompetanse(
     val erAnnenForelderOmfattetAvNorskLovgivning: Boolean? = false,
 ) {
     constructor(kompetanse: Kompetanse) :
-            this(
-                søkersAktivitet = kompetanse.søkersAktivitet,
-                annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
-                annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland,
-                søkersAktivitetsland = kompetanse.søkersAktivitetsland,
-                barnetsBostedsland = kompetanse.barnetsBostedsland,
-                resultat = kompetanse.resultat,
-                erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
-            )
+        this(
+            søkersAktivitet = kompetanse.søkersAktivitet,
+            annenForeldersAktivitet = kompetanse.annenForeldersAktivitet,
+            annenForeldersAktivitetsland = kompetanse.annenForeldersAktivitetsland,
+            søkersAktivitetsland = kompetanse.søkersAktivitetsland,
+            barnetsBostedsland = kompetanse.barnetsBostedsland,
+            resultat = kompetanse.resultat,
+            erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
+        )
 }
 
 private fun List<Kompetanse>.tilSplittkriterierForKompetanseTidslinje(): Tidslinje<Map<Aktør, SplittkriterierForKompetanse>> {

--- a/src/test/resources/application-dev-postgres-preprod.yaml
+++ b/src/test/resources/application-dev-postgres-preprod.yaml
@@ -135,7 +135,7 @@ spring:
 AZURE_APP_WELL_KNOWN_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
 
-SANITY_DATASET: "ks-brev"
+SANITY_DATASET: "ks-v2"
 
 
 FAMILIE_KS_SAK_API_URL: http://localhost:8086/api


### PR DESCRIPTION
Vi ønsker ikke å få to forskjellige vedtaksperioder fordi barnets alder blir splittet opp på grunn av lovendringen som oppstår.
Det vi da gjør istedenfor er å filtrere ut barnets alder vilkåret og slår sammen periodene dersom de er like uten vilkåret.
Deretter så sjekker vi for splittkriterier som vanlig.