### PR TITLE
Sperre godkjenning av teknisk endring for de uinnvidde

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
@@ -46,6 +46,17 @@ class BeslutteVedtakSteg(
         logger.info("Utfører steg ${getBehandlingssteg().name} for behandling $behandlingId")
         val behandling = behandlingService.hentBehandling(behandlingId)
 
+        if (behandling.erTekniskEndring() &&
+            !unleashService.isEnabled(
+                FeatureToggleConfig.TEKNISK_ENDRING,
+                behandling.id,
+            )
+        ) {
+            throw FunksjonellFeil(
+                "Du har ikke tilgang til å beslutte en behandling med årsak=${behandling.opprettetÅrsak.visningsnavn}. Ta kontakt med teamet dersom dette ikke stemmer.",
+            )
+        }
+
         validerAtBehandlingKanBesluttes(behandling)
 
         val besluttVedtakDto = behandlingStegDto as BesluttVedtakDto


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22146

Behandlinger med årsak `TEKNISK_ENDRING` skal bare kunne godkjennes av saksbehandlere med tilgang til å teknisk endring.

Løser dette ved å kaste en feil i `BeslutteVedtakSteg` dersom saksbehandler som prøver å godkjenne ikke er lagt inn i [toggle](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-sak.behandling.teknisk-endring)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
