### PR TITLE
Utfør simulering- og vedtaksteg for autovedtak årsak lovendring 2024 hvis brev skal sendes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
@@ -164,9 +164,9 @@ class BrevController(
             handling = "Vis og lagre vedtaksbrev",
         )
 
-        val generertPdf = genererBrevService.genererBrevForBehandling(behandlingId)
-
         val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
+        val generertPdf = genererBrevService.genererBrevForBehandling(vedtak)
+
         vedtak.stønadBrevPdf = generertPdf
 
         return Ressurs.success(generertPdf)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.iverksettmotoppdrag.IverksettMotOppdragTask
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.prosessering.internal.TaskService
@@ -25,7 +24,6 @@ class AutovedtakLovendringService(
     private val taskService: TaskService,
     private val autovedtakService: AutovedtakService,
     private val stegService: StegService,
-    private val vedtakRepository: VedtakRepository,
 ) {
     @Transactional
     fun revurderFagsak(fagsakId: Long): Behandling {
@@ -52,9 +50,10 @@ class AutovedtakLovendringService(
             stegService.utførSteg(behandlingId = behandlingEtterBehandlingsresultat.id, behandlingSteg = BehandlingSteg.SIMULERING)
         }
 
-        stegService.utførSteg(behandlingId = behandlingEtterBehandlingsresultat.id, behandlingSteg = BehandlingSteg.VEDTAK)
-
-        val vedtak = vedtakRepository.findByBehandlingAndAktiv(behandlingEtterBehandlingsresultat.id)
+        val vedtak =
+            autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(
+                behandlingEtterBehandlingsresultat,
+            )
 
         taskService.save(
             IverksettMotOppdragTask.opprettTask(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.iverksettmotoppdrag.IverksettMotOppdragTask
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.prosessering.internal.TaskService
@@ -24,6 +25,7 @@ class AutovedtakLovendringService(
     private val taskService: TaskService,
     private val autovedtakService: AutovedtakService,
     private val stegService: StegService,
+    private val vedtakService: VedtakService,
 ) {
     @Transactional
     fun revurderFagsak(fagsakId: Long): Behandling {
@@ -49,12 +51,12 @@ class AutovedtakLovendringService(
 
         if (behandlingEtterBehandlingsresultat.skalSendeVedtaksbrev()) {
             stegService.utførSteg(behandlingId = behandlingEtterBehandlingsresultat.id, behandlingSteg = BehandlingSteg.SIMULERING)
+            stegService.utførSteg(behandlingId = behandlingEtterBehandlingsresultat.id, behandlingSteg = BehandlingSteg.VEDTAK)
+        } else {
+            autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(behandlingEtterBehandlingsresultat)
         }
 
-        val vedtak =
-            autovedtakService.opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(
-                behandlingEtterBehandlingsresultat,
-            )
+        val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId = behandlingEtterBehandlingsresultat.id)
 
         taskService.save(
             IverksettMotOppdragTask.opprettTask(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakService.kt
@@ -6,16 +6,27 @@ import no.nav.familie.ks.sak.kjerne.behandling.OpprettBehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Beslutning
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
+import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
+import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class AutovedtakService(
     private val stegService: StegService,
     private val behandlingService: BehandlingService,
     private val opprettBehandlingService: OpprettBehandlingService,
+    private val totrinnskontrollService: TotrinnskontrollService,
+    private val loggService: LoggService,
+    private val vedtakService: VedtakService,
+    private val genererBrevService: GenererBrevService,
 ) {
     fun opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
         aktør: Aktør,
@@ -35,5 +46,25 @@ class AutovedtakService(
         stegService.utførSteg(behandlingId = nyBehandling.id, behandlingSteg = BehandlingSteg.BEHANDLINGSRESULTAT)
 
         return behandlingService.hentBehandling(behandlingId = nyBehandling.id)
+    }
+
+    fun opprettToTrinnskontrollOgVedtaksbrevForAutomatiskBehandling(behandling: Behandling): Vedtak {
+        totrinnskontrollService.opprettAutomatiskTotrinnskontroll(behandling)
+
+        loggService.opprettBeslutningOmVedtakLogg(
+            behandling = behandling,
+            beslutning = Beslutning.GODKJENT,
+            begrunnelse = null,
+        )
+
+        val vedtak = vedtakService.hentAktivVedtakForBehandling(behandling.id)
+
+        vedtak.vedtaksdato = LocalDateTime.now()
+        if (behandling.skalSendeVedtaksbrev()) {
+            val brev = genererBrevService.genererBrevForBehandling(behandling.id)
+            vedtak.stønadBrevPdf = brev
+        }
+
+        return vedtakService.oppdaterVedtak(vedtak)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakService.kt
@@ -11,12 +11,10 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
-import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
 
 @Service
 class AutovedtakService(
@@ -26,7 +24,6 @@ class AutovedtakService(
     private val totrinnskontrollService: TotrinnskontrollService,
     private val loggService: LoggService,
     private val vedtakService: VedtakService,
-    private val genererBrevService: GenererBrevService,
 ) {
     fun opprettAutomatiskBehandlingOgKjørTilBehandlingsresultat(
         aktør: Aktør,
@@ -57,14 +54,6 @@ class AutovedtakService(
             begrunnelse = null,
         )
 
-        val vedtak = vedtakService.hentAktivVedtakForBehandling(behandling.id)
-
-        vedtak.vedtaksdato = LocalDateTime.now()
-        if (behandling.skalSendeVedtaksbrev()) {
-            val brev = genererBrevService.genererBrevForBehandling(behandling.id)
-            vedtak.stønadBrevPdf = brev
-        }
-
-        return vedtakService.oppdaterVedtak(vedtak)
+        return vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -161,6 +161,7 @@ data class Behandling(
     fun skalSendeVedtaksbrev(): Boolean =
         when {
             type == TEKNISK_ENDRING -> false
+            // TODO: Legg til mulighet for å sende brev for behandling med årsak lovendring med fremtidig opphør
             opprettetÅrsak in listOf(BehandlingÅrsak.SATSENDRING, BehandlingÅrsak.LOVENDRING_2024) -> false
             else -> true
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -161,7 +161,6 @@ data class Behandling(
     fun skalSendeVedtaksbrev(): Boolean =
         when {
             type == TEKNISK_ENDRING -> false
-            opprettetÅrsak == BehandlingÅrsak.LOVENDRING_2024 && resultat in listOf(Behandlingsresultat.ENDRET_OG_OPPHØRT) -> true
             opprettetÅrsak in listOf(BehandlingÅrsak.SATSENDRING, BehandlingÅrsak.LOVENDRING_2024) -> false
             else -> true
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
@@ -33,7 +33,7 @@ enum class BehandlingSteg(
     VEDTAK(
         sekvens = 6,
         gyldigBehandlerRolle = listOf(BehandlerRolle.SYSTEM, BehandlerRolle.SAKSBEHANDLER),
-        gyldigForÅrsaker = BehandlingÅrsak.entries.minus(listOf(SATSENDRING)),
+        gyldigForÅrsaker = BehandlingÅrsak.entries.minus(listOf(SATSENDRING, LOVENDRING_2024)),
     ),
     BESLUTTE_VEDTAK(
         sekvens = 7,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BehandlingSteg.kt
@@ -33,7 +33,7 @@ enum class BehandlingSteg(
     VEDTAK(
         sekvens = 6,
         gyldigBehandlerRolle = listOf(BehandlerRolle.SYSTEM, BehandlerRolle.SAKSBEHANDLER),
-        gyldigForÅrsaker = BehandlingÅrsak.entries.minus(listOf(SATSENDRING, LOVENDRING_2024)),
+        gyldigForÅrsaker = BehandlingÅrsak.entries.minus(listOf(SATSENDRING)),
     ),
     BESLUTTE_VEDTAK(
         sekvens = 7,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
-import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
@@ -25,7 +24,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Service
 class BeslutteVedtakSteg(
@@ -36,7 +34,6 @@ class BeslutteVedtakSteg(
     private val loggService: LoggService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val unleashService: UnleashNextMedContextService,
-    private val genererBrevService: GenererBrevService,
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.BESLUTTE_VEDTAK
@@ -76,15 +73,7 @@ class BeslutteVedtakSteg(
             tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(behandling)
 
             // Oppdater vedtaksbrev med beslutter
-            val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
-
-            vedtak.vedtaksdato = LocalDateTime.now()
-            if (behandling.skalSendeVedtaksbrev()) {
-                val brev = genererBrevService.genererBrevForBehandling(behandling.id)
-                vedtak.stønadBrevPdf = brev
-            }
-
-            vedtakService.oppdaterVedtak(vedtak)
+            vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
         } else {
             val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId)
             // Her oppdaterer vi endretAv til beslutter saksbehandler og endretTid til næværende tidspunkt

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -195,7 +195,7 @@ class StegService(
 
             BEHANDLINGSRESULTAT ->
                 if (behandling.skalBehandlesAutomatisk() && !behandling.skalSendeVedtaksbrev()) {
-                    VEDTAK
+                    IVERKSETT_MOT_OPPDRAG
                 } else {
                     nesteGyldigeStadier.first()
                 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakSteg.kt
@@ -8,12 +8,12 @@ import no.nav.familie.ks.sak.integrasjon.oppgave.OpprettOppgaveTask
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Beslutning.GODKJENT
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.IBehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.validerPerioderInneholderBegrunnelser
-import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.prosessering.internal.TaskService
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Service
 class VedtakSteg(
@@ -33,7 +32,6 @@ class VedtakSteg(
     private val oppgaveService: OppgaveService,
     private val vedtakService: VedtakService,
     private val vedtaksperiodeService: VedtaksperiodeService,
-    private val genererBrevService: GenererBrevService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.VEDTAK
 
@@ -44,29 +42,26 @@ class VedtakSteg(
         val behandling = behandlingService.hentBehandling(behandlingId)
         validerAtBehandlingErGyldigForVedtak(behandling)
 
-        loggService.opprettSendTilBeslutterLogg(behandling.id)
-        totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
+        if (behandling.skalBehandlesAutomatisk()) {
+            loggService.opprettBeslutningOmVedtakLogg(behandling = behandling, beslutning = GODKJENT, begrunnelse = null)
+            totrinnskontrollService.opprettAutomatiskTotrinnskontroll(behandling)
+        } else {
+            loggService.opprettSendTilBeslutterLogg(behandling.id)
+            totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
-        val godkjenneVedtakTask =
-            OpprettOppgaveTask.opprettTask(
-                behandlingId = behandling.id,
-                oppgavetype = Oppgavetype.GodkjenneVedtak,
-                fristForFerdigstillelse = LocalDate.now(),
-            )
+            val godkjenneVedtakTask =
+                OpprettOppgaveTask.opprettTask(
+                    behandlingId = behandling.id,
+                    oppgavetype = Oppgavetype.GodkjenneVedtak,
+                    fristForFerdigstillelse = LocalDate.now(),
+                )
 
-        taskService.save(godkjenneVedtakTask)
+            taskService.save(godkjenneVedtakTask)
 
-        opprettFerdigstillOppgaveTasker(behandling)
-
-        val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
-
-        vedtak.vedtaksdato = LocalDateTime.now()
-        if (behandling.skalSendeVedtaksbrev()) {
-            val brev = genererBrevService.genererBrevForBehandling(behandling.id)
-            vedtak.stønadBrevPdf = brev
+            opprettFerdigstillOppgaveTasker(behandling)
         }
 
-        vedtakService.oppdaterVedtak(vedtak)
+        vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
     }
 
     private fun opprettFerdigstillOppgaveTasker(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakSteg.kt
@@ -44,24 +44,19 @@ class VedtakSteg(
         val behandling = behandlingService.hentBehandling(behandlingId)
         validerAtBehandlingErGyldigForVedtak(behandling)
 
-        if (behandling.skalBehandlesAutomatisk()) {
-            loggService.opprettSendTilBeslutterLogg(behandling.id)
-            totrinnskontrollService.opprettAutomatiskTotrinnskontroll(behandling = behandling)
-        } else {
-            loggService.opprettSendTilBeslutterLogg(behandling.id)
-            totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
+        loggService.opprettSendTilBeslutterLogg(behandling.id)
+        totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling)
 
-            val godkjenneVedtakTask =
-                OpprettOppgaveTask.opprettTask(
-                    behandlingId = behandling.id,
-                    oppgavetype = Oppgavetype.GodkjenneVedtak,
-                    fristForFerdigstillelse = LocalDate.now(),
-                )
+        val godkjenneVedtakTask =
+            OpprettOppgaveTask.opprettTask(
+                behandlingId = behandling.id,
+                oppgavetype = Oppgavetype.GodkjenneVedtak,
+                fristForFerdigstillelse = LocalDate.now(),
+            )
 
-            taskService.save(godkjenneVedtakTask)
+        taskService.save(godkjenneVedtakTask)
 
-            opprettFerdigstillOppgaveTasker(behandling)
-        }
+        opprettFerdigstillOppgaveTasker(behandling)
 
         val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -104,7 +104,7 @@ class GenererBrevService(
     fun genererBrevForBehandling(behandlingId: Long): ByteArray {
         val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
         try {
-            if (vedtak.behandling.steg > BehandlingSteg.BESLUTTE_VEDTAK) {
+            if (!vedtak.behandling.skalBehandlesAutomatisk() && vedtak.behandling.steg > BehandlingSteg.BESLUTTE_VEDTAK) {
                 throw FunksjonellFeil("Ikke tillatt å generere brev etter at behandlingen er sendt fra beslutter")
             }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -101,8 +101,7 @@ class GenererBrevService(
         }
     }
 
-    fun genererBrevForBehandling(behandlingId: Long): ByteArray {
-        val vedtak = vedtakService.hentAktivVedtakForBehandling(behandlingId)
+    fun genererBrevForBehandling(vedtak: Vedtak): ByteArray {
         try {
             if (!vedtak.behandling.skalBehandlesAutomatisk() && vedtak.behandling.steg > BehandlingSteg.BESLUTTE_VEDTAK) {
                 throw FunksjonellFeil("Ikke tillatt å generere brev etter at behandlingen er sendt fra beslutter")

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.SimuleringService
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.feilutbetaltvaluta.FeilutbetaltValutaService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøsRepository
@@ -62,7 +61,6 @@ import java.math.BigDecimal
 @Service
 class GenererBrevService(
     private val brevKlient: BrevKlient,
-    private val vedtakService: VedtakService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val simuleringService: SimuleringService,
     private val vedtaksperiodeService: VedtaksperiodeService,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
@@ -164,7 +164,7 @@ class BeslutteVedtakStegTest {
         every { tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(any()) } just runs
 
         every { vedtakService.hentAktivVedtakForBehandling(any()) } returns mockk(relaxed = true)
-        every { vedtakService.oppdaterVedtak(any()) } returns mockk()
+        every { vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(any()) } returns mockk()
         beslutteVedtakSteg.utførSteg(200, besluttVedtakDto)
 
         verify(exactly = 1) {
@@ -177,9 +177,7 @@ class BeslutteVedtakStegTest {
             )
         }
         verify(exactly = 1) { loggService.opprettBeslutningOmVedtakLogg(any(), any(), any()) }
-        verify(exactly = 1) { genererBrevService.genererBrevForBehandling(any()) }
-        verify(exactly = 1) { vedtakService.hentAktivVedtakForBehandling(any()) }
-        verify(exactly = 1) { vedtakService.oppdaterVedtak(any()) }
+        verify(exactly = 1) { vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(any()) }
         verify(exactly = 1) { tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakServiceTest.kt
@@ -5,21 +5,34 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType.REVURDERING
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat.ENDRET_OG_OPPHØRT
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat.INNVILGET
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak.LOVENDRING_2024
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
+import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDateTime
 import org.hamcrest.CoreMatchers.`is` as Is
 
 @ExtendWith(MockKExtension::class)
@@ -29,6 +42,9 @@ class VedtakServiceTest {
 
     @MockK
     private lateinit var vedtaksperiodeService: VedtaksperiodeService
+
+    @MockK
+    private lateinit var genererBrevService: GenererBrevService
 
     @InjectMockKs
     private lateinit var vedtakService: VedtakService
@@ -41,6 +57,88 @@ class VedtakServiceTest {
 
         Assertions.assertNotNull(hentetVedtak)
         verify(exactly = 1) { vedtakRepository.hentVedtak(1) }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BehandlingÅrsak::class, names = ["SATSENDRING"], mode = EnumSource.Mode.EXCLUDE)
+    fun `oppdaterVedtakMedDatoOgStønadsbrev - skal oppdatere vedtak med dato og stønadsbrev`(
+        behandlingÅrsak: BehandlingÅrsak,
+    ) {
+        val behandling = lagBehandling(opprettetÅrsak = behandlingÅrsak, resultat = ENDRET_OG_OPPHØRT)
+        val vedtak = lagVedtak(behandling)
+        val brev = "brev".toByteArray()
+
+        mockkStatic(LocalDateTime::class)
+
+        every { genererBrevService.genererBrevForBehandling(any()) } returns brev
+        every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns vedtak
+        every { vedtakRepository.saveAndFlush(any()) } answers { firstArg() }
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 1, 1, 0, 0)
+
+        val oppdatertVedtak = vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
+
+        assertThat(oppdatertVedtak.stønadBrevPdf, Is(brev))
+        assertThat(oppdatertVedtak.vedtaksdato, Is(LocalDateTime.of(2024, 1, 1, 0, 0)))
+
+        verify(exactly = 1) { genererBrevService.genererBrevForBehandling(vedtak) }
+        verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
+        verify(exactly = 1) { vedtakRepository.saveAndFlush(oppdatertVedtak) }
+
+        unmockkStatic(LocalDateTime::class)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BehandlingÅrsak::class, names = ["LOVENDRING_2024", "SATSENDRING"])
+    fun `oppdaterVedtakMedDatoOgStønadsbrev - skal oppdatere vedtak med dato, men ikke stønadsbrev`(
+        behandlingÅrsak: BehandlingÅrsak,
+    ) {
+        val behandling = lagBehandling(opprettetÅrsak = behandlingÅrsak, resultat = INNVILGET, type = REVURDERING)
+        val vedtak = lagVedtak(behandling)
+
+        mockkStatic(LocalDateTime::class)
+
+        every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns vedtak
+        every { vedtakRepository.saveAndFlush(any()) } answers { firstArg() }
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 1, 1, 0, 0)
+
+        val oppdatertVedtak = vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
+
+        assertThat(oppdatertVedtak.stønadBrevPdf, IsNull())
+        assertThat(oppdatertVedtak.vedtaksdato, Is(LocalDateTime.of(2024, 1, 1, 0, 0)))
+
+        verify(exactly = 0) { genererBrevService.genererBrevForBehandling(vedtak) }
+        verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
+        verify(exactly = 1) { vedtakRepository.saveAndFlush(oppdatertVedtak) }
+
+        unmockkStatic(LocalDateTime::class)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Behandlingsresultat::class, names = ["ENDRET_OG_OPPHØRT"], mode = EnumSource.Mode.EXCLUDE)
+    fun `oppdaterVedtakMedDatoOgStønadsbrev - skal oppdatere vedtak med dato, men ikke stønadsbrev for årsak LOVENDRING_2024 og resultat ikke lik ENDRET_OG_OPPHØRT`(
+        behandlingsResultat: Behandlingsresultat,
+    ) {
+        val behandling = lagBehandling(opprettetÅrsak = LOVENDRING_2024, resultat = behandlingsResultat, type = REVURDERING)
+        val vedtak = lagVedtak(behandling)
+        val brev = "brev".toByteArray()
+
+        mockkStatic(LocalDateTime::class)
+
+        every { genererBrevService.genererBrevForBehandling(any()) } returns brev
+        every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns vedtak
+        every { vedtakRepository.saveAndFlush(any()) } answers { firstArg() }
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 1, 1, 0, 0)
+
+        val oppdatertVedtak = vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
+
+        assertThat(oppdatertVedtak.stønadBrevPdf, IsNull())
+        assertThat(oppdatertVedtak.vedtaksdato, Is(LocalDateTime.of(2024, 1, 1, 0, 0)))
+
+        verify(exactly = 0) { genererBrevService.genererBrevForBehandling(vedtak) }
+        verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
+        verify(exactly = 1) { vedtakRepository.saveAndFlush(oppdatertVedtak) }
+
+        unmockkStatic(LocalDateTime::class)
     }
 
     @ParameterizedTest

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakStegTest.kt
@@ -17,7 +17,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
-import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
 import no.nav.familie.prosessering.internal.TaskService
@@ -51,9 +50,6 @@ class VedtakStegTest {
 
     @MockK
     private lateinit var vedtaksperiodeService: VedtaksperiodeService
-
-    @MockK
-    private lateinit var genererBrevService: GenererBrevService
 
     @InjectMockKs
     private lateinit var vedtakSteg: VedtakSteg
@@ -106,9 +102,7 @@ class VedtakStegTest {
         every { taskService.save(any()) } returns mockk()
         every { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling) } returns emptyList()
         every { vedtakService.hentAktivVedtakForBehandling(any()) } returns mockk(relaxed = true)
-        every { vedtakService.oppdaterVedtak(any()) } returns mockk()
         every { vedtaksperiodeService.hentUtvidetVedtaksperioderMedBegrunnelser(any()) } returns mockk(relaxed = true)
-        every { genererBrevService.genererBrevForBehandling(any()) } returns ByteArray(30)
         every { vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(any()) } returns mockk()
 
         vedtakSteg.utførSteg(200)
@@ -120,5 +114,6 @@ class VedtakStegTest {
         verify(exactly = 1) { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling) }
         verify(exactly = 1) { vedtakService.hentAktivVedtakForBehandling(behandling.id) }
         verify(exactly = 1) { vedtaksperiodeService.hentUtvidetVedtaksperioderMedBegrunnelser(any()) }
+        verify(exactly = 1) { vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakStegTest.kt
@@ -109,6 +109,7 @@ class VedtakStegTest {
         every { vedtakService.oppdaterVedtak(any()) } returns mockk()
         every { vedtaksperiodeService.hentUtvidetVedtaksperioderMedBegrunnelser(any()) } returns mockk(relaxed = true)
         every { genererBrevService.genererBrevForBehandling(any()) } returns ByteArray(30)
+        every { vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(any()) } returns mockk()
 
         vedtakSteg.utførSteg(200)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.SimuleringService
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.feilutbetaltvaluta.FeilutbetaltValutaService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøsRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
@@ -44,7 +43,6 @@ class GenererBrevServiceTest {
     val genererBrevService =
         GenererBrevService(
             brevKlient = brevKlient,
-            vedtakService = mockk<VedtakService>(),
             personopplysningGrunnlagService = personopplysningGrunnlagService,
             simuleringService = mockk<SimuleringService>(),
             vedtaksperiodeService = mockk<VedtaksperiodeService>(),

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
@@ -43,6 +43,7 @@ import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ks.sak.statistikk.saksstatistikk.SakStatistikkService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
@@ -185,6 +186,7 @@ class AutovedtakLovendringTest(
     }
 
     @Test
+    @Disabled
     fun `automatisk revurdering av fagsak som har fremtidig opphør beholder fremtidig opphør og sender brev`() {
         // arrange
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
@@ -108,7 +108,7 @@ class AutovedtakLovendringTest(
 
         justRun { loggService.opprettBehandlingLogg(any()) }
         justRun { loggService.opprettVilkårsvurderingLogg(any(), any(), any()) }
-        justRun { loggService.opprettSendTilBeslutterLogg(any()) }
+        justRun { loggService.opprettBeslutningOmVedtakLogg(any(), any(), any()) }
 
         justRun { utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(any(), any()) }
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/atuovedtak/AutovedtakLovendringTest.kt
@@ -188,6 +188,7 @@ class AutovedtakLovendringTest(
     @Test
     @Disabled
     fun `automatisk revurdering av fagsak som har fremtidig opphør beholder fremtidig opphør og sender brev`() {
+        // TODO: Fjern @Disabled når løype for fremtidig opphør med brevutsending er implementert
         // arrange
 
         every { brevklient.genererBrev(any(), any()) } returns "brev".toByteArray()


### PR DESCRIPTION
For å kunne vise simulering og vedtaksidene i frontend må disse gjennomføres for automatisk behandlinger der brev skal sendes.

- Brev skal sendes $\rightarrow$ utfør simulering- og vedtaksteget etter behandlingsresultatsteget (Denne løypen er deaktivert foreløpig. Brev og logikk for fremtidig opphør må implementeres i en senere PR)
- Brev skal ikke sendes $\rightarrow$ opprett en automatisk godkjent totrinnskontroll etter behandlingsresultatsteget, og gå rett til iverksett mot oppdrag