### PR TITLE
NAV-20911: Oppretter SammensattKontrollsak klasser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/SammensattKontrollsakDtos.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/SammensattKontrollsakDtos.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.ks.sak.api.dto
+
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak.SammensattKontrollsak
+
+data class SammensattKontrollsakDto(
+    val id: Long,
+    val behandlingId: Long,
+    val fritekst: String,
+)
+
+data class SlettSammensattKontrollsakDto(
+    val id: Long,
+)
+
+data class OppdaterSammensattKontrollsakDto(
+    val id: Long,
+    val fritekst: String,
+)
+
+data class OpprettSammensattKontrollsakDto(
+    val behandlingId: Long,
+    val fritekst: String,
+)
+
+fun OpprettSammensattKontrollsakDto.tilSammensattKontrollsak(): SammensattKontrollsak =
+    SammensattKontrollsak(
+        behandlingId = this.behandlingId,
+        fritekst = this.fritekst,
+    )

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -6,5 +6,6 @@ class FeatureToggleConfig {
         const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
         const val TEKNISK_ENDRING = "familie-ks-sak.behandling.teknisk-endring"
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ks-sak.behandling.korreksjon-vedtaksbrev"
+        const val KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER = "familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -19,6 +19,9 @@ import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.entitet.BaseEntitet
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus.OPPRETTET
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus.SATT_PÅ_MASKINELL_VENT
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus.UTREDES
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType.FØRSTEGANGSBEHANDLING
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType.REVURDERING
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType.TEKNISK_ENDRING
@@ -181,6 +184,8 @@ data class Behandling(
     fun erLovendring() = opprettetÅrsak == BehandlingÅrsak.LOVENDRING_2024
 
     fun skalBehandlesAutomatisk(): Boolean = this.opprettetÅrsak in listOf(BehandlingÅrsak.LOVENDRING_2024)
+
+    fun erRedigerbar() = status in setOf(OPPRETTET, UTREDES, SATT_PÅ_MASKINELL_VENT)
 }
 
 /**

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsak.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsak.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import no.nav.familie.ks.sak.api.dto.SammensattKontrollsakDto
+import no.nav.familie.ks.sak.common.entitet.BaseEntitet
+
+@Entity(name = "SammensattKontrollsak")
+@Table(name = "sammensatt_kontrollsak")
+data class SammensattKontrollsak(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sammensatt_kontrollsak_seq_generator")
+    @SequenceGenerator(
+        name = "sammensatt_kontrollsak_seq_generator",
+        sequenceName = "sammensatt_kontrollsak_seq",
+        allocationSize = 50,
+    )
+    val id: Long = 0L,
+    @Column(name = "fk_behandling_id", updatable = false, nullable = false)
+    val behandlingId: Long,
+    @Column(name = "fritekst", nullable = false)
+    var fritekst: String,
+) : BaseEntitet()
+
+fun SammensattKontrollsak.tilSammensattKontrollDto(): SammensattKontrollsakDto =
+    SammensattKontrollsakDto(
+        id = this.id,
+        behandlingId = this.behandlingId,
+        fritekst = this.fritekst,
+    )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakController.kt
@@ -1,0 +1,106 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import no.nav.familie.ks.sak.api.dto.OppdaterSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.OpprettSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.SammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.SlettSammensattKontrollsakDto
+import no.nav.familie.prosessering.rest.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/sammensatt-kontrollsak")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class SammensattKontrollsakController(
+    private val sammensattKontrollsakValidator: SammensattKontrollsakValidator,
+    private val sammensattKontrollsakService: SammensattKontrollsakService,
+) {
+    @GetMapping(
+        path = ["/{behandlingId}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun hentSammensattKontrollsak(
+        @PathVariable behandlingId: Long,
+    ): ResponseEntity<Ressurs<SammensattKontrollsakDto?>> {
+        sammensattKontrollsakValidator.validerHentSammensattKontrollsakTilgang()
+
+        val sammensattKontrollsak =
+            sammensattKontrollsakService.finnSammensattKontrollsakForBehandling(
+                behandlingId = behandlingId,
+            )
+
+        return ResponseEntity.ok(Ressurs.success(sammensattKontrollsak?.tilSammensattKontrollDto()))
+    }
+
+    @PostMapping(
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun opprettSammensattKontrollsak(
+        @RequestBody opprettSammensattKontrollsakDto: OpprettSammensattKontrollsakDto,
+    ): ResponseEntity<Ressurs<SammensattKontrollsakDto>> {
+        sammensattKontrollsakValidator.validerOpprettSammensattKontrollsakTilgang()
+
+        sammensattKontrollsakValidator.validerRedigerbarBehandlingForBehandlingId(
+            behandlingId = opprettSammensattKontrollsakDto.behandlingId,
+        )
+
+        val sammensattKontrollsak =
+            sammensattKontrollsakService.opprettSammensattKontrollsak(
+                opprettSammensattKontrollsakDto = opprettSammensattKontrollsakDto,
+            )
+
+        return ResponseEntity.ok(Ressurs.success(sammensattKontrollsak.tilSammensattKontrollDto()))
+    }
+
+    @PutMapping(
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun oppdaterSammensattKontrollsak(
+        @RequestBody oppdaterSammensattKontrollsakDto: OppdaterSammensattKontrollsakDto,
+    ): ResponseEntity<Ressurs<SammensattKontrollsakDto>> {
+        sammensattKontrollsakValidator.validerOppdaterSammensattKontrollsakTilgang()
+
+        sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+            sammensattKontrollsakId = oppdaterSammensattKontrollsakDto.id,
+        )
+
+        val sammensattKontrollsak =
+            sammensattKontrollsakService.oppdaterSammensattKontrollsak(
+                oppdaterSammensattKontrollsakDto = oppdaterSammensattKontrollsakDto,
+            )
+
+        return ResponseEntity.ok(Ressurs.success(sammensattKontrollsak.tilSammensattKontrollDto()))
+    }
+
+    @DeleteMapping(
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun slettSammensattKontrollsak(
+        @RequestBody slettSammensattKontrollsakDto: SlettSammensattKontrollsakDto,
+    ): ResponseEntity<Ressurs<Long>> {
+        sammensattKontrollsakValidator.validerSlettSammensattKontrollsakTilgang()
+
+        sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+            sammensattKontrollsakId = slettSammensattKontrollsakDto.id,
+        )
+
+        sammensattKontrollsakService.slettSammensattKontrollsak(
+            slettSammensattKontrollsakDto = slettSammensattKontrollsakDto,
+        )
+
+        return ResponseEntity.ok(Ressurs.success(slettSammensattKontrollsakDto.id))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakRepository.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface SammensattKontrollsakRepository : JpaRepository<SammensattKontrollsak, Long> {
+    @Query(value = "SELECT sk FROM SammensattKontrollsak sk WHERE sk.behandlingId = :behandlingId")
+    fun finnSammensattKontrollsakForBehandling(behandlingId: Long): SammensattKontrollsak?
+
+    @Query(value = "SELECT sk FROM SammensattKontrollsak sk WHERE sk.id = :sammensattKontrollsakId")
+    fun finnSammensattKontrollsak(sammensattKontrollsakId: Long): SammensattKontrollsak?
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakService.kt
@@ -1,0 +1,85 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import no.nav.familie.ks.sak.api.dto.OppdaterSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.OpprettSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.SlettSammensattKontrollsakDto
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.kjerne.logg.LoggService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SammensattKontrollsakService(
+    private val sammensattKontrollsakRepository: SammensattKontrollsakRepository,
+    private val loggService: LoggService,
+) {
+    fun finnSammensattKontrollsak(
+        sammensattKontrollsakId: Long,
+    ): SammensattKontrollsak? =
+        sammensattKontrollsakRepository.finnSammensattKontrollsak(
+            sammensattKontrollsakId = sammensattKontrollsakId,
+        )
+
+    fun finnSammensattKontrollsakForBehandling(
+        behandlingId: Long,
+    ): SammensattKontrollsak? =
+        sammensattKontrollsakRepository.finnSammensattKontrollsakForBehandling(
+            behandlingId = behandlingId,
+        )
+
+    @Transactional
+    fun opprettSammensattKontrollsak(
+        opprettSammensattKontrollsakDto: OpprettSammensattKontrollsakDto,
+    ): SammensattKontrollsak {
+        val lagretSammensattKontrollsak =
+            sammensattKontrollsakRepository.save(
+                SammensattKontrollsak(
+                    behandlingId = opprettSammensattKontrollsakDto.behandlingId,
+                    fritekst = opprettSammensattKontrollsakDto.fritekst,
+                ),
+            )
+        loggService.opprettSammensattKontrollsakOpprettetLogg(
+            behandlingId = lagretSammensattKontrollsak.behandlingId,
+        )
+        return lagretSammensattKontrollsak
+    }
+
+    @Transactional
+    fun oppdaterSammensattKontrollsak(
+        oppdaterSammensattKontrollsakDto: OppdaterSammensattKontrollsakDto,
+    ): SammensattKontrollsak {
+        val eksisterendeSammensattKontrollsak =
+            sammensattKontrollsakRepository.finnSammensattKontrollsak(
+                sammensattKontrollsakId = oppdaterSammensattKontrollsakDto.id,
+            ) ?: throw Feil(
+                "Fant ingen eksisterende sammensatt kontrollsak for id=${oppdaterSammensattKontrollsakDto.id}",
+            )
+        eksisterendeSammensattKontrollsak.fritekst = oppdaterSammensattKontrollsakDto.fritekst
+        val lagretSammensattKontrollsak =
+            sammensattKontrollsakRepository.save(
+                eksisterendeSammensattKontrollsak,
+            )
+        loggService.opprettSammensattKontrollsakOppdatertLogg(
+            behandlingId = lagretSammensattKontrollsak.behandlingId,
+        )
+        return lagretSammensattKontrollsak
+    }
+
+    @Transactional
+    fun slettSammensattKontrollsak(
+        slettSammensattKontrollsakDto: SlettSammensattKontrollsakDto,
+    ) {
+        val sammensattKontrollsak =
+            sammensattKontrollsakRepository.finnSammensattKontrollsak(
+                sammensattKontrollsakId = slettSammensattKontrollsakDto.id,
+            ) ?: throw Feil(
+                "Fant ingen eksisterende sammensatt kontrollsak for id=${slettSammensattKontrollsakDto.id}",
+            )
+        sammensattKontrollsakRepository.deleteById(
+            sammensattKontrollsak.id,
+        )
+        loggService.opprettSammensattKontrollsakSlettetLogg(
+            behandlingId = sammensattKontrollsak.behandlingId,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
@@ -1,0 +1,99 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.sikkerhet.TilgangService
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+@Component
+class SammensattKontrollsakValidator(
+    private val unleashService: UnleashNextMedContextService,
+    private val tilgangService: TilgangService,
+    private val sammensattKontrollsakService: SammensattKontrollsakService,
+    private val behandlingService: BehandlingService,
+) {
+    fun validerHentSammensattKontrollsakTilgang() {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+            throw FunksjonellFeil(
+                melding = "Mangler tilgang for å hente sammensatt kontrollsak.",
+                httpStatus = HttpStatus.FORBIDDEN,
+            )
+        }
+
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "Hent SammensattKontrollsak",
+        )
+    }
+
+    fun validerOpprettSammensattKontrollsakTilgang() {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+            throw FunksjonellFeil(
+                melding = "Mangler tilgang for å opprette sammensatt kontrollsak.",
+                httpStatus = HttpStatus.FORBIDDEN,
+            )
+        }
+
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "Opprett SammensattKontrollsak",
+        )
+    }
+
+    fun validerOppdaterSammensattKontrollsakTilgang() {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+            throw FunksjonellFeil(
+                melding = "Mangler tilgang for å oppdatere sammensatt kontrollsak.",
+                httpStatus = HttpStatus.FORBIDDEN,
+            )
+        }
+
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "Oppdater SammensattKontrollsak",
+        )
+    }
+
+    fun validerSlettSammensattKontrollsakTilgang() {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+            throw FunksjonellFeil(
+                melding = "Mangler tilgang for å slette sammensatt kontrollsak.",
+                httpStatus = HttpStatus.FORBIDDEN,
+            )
+        }
+
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+            handling = "Slett SammensattKontrollsak",
+        )
+    }
+
+    fun validerRedigerbarBehandlingForSammensattKontrollsakId(
+        sammensattKontrollsakId: Long,
+    ) {
+        val sammensattKontrollsak =
+            sammensattKontrollsakService.finnSammensattKontrollsak(
+                sammensattKontrollsakId = sammensattKontrollsakId,
+            ) ?: throw FunksjonellFeil(
+                melding = "Fant ingen sammensatt kontrollsak for id=$sammensattKontrollsakId.",
+                httpStatus = HttpStatus.BAD_REQUEST,
+            )
+        validerRedigerbarBehandlingForBehandlingId(sammensattKontrollsak.behandlingId)
+    }
+
+    fun validerRedigerbarBehandlingForBehandlingId(
+        behandlingId: Long,
+    ) {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        if (!behandling.erRedigerbar()) {
+            throw FunksjonellFeil(
+                melding = "Behandlingen er låst for videre redigering (${behandling.status})",
+                httpStatus = HttpStatus.BAD_REQUEST,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggService.kt
@@ -578,6 +578,60 @@ class LoggService(
         )
     }
 
+    fun opprettSammensattKontrollsakOpprettetLogg(
+        behandlingId: Long,
+    ) {
+        lagreLogg(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.SAMMENSATT_KONTROLLSAK_OPPRETTET,
+                rolle =
+                    SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
+                        rolleConfig,
+                        BehandlerRolle.SAKSBEHANDLER,
+                    ),
+                tittel = LoggType.SAMMENSATT_KONTROLLSAK_OPPRETTET.tittel,
+                tekst = "En sammensatt kontrollsak har blitt opprettet",
+            ),
+        )
+    }
+
+    fun opprettSammensattKontrollsakOppdatertLogg(
+        behandlingId: Long,
+    ) {
+        lagreLogg(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.SAMMENSATT_KONTROLLSAK_OPPDATERT,
+                rolle =
+                    SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
+                        rolleConfig,
+                        BehandlerRolle.SAKSBEHANDLER,
+                    ),
+                tittel = LoggType.SAMMENSATT_KONTROLLSAK_OPPDATERT.tittel,
+                tekst = "En sammensatt kontrollsak har blitt oppdatert",
+            ),
+        )
+    }
+
+    fun opprettSammensattKontrollsakSlettetLogg(
+        behandlingId: Long,
+    ) {
+        lagreLogg(
+            Logg(
+                behandlingId = behandlingId,
+                type = LoggType.SAMMENSATT_KONTROLLSAK_SLETTET,
+                rolle =
+                    SikkerhetContext.hentRolletilgangFraSikkerhetscontext(
+                        rolleConfig,
+                        BehandlerRolle.SAKSBEHANDLER,
+                    ),
+                tittel = LoggType.SAMMENSATT_KONTROLLSAK_SLETTET.tittel,
+                tekst = "En sammensatt kontrollsak har blitt slettet",
+            ),
+        )
+    }
+
     companion object {
         private val logger = LoggerFactory.getLogger(LoggService::class.java)
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggType.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggType.kt
@@ -37,4 +37,7 @@ enum class LoggType(
     REFUSJON_EØS_LAGT_TIL("Refusjon EØS lagt til"),
     REFUSJON_EØS_FJERNET("Refusjon EØS fjernet"),
     BREVMOTTAKER_LAGT_TIL_ELLER_FJERNET("Brevmottaker lagt til eller fjernet"),
+    SAMMENSATT_KONTROLLSAK_OPPRETTET("Sammensatt kontrollsak opprettet"),
+    SAMMENSATT_KONTROLLSAK_OPPDATERT("Sammensatt kontrollsak oppdatert"),
+    SAMMENSATT_KONTROLLSAK_SLETTET("Sammensatt kontrollsak slettet"),
 }

--- a/src/main/resources/db/migration/V25__oppretter_sammensatt_kontrollsak_tabeller.sql
+++ b/src/main/resources/db/migration/V25__oppretter_sammensatt_kontrollsak_tabeller.sql
@@ -1,0 +1,14 @@
+CREATE TABLE sammensatt_kontrollsak
+(
+    id               BIGINT PRIMARY KEY,
+    fk_behandling_id BIGINT REFERENCES BEHANDLING (ID)   NOT NULL,
+    fritekst         VARCHAR,
+    versjon          BIGINT       DEFAULT 0              NOT NULL,
+    opprettet_av     VARCHAR      DEFAULT 'VL'           NOT NULL,
+    opprettet_tid    TIMESTAMP(3) DEFAULT localtimestamp NOT NULL,
+    endret_av        VARCHAR,
+    endret_tid       TIMESTAMP(3)
+);
+
+CREATE SEQUENCE sammensatt_kontrollsak_seq INCREMENT BY 50 START WITH 1000000 NO CYCLE;
+CREATE UNIQUE INDEX sammensatt_kontrollsak_seq_fk_behandling_id_idx ON sammensatt_kontrollsak (fk_behandling_id);

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/SammensattKontrollsakDtosTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/SammensattKontrollsakDtosTest.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ks.sak.api.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SammensattKontrollsakDtosTest {
+    @Test
+    fun `skal mappe fra opprett dto til entity`() {
+        // Arrange
+        val opprettSammensattKontrollsakDto =
+            OpprettSammensattKontrollsakDto(
+                behandlingId = 1L,
+                fritekst = "blabla",
+            )
+
+        // Act
+        val sammensattKontrollsak = opprettSammensattKontrollsakDto.tilSammensattKontrollsak()
+
+        // Assert
+        assertThat(sammensattKontrollsak.id).isEqualTo(0L)
+        assertThat(sammensattKontrollsak.behandlingId).isEqualTo(opprettSammensattKontrollsakDto.behandlingId)
+        assertThat(sammensattKontrollsak.fritekst).isEqualTo(opprettSammensattKontrollsakDto.fritekst)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakServiceTest.kt
@@ -1,0 +1,350 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.ks.sak.api.dto.OppdaterSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.OpprettSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.SlettSammensattKontrollsakDto
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.kjerne.logg.LoggService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SammensattKontrollsakServiceTest {
+    private val mockedSammensattKontrollsakRepository: SammensattKontrollsakRepository = mockk()
+    private val mockedLoggService: LoggService = mockk()
+
+    private val sammensattKontrollsakService: SammensattKontrollsakService =
+        SammensattKontrollsakService(
+            sammensattKontrollsakRepository = mockedSammensattKontrollsakRepository,
+            loggService = mockedLoggService,
+        )
+
+    @Nested
+    inner class FinnSammensattKontrollsakTest {
+        @Test
+        fun `skal finne sammensatt kontrollsak når det finnes innslag i databasen`() {
+            // Arrange
+            val lagretSammensattKontrollsak =
+                SammensattKontrollsak(
+                    id = 0L,
+                    behandlingId = 123L,
+                    fritekst = "blabla",
+                )
+
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = lagretSammensattKontrollsak.id,
+                )
+            } returns lagretSammensattKontrollsak
+
+            // Act
+            val funnetSammensattKontrollsak =
+                sammensattKontrollsakService.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = lagretSammensattKontrollsak.id,
+                )
+
+            // Assert
+            assertThat(funnetSammensattKontrollsak).isNotNull()
+            assertThat(funnetSammensattKontrollsak?.id).isEqualTo(lagretSammensattKontrollsak.id)
+            assertThat(funnetSammensattKontrollsak?.behandlingId).isEqualTo(lagretSammensattKontrollsak.behandlingId)
+            assertThat(funnetSammensattKontrollsak?.fritekst).isEqualTo(lagretSammensattKontrollsak.fritekst)
+        }
+
+        @Test
+        fun `skal ikke finne sammensatt kontrollsak når det ikke finnes et innslag i databasen`() {
+            // Arrange
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = 0L,
+                )
+            } returns null
+
+            // Act
+            val funnetSammensattKontrollsak =
+                sammensattKontrollsakService.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = 0L,
+                )
+
+            // Assert
+            assertThat(funnetSammensattKontrollsak).isNull()
+        }
+    }
+
+    @Nested
+    inner class FinnSammensattKontrollsakForBehandlingTest {
+        @Test
+        fun `skal finne sammensatt kontrollsak når det finnes et innslag i databasen`() {
+            // Arrange
+            val lagretSammensattKontrollsak =
+                SammensattKontrollsak(
+                    id = 0L,
+                    behandlingId = 123L,
+                    fritekst = "blabla",
+                )
+
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsakForBehandling(
+                    behandlingId = 0L,
+                )
+            } returns lagretSammensattKontrollsak
+
+            // Act
+            val funnetSammensattKontrollsak =
+                sammensattKontrollsakService.finnSammensattKontrollsakForBehandling(
+                    behandlingId = 0L,
+                )
+
+            // Assert
+            assertThat(funnetSammensattKontrollsak).isNotNull()
+            assertThat(funnetSammensattKontrollsak?.id).isEqualTo(lagretSammensattKontrollsak.id)
+            assertThat(funnetSammensattKontrollsak?.behandlingId).isEqualTo(lagretSammensattKontrollsak.behandlingId)
+            assertThat(funnetSammensattKontrollsak?.fritekst).isEqualTo(lagretSammensattKontrollsak.fritekst)
+        }
+
+        @Test
+        fun `skal ikke finne sammensatt kontrollsak når det ikke finnes et innslag i databasen`() {
+            // Arrange
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsakForBehandling(
+                    behandlingId = 0L,
+                )
+            } returns null
+
+            // Act
+            val funnetSammensattKontrollsak =
+                sammensattKontrollsakService.finnSammensattKontrollsakForBehandling(
+                    behandlingId = 0L,
+                )
+
+            // Assert
+            assertThat(funnetSammensattKontrollsak).isNull()
+        }
+    }
+
+    @Nested
+    inner class OpprettSammensattKontrollsakTest {
+        @Test
+        fun `skal opprette sammensatt kontrollsak`() {
+            // Arrange
+            val opprettSammensattKontrollsakDto =
+                OpprettSammensattKontrollsakDto(
+                    behandlingId = 123L,
+                    fritekst = "blabla",
+                )
+
+            val mockedSammensattKontrollsak =
+                SammensattKontrollsak(
+                    id = 1L,
+                    behandlingId = 123L,
+                    fritekst = "blabla",
+                )
+
+            every {
+                mockedSammensattKontrollsakRepository.save(
+                    any(),
+                )
+            } returns mockedSammensattKontrollsak
+
+            every {
+                mockedLoggService.opprettSammensattKontrollsakOpprettetLogg(
+                    behandlingId = any(),
+                )
+            } just runs
+
+            // Act
+            val opprettetSammensattKontrollsak =
+                sammensattKontrollsakService.opprettSammensattKontrollsak(
+                    opprettSammensattKontrollsakDto = opprettSammensattKontrollsakDto,
+                )
+
+            // Assert
+            assertThat(opprettetSammensattKontrollsak.id).isEqualTo(mockedSammensattKontrollsak.id)
+            assertThat(opprettetSammensattKontrollsak.behandlingId).isEqualTo(mockedSammensattKontrollsak.behandlingId)
+            assertThat(opprettetSammensattKontrollsak.fritekst).isEqualTo(mockedSammensattKontrollsak.fritekst)
+            verify(exactly = 1) {
+                mockedSammensattKontrollsakRepository.save(
+                    any(SammensattKontrollsak::class),
+                )
+            }
+            verify(exactly = 1) {
+                mockedLoggService.opprettSammensattKontrollsakOpprettetLogg(
+                    behandlingId = opprettetSammensattKontrollsak.behandlingId,
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class OppdaterSammensattKontrollsakTest {
+        @Test
+        fun `skal kaste exception om man prøver å oppdatere en ikke eksisterende sammensatt kontrollsak`() {
+            // Arrange
+            val oppdaterSammensattKontrollsakDto =
+                OppdaterSammensattKontrollsakDto(
+                    id = 0L,
+                    fritekst = "blabla",
+                )
+
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = any(),
+                )
+            } returns null
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    sammensattKontrollsakService.oppdaterSammensattKontrollsak(
+                        oppdaterSammensattKontrollsakDto = oppdaterSammensattKontrollsakDto,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Fant ingen eksisterende sammensatt kontrollsak for id=0")
+        }
+
+        @Test
+        fun `skal oppdatere eksisterende sammensatt kontrollsak`() {
+            // Arrange
+            val sammensattKontrollsakSlot = slot<SammensattKontrollsak>()
+
+            val oppdaterSammensattKontrollsakDto =
+                OppdaterSammensattKontrollsakDto(
+                    id = 0L,
+                    fritekst = "blabla",
+                )
+
+            val sammensattKontrollsak =
+                SammensattKontrollsak(
+                    id = 0L,
+                    behandlingId = 123L,
+                    fritekst = "bla",
+                )
+
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsak(any())
+            } returns sammensattKontrollsak
+
+            every {
+                mockedSammensattKontrollsakRepository.save(
+                    capture(
+                        sammensattKontrollsakSlot,
+                    ),
+                )
+            } returns sammensattKontrollsak
+
+            every {
+                mockedLoggService.opprettSammensattKontrollsakOppdatertLogg(
+                    any(),
+                )
+            } just runs
+
+            // Act
+            val oppdatertSammensattKontrollsak =
+                sammensattKontrollsakService.oppdaterSammensattKontrollsak(
+                    oppdaterSammensattKontrollsakDto = oppdaterSammensattKontrollsakDto,
+                )
+
+            // Assert
+            assertThat(oppdatertSammensattKontrollsak.id).isEqualTo(sammensattKontrollsak.id)
+            assertThat(oppdatertSammensattKontrollsak.behandlingId).isEqualTo(sammensattKontrollsak.behandlingId)
+            assertThat(oppdatertSammensattKontrollsak.fritekst).isEqualTo("blabla")
+            assertThat(sammensattKontrollsakSlot.captured.id).isEqualTo(sammensattKontrollsak.id)
+            assertThat(sammensattKontrollsakSlot.captured.behandlingId).isEqualTo(sammensattKontrollsak.behandlingId)
+            assertThat(sammensattKontrollsakSlot.captured.fritekst).isEqualTo("blabla")
+            verify(exactly = 1) {
+                mockedSammensattKontrollsakRepository.save(
+                    oppdatertSammensattKontrollsak,
+                )
+            }
+            verify(exactly = 1) {
+                mockedLoggService.opprettSammensattKontrollsakOppdatertLogg(
+                    behandlingId = oppdatertSammensattKontrollsak.behandlingId,
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class SlettSammensattKontrollsakTest {
+        @Test
+        fun `skal kaste exception om man prøver å slette en sammensatt kontrollsak som ikke finnes`() {
+            // Arrange
+            val slettSammensattKontrollsakDto =
+                SlettSammensattKontrollsakDto(
+                    id = 0L,
+                )
+
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = slettSammensattKontrollsakDto.id,
+                )
+            } returns null
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    sammensattKontrollsakService.slettSammensattKontrollsak(
+                        slettSammensattKontrollsakDto = slettSammensattKontrollsakDto,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Fant ingen eksisterende sammensatt kontrollsak for id=${slettSammensattKontrollsakDto.id}")
+        }
+
+        @Test
+        fun `skal slette sammensatt kontrollsak`() {
+            // Arrange
+            val slettSammensattKontrollsakDto =
+                SlettSammensattKontrollsakDto(
+                    id = 0L,
+                )
+
+            val sammensattKontrollsak =
+                SammensattKontrollsak(
+                    id = 0L,
+                    behandlingId = 123L,
+                    fritekst = "blabla",
+                )
+
+            every {
+                mockedSammensattKontrollsakRepository.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = slettSammensattKontrollsakDto.id,
+                )
+            } returns sammensattKontrollsak
+
+            every {
+                mockedSammensattKontrollsakRepository.deleteById(
+                    any(),
+                )
+            } just runs
+
+            every {
+                mockedLoggService.opprettSammensattKontrollsakSlettetLogg(
+                    any(),
+                )
+            } just runs
+
+            // Act
+            sammensattKontrollsakService.slettSammensattKontrollsak(
+                slettSammensattKontrollsakDto = slettSammensattKontrollsakDto,
+            )
+
+            // Assert
+            verify(exactly = 1) {
+                mockedSammensattKontrollsakRepository.deleteById(
+                    sammensattKontrollsak.id,
+                )
+            }
+            verify(exactly = 1) {
+                mockedLoggService.opprettSammensattKontrollsakSlettetLogg(
+                    behandlingId = sammensattKontrollsak.behandlingId,
+                )
+            }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakTest.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SammensattKontrollsakTest {
+    @Test
+    fun `skal mappe entity til dto`() {
+        // Arrange
+        val sammensattKontrollsak =
+            SammensattKontrollsak(
+                id = 0L,
+                behandlingId = 1L,
+                fritekst = "blabla",
+            )
+
+        // Act
+        val sammensattKontrollsakDto = sammensattKontrollsak.tilSammensattKontrollDto()
+
+        // Assert
+        assertThat(sammensattKontrollsakDto.id).isEqualTo(sammensattKontrollsak.id)
+        assertThat(sammensattKontrollsakDto.behandlingId).isEqualTo(sammensattKontrollsak.behandlingId)
+        assertThat(sammensattKontrollsakDto.fritekst).isEqualTo(sammensattKontrollsak.fritekst)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
@@ -1,0 +1,451 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.common.exception.RolleTilgangskontrollFeil
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.sikkerhet.TilgangService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.http.HttpStatus
+
+class SammensattKontrollsakValidatorTest {
+    private val unleashService: UnleashNextMedContextService = mockk()
+    private val tilgangService: TilgangService = mockk()
+    private val sammensattKontrollsakService: SammensattKontrollsakService = mockk()
+    private val behandlingService: BehandlingService = mockk()
+
+    private val sammensattKontrollsakValidator: SammensattKontrollsakValidator =
+        SammensattKontrollsakValidator(
+            unleashService = unleashService,
+            tilgangService = tilgangService,
+            sammensattKontrollsakService = sammensattKontrollsakService,
+            behandlingService = behandlingService,
+        )
+
+    @Nested
+    inner class ValiderHentSammensattKontrollsakTilgangTest {
+        @Test
+        fun `skal kaste exception om toggel ikke er skrudd på`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns false
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    sammensattKontrollsakValidator.validerHentSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang for å hente sammensatt kontrollsak.")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal kaste exception om man mangler egnet rolle`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } throws RolleTilgangskontrollFeil("Mangler tilgang", httpStatus = HttpStatus.FORBIDDEN)
+
+            // Act & assert
+            val exception =
+                assertThrows<RolleTilgangskontrollFeil> {
+                    sammensattKontrollsakValidator.validerHentSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal ikke kaste feil om valideringen er godkjent`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } just runs
+
+            // Act & assert
+            assertDoesNotThrow {
+                sammensattKontrollsakValidator.validerHentSammensattKontrollsakTilgang()
+            }
+        }
+    }
+
+    @Nested
+    inner class ValiderOpprettSammensattKontrollsakTilgangTest {
+        @Test
+        fun `skal kaste exception om toggel ikke er skrudd på`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns false
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    sammensattKontrollsakValidator.validerOpprettSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang for å opprette sammensatt kontrollsak.")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal kaste exception om man mangler egnet rolle`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } throws RolleTilgangskontrollFeil("Mangler tilgang", httpStatus = HttpStatus.FORBIDDEN)
+
+            // Act & assert
+            val exception =
+                assertThrows<RolleTilgangskontrollFeil> {
+                    sammensattKontrollsakValidator.validerOpprettSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal ikke kaste feil om valideringen er godkjent`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } just runs
+
+            // Act & assert
+            assertDoesNotThrow {
+                sammensattKontrollsakValidator.validerOpprettSammensattKontrollsakTilgang()
+            }
+        }
+    }
+
+    @Nested
+    inner class ValiderOppdaterSammensattKontrollsakTilgangTest {
+        @Test
+        fun `skal kaste exception om toggel ikke er skrudd på`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns false
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    sammensattKontrollsakValidator.validerOppdaterSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang for å oppdatere sammensatt kontrollsak.")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal kaste exception om man mangler egnet rolle`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } throws RolleTilgangskontrollFeil("Mangler tilgang", httpStatus = HttpStatus.FORBIDDEN)
+
+            // Act & assert
+            val exception =
+                assertThrows<RolleTilgangskontrollFeil> {
+                    sammensattKontrollsakValidator.validerOppdaterSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal ikke kaste feil om valideringen er godkjent`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } just runs
+
+            // Act & assert
+            assertDoesNotThrow {
+                sammensattKontrollsakValidator.validerOppdaterSammensattKontrollsakTilgang()
+            }
+        }
+    }
+
+    @Nested
+    inner class ValiderSlettSammensattKontrollsakTilgangTest {
+        @Test
+        fun `skal kaste exception om toggel ikke er skrudd på`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns false
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    sammensattKontrollsakValidator.validerSlettSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang for å slette sammensatt kontrollsak.")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal kaste exception om man mangler egnet rolle`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } throws RolleTilgangskontrollFeil("Mangler tilgang", httpStatus = HttpStatus.FORBIDDEN)
+
+            // Act & assert
+            val exception =
+                assertThrows<RolleTilgangskontrollFeil> {
+                    sammensattKontrollsakValidator.validerSlettSammensattKontrollsakTilgang()
+                }
+            assertThat(exception.melding).isEqualTo("Mangler tilgang")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        }
+
+        @Test
+        fun `skal ikke kaste feil om valideringen er godkjent`() {
+            // Arrange
+            every {
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+            } returns true
+
+            every {
+                tilgangService.validerTilgangTilHandling(
+                    minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+                    any(),
+                )
+            } just runs
+
+            // Act & assert
+            assertDoesNotThrow {
+                sammensattKontrollsakValidator.validerSlettSammensattKontrollsakTilgang()
+            }
+        }
+    }
+
+    @Nested
+    inner class ValiderRedigerbarBehandlingForSammensattKontrollsakIdTest {
+        @Test
+        fun `skal kaste exception om ingen sammensatt kontrollsak blir funnet for id`() {
+            // Arrange
+            val sammensattKontrollsakId = 0L
+
+            every {
+                sammensattKontrollsakService.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = sammensattKontrollsakId,
+                )
+            } returns null
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                        sammensattKontrollsakId = sammensattKontrollsakId,
+                    )
+                }
+            assertThat(exception.melding).isEqualTo("Fant ingen sammensatt kontrollsak for id=$sammensattKontrollsakId.")
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["OPPRETTET", "UTREDES", "SATT_PÅ_MASKINELL_VENT"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal kaste exception om behandlingen ikke er redigerbar`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    status = behandlingStatus,
+                )
+
+            val sammensattKontrollsak =
+                SammensattKontrollsak(
+                    id = 0L,
+                    behandlingId = behandling.id,
+                    fritekst = "blabla",
+                )
+
+            every {
+                sammensattKontrollsakService.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = sammensattKontrollsak.id,
+                )
+            } returns sammensattKontrollsak
+
+            every {
+                behandlingService.hentBehandling(
+                    behandlingId = sammensattKontrollsak.behandlingId,
+                )
+            } returns behandling
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                        sammensattKontrollsakId = sammensattKontrollsak.id,
+                    )
+                }
+            assertThat(exception.melding).isEqualTo("Behandlingen er låst for videre redigering ($behandlingStatus)")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["FATTER_VEDTAK", "IVERKSETTER_VEDTAK", "AVSLUTTET"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal ikke kaste exception om behandlingen er redigerbar`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    status = behandlingStatus,
+                )
+
+            val sammensattKontrollsak =
+                SammensattKontrollsak(
+                    id = 0L,
+                    behandlingId = behandling.id,
+                    fritekst = "",
+                )
+
+            every {
+                sammensattKontrollsakService.finnSammensattKontrollsak(
+                    sammensattKontrollsakId = sammensattKontrollsak.id,
+                )
+            } returns sammensattKontrollsak
+
+            every {
+                behandlingService.hentBehandling(behandlingId = sammensattKontrollsak.behandlingId)
+            } returns behandling
+
+            // Act & assert
+            assertDoesNotThrow {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                    sammensattKontrollsakId = sammensattKontrollsak.id,
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class ValiderRedigerbarBehandlingForBehandlingIdTest {
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["OPPRETTET", "UTREDES", "SATT_PÅ_MASKINELL_VENT"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal kaste exception om behandlingen ikke er redigerbar`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    status = behandlingStatus,
+                )
+
+            every {
+                behandlingService.hentBehandling(123L)
+            } returns behandling
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    sammensattKontrollsakValidator.validerRedigerbarBehandlingForBehandlingId(123L)
+                }
+            assertThat(exception.melding).isEqualTo("Behandlingen er låst for videre redigering ($behandlingStatus)")
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["FATTER_VEDTAK", "IVERKSETTER_VEDTAK", "AVSLUTTET"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal ikke kaste exception om behandlingen er redigerbar`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    status = behandlingStatus,
+                )
+
+            every {
+                behandlingService.hentBehandling(123L)
+            } returns behandling
+
+            // Act & assert
+            assertDoesNotThrow {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForBehandlingId(123L)
+            }
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/LoggServiceTest.kt
@@ -498,4 +498,67 @@ class LoggServiceTest {
             assertThat(capturedLogg.rolle, Is(BehandlerRolle.SYSTEM))
         }
     }
+
+    @Test
+    fun `skal opprette logg for opprettet sammensatt kontrollsak`() {
+        // Arrange
+        val slot = slot<Logg>()
+
+        every { loggRepository.save(capture(slot)) } returns mockk()
+
+        // Act
+        loggService.opprettSammensattKontrollsakOpprettetLogg(
+            behandlingId = 123L,
+        )
+
+        // Assert
+        val capturedLogg = slot.captured
+        assertThat(capturedLogg.behandlingId, Is(123L))
+        assertThat(capturedLogg.type, Is(LoggType.SAMMENSATT_KONTROLLSAK_OPPRETTET))
+        assertThat(capturedLogg.rolle, Is(BehandlerRolle.SYSTEM))
+        assertThat(capturedLogg.tittel, Is(LoggType.SAMMENSATT_KONTROLLSAK_OPPRETTET.tittel))
+        assertThat(capturedLogg.tekst, Is("En sammensatt kontrollsak har blitt opprettet"))
+    }
+
+    @Test
+    fun `skal opprette logg for oppdatert sammensatt kontrollsak`() {
+        // Arrange
+        val slot = slot<Logg>()
+
+        every { loggRepository.save(capture(slot)) } returns mockk()
+
+        // Act
+        loggService.opprettSammensattKontrollsakOppdatertLogg(
+            behandlingId = 123L,
+        )
+
+        // Assert
+        val capturedLogg = slot.captured
+        assertThat(capturedLogg.behandlingId, Is(123L))
+        assertThat(capturedLogg.type, Is(LoggType.SAMMENSATT_KONTROLLSAK_OPPDATERT))
+        assertThat(capturedLogg.rolle, Is(BehandlerRolle.SYSTEM))
+        assertThat(capturedLogg.tittel, Is(LoggType.SAMMENSATT_KONTROLLSAK_OPPDATERT.tittel))
+        assertThat(capturedLogg.tekst, Is("En sammensatt kontrollsak har blitt oppdatert"))
+    }
+
+    @Test
+    fun `skal opprette logg for slettet sammensatt kontrollsak`() {
+        // Arrange
+        val slot = slot<Logg>()
+
+        every { loggRepository.save(capture(slot)) } returns mockk()
+
+        // Act
+        loggService.opprettSammensattKontrollsakSlettetLogg(
+            behandlingId = 123L,
+        )
+
+        // Assert
+        val capturedLogg = slot.captured
+        assertThat(capturedLogg.behandlingId, Is(123L))
+        assertThat(capturedLogg.type, Is(LoggType.SAMMENSATT_KONTROLLSAK_SLETTET))
+        assertThat(capturedLogg.rolle, Is(BehandlerRolle.SYSTEM))
+        assertThat(capturedLogg.tittel, Is(LoggType.SAMMENSATT_KONTROLLSAK_SLETTET.tittel))
+        assertThat(capturedLogg.tekst, Is("En sammensatt kontrollsak har blitt slettet"))
+    }
 }

--- a/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
+++ b/src/test/integrasjonstester/kotlin/OppslagSpringRunnerTest.kt
@@ -147,14 +147,14 @@ abstract class OppslagSpringRunnerTest {
     fun opprettSøkerFagsakOgBehandling(
         søker: Aktør = randomAktør(),
         barn: Aktør = randomAktør(),
-        fagsakStatus: FagsakStatus,
+        fagsakStatus: FagsakStatus = FagsakStatus.OPPRETTET,
         behandlingStatus: BehandlingStatus = BehandlingStatus.UTREDES,
         behandlingResultat: Behandlingsresultat = Behandlingsresultat.IKKE_VURDERT,
     ) {
         this.søker = lagreAktør(søker)
         this.barn = lagreAktør(barn)
-        fagsak = lagreFagsak(lagFagsak(aktør = søker, status = fagsakStatus))
-        behandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD, status = behandlingStatus, resultat = behandlingResultat))
+        this.fagsak = lagreFagsak(lagFagsak(aktør = søker, status = fagsakStatus))
+        this.behandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD, status = behandlingStatus, resultat = behandlingResultat))
     }
 
     fun opprettPersonopplysningGrunnlagOgPersonForBehandling(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakControllerTest.kt
@@ -1,0 +1,649 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.api.dto.OppdaterSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.OpprettSammensattKontrollsakDto
+import no.nav.familie.ks.sak.api.dto.SlettSammensattKontrollsakDto
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.hamcrest.CoreMatchers.`is` as Is
+
+class SammensattKontrollsakControllerTest : OppslagSpringRunnerTest() {
+    private val controllerUrl: String = "/api/sammensatt-kontrollsak"
+
+    @Autowired
+    private lateinit var sammensattKontrollsakRepository: SammensattKontrollsakRepository
+
+    @MockkBean
+    private lateinit var sammensattKontrollsakValidator: SammensattKontrollsakValidator
+
+    @BeforeEach
+    fun setUp() {
+        RestAssured.port = port
+    }
+
+    @Nested
+    inner class HentSammensattKontrollsakTest {
+        @Test
+        fun `skal returnere UNAUTHORIZED om token ikke er satt`() {
+            // Act & assert
+            When {
+                get("$controllerUrl/123")
+            } Then {
+                statusCode(HttpStatus.UNAUTHORIZED.value())
+            }
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når valideringen feiler`() {
+            // Arrange
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerHentSammensattKontrollsakTilgang()
+            } throws
+                FunksjonellFeil(
+                    melding = "En feil oppstod",
+                    httpStatus = HttpStatus.FORBIDDEN,
+                )
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+            } When {
+                get("$controllerUrl/123")
+            } Then {
+                statusCode(HttpStatus.FORBIDDEN.value())
+                body("data", nullValue())
+                body("status", Is("FUNKSJONELL_FEIL"))
+                body("melding", Is("En feil oppstod"))
+                body("frontendFeilmelding", Is("En feil oppstod"))
+            }
+        }
+
+        @Test
+        fun `skal hente sammensatt kontrollsak for behandlingId`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val sammensattKontrollsak =
+                SammensattKontrollsak(
+                    behandlingId = behandling.id,
+                    fritekst = "blabla",
+                )
+
+            sammensattKontrollsakRepository.save(sammensattKontrollsak)
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerHentSammensattKontrollsakTilgang()
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+            } When {
+                get("$controllerUrl/${behandling.id}")
+            } Then {
+                statusCode(HttpStatus.OK.value())
+                body("data.id", notNullValue())
+                body("data.behandlingId", Is(behandling.id.toInt()))
+                body("data.fritekst", Is("blabla"))
+                body("status", Is("SUKSESS"))
+                body("melding", Is("Innhenting av data var vellykket"))
+                body("frontendFeilmelding", nullValue())
+            }
+        }
+
+        @Test
+        fun `skal håndtere tilfeller hvor ingen sammensatt kontrollsak er funnet for behandlingId`() {
+            // Arrange
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerHentSammensattKontrollsakTilgang()
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+            } When {
+                get("$controllerUrl/123")
+            } Then {
+                statusCode(HttpStatus.OK.value())
+                body("data", nullValue())
+                body("status", Is("SUKSESS"))
+                body("melding", Is("Innhenting av data var vellykket"))
+                body("frontendFeilmelding", nullValue())
+            }
+        }
+    }
+
+    @Nested
+    inner class OpprettSammensattKontrollsakTest {
+        @Test
+        fun `skal returnere UNAUTHORIZED om token ikke er satt`() {
+            // Arrange
+            val body =
+                objectMapper.writeValueAsString(
+                    OpprettSammensattKontrollsakDto(
+                        behandlingId = 123L,
+                        fritekst = "blabla",
+                    ),
+                )
+
+            // Act & assert
+            Given {
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                post(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.UNAUTHORIZED.value())
+            }
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når validering av tilgang feiler`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val body =
+                objectMapper.writeValueAsString(
+                    OpprettSammensattKontrollsakDto(
+                        behandlingId = behandling.id,
+                        fritekst = "blabla",
+                    ),
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerOpprettSammensattKontrollsakTilgang()
+            } throws
+                FunksjonellFeil(
+                    melding = "En feil oppstod",
+                    httpStatus = HttpStatus.FORBIDDEN,
+                )
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForBehandlingId(
+                    behandlingId = behandling.id,
+                )
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                post(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.FORBIDDEN.value())
+                body("data", nullValue())
+                body("status", Is("FUNKSJONELL_FEIL"))
+                body("melding", Is("En feil oppstod"))
+                body("frontendFeilmelding", Is("En feil oppstod"))
+            }
+        }
+
+        @Test
+        fun `skal returnere 400 bad request når validering av redigerbar behandling feiler`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val body =
+                objectMapper.writeValueAsString(
+                    OpprettSammensattKontrollsakDto(
+                        behandlingId = behandling.id,
+                        fritekst = "blabla",
+                    ),
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerOpprettSammensattKontrollsakTilgang()
+            } just runs
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForBehandlingId(
+                    behandlingId = behandling.id,
+                )
+            } throws
+                FunksjonellFeil(
+                    melding = "En feil oppstod",
+                    httpStatus = HttpStatus.BAD_REQUEST,
+                )
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                post(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.BAD_REQUEST.value())
+                body("data", nullValue())
+                body("status", Is("FUNKSJONELL_FEIL"))
+                body("melding", Is("En feil oppstod"))
+                body("frontendFeilmelding", Is("En feil oppstod"))
+            }
+        }
+
+        @Test
+        fun `skal opprette sammensatt kontrollsak`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val body =
+                objectMapper.writeValueAsString(
+                    OpprettSammensattKontrollsakDto(
+                        behandlingId = behandling.id,
+                        fritekst = "blabla",
+                    ),
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerOpprettSammensattKontrollsakTilgang()
+            } just runs
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForBehandlingId(
+                    behandlingId = behandling.id,
+                )
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                post(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.OK.value())
+                body("data.id", notNullValue())
+                body("data.behandlingId", Is(behandling.id.toInt()))
+                body("data.fritekst", Is("blabla"))
+                body("status", Is("SUKSESS"))
+                body("melding", Is("Innhenting av data var vellykket"))
+                body("frontendFeilmelding", nullValue())
+            }
+        }
+    }
+
+    @Nested
+    inner class OppdaterSammensattKontrollsakTest {
+        @Test
+        fun `skal returnere UNAUTHORIZED om token ikke er satt`() {
+            // Arrange
+            val body =
+                objectMapper.writeValueAsString(
+                    OppdaterSammensattKontrollsakDto(
+                        id = 0L,
+                        fritekst = "blabla",
+                    ),
+                )
+
+            // Act & assert
+            Given {
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                put(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.UNAUTHORIZED.value())
+            }
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når validering av tilgang feiler`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val oppdaterSammensattKontrollsakDto =
+                OppdaterSammensattKontrollsakDto(
+                    id = 0L,
+                    fritekst = "blabla",
+                )
+
+            val body =
+                objectMapper.writeValueAsString(
+                    oppdaterSammensattKontrollsakDto,
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerOppdaterSammensattKontrollsakTilgang()
+            } throws
+                FunksjonellFeil(
+                    melding = "En feil oppstod",
+                    httpStatus = HttpStatus.FORBIDDEN,
+                )
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                    sammensattKontrollsakId = oppdaterSammensattKontrollsakDto.id,
+                )
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                put(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.FORBIDDEN.value())
+                body("data", nullValue())
+                body("status", Is("FUNKSJONELL_FEIL"))
+                body("melding", Is("En feil oppstod"))
+                body("frontendFeilmelding", Is("En feil oppstod"))
+            }
+        }
+
+        @Test
+        fun `skal returnere 400 bad request når validering av redigerbar behandling feiler`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val oppdaterSammensattKontrollsakDto =
+                OppdaterSammensattKontrollsakDto(
+                    id = 0L,
+                    fritekst = "blabla",
+                )
+
+            val body =
+                objectMapper.writeValueAsString(
+                    oppdaterSammensattKontrollsakDto,
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerOppdaterSammensattKontrollsakTilgang()
+            } just runs
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                    sammensattKontrollsakId = oppdaterSammensattKontrollsakDto.id,
+                )
+            } throws
+                FunksjonellFeil(
+                    melding = "En feil oppstod",
+                    httpStatus = HttpStatus.BAD_REQUEST,
+                )
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                put(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.BAD_REQUEST.value())
+                body("data", nullValue())
+                body("status", Is("FUNKSJONELL_FEIL"))
+                body("melding", Is("En feil oppstod"))
+                body("frontendFeilmelding", Is("En feil oppstod"))
+            }
+        }
+
+        @Test
+        fun `skal oppdatere sammensatt kontrollsak`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            sammensattKontrollsakRepository.save(
+                SammensattKontrollsak(
+                    behandlingId = behandling.id,
+                    fritekst = "blabla",
+                ),
+            )
+
+            val sammensattKontrollsak =
+                sammensattKontrollsakRepository.finnSammensattKontrollsakForBehandling(
+                    behandlingId = behandling.id,
+                ) ?: throw Feil("Fant ingen sammensatt kontrollsak")
+
+            val oppdaterSammensattKontrollsakDto =
+                OppdaterSammensattKontrollsakDto(
+                    id = sammensattKontrollsak.id,
+                    fritekst = "blabla",
+                )
+
+            val body =
+                objectMapper.writeValueAsString(
+                    oppdaterSammensattKontrollsakDto,
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerOppdaterSammensattKontrollsakTilgang()
+            } just runs
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                    sammensattKontrollsakId = oppdaterSammensattKontrollsakDto.id,
+                )
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                put(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.OK.value())
+                body("data.id", Is(sammensattKontrollsak.id.toInt()))
+                body("data.behandlingId", Is(behandling.id.toInt()))
+                body("data.fritekst", Is("blabla"))
+                body("status", Is("SUKSESS"))
+                body("melding", Is("Innhenting av data var vellykket"))
+                body("frontendFeilmelding", nullValue())
+            }
+        }
+    }
+
+    @Nested
+    inner class SlettSammensattKontrollsakTest {
+        @Test
+        fun `skal returnere UNAUTHORIZED om token ikke er satt`() {
+            // Arrange
+            val body =
+                objectMapper.writeValueAsString(
+                    SlettSammensattKontrollsakDto(
+                        id = 0L,
+                    ),
+                )
+
+            // Act & assert
+            Given {
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                delete(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.UNAUTHORIZED.value())
+            }
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når validering av tilgang feiler`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val slettSammensattKontrollsakDto =
+                SlettSammensattKontrollsakDto(
+                    id = 0L,
+                )
+
+            val body =
+                objectMapper.writeValueAsString(
+                    slettSammensattKontrollsakDto,
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerSlettSammensattKontrollsakTilgang()
+            } throws
+                FunksjonellFeil(
+                    melding = "En feil oppstod",
+                    httpStatus = HttpStatus.FORBIDDEN,
+                )
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                    sammensattKontrollsakId = slettSammensattKontrollsakDto.id,
+                )
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                delete(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.FORBIDDEN.value())
+                body("data", nullValue())
+                body("status", Is("FUNKSJONELL_FEIL"))
+                body("melding", Is("En feil oppstod"))
+                body("frontendFeilmelding", Is("En feil oppstod"))
+            }
+        }
+
+        @Test
+        fun `skal returnere 400 bad request når validering av redigerbar behandling feiler`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            val slettSammensattKontrollsakDto =
+                SlettSammensattKontrollsakDto(
+                    id = 0L,
+                )
+
+            val body =
+                objectMapper.writeValueAsString(
+                    slettSammensattKontrollsakDto,
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerSlettSammensattKontrollsakTilgang()
+            } just runs
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                    sammensattKontrollsakId = slettSammensattKontrollsakDto.id,
+                )
+            } throws
+                FunksjonellFeil(
+                    melding = "En feil oppstod",
+                    httpStatus = HttpStatus.BAD_REQUEST,
+                )
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                delete(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.BAD_REQUEST.value())
+                body("data", nullValue())
+                body("status", Is("FUNKSJONELL_FEIL"))
+                body("melding", Is("En feil oppstod"))
+                body("frontendFeilmelding", Is("En feil oppstod"))
+            }
+        }
+
+        @Test
+        fun `skal slette sammensatt kontrollsak`() {
+            // Arrange
+            opprettSøkerFagsakOgBehandling()
+
+            sammensattKontrollsakRepository.save(
+                SammensattKontrollsak(
+                    behandlingId = behandling.id,
+                    fritekst = "blabla",
+                ),
+            )
+
+            val sammensattKontrollsak =
+                sammensattKontrollsakRepository.finnSammensattKontrollsakForBehandling(
+                    behandlingId = behandling.id,
+                ) ?: throw Feil("Fant ingen sammensatt kontrollsak")
+
+            val slettSammensattKontrollsakDto =
+                SlettSammensattKontrollsakDto(
+                    id = sammensattKontrollsak.id,
+                )
+
+            val body =
+                objectMapper.writeValueAsString(
+                    slettSammensattKontrollsakDto,
+                )
+
+            val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+            every {
+                sammensattKontrollsakValidator.validerSlettSammensattKontrollsakTilgang()
+            } just runs
+
+            every {
+                sammensattKontrollsakValidator.validerRedigerbarBehandlingForSammensattKontrollsakId(
+                    sammensattKontrollsakId = slettSammensattKontrollsakDto.id,
+                )
+            } just runs
+
+            // Act & assert
+            Given {
+                header("Authorization", "Bearer $token")
+                contentType(ContentType.JSON)
+                body(body)
+            } When {
+                delete(controllerUrl)
+            } Then {
+                statusCode(HttpStatus.OK.value())
+                body("data", Is(sammensattKontrollsak.id.toInt()))
+                body("status", Is("SUKSESS"))
+                body("melding", Is("Innhenting av data var vellykket"))
+                body("frontendFeilmelding", nullValue())
+            }
+        }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakRepositoryTest.kt
@@ -1,0 +1,66 @@
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak
+
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak.SammensattKontrollsak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsak.SammensattKontrollsakRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class SammensattKontrollsakRepositoryTest(
+    @Autowired private val sammensattKontrollsakRepository: SammensattKontrollsakRepository,
+) : OppslagSpringRunnerTest() {
+    @Test
+    fun `skal finne sammensatt kontrollsak for behandling`() {
+        // Arrange
+        opprettSøkerFagsakOgBehandling()
+
+        val lagretSammensattKontrollsak =
+            SammensattKontrollsak(
+                id = 0L,
+                behandlingId = behandling.id,
+                fritekst = "blabla",
+            )
+
+        sammensattKontrollsakRepository.save(lagretSammensattKontrollsak)
+
+        // Act
+        val sammensattKontrollsakForBehandling =
+            sammensattKontrollsakRepository.finnSammensattKontrollsakForBehandling(
+                behandlingId = lagretSammensattKontrollsak.behandlingId,
+            )
+
+        // Assert
+        assertThat(sammensattKontrollsakForBehandling).isNotNull()
+        assertThat(sammensattKontrollsakForBehandling?.id).isEqualTo(lagretSammensattKontrollsak.id)
+        assertThat(sammensattKontrollsakForBehandling?.behandlingId).isEqualTo(lagretSammensattKontrollsak.behandlingId)
+        assertThat(sammensattKontrollsakForBehandling?.fritekst).isEqualTo(lagretSammensattKontrollsak.fritekst)
+    }
+
+    @Test
+    fun `skal finne sammensatt kontrollsak`() {
+        // Arrange
+        opprettSøkerFagsakOgBehandling()
+
+        val lagretSammensattKontrollsak =
+            SammensattKontrollsak(
+                id = 0L,
+                behandlingId = behandling.id,
+                fritekst = "blabla",
+            )
+
+        sammensattKontrollsakRepository.save(lagretSammensattKontrollsak)
+
+        // Act
+        val funnetSammensattKontrollsak =
+            sammensattKontrollsakRepository.finnSammensattKontrollsak(
+                sammensattKontrollsakId = lagretSammensattKontrollsak.id,
+            )
+
+        // Assert
+        assertThat(funnetSammensattKontrollsak).isNotNull()
+        assertThat(funnetSammensattKontrollsak?.id).isEqualTo(lagretSammensattKontrollsak.id)
+        assertThat(funnetSammensattKontrollsak?.behandlingId).isEqualTo(lagretSammensattKontrollsak.behandlingId)
+        assertThat(funnetSammensattKontrollsak?.fritekst).isEqualTo(lagretSammensattKontrollsak.fritekst)
+    }
+}


### PR DESCRIPTION
Legger til klasser for sammensatt kontrollsak. Disse kan merges inn da de ikke burde påvirke prod på noen måte. Oppretter en egen PR for det som omhandler brev. 

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20911

Feature-toggle opprettet her: https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker