### PR TITLE
Bytt til funksjonell feil fra feil ved sjekk om barn er 1 år eller ikke

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/RegistrereSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/RegistrereSøknadSteg.kt
@@ -106,8 +106,8 @@ class RegistrereSøknadSteg(
             val datoBarnFyller1År = barnFødselsdato.plusYears(1)
 
             if (datoBarnFyller1År > sisteDagIInneværendeMåned) {
-                throw Feil(
-                    message = "Det er ikke mulig å behandle barn som fyller 1 år senere enn inneværende måned.",
+                throw FunksjonellFeil(
+                    melding = "Det er ikke mulig å behandle barn som fyller 1 år senere enn inneværende måned.",
                     frontendFeilmelding = "Det er søkt for tidlig for barn ${barn.personnummer ?: "uten ident"}. Søknaden kan tidligst behandles ${datoBarnFyller1År.tilMånedÅr()}.",
                 )
             }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.api.dto.tilSøknadGrunnlag
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
-import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.data.lagPdlPersonInfo
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
@@ -209,7 +209,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
                 endringAvOpplysningerBegrunnelse = "",
             )
 
-        assertThrows<Feil> {
+        assertThrows<FunksjonellFeil> {
             registrereSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto, false))
         }
     }


### PR DESCRIPTION
Endrer til funksjonell feil slik at vi ikke spammer loggene når dette skjer.
Synes også det er mer riktig at det er funksjonell feil.