### PR TITLE
Opprett automatisk totrinnskontroll AutovedtakLovendringService

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.iverksettmotoppdrag.IverksettMotOppdragTask
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.prosessering.internal.TaskService
@@ -25,7 +24,6 @@ class AutovedtakLovendringService(
     private val taskService: TaskService,
     private val autovedtakService: AutovedtakService,
     private val stegService: StegService,
-    private val vedtakRepository: VedtakRepository,
 ) {
     @Transactional
     fun revurderFagsak(fagsakId: Long): Behandling {
@@ -52,9 +50,10 @@ class AutovedtakLovendringService(
             stegService.utførSteg(behandlingId = behandlingEtterBehandlingsresultat.id, behandlingSteg = BehandlingSteg.SIMULERING)
         }
 
-        stegService.utførSteg(behandlingId = behandlingEtterBehandlingsresultat.id, behandlingSteg = BehandlingSteg.VEDTAK)
-
-        val vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingEtterBehandlingsresultat.id)
+        val vedtak =
+            autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(
+                behandlingEtterBehandlingsresultat,
+            )
 
         taskService.save(
             IverksettMotOppdragTask.opprettTask(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakService.kt
@@ -6,16 +6,27 @@ import no.nav.familie.ks.sak.kjerne.behandling.OpprettBehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Beslutning
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
+import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
+import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class AutovedtakService(
     private val stegService: StegService,
     private val behandlingService: BehandlingService,
     private val opprettBehandlingService: OpprettBehandlingService,
+    private val totrinnskontrollService: TotrinnskontrollService,
+    private val loggService: LoggService,
+    private val vedtakService: VedtakService,
+    private val genererBrevService: GenererBrevService,
 ) {
     fun opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
         aktør: Aktør,
@@ -35,5 +46,25 @@ class AutovedtakService(
         stegService.utførSteg(behandlingId = nyBehandling.id, behandlingSteg = BehandlingSteg.BEHANDLINGSRESULTAT)
 
         return behandlingService.hentBehandling(behandlingId = nyBehandling.id)
+    }
+
+    fun opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(behandling: Behandling): Vedtak {
+        totrinnskontrollService.opprettAutomatiskTotrinnskontroll(behandling)
+
+        loggService.opprettBeslutningOmVedtakLogg(
+            behandling = behandling,
+            beslutning = Beslutning.GODKJENT,
+            begrunnelse = null,
+        )
+
+        val vedtak = vedtakService.hentAktivVedtakForBehandling(behandling.id)
+
+        vedtak.vedtaksdato = LocalDateTime.now()
+        if (behandling.skalSendeVedtaksbrev()) {
+            val brev = genererBrevService.genererBrevForBehandling(behandling.id)
+            vedtak.stønadBrevPdf = brev
+        }
+
+        return vedtakService.oppdaterVedtak(vedtak)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
@@ -33,7 +33,7 @@ enum class BehandlingSteg(
     VEDTAK(
         sekvens = 6,
         gyldigBehandlerRolle = listOf(BehandlerRolle.SYSTEM, BehandlerRolle.SAKSBEHANDLER),
-        gyldigForÅrsaker = BehandlingÅrsak.entries.minus(listOf(SATSENDRING)),
+        gyldigForÅrsaker = BehandlingÅrsak.entries.minus(listOf(SATSENDRING, LOVENDRING_2024)),
     ),
     BESLUTTE_VEDTAK(
         sekvens = 7,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -195,7 +195,7 @@ class StegService(
 
             BEHANDLINGSRESULTAT ->
                 if (behandling.skalBehandlesAutomatisk() && !behandling.skalSendeVedtaksbrev()) {
-                    VEDTAK
+                    IVERKSETT_MOT_OPPDRAG
                 } else {
                     nesteGyldigeStadier.first()
                 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakSteg.kt
@@ -44,24 +44,19 @@ class VedtakSteg(
         val behandling = behandlingService.hentBehandling(behandlingId)
         validerAtBehandlingErGyldigForVedtak(behandling)
 
-        if (behandling.skalBehandlesAutomatisk()) {
-            loggService.opprettSendTilBeslutterLogg(behandling.id)
-            totrinnskontrollService.opprettAutomatiskTotrinnskontroll(behandling = behandling)
-        } else {
-            loggService.opprettSendTilBeslutterLogg(behandling.id)
-            totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
+        loggService.opprettSendTilBeslutterLogg(behandling.id)
+        totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
-            val godkjenneVedtakTask =
-                OpprettOppgaveTask.opprettTask(
-                    behandlingId = behandling.id,
-                    oppgavetype = Oppgavetype.GodkjenneVedtak,
-                    fristForFerdigstillelse = LocalDate.now(),
-                )
+        val godkjenneVedtakTask =
+            OpprettOppgaveTask.opprettTask(
+                behandlingId = behandling.id,
+                oppgavetype = Oppgavetype.GodkjenneVedtak,
+                fristForFerdigstillelse = LocalDate.now(),
+            )
 
-            taskService.save(godkjenneVedtakTask)
+        taskService.save(godkjenneVedtakTask)
 
-            opprettFerdigstillOppgaveTasker(behandling)
-        }
+        opprettFerdigstillOppgaveTasker(behandling)
 
         val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -104,7 +104,7 @@ class GenererBrevService(
     fun genererBrevForBehandling(behandlingId: Long): ByteArray {
         val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
         try {
-            if (vedtak.behandling.steg > BehandlingSteg.BESLUTTE_VEDTAK) {
+            if (!vedtak.behandling.skalBehandlesAutomatisk() && vedtak.behandling.steg > BehandlingSteg.BESLUTTE_VEDTAK) {
                 throw FunksjonellFeil("Ikke tillatt å generere brev etter at behandlingen er sendt fra beslutter")
             }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
@@ -108,7 +108,7 @@ class AutovedtakLovendringTest(
 
         justRun { loggService.opprettBehandlingLogg(any()) }
         justRun { loggService.opprettVilkårsvurderingLogg(any(), any(), any()) }
-        justRun { loggService.opprettSendTilBeslutterLogg(any()) }
+        justRun { loggService.opprettBeslutningOmVedtakLogg(any(), any(), any()) }
 
         justRun { utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(any(), any()) }
     }


### PR DESCRIPTION
I stedet for å gjennomføre vedtakssteget opprettes automatisk godkjent totrinnskontroll og vedtaksbrev i `AutovedtakLovendringService::revurderFagsak`, og går rett fra `BEHANDLINGSRESULTAT` til `IVERKSETT_MOT_OPPDRAG` for automatiske behandlinger for lovendring, som *ikke* skal sende vedtaksbrev

Dette fører til mindre forskjeller mellom ks-sak og ba-sak, og gjør det lettere å filtrere bort simulering- og vedtaksteget i frontend