### PR TITLE
Fiks logikken på når vi sjekker forrige behandling sin opphørsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -44,8 +44,6 @@ object BehandlingsresultatOpphørUtils {
                 endretAndelerForForrigeBehandling = forrigeEndretAndeler,
             )
 
-        val forrigeBehandlingOpphørsdato = forrigeAndeler.utledOpphørsdatoForForrigeBehandling(forrigeEndretAndeler = forrigeEndretAndeler)
-
         val cutOffDato =
             if (erToggleForLovendringAugust2024På) {
                 nåMåned.plusMonths(2)
@@ -53,10 +51,16 @@ object BehandlingsresultatOpphørUtils {
                 nåMåned.plusMonths(1)
             }
 
+        val forrigeBehandlingOpphørsdato = forrigeAndeler.utledOpphørsdatoForForrigeBehandling(
+            forrigeEndretAndeler = forrigeEndretAndeler,
+        )
+
+        val harTidligereOpphørsDatoEnnForrigeBehandling = forrigeBehandlingOpphørsdato?.let { it > nåværendeBehandlingOpphørsdato } ?: true
+
         return when {
             // Rekkefølgen av sjekkene er viktig for å komme fram til riktig opphørsresultat.
             nåværendeBehandlingOpphørsdato == null -> Opphørsresultat.IKKE_OPPHØRT // Både forrige og nåværende behandling har ingen andeler
-            nåværendeBehandlingOpphørsdato <= cutOffDato && forrigeBehandlingOpphørsdato > nåværendeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige har senere opphørsdato
+            nåværendeBehandlingOpphørsdato <= cutOffDato && harTidligereOpphørsDatoEnnForrigeBehandling -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige har senere opphørsdato
             nåværendeBehandlingOpphørsdato <= cutOffDato && nåværendeBehandlingOpphørsdato == forrigeBehandlingOpphørsdato -> Opphørsresultat.FORTSATT_OPPHØRT
             else -> Opphørsresultat.IKKE_OPPHØRT
         }
@@ -98,7 +102,7 @@ object BehandlingsresultatOpphørUtils {
     /**
      * Hvis det ikke fantes noen andeler i forrige behandling defaulter vi til inneværende måned
      */
-    private fun List<AndelTilkjentYtelse>.utledOpphørsdatoForForrigeBehandling(forrigeEndretAndeler: List<EndretUtbetalingAndel>): YearMonth = this.filtrerBortIrrelevanteAndeler(endretAndeler = forrigeEndretAndeler).finnOpphørsdato() ?: YearMonth.now().nesteMåned()
+    private fun List<AndelTilkjentYtelse>.utledOpphørsdatoForForrigeBehandling(forrigeEndretAndeler: List<EndretUtbetalingAndel>): YearMonth? = this.filtrerBortIrrelevanteAndeler(endretAndeler = forrigeEndretAndeler).finnOpphørsdato()
 
     /**
      * Hvis det eksisterer andeler med beløp == 0 så ønsker vi å filtrere bort disse dersom det eksisterer endret utbetaling andel for perioden

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -51,9 +51,10 @@ object BehandlingsresultatOpphørUtils {
                 nåMåned.plusMonths(1)
             }
 
-        val forrigeBehandlingOpphørsdato = forrigeAndeler.utledOpphørsdatoForForrigeBehandling(
-            forrigeEndretAndeler = forrigeEndretAndeler,
-        )
+        val forrigeBehandlingOpphørsdato =
+            forrigeAndeler.utledOpphørsdatoForForrigeBehandling(
+                forrigeEndretAndeler = forrigeEndretAndeler,
+            )
 
         val harTidligereOpphørsDatoEnnForrigeBehandling = forrigeBehandlingOpphørsdato?.let { it > nåværendeBehandlingOpphørsdato } ?: true
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -38,7 +38,6 @@ class BehandlingsresultatOpphørUtilsTest {
     val for2mndSiden = YearMonth.now().minusMonths(2)
     val for1mndSiden = YearMonth.now().minusMonths(1)
     val om1mnd = YearMonth.now().plusMonths(1)
-    val om2Mnd = YearMonth.now().plusMonths(2)
     val om4mnd = YearMonth.now().plusMonths(4)
 
     @BeforeEach

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -38,6 +38,7 @@ class BehandlingsresultatOpphørUtilsTest {
     val for2mndSiden = YearMonth.now().minusMonths(2)
     val for1mndSiden = YearMonth.now().minusMonths(1)
     val om1mnd = YearMonth.now().plusMonths(1)
+    val om2Mnd = YearMonth.now().plusMonths(2)
     val om4mnd = YearMonth.now().plusMonths(4)
 
     @BeforeEach
@@ -754,5 +755,34 @@ class BehandlingsresultatOpphørUtilsTest {
             )
 
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
+    }
+
+    @Test
+    fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom kontantstøtten opphører to måneder fram i tid`() {
+        val barn1Aktør = randomAktør()
+
+        val nåværendeAndeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    fom = for3mndSiden,
+                    tom = om1mnd,
+                    beløp = 1054,
+                    aktør = barn1Aktør,
+                ),
+            )
+
+        val opphørsresultat =
+            hentOpphørsresultatPåBehandling(
+                nåværendeAndeler = nåværendeAndeler,
+                forrigeAndeler = emptyList(),
+                nåværendeEndretAndeler = emptyList(),
+                forrigeEndretAndeler = emptyList(),
+                nåværendePersonResultaterPåBarn = emptyList(),
+                forrigePersonResultaterPåBarn = emptyList(),
+                nåMåned = YearMonth.now(),
+                erToggleForLovendringAugust2024På = true,
+            )
+
+        assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 }


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21791

Vi får innvilget istedenfor innvilget og opphørt i behandlingen i produksjon.
Dette oppstår fordi dersom forrige behandling ikke finnes, så defaulter vi til neste måned.
Men dette fører til at vi ikke for OPPHØRT, siden man bare får opphørt dersom opphørsdato på nåværende behandling er mindre enn forrige behandlings opphørsdato (som defaultes til 2024-08, mens opphørsdato på nåværende er 2024-09).

Endrer på det slik at vi defaulter til true hvis forrige behandling ikke finnes.