### PR TITLE
Legger til avstemmingId på grensesnittavstemming for at task kan kunne rekjøres

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -78,6 +78,7 @@ class OppdragKlient(
     fun sendGrensesnittavstemmingTilOppdrag(
         fom: LocalDateTime,
         tom: LocalDateTime,
+        avstemmingId: UUID?,
     ): String {
         val uri = URI.create("$familieOppdragUri/grensesnittavstemming")
         return kallEksternTjenesteRessurs(
@@ -85,7 +86,16 @@ class OppdragKlient(
             uri = uri,
             formål = "Gjør grensesnittavstemming mot oppdrag",
         ) {
-            postForEntity(uri = uri, payload = GrensesnittavstemmingRequest(FAGSYSTEM, fom, tom))
+            postForEntity(
+                uri = uri,
+                payload =
+                    GrensesnittavstemmingRequest(
+                        fagsystem = FAGSYSTEM,
+                        fra = fom,
+                        til = tom,
+                        avstemmingId = avstemmingId,
+                    ),
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingService.kt
@@ -20,8 +20,9 @@ class AvstemmingService(
     fun sendGrensesnittavstemming(
         fom: LocalDateTime,
         tom: LocalDateTime,
+        avstemmingId: UUID?,
     ) {
-        oppdragKlient.sendGrensesnittavstemmingTilOppdrag(fom, tom)
+        oppdragKlient.sendGrensesnittavstemmingTilOppdrag(fom = fom, tom = tom, avstemmingId = avstemmingId)
     }
 
     fun sendKonsistensavstemmingStartMelding(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingTask.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.Properties
+import java.util.UUID
 
 @Service
 @TaskStepBeskrivelse(
@@ -22,8 +23,8 @@ class GrensesnittavstemmingTask(
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val taskData = objectMapper.readValue(task.payload, GrensesnittavstemmingTaskDto::class.java)
-        logger.info("Kjører $TASK_STEP_TYPE for fom=${taskData.fom}, tom=${taskData.tom}")
-        avstemmingService.sendGrensesnittavstemming(taskData.fom, taskData.tom)
+        logger.info("Kjører $TASK_STEP_TYPE for fom=${taskData.fom}, tom=${taskData.tom}, avstemmingId=${taskData.avstemmingId}")
+        avstemmingService.sendGrensesnittavstemming(fom = taskData.fom, tom = taskData.tom, avstemmingId = taskData.avstemmingId)
     }
 
     companion object {
@@ -32,14 +33,16 @@ class GrensesnittavstemmingTask(
         fun opprettTask(
             fom: LocalDateTime,
             tom: LocalDateTime,
+            avstemmingId: UUID = UUID.randomUUID(),
         ) = Task(
             type = TASK_STEP_TYPE,
-            payload = objectMapper.writeValueAsString(GrensesnittavstemmingTaskDto(fom, tom)),
+            payload = objectMapper.writeValueAsString(GrensesnittavstemmingTaskDto(fom, tom, avstemmingId)),
             properties =
                 Properties().apply {
                     // la til denne i properties slik at de kan vises i familie-prosessering
                     this["fom"] = fom.toString()
                     this["tom"] = tom.toString()
+                    this["avstemmingId"] = avstemmingId.toString()
                 },
         )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/domene/GrensesnittavstemmingTaskDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/domene/GrensesnittavstemmingTaskDto.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.ks.sak.kjerne.avstemming.domene
 
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class GrensesnittavstemmingTaskDto(
     val fom: LocalDateTime,
     val tom: LocalDateTime,
+    val avstemmingId: UUID?,
 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingSchedulerTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
 internal class GrensesnittavstemmingSchedulerTest {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingSchedulerTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
+import java.util.*
 
 @ExtendWith(MockKExtension::class)
 internal class GrensesnittavstemmingSchedulerTest {
@@ -190,6 +191,6 @@ internal class GrensesnittavstemmingSchedulerTest {
         tom: LocalDate,
     ) = Task(
         type = GrensesnittavstemmingTask.TASK_STEP_TYPE,
-        payload = objectMapper.writeValueAsString(GrensesnittavstemmingTaskDto(fom.atStartOfDay(), tom.atStartOfDay())),
+        payload = objectMapper.writeValueAsString(GrensesnittavstemmingTaskDto(fom.atStartOfDay(), tom.atStartOfDay(), UUID.randomUUID())),
     )
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tasken kan time ut mot familie-oppdrag hvis f.eks. familie-oppdrag har mye å gjøre, men likevel kjøre ferdig i familie-oppdrag. Legger man med avstemmingId så kjøres det ikke en ny grensesnittavstemming hvis den faktisk ble ferdigkjørt


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Kopierer funksjonalitet i ba-sak
