### PR TITLE
Legg inn riktig lengde på perioder i adopsjonssaker dersom de lå inne som for lange i forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -415,7 +415,7 @@ private fun Collection<VilkårResultat>.overskrivMedVilkårResultaterFraForrigeB
                     vilkårResultaterAvSammeTypeIForrigeBehandling
                         .filter { it.erAdopsjonOppfylt() }
                         .filter { it.resultat in listOf(Resultat.IKKE_AKTUELT, Resultat.OPPFYLT) }
-                        .forkortHvisSkalForkortesEtterRegelverkEndring()
+                        .justerTomTilRiktigLengde()
                         .splittOppOmKrysserRegelverksendring()
                 }
 
@@ -448,14 +448,14 @@ private fun VilkårResultat.krysserRegelendring() =
     (periodeFom ?: TIDENES_MORGEN).isBefore(DATO_LOVENDRING_2024) &&
         (periodeTom ?: TIDENES_ENDE).erSammeEllerEtter(DATO_LOVENDRING_2024)
 
-fun Collection<VilkårResultat>.forkortHvisSkalForkortesEtterRegelverkEndring(): List<VilkårResultat> =
+fun Collection<VilkårResultat>.justerTomTilRiktigLengde(): List<VilkårResultat> =
     this.flatMap {
         it.periodeFom ?: throw IllegalStateException("Barnets alder vilkår kan ikke begynne tidenes morgen")
-        it.periodeTom ?: throw IllegalStateException("Barnets alder vilkår kan ikke ende tidenes ende")
+        it.periodeTom ?: throw IllegalStateException("Barnets alder vilkår kan ikke ende ved tidenes ende")
 
         val lengdePåPeriode = it.periodeFom!!.until(it.periodeTom).toTotalMonths()
 
-        if (lengdePåPeriode > 7 && (it.krysserRegelendring() || it.periodeFom!! >= DATO_LOVENDRING_2024)) {
+        if (lengdePåPeriode > 7 && it.periodeTom!! >= DATO_LOVENDRING_2024) {
             listOf(it.kopier(periodeTom = it.periodeFom!!.plusMonths(7)))
         } else {
             listOf(it)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -454,10 +454,17 @@ fun Collection<VilkårResultat>.forkortTomTilGyldigLengde(): List<VilkårResulta
         it.periodeTom ?: throw IllegalStateException("Barnets alder vilkår kan ikke ende ved tidenes ende")
 
         val lengdePåPeriode = it.periodeFom!!.until(it.periodeTom).toTotalMonths()
+        val fomTilLovendringsDato = it.periodeFom!!.until(DATO_LOVENDRING_2024).toTotalMonths()
 
-        if (lengdePåPeriode > 7 && it.periodeTom!! >= DATO_LOVENDRING_2024) {
-            listOf(it.kopier(periodeTom = it.periodeFom!!.plusMonths(7)))
-        } else {
-            listOf(it)
+        when {
+            fomTilLovendringsDato < 7 && lengdePåPeriode > 7 && it.periodeTom!! >= DATO_LOVENDRING_2024 -> {
+                listOf(it.kopier(periodeTom = it.periodeFom!!.plusMonths(7)))
+            }
+            fomTilLovendringsDato > 7 && it.periodeTom!! >= DATO_LOVENDRING_2024 -> {
+                listOf(it.kopier(periodeTom = DATO_LOVENDRING_2024.minusDays(1)))
+            }
+            else -> {
+                listOf(it)
+            }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -415,7 +415,7 @@ private fun Collection<VilkårResultat>.overskrivMedVilkårResultaterFraForrigeB
                     vilkårResultaterAvSammeTypeIForrigeBehandling
                         .filter { it.erAdopsjonOppfylt() }
                         .filter { it.resultat in listOf(Resultat.IKKE_AKTUELT, Resultat.OPPFYLT) }
-                        .justerTomTilRiktigLengde()
+                        .forkortTomTilGyldigLengde()
                         .splittOppOmKrysserRegelverksendring()
                 }
 
@@ -448,7 +448,7 @@ private fun VilkårResultat.krysserRegelendring() =
     (periodeFom ?: TIDENES_MORGEN).isBefore(DATO_LOVENDRING_2024) &&
         (periodeTom ?: TIDENES_ENDE).erSammeEllerEtter(DATO_LOVENDRING_2024)
 
-fun Collection<VilkårResultat>.justerTomTilRiktigLengde(): List<VilkårResultat> =
+fun Collection<VilkårResultat>.forkortTomTilGyldigLengde(): List<VilkårResultat> =
     this.flatMap {
         it.periodeFom ?: throw IllegalStateException("Barnets alder vilkår kan ikke begynne tidenes morgen")
         it.periodeTom ?: throw IllegalStateException("Barnets alder vilkår kan ikke ende ved tidenes ende")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -350,4 +350,19 @@ class VilkårsvurderingUtilsTest {
 
         assertEquals(LocalDate.of(2025, 3, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
+
+    @Test
+    fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter til lovendringsdato hvis den forkortes under 7 mnder`() {
+        val vilkårResultat =
+            lagVilkårResultat(
+                vilkårType = Vilkår.BARNETS_ALDER,
+                periodeFom = LocalDate.of(2023, 10, 15),
+                periodeTom = LocalDate.of(2024, 9, 15),
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
+            )
+
+        val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
+
+        assertEquals(LocalDate.of(2024, 7, 31), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -316,7 +316,7 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
-        val resultat = listOf(vilkårResultat).forkortHvisSkalForkortesEtterRegelverkEndring()
+        val resultat = listOf(vilkårResultat).justerTomTilRiktigLengde()
 
         assertEquals(LocalDate.of(2024, 12, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
@@ -331,7 +331,7 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
-        val resultat = listOf(vilkårResultat).forkortHvisSkalForkortesEtterRegelverkEndring()
+        val resultat = listOf(vilkårResultat).justerTomTilRiktigLengde()
 
         assertEquals(LocalDate.of(2024, 7, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
@@ -346,7 +346,7 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
-        val resultat = listOf(vilkårResultat).forkortHvisSkalForkortesEtterRegelverkEndring()
+        val resultat = listOf(vilkårResultat).justerTomTilRiktigLengde()
 
         assertEquals(LocalDate.of(2025, 3, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ks.sak.data.lagVilkårsvurderingOppfylt
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -303,5 +304,50 @@ class VilkårsvurderingUtilsTest {
 
         val personResultaterBarn2 = vilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == personIdentBarn2 }
         personResultaterBarn2.vilkårResultater.forEach { assertEquals(dødsdatoBarn2, it.periodeTom) }
+    }
+
+    @Test
+    fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter hvis periode krysser lovendringsdato`() {
+        val vilkårResultat =
+            lagVilkårResultat(
+                vilkårType = Vilkår.BARNETS_ALDER,
+                periodeFom = LocalDate.of(2024, 5, 1),
+                periodeTom = LocalDate.of(2025, 5, 1),
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
+            )
+
+        val resultat = listOf(vilkårResultat).forkortHvisSkalForkortesEtterRegelverkEndring()
+
+        assertEquals(LocalDate.of(2024, 12, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
+    }
+
+    @Test
+    fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter ikke hvis periode ikke krysser lovendringsdato`() {
+        val vilkårResultat =
+            lagVilkårResultat(
+                vilkårType = Vilkår.BARNETS_ALDER,
+                periodeFom = LocalDate.of(2023, 7, 1),
+                periodeTom = LocalDate.of(2024, 7, 1),
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
+            )
+
+        val resultat = listOf(vilkårResultat).forkortHvisSkalForkortesEtterRegelverkEndring()
+
+        assertEquals(LocalDate.of(2024, 7, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
+    }
+
+    @Test
+    fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter hvis periode er laget etter nytt lovverk og er lengre enn 7 mnd`() {
+        val vilkårResultat =
+            lagVilkårResultat(
+                vilkårType = Vilkår.BARNETS_ALDER,
+                periodeFom = LocalDate.of(2024, 8, 1),
+                periodeTom = LocalDate.of(2025, 7, 1),
+                utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
+            )
+
+        val resultat = listOf(vilkårResultat).forkortHvisSkalForkortesEtterRegelverkEndring()
+
+        assertEquals(LocalDate.of(2025, 3, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -316,7 +316,7 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
-        val resultat = listOf(vilkårResultat).justerTomTilRiktigLengde()
+        val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
         assertEquals(LocalDate.of(2024, 12, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
@@ -331,7 +331,7 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
-        val resultat = listOf(vilkårResultat).justerTomTilRiktigLengde()
+        val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
         assertEquals(LocalDate.of(2024, 7, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
@@ -346,7 +346,7 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
-        val resultat = listOf(vilkårResultat).justerTomTilRiktigLengde()
+        val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
         assertEquals(LocalDate.of(2025, 3, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }

--- a/src/test/resources/cucumber/vilkår/kopiering_av_vilkårsvurdering.feature
+++ b/src/test/resources/cucumber/vilkår/kopiering_av_vilkårsvurdering.feature
@@ -44,7 +44,7 @@ Egenskap: opprettVilkårsvurdering - tester for kopiering av vilkårresultater f
       | 2       | BARNETS_ALDER                                          | 17.01.2024 | 31.07.2024 | OPPFYLT  |                  |              | Ja                    |
       | 2       | BARNETS_ALDER                                          | 01.08.2024 | 17.08.2024 | OPPFYLT  |                  |              | Ja                    |
 
-  Scenario: Ved revurdering av adopsjonsak, skal barnets aldervilkår skal splittes på regelendringsdato, men datoer skal ikke endres
+  Scenario: Ved revurdering av adopsjonsak, skal barnets aldervilkår splittes på regelendringsdato, og datoer skal endres hvis de er lengre enn 7 mnd
     Og følgende dagens dato 27.06.2024
 
     Og følgende vilkårresultater for behandling 1
@@ -64,7 +64,7 @@ Egenskap: opprettVilkårsvurdering - tester for kopiering av vilkårresultater f
       | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.01.2023 |            | OPPFYLT  | NASJONALE_REGLER |              |
       | 2       | BARNEHAGEPLASS                                         |                  | 17.01.2023 |            | OPPFYLT  |                  |              |
       | 2       | BARNETS_ALDER                                          | ADOPSJON         | 17.01.2024 | 31.07.2024 | OPPFYLT  |                  |              |
-      | 2       | BARNETS_ALDER                                          | ADOPSJON         | 01.08.2024 | 17.01.2025 | OPPFYLT  |                  |              |
+      | 2       | BARNETS_ALDER                                          | ADOPSJON         | 01.08.2024 | 17.08.2024 | OPPFYLT  |                  |              |
 
   Scenario: Ved kopiering av vilkårresultater skal avslag og opphør for barnehageplassvilkåret beholdes fra forrige behanlding
     Og følgende dagens dato 27.06.2024


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21996)

Ved adopsjonssaker generer vi ikke periodene på nytt på barnets alder - vilkåret automatisk. Det gjør at valideringen senere feiler siden vilkåret har feil lengde. Legger inn slik at vi forkorter barnets alder vilkåret til 7 mnd dersom det var lagt inn som lengre enn 7 mnd og periodens tom er etter lovverksendringen. 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
