### PR TITLE
Bug: godta avslag uten perioder for barnets alder-vilkåret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -228,7 +228,7 @@ class VilkårsvurderingSteg(
             val barnehageplassTidslinje = personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS }.tilTidslinje()
             val barnetsAlderTidslinje =
                 personResultat.vilkårResultater
-                    .filter { it.vilkårType == Vilkår.BARNETS_ALDER }
+                    .filter { it.vilkårType == Vilkår.BARNETS_ALDER && !it.erAvslagUtenPeriode() }
                     .tilTidslinje()
                     .klipp(barnehageplassTidslinje.startsTidspunkt, if (sistePeriodeErFremtidigOpphør) sistePeriode.periodeTom!! else TIDENES_ENDE)
 


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21792

Tillat å legge inn generelt avslag (avslag uten perioder) for barnets alder-vilkåret. Dette ble til nå stoppet pga en feil i tidslinje-rammeverket når vi kjørte `tilTidslinje()`-funksjonen