### PR TITLE
Kast feil i behandling for lovendring hvis det er fremtidig opphør for et barn og færre andeler for annet barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -299,31 +299,59 @@ class BehandlingService(
 
         val aktører = (andelerNåværendeBehandling.map { it.aktør } + andelerForrigeBehandling.map { it.aktør }).distinct()
 
+        // Finn endringer i andeler per person
+        // Hvis et barn får ny andel i august OG annet barn får endring i andeler -> kast feil
+        // Hvis et barn får ny andel i august -> kast feil
+
+        val erBarnSomFåNyrAndelIAugust =
+            aktører.any { aktør ->
+                val sisteNåværendeUtbetalingForAktør =
+                    andelerNåværendeBehandling.filter<AndelTilkjentYtelse> { it.aktør == aktør }.maxOfOrNull<AndelTilkjentYtelse, YearMonth> { it.stønadTom } ?: return@any false
+                val sisteForrigeUtbetalingForAktør =
+                    andelerForrigeBehandling.filter { it.aktør == aktør }.maxOfOrNull { it.stønadTom } ?: TIDENES_MORGEN.toYearMonth()
+
+                val antallMånederMellomForrigeOgNåværendeUtbetalinger =
+                    Period
+                        .between(
+                            sisteForrigeUtbetalingForAktør.toLocalDate(),
+                            sisteNåværendeUtbetalingForAktør.toLocalDate(),
+                        ).months
+
+                if (antallMånederMellomForrigeOgNåværendeUtbetalinger > 1) {
+                    throw Feil("Antall måneder differanse mellom forrige og nåværende utbetaling overstiger 1")
+                }
+
+                val erOpphørIAugustForForrigeUtbetaling = sisteForrigeUtbetalingForAktør == YearMonth.of(2024, 7)
+                val erOpphørISeptemberForNåværendeUtbetaling = sisteNåværendeUtbetalingForAktør == YearMonth.of(2024, 8)
+
+                erOpphørIAugustForForrigeUtbetaling && erOpphørISeptemberForNåværendeUtbetaling
+            }
+
+        val erBarnSomMisterAndel =
+            aktører.any { aktør ->
+                val sisteNåværendeUtbetalingForAktør =
+                    andelerNåværendeBehandling.filter<AndelTilkjentYtelse> { it.aktør == aktør }.maxOfOrNull<AndelTilkjentYtelse, YearMonth> { it.stønadTom } ?: return@any false
+                val sisteForrigeUtbetalingForAktør =
+                    andelerForrigeBehandling.filter { it.aktør == aktør }.maxOfOrNull { it.stønadTom } ?: TIDENES_MORGEN.toYearMonth()
+
+                sisteNåværendeUtbetalingForAktør < sisteForrigeUtbetalingForAktør
+            }
+
+        if (erBarnSomFåNyrAndelIAugust && erBarnSomMisterAndel) {
+            throw Feil("LOVENDRING_2024_FLERE_BARN: Det finnes et barn som får ny andel i august og et annet barn som mister minst en andel")
+        }
+
+        if (erBarnSomFåNyrAndelIAugust) {
+            throw Feil(
+                "LOVENDRING_2024_ANDEL_I_AUGUST: Forrige behandling har opphør i august. Nåværende behandling har opphør i september. Disse tilfellene skal ikke revurderes",
+            )
+        }
+
         return aktører.any { aktør ->
             val sisteNåværendeUtbetalingForAktør =
                 andelerNåværendeBehandling.filter<AndelTilkjentYtelse> { it.aktør == aktør }.maxOfOrNull<AndelTilkjentYtelse, YearMonth> { it.stønadTom } ?: return@any false
             val sisteForrigeUtbetalingForAktør =
                 andelerForrigeBehandling.filter { it.aktør == aktør }.maxOfOrNull { it.stønadTom } ?: TIDENES_MORGEN.toYearMonth()
-
-            val erOpphørIAugustForForrigeUtbetaling = sisteForrigeUtbetalingForAktør == YearMonth.of(2024, 7)
-            val erOpphørISeptemberForNåværendeUtbetaling = sisteNåværendeUtbetalingForAktør == YearMonth.of(2024, 8)
-
-            if (erOpphørIAugustForForrigeUtbetaling && erOpphørISeptemberForNåværendeUtbetaling) {
-                throw Feil(
-                    "Forrige behandling har opphør i august. Nåværende behandling har opphør i september. Disse tilfellene skal ikke revurderes",
-                )
-            }
-
-            val antallMånederMellomForrigeOgNåværendeUtbetalinger =
-                Period
-                    .between(
-                        sisteForrigeUtbetalingForAktør.toLocalDate(),
-                        sisteNåværendeUtbetalingForAktør.toLocalDate(),
-                    ).months
-
-            if (antallMånederMellomForrigeOgNåværendeUtbetalinger > 1) {
-                throw Feil("Antall måneder differanse mellom forrige og nåværende utbetaling overstiger 1")
-            }
 
             sisteForrigeUtbetalingForAktør < sisteNåværendeUtbetalingForAktør
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
@@ -253,9 +253,7 @@ class AutovedtakLovendringTest(
             assertThrows<Feil> {
                 autovedtakLovendringService.revurderFagsak(fagsakId = fagsak.id, erFremtidigOpphør = true)
             }
-        assertThat(exception.message).isEqualTo(
-            "Forrige behandling har opphør i august. Nåværende behandling har opphør i september. Disse tilfellene skal ikke revurderes",
-        )
+        assertThat(exception.message).contains("LOVENDRING_2024_ANDEL_I_AUGUST")
 
         verify(exactly = 0) { simuleringService.oppdaterSimuleringPåBehandling(any<Long>()) }
         verify(exactly = 0) { brevklient.genererBrev(any(), any()) }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-21556

Hvis en automatisk behandling med årsak lovendring fører til ny andel i august 2024 for ett barn, og færre andeler for et annet barn ønsker vi å avbryte behandlingen med en egen feilmelding

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
