### PR TITLE
Bytter til distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
+FROM busybox:1.36.1-uclibc as busybox
 
-ENV APPD_ENABLED=true
+# Final image
+FROM gcr.io/distroless/java21:nonroot
+COPY --from=busybox /bin/printenv /bin/printenv
+COPY --chown=nonroot:nonroot ./build/libs/familie-ks-sak.jar /app/app.jar
+WORKDIR /app
+
 ENV APP_NAME=familie-ks-sak
-
-COPY ./build/libs/familie-ks-sak.jar "app.jar"
+ENV TZ="Europe/Oslo"
+# TLS Config works around an issue in OpenJDK... See: https://github.com/kubernetes-client/java/issues/854
+ENTRYPOINT [ "java", "-Djdk.tls.client.protocols=TLSv1.2", "-jar", "/app/app.jar" ]

--- a/hentMiljøvariabler.sh
+++ b/hentMiljøvariabler.sh
@@ -1,7 +1,7 @@
 kubectl config use-context dev-gcp
 PODNAVN=$(kubectl -n teamfamilie get pods --field-selector=status.phase==Running -o name | grep familie-ks-sak | grep -v "frontend" |  sed "s/^.\{4\}//" | head -n 1);
 
-PODVARIABLER="$(kubectl -n teamfamilie exec -c familie-ks-sak -it "$PODNAVN" -- env)"
+PODVARIABLER="$(kubectl -n teamfamilie exec -c familie-ks-sak -it "$PODNAVN" -- printenv)"
 UNLEASH_VARIABLER="$(kubectl -n teamfamilie get secret familie-ks-sak-unleash-api-token -o json | jq '.data | map_values(@base64d)')"
 
 AZURE_APP_CLIENT_ID="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_ID" | tr -d '\r' )"


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Gjør som på ba-sak. Bytter til distroless. For å få helt kontroll på Timezone/TZ for datavarehusendringer som følger. 

Bruker printenv i stedet for env for å hente ut miljøvariabler.


Testet preprod og DevLauncherPostgresPreprod
