### PR TITLE
Gå bort i fra ks-v2

### DIFF
--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -107,7 +107,7 @@ sentry.environment: preprod
 
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de"
 
-SANITY_DATASET: "ks-v2"
+SANITY_DATASET: "ks-brev"
 
 PDL_URL: https://pdl-api.dev-fss-pub.nais.io
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -111,7 +111,7 @@ sentry.environment: prod
 
 prosessering.rolle: "87190cf3-b278-457d-8ab7-1a5c55a9edd7"
 
-SANITY_DATASET: "ks-v2"
+SANITY_DATASET: "ks-brev"
 
 PDL_URL: https://pdl-api.prod-fss-pub.nais.io
 PDL_SCOPE: api://prod-fss.pdl.pdl-api/.default

--- a/src/test/resources/application-dev-postgres-preprod.yaml
+++ b/src/test/resources/application-dev-postgres-preprod.yaml
@@ -135,7 +135,7 @@ spring:
 AZURE_APP_WELL_KNOWN_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
 
-SANITY_DATASET: "ks-v2"
+SANITY_DATASET: "ks-brev"
 
 
 FAMILIE_KS_SAK_API_URL: http://localhost:8086/api


### PR DESCRIPTION
Nå som vi er live med lovendringen så tenker jeg at vi kan gå tilbake til KS-brev.
Innholdet i V2 er migrert til ks-brev.

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21842