### PR TITLE
Fjerner erEksplisittAvslagPåSøknad flagget ved kopiering av Barnehageplass-vilkåret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -397,7 +397,12 @@ private fun Collection<VilkårResultat>.overskrivMedVilkårResultaterFraForrigeB
                         /* *
                          * Ønsker å dra med vilkårresultatene som er avslått og opphørt i forrige behandling
                          * for barnehagevilkåret fordi vi krever at alle peridene skal være vurdert, også de med opphør
+                         *
+                         * kopierer ikke med eksplisitt avslag på søknad for dette ikke vil validere med
+                         * validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag ved revurdering av
+                         * en sak som har hatt eksplisitt avslag i forrige behandling.
                          * */
+                    vilkårResultaterAvSammeTypeIForrigeBehandling.filter { it.erEksplisittAvslagPåSøknad == true && it.vilkårType == Vilkår.BARNEHAGEPLASS }.forEach { it.erEksplisittAvslagPåSøknad = null }
                     vilkårResultaterAvSammeTypeIForrigeBehandling
                 }
 

--- a/src/test/resources/cucumber/vilkår/kopiering_av_vilkårsvurdering.feature
+++ b/src/test/resources/cucumber/vilkår/kopiering_av_vilkårsvurdering.feature
@@ -87,7 +87,7 @@ Egenskap: opprettVilkårsvurdering - tester for kopiering av vilkårresultater f
 
       | 3       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET | 17.12.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER |              |                       |
       | 3       | BARNEHAGEPLASS                                         | 17.12.2022 | 16.02.2023 | IKKE_OPPFYLT | Nei                  |                      |                  | 40           |                       |
-      | 3       | BARNEHAGEPLASS                                         | 17.02.2023 | 31.04.2024 | IKKE_OPPFYLT | Ja                   |                      |                  | 40           |                       |
+      | 3       | BARNEHAGEPLASS                                         | 17.02.2023 | 31.04.2024 | IKKE_OPPFYLT |                      |                      |                  | 40           |                       |
       | 3       | BARNETS_ALDER                                          | 17.12.2023 | 31.07.2024 | OPPFYLT      |                      |                      |                  |              | Ja                    |
       | 3       | BARNEHAGEPLASS                                         | 01.05.2024 |            | OPPFYLT      | Nei                  |                      |                  |              |                       |
 


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22011

Man får ikke revurdert en sak med en eksplisitt avslag pga barnehageplass. Den vil stoppes i validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag med feilmelding "Det eksisterer personer som har fått eksplisitt avslag, men som det ikke er blitt fremstilt krav for" fordi den ikke er en søknad.

Filtrerer man bort perioder med eksplisitt avslag, så feiler valideringen på at ikke hele perioden er utfylt

Løsningen blir å kopiere med periodene uten at flagget. Da vil begge sjekke valideres og behandlingsresultat bli rett.