### PR TITLE
validering av barnets alder vilkår støtter adopsjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtils.kt
@@ -3,6 +3,7 @@ import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import java.time.LocalDate
@@ -11,6 +12,7 @@ fun lagAutomatiskGenererteVilkårForBarnetsAlder(
     personResultat: PersonResultat,
     behandling: Behandling,
     fødselsdato: LocalDate,
+    erAdopsjon: Boolean = false,
 ): List<VilkårResultat> {
     val periodeFomBarnetsAlderLov2024 = fødselsdato.plusMonths(13)
     val periodeTomBarnetsAlderLov2024 = fødselsdato.plusMonths(19)
@@ -32,6 +34,7 @@ fun lagAutomatiskGenererteVilkårForBarnetsAlder(
                 behandlingId = behandling.id,
                 periodeFom = periodeFomBarnetsAlderLov2021,
                 periodeTom = minOf(periodeTomBarnetsAlderLov2021, DATO_LOVENDRING_2024.minusDays(1)),
+                utdypendeVilkårsvurderinger = if (erAdopsjon) listOf(UtdypendeVilkårsvurdering.ADOPSJON) else emptyList(),
             )
         } else {
             null
@@ -48,6 +51,7 @@ fun lagAutomatiskGenererteVilkårForBarnetsAlder(
                 behandlingId = behandling.id,
                 periodeFom = maxOf(periodeFomBarnetsAlderLov2024, DATO_LOVENDRING_2024),
                 periodeTom = periodeTomBarnetsAlderLov2024,
+                utdypendeVilkårsvurderinger = if (erAdopsjon) listOf(UtdypendeVilkårsvurdering.ADOPSJON) else emptyList(),
             )
         } else {
             null

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
@@ -3,10 +3,14 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
+import no.nav.familie.ks.sak.common.util.toYearMonth
 import java.time.LocalDate
+import java.time.YearMonth
 
 data class VilkårLovverkInformasjonForBarn(
     val fødselsdato: LocalDate,
+    val periodeFomForAdoptertBarn: YearMonth? = null,
+    val periodeTomForAdoptertBarn: YearMonth? = null,
 ) {
     val periodeFomBarnetsAlderLov2021: LocalDate
     val periodeTomBarnetsAlderLov2021: LocalDate
@@ -19,8 +23,8 @@ data class VilkårLovverkInformasjonForBarn(
         this.periodeTomBarnetsAlderLov2021 = fødselsdato.plusYears(2)
         this.periodeFomBarnetsAlderLov2024 = fødselsdato.plusMonths(13)
         this.periodeTomBarnetsAlderLov2024 = fødselsdato.plusMonths(19)
-        val erTruffetAvLovverk2021 = periodeFomBarnetsAlderLov2021.isBefore(DATO_LOVENDRING_2024)
-        val erTruffetAvLovverk2024 = periodeTomBarnetsAlderLov2024.erSammeEllerEtter(DATO_LOVENDRING_2024)
+        val erTruffetAvLovverk2021 = periodeFomForAdoptertBarn?.isBefore(DATO_LOVENDRING_2024.toYearMonth()) ?: periodeFomBarnetsAlderLov2021.isBefore(DATO_LOVENDRING_2024)
+        val erTruffetAvLovverk2024 = periodeTomForAdoptertBarn?.isAfter(DATO_LOVENDRING_2024.toYearMonth().minusMonths(1)) ?: periodeTomBarnetsAlderLov2024.erSammeEllerEtter(DATO_LOVENDRING_2024)
 
         this.lovverk =
             when {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
+import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import java.time.LocalDate
 import java.time.YearMonth
@@ -24,7 +25,7 @@ data class VilkårLovverkInformasjonForBarn(
         this.periodeFomBarnetsAlderLov2024 = fødselsdato.plusMonths(13)
         this.periodeTomBarnetsAlderLov2024 = fødselsdato.plusMonths(19)
         val erTruffetAvLovverk2021 = periodeFomForAdoptertBarn?.isBefore(DATO_LOVENDRING_2024.toYearMonth()) ?: periodeFomBarnetsAlderLov2021.isBefore(DATO_LOVENDRING_2024)
-        val erTruffetAvLovverk2024 = periodeTomForAdoptertBarn?.isAfter(DATO_LOVENDRING_2024.toYearMonth().minusMonths(1)) ?: periodeTomBarnetsAlderLov2024.erSammeEllerEtter(DATO_LOVENDRING_2024)
+        val erTruffetAvLovverk2024 = periodeTomForAdoptertBarn?.toLocalDate()?.erSammeEllerEtter(DATO_LOVENDRING_2024) ?: periodeTomBarnetsAlderLov2024.erSammeEllerEtter(DATO_LOVENDRING_2024)
 
         this.lovverk =
             when {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårResultat.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårResultat.kt
@@ -134,6 +134,7 @@ class VilkårResultat(
         resultat: Resultat = this.resultat,
         periodeTom: LocalDate? = this.periodeTom,
         begrunnelse: String = this.begrunnelse,
+        utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = this.utdypendeVilkårsvurderinger,
     ) = VilkårResultat(
         personResultat = personResultat ?: this.personResultat,
         erAutomatiskVurdert = this.erAutomatiskVurdert,
@@ -147,7 +148,7 @@ class VilkårResultat(
         regelOutput = this.regelOutput,
         erEksplisittAvslagPåSøknad = this.erEksplisittAvslagPåSøknad,
         vurderesEtter = this.vurderesEtter,
-        utdypendeVilkårsvurderinger = this.utdypendeVilkårsvurderinger,
+        utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
         antallTimer = this.antallTimer,
         søkerHarMeldtFraOmBarnehageplass = this.søkerHarMeldtFraOmBarnehageplass,
     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -51,7 +51,13 @@ object TilkjentYtelseValidator {
 
             val relevantBarn = barna.single { it.aktør == aktør }
 
-            val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(relevantBarn.fødselsdato)
+            val vilkårLovverkInformasjonForBarn =
+                if (alleBarnetsAlderVilkårResultater.any { it.erAdopsjonOppfylt() }) {
+                    VilkårLovverkInformasjonForBarn(relevantBarn.fødselsdato, stønadFom, stønadTom)
+                } else {
+                    VilkårLovverkInformasjonForBarn(relevantBarn.fødselsdato)
+                }
+
             val barnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater.filter { it.personResultat?.aktør == aktør }
 
             val maksAntallMånederMedUtbetaling = utledMaksAntallMånederMedUtbetaling(vilkårLovverkInformasjonForBarn, barnetsAlderVilkårResultater)
@@ -61,7 +67,7 @@ object TilkjentYtelseValidator {
 
             if (antallMånederUtbetalt > maksAntallMånederMedUtbetaling) {
                 val feilmelding =
-                    "Kontantstøtte kan maks utbetales for $maksAntallMånederMedUtbetaling måneder. Du er i ferd med å utbetale mer enn dette for barn med fnr ${aktør.aktivFødselsnummer()}. " +
+                    "Kontantstøtte kan maks utbetales for $maksAntallMånederMedUtbetaling måneder. Du er i ferd med å utbetale $antallMånederUtbetalt måneder for barn med fnr ${aktør.aktivFødselsnummer()}. " +
                         "Kontroller datoene på vilkårene eller ta kontakt med Team BAKS"
                 throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21996)

For å kunne kjøre revurdering av fagsaker som har adopsjon trenger vi at valideringen av disse sakene ikke bruker fødselsdato, men heller baserer seg på lengden på andelene. 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
