### PR TITLE
Bug: opphørsbegrunnelser som gjelder første periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.brev.begrunnelser
 
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.common.tidslinje.TidslinjePeriode
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.klipp
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
@@ -36,6 +35,7 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import java.time.LocalDate
 
 class BegrunnelserForPeriodeContext(
     private val utvidetVedtaksperiodeMedBegrunnelser: UtvidetVedtaksperiodeMedBegrunnelser,
@@ -338,8 +338,8 @@ class BegrunnelserForPeriodeContext(
                 val perioderMedVilkårForPerson = vilkårResultatTidslinjeForPerson.tilPerioder()
                 val månedenFørVedtaksperioden = vedtaksperiode.fom.minusMonths(1)
 
-                val vilkårResultaterForrigeMåned = perioderMedVilkårForPerson.singleOrNull { it.fom != null && it.fom <= månedenFørVedtaksperioden && (it.tom == null || it.tom >= månedenFørVedtaksperioden) }?.verdi ?: emptyList()
-                val vilkårResultaterDenneMåneden = perioderMedVilkårForPerson.singleOrNull { it.fom != null && it.fom <= vedtaksperiode.fom && (it.tom == null || it.tom >= vedtaksperiode.fom) }?.verdi ?: emptyList()
+                val vilkårResultaterForrigeMåned = perioderMedVilkårForPerson.tilInnoldForMåned(månedenFørVedtaksperioden)
+                val vilkårResultaterDenneMåneden = perioderMedVilkårForPerson.tilInnoldForMåned(vedtaksperiode.fom)
 
                 val oppfylteVilkårForrigeMåned = vilkårResultaterForrigeMåned.filter { it.erOppfylt() || it.erIkkeAktuelt() }
 
@@ -363,7 +363,7 @@ class BegrunnelserForPeriodeContext(
             }.toMap()
             .filterValues { it.isNotEmpty() }
 
-    private fun List<TidslinjePeriode<List<VilkårResultat>>>.tilInnoldIPerioden(): List<VilkårResultat> = this.lastOrNull()?.periodeVerdi?.verdi ?: emptyList()
+    private fun List<no.nav.familie.ks.sak.common.tidslinje.Periode<List<VilkårResultat>?>>.tilInnoldForMåned(dato: LocalDate?): List<VilkårResultat> = this.singleOrNull { it.fom != null && it.fom <= dato && (it.tom == null || it.tom >= dato) }?.verdi ?: emptyList()
 
     private fun Aktør.hentPerson() = (
         personopplysningGrunnlag.personer.singleOrNull { it.aktør.aktivFødselsnummer() == aktivFødselsnummer() }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -351,7 +351,7 @@ class BegrunnelserForPeriodeContext(
                         vilkårSluttetMånedenFørVedtaksperioden
                     }
 
-                val vilkårSomIkkeErOppfyltFraOgMedDennePerioden = personResultater.find { it.aktør == person.aktør }?.vilkårResultater?.filter { it.periodeFom == vedtaksperiode.fom } ?: emptyList()
+                val vilkårSomIkkeErOppfyltFraOgMedDennePerioden = personResultater.find { it.aktør == person.aktør }?.vilkårResultater?.filter { it.periodeFom?.toYearMonth() == vedtaksperiode.fom.toYearMonth() } ?: emptyList()
 
                 val vilkårSomIkkeErOppfyltEllerSlutterMånedenFør = vilkårSomSlutterMånedenFørDenneVedtaksperioden + vilkårSomIkkeErOppfyltFraOgMedDennePerioden
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -337,25 +337,27 @@ class BegrunnelserForPeriodeContext(
             .mapKeys { (aktør, _) -> aktør.hentPerson() }
             .mapNotNull { (person, vilkårResultatTidslinjeForPerson) ->
 
-                val tidslinjeMedVilkårSomSluttetMånedenFør = vilkårResultatTidslinjeForPerson
-                    .konverterTilMåned(antallMndBakoverITid = 1) { _, vindu ->
-                        val forrigeMåned = vindu[0]
-                        val denneMåneden = vindu[1]
-                        val oppfylteVilkårForrigeMåned =
-                            forrigeMåned.tilInnoldIPerioden().filter { it.erOppfylt() || it.erIkkeAktuelt() }
+                val tidslinjeMedVilkårSomSluttetMånedenFør =
+                    vilkårResultatTidslinjeForPerson
+                        .konverterTilMåned(antallMndBakoverITid = 1) { _, vindu ->
+                            val forrigeMåned = vindu[0]
+                            val denneMåneden = vindu[1]
+                            val oppfylteVilkårForrigeMåned =
+                                forrigeMåned.tilInnoldIPerioden().filter { it.erOppfylt() || it.erIkkeAktuelt() }
 
-                        val vilkårSomSluttetMånedenFør = oppfylteVilkårForrigeMåned
-                            .filter { vilkårResultatFraForrigeMåned ->
-                                val tilsvarendeVilkårDennePerioden =
-                                    denneMåneden
-                                        .tilInnoldIPerioden()
-                                        .filter { it.vilkårType == vilkårResultatFraForrigeMåned.vilkårType && it.resultat == vilkårResultatFraForrigeMåned.resultat }
+                            val vilkårSomSluttetMånedenFør =
+                                oppfylteVilkårForrigeMåned
+                                    .filter { vilkårResultatFraForrigeMåned ->
+                                        val tilsvarendeVilkårDennePerioden =
+                                            denneMåneden
+                                                .tilInnoldIPerioden()
+                                                .filter { it.vilkårType == vilkårResultatFraForrigeMåned.vilkårType && it.resultat == vilkårResultatFraForrigeMåned.resultat }
 
-                                val vilkårSluttetMånedenFør = tilsvarendeVilkårDennePerioden.isEmpty()
-                                vilkårSluttetMånedenFør
-                            }.tilPeriodeVerdi()
-                        vilkårSomSluttetMånedenFør
-                    }.tilPerioderIkkeNull()
+                                        val vilkårSluttetMånedenFør = tilsvarendeVilkårDennePerioden.isEmpty()
+                                        vilkårSluttetMånedenFør
+                                    }.tilPeriodeVerdi()
+                            vilkårSomSluttetMånedenFør
+                        }.tilPerioderIkkeNull()
 
                 val vilkårSomSlutterMånedenFørDenneVedtaksperioden =
                     tidslinjeMedVilkårSomSluttetMånedenFør

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -339,6 +339,7 @@ class BegrunnelserForPeriodeContext(
 
                 val tidslinjeMedVilkårSomSluttetMånedenFør =
                     vilkårResultatTidslinjeForPerson
+                        .klipp(vedtaksperiode.fom.minusMonths(1), vedtaksperiode.fom)
                         .konverterTilMåned(antallMndBakoverITid = 1) { _, vindu ->
                             val forrigeMåned = vindu[0]
                             val denneMåneden = vindu[1]

--- a/src/test/resources/cucumber/opphør-første-periode.feature
+++ b/src/test/resources/cucumber/opphør-første-periode.feature
@@ -114,3 +114,48 @@ Egenskap: Opphør første periode
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.12.2023 til 30.11.2024
       | Begrunnelse                          | Type     | Gjelder søker | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Gjelder andre forelder | Antall timer barnehageplass |
       | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | Ja            | 0           | desember 2023                        | 0     | false                  |                             |
+
+  Scenario: Når det er ikke oppfylt fra første periode på revurdering ønsker vi å få opp riktige begrunnelser
+    Og følgende dagens dato 14.02.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET               |                  | 15.03.2010 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | MEDLEMSKAP                   |                  | 15.10.2018 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 01.12.2008 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 25.08.2022 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BARNEHAGEPLASS               |                  | 25.08.2022 |            | OPPFYLT  | Nei                  |                      |                  |
+      | 2       | BARNETS_ALDER                |                  | 25.08.2023 | 25.08.2024 | OPPFYLT  | Nei                  |                      |                  |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   |
+      | 1       | BOSATT_I_RIKET               |                  | 15.03.2010 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER |
+      | 1       | MEDLEMSKAP                   |                  | 15.09.2023 |            | IKKE_OPPFYLT | Nei                  |                      | NASJONALE_REGLER |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 01.12.2008 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 25.08.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER |
+      | 2       | BARNEHAGEPLASS               |                  | 25.08.2022 |            | OPPFYLT      | Nei                  |                      |                  |
+      | 2       | BARNETS_ALDER                |                  | 25.08.2023 | 25.08.2024 | OPPFYLT      | Nei                  |                      |                  |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                                                                                                                                                                                          | Ugyldige begrunnelser |
+      | 01.09.2023 | 31.08.2024 | OPPHØR             |                                | OPPHØR_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR, OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR, OPPHØR_IKKE_MEDLEM_FOLKETRYGDEN_ELLER_EOS_I_5_ÅR, OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_ELLER_EØS_I_5_AAR |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser                                                                                                                                                                                          | Eøsbegrunnelser | Fritekster |
+      | 01.09.2023 | 31.08.2024 | OPPHØR_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR, OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR, OPPHØR_IKKE_MEDLEM_FOLKETRYGDEN_ELLER_EOS_I_5_ÅR, OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_ELLER_EØS_I_5_AAR |                 |            |
+
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2023 til 31.08.2024
+      | Begrunnelse                                                   | Type     | Antall barn | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder |
+      | OPPHØR_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR                      | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |
+      | OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR            | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |
+      | OPPHØR_IKKE_MEDLEM_FOLKETRYGDEN_ELLER_EOS_I_5_ÅR              | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |
+      | OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_ELLER_EØS_I_5_AAR | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21811

Skriver om logikken for å finne vilkår som er utgjørende for opphørsbegrunnelser som trigges av "gjelder første periode". Skjønte ikke helt hvorfor logikken var så komplisert fra før, sånn jeg ser det fant man vilkår som sluttet måneden før vedtaksperioden to ganger i samme funksjon? I tillegg funket ikke logikken for å finne ikke oppfylte perioder sånn som man sikkert hadde tenkt når man skrev koden. Grunnen til det er at forskyvningskoden som blir brukt filtrerer ut ikke oppfylte vilkår, og man kan da ikke sjekke på om alle vilkårene er oppfylt, fordi det alltid vil være sant (siden de ikke oppfylte er filtrert ut). 

Skriver derfor om logikken til å gjøre to ting:
1. Finne oppfylte/ikke aktuelle vilkår som sluttet måneden før vedtaksperioden vi ser på. Dette gjør man ved å forskyve vilkårene riktig og se hvilke vilkår som var oppfylt måneden før vedtaksperioden, men som ikke finnes eller ikke er oppfylt lenger for måneden vedtaksperioden gjelder fra (altså fom-datoen)
2. Finner ikke oppfylte vilkår som har fom-dato i samme måned som vedtaksperioden sin fom

Har skrevet en test som verifiserer at problemet blir fikset, og det finnes allerede to tester som fortsatt funker etter omskriving av koden.

Har også verifisert at begrunnelsene dukker opp når jeg kjører opp lokalt og reproduserer prod-saken:
![image](https://github.com/user-attachments/assets/0f0b2679-ddf1-49a5-a5f7-400097d31c83)
