### PR TITLE
Ved automatisk behandling skal alle endrede utbetalinger tas med

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -309,6 +309,26 @@ class ForvaltningController(
         return ResponseEntity.ok(Ressurs.success("Automatisk revurdering opprettet"))
     }
 
+    @PostMapping("/automatisk-revurdering-lovendring")
+    @Operation(
+        summary = "Oppretter en AutovedtakLovendringTask",
+        description = "Oppretter en AutovedtakLovendringTask som trigger en lovendring på en liste med fagsaker. Det er ingen validering som stopper lovendring-revurdering på dette endepunktet",
+    )
+    fun opprettAutomatiskLovendringRevurderingFlereFagsaker(
+        @RequestBody fagsakListe: List<Long>,
+    ): ResponseEntity<Ressurs<String>> {
+        tilgangService.validerTilgangTilHandling(
+            minimumBehandlerRolle = BehandlerRolle.FORVALTER,
+            handling = "opprette automatisk revurdering",
+        )
+
+        fagsakListe.forEach {
+            AutovedtakLovendringTask.opprettTask(it).apply { taskService.save(this) }
+        }
+
+        return ResponseEntity.ok(Ressurs.success("Automatisk revurdering opprettet"))
+    }
+
     @PostMapping("/automatisk-revurdering-lovendring-ikke-fremtidig-opphor/{limit}")
     @Operation(
         summary = "Oppretter AutovedtakLovendringIkkeFremtidigOpphørTask for løpende saker uten fremtidig opphør",

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -7,5 +7,6 @@ class FeatureToggleConfig {
         const val TEKNISK_ENDRING = "familie-ks-sak.behandling.teknisk-endring"
         const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ks-sak.behandling.korreksjon-vedtaksbrev"
         const val KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER = "familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"
+        const val KAN_KJORE_LOVENDRING_FLERE_GANGER = "familie-ks-sak.kan-kjore-lovendring-flere-ganger"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
@@ -32,6 +32,19 @@ class UnleashNextMedContextService(
         )
     }
 
+    fun isEnabledForFagsak(
+        fagsakId: Long,
+        toggleId: String,
+    ): Boolean {
+        return unleashService.isEnabled(
+            toggleId,
+            properties =
+                mapOf(
+                    UnleashContextFields.FAGSAK_ID to fagsakId.toString(),
+                ),
+        )
+    }
+
     fun isEnabled(toggleId: String): Boolean =
         unleashService.isEnabled(
             toggleId,

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
@@ -35,15 +35,14 @@ class UnleashNextMedContextService(
     fun isEnabledForFagsak(
         fagsakId: Long,
         toggleId: String,
-    ): Boolean {
-        return unleashService.isEnabled(
+    ): Boolean =
+        unleashService.isEnabled(
             toggleId,
             properties =
                 mapOf(
                     UnleashContextFields.FAGSAK_ID to fagsakId.toString(),
                 ),
         )
-    }
 
     fun isEnabled(toggleId: String): Boolean =
         unleashService.isEnabled(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringService.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ks.sak.kjerne.autovedtak
 
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.SettPåMaskinellVentÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.SnikeIKøenService
@@ -29,6 +31,7 @@ class AutovedtakLovendringService(
     private val stegService: StegService,
     private val vedtakService: VedtakService,
     private val behandlingService: BehandlingService,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -37,7 +40,7 @@ class AutovedtakLovendringService(
         fagsakId: Long,
         erFremtidigOpphør: Boolean = false,
     ): Behandling? =
-        if (behandlingRepository.finnBehandlinger(fagsakId).any { it.opprettetÅrsak == BehandlingÅrsak.LOVENDRING_2024 }) {
+        if (!unleashNextMedContextService.isEnabledForFagsak(fagsakId, FeatureToggleConfig.KAN_KJORE_LOVENDRING_FLERE_GANGER) && behandlingRepository.finnBehandlinger(fagsakId).any { it.opprettetÅrsak == BehandlingÅrsak.LOVENDRING_2024 }) {
             logger.info("Lovendring 2024 allerede kjørt for fagsakId=$fagsakId")
             null
         } else {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -72,6 +72,7 @@ class BeregningService(
                 .finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
                 .filter {
                     when {
+                        behandling.skalBehandlesAutomatisk() -> true
                         endretUtbetalingAndel != null -> it.id == endretUtbetalingAndel.id || it.andelerTilkjentYtelse.isNotEmpty()
                         else -> it.andelerTilkjentYtelse.isNotEmpty()
                     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
@@ -123,6 +123,7 @@ class AutovedtakLovendringTest(
         justRun { arbeidsfordelingService.fastsettBehandledeEnhet(any(), any()) }
         justRun { sakStatistikkService.opprettSendingAvBehandlingensTilstand(any(), any()) }
         every { unleashNextMedContextService.isEnabled(any()) } returns true
+        every { unleashNextMedContextService.isEnabledForFagsak(any(), any()) } returns false
         every { personService.lagPerson(any(), any(), any(), any(), any()) } answers {
             val aktør = firstArg<Aktør>()
             personRepository.findByAktør(aktør).first()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
@@ -596,8 +596,8 @@ class AutovedtakLovendringTest(
         aktør: Aktør = barn,
         prosent: BigDecimal = BigDecimal.valueOf(100),
         sats: Int = maksBeløp(),
-        kalkulertUtbetalingsbeløp: Int = prosent.toDouble().div(100).times(sats).toInt(),
-        nasjonaltPeriodebeløp: Int = prosent.toDouble().div(100).times(sats).toInt(),
+        kalkulertUtbetalingsbeløp: Int = (prosent.toDouble() / 100 * sats).toInt(),
+        nasjonaltPeriodebeløp: Int = (prosent.toDouble() / 100 * sats).toInt(),
     ) {
         tilkjentYtelse.andelerTilkjentYtelse.add(
             andelTilkjentYtelseRepository.save(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/autovedtak/AutovedtakLovendringTest.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagEndretUtbetalingAndel
 import no.nav.familie.ks.sak.data.lagLogg
 import no.nav.familie.ks.sak.data.lagPersonResultat
 import no.nav.familie.ks.sak.data.lagVilkårResultaterForBarn
@@ -41,8 +42,12 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårsvurderingRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.brev.BrevKlient
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse.OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakStatus.LØPENDE
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
@@ -70,6 +75,7 @@ import java.time.YearMonth
 class AutovedtakLovendringTest(
     @Autowired private val autovedtakLovendringService: AutovedtakLovendringService,
     @Autowired private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    @Autowired private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
     @Autowired private val personRepository: PersonRepository,
     @Autowired private val vilkårsvurderingRepository: VilkårsvurderingRepository,
     @Autowired private val behandlingRepository: BehandlingRepository,
@@ -425,6 +431,84 @@ class AutovedtakLovendringTest(
     }
 
     @Test
+    fun `automatisk revurdering av fagsak som har endete utbetalinger i forrige behandling får endrete utbetalinger i ny behandling`() {
+        // arrange
+        val fødselsdatoBarn = LocalDate.of(2023, 1, 1)
+        val stønadFom = fødselsdatoBarn.plusYears(1).plusMonths(1).toYearMonth()
+        val stønadTomGammeltRegelverk = fødselsdatoBarn.plusYears(2).minusMonths(1).toYearMonth()
+        val stønadTomNyttRegelverk = fødselsdatoBarn.plusYears(1).plusMonths(7).toYearMonth()
+        val sats = maksBeløp()
+
+        opprettSøkerFagsakOgBehandling(fagsakStatus = LØPENDE, behandlingStatus = AVSLUTTET, behandlingResultat = INNVILGET)
+        opprettPersonopplysningGrunnlagOgPersonForBehandling(lagBarn = true, fødselsdatoBarn = fødselsdatoBarn)
+        lagVilkårsvurderingEtterGammeltRegelverk(fødselsdatoBarn)
+
+        lagTilkjentYtelse()
+        leggTilAndelTilkjentYtelse(
+            stønadFom = stønadFom,
+            stønadTom = stønadFom.plusMonths(2),
+            prosent = BigDecimal.ZERO,
+            sats = sats,
+        )
+        leggTilAndelTilkjentYtelse(
+            stønadFom = stønadFom.plusMonths(3),
+            stønadTom = stønadTomGammeltRegelverk,
+            sats = sats,
+        )
+        endretUtbetalingAndelRepository.saveAndFlush(
+            lagEndretUtbetalingAndel(
+                behandlingId = behandling.id,
+                person = personRepository.findByAktør(barn).first(),
+                prosent = BigDecimal.ZERO,
+                periodeFom = stønadFom,
+                periodeTom = stønadFom.plusMonths(2),
+                årsak = Årsak.ETTERBETALING_3MND,
+                avtaletidspunktDeltBosted = null,
+            ),
+        )
+
+        every { localDateProvider.now() } returns LocalDate.of(2024, 8, 1)
+        every { behandlingService.hentSisteBehandlingSomErIverksatt(fagsak.id) } returns behandling
+
+        // act
+        val nyBehandling = autovedtakLovendringService.revurderFagsak(fagsakId = fagsak.id)!!
+
+        // assert
+        assertThat(nyBehandling.opprettetÅrsak).isEqualTo(LOVENDRING_2024)
+        assertThat(nyBehandling.steg).isEqualTo(BehandlingSteg.IVERKSETT_MOT_OPPDRAG)
+
+        val andelTilkjentYtelseNy = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(nyBehandling.id)
+        assertThat(andelTilkjentYtelseNy)
+            .hasSize(2)
+            .anySatisfy {
+                assertThat(it.stønadFom).isEqualTo(stønadFom)
+                assertThat(it.stønadTom).isEqualTo(stønadFom.plusMonths(2))
+                assertThat(it.prosent).isEqualTo(BigDecimal.ZERO)
+                assertThat(it.kalkulertUtbetalingsbeløp).isEqualTo(0)
+            }.anySatisfy {
+                assertThat(it.stønadFom).isEqualTo(stønadFom.plusMonths(3))
+                assertThat(it.stønadTom).isEqualTo(stønadTomNyttRegelverk)
+                assertThat(it.prosent).isEqualTo(BigDecimal.valueOf(100))
+                assertThat(it.sats).isEqualTo(sats)
+                assertThat(it.kalkulertUtbetalingsbeløp).isEqualTo(sats)
+            }
+
+        val endreteUtbetalingerNy = endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(nyBehandling.id)
+        assertThat(endreteUtbetalingerNy)
+            .hasSize(1)
+            .anySatisfy {
+                assertThat(it.fom).isEqualTo(stønadFom)
+                assertThat(it.tom).isEqualTo(stønadFom.plusMonths(2))
+                assertThat(it.prosent).isEqualTo(BigDecimal.ZERO)
+            }
+
+        verify(inverse = true) { simuleringService.oppdaterSimuleringPåBehandling(any<Long>()) }
+        verify(inverse = true) { brevklient.genererBrev(any(), any()) }
+
+        assertTotrinnskontroll(nyBehandling)
+    }
+
+    @Test
     fun `automatisk revurdering av fagsak som blir truffet av nytt regelverk skal snike i køen`() {
         // arrange
 
@@ -499,6 +583,34 @@ class AutovedtakLovendringTest(
                     aktør = aktør,
                     stønadFom = stønadFom,
                     stønadTom = stønadTom,
+                ),
+            ),
+        )
+    }
+
+    private fun leggTilAndelTilkjentYtelse(
+        tilkjentYtelse: TilkjentYtelse = this.tilkjentYtelse,
+        behandling: Behandling = this.behandling,
+        stønadFom: YearMonth = YearMonth.now(),
+        stønadTom: YearMonth = YearMonth.now(),
+        aktør: Aktør = barn,
+        prosent: BigDecimal = BigDecimal.valueOf(100),
+        sats: Int = maksBeløp(),
+        kalkulertUtbetalingsbeløp: Int = prosent.toDouble().div(100).times(sats).toInt(),
+        nasjonaltPeriodebeløp: Int = prosent.toDouble().div(100).times(sats).toInt(),
+    ) {
+        tilkjentYtelse.andelerTilkjentYtelse.add(
+            andelTilkjentYtelseRepository.save(
+                lagAndelTilkjentYtelse(
+                    tilkjentYtelse = tilkjentYtelse,
+                    behandling = behandling,
+                    aktør = aktør,
+                    stønadFom = stønadFom,
+                    stønadTom = stønadTom,
+                    prosent = prosent,
+                    sats = sats,
+                    kalkulertUtbetalingsbeløp = kalkulertUtbetalingsbeløp,
+                    nasjonaltPeriodebeløp = nasjonaltPeriodebeløp,
                 ),
             ),
         )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22118

Kjøring av automatisk behandling årsak lovendring fører til feilutbetaling fordi endrete utbetalinger blir kopiert, men endrer ikke andelene

Ved automatiske behandlinger ønsker vi alltid å inkludere alle endrete utbetalinger

Legger til [feature toggle](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-sak.kan-kjore-lovendring-flere-ganger) for å kunne revurdere fagsaker flere ganger for å kunne korrigere feil behandlinger

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
