### PR TITLE
Fjerner side-effects fra lagBehandlingStegTilstand testmetoden

### DIFF
--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -276,6 +276,14 @@ fun lagBehandling(
     status: BehandlingStatus = BehandlingStatus.UTREDES,
     id: Long = nesteBehandlingId(),
     endretTidspunkt: LocalDateTime = LocalDateTime.now(),
+    lagBehandlingStegTilstander: (behandling: Behandling) -> Set<BehandlingStegTilstand> = {
+        setOf(
+            BehandlingStegTilstand(
+                behandling = it,
+                behandlingSteg = BehandlingSteg.REGISTRERE_PERSONGRUNNLAG,
+            ),
+        )
+    },
 ): Behandling {
     val behandling =
         Behandling(
@@ -287,26 +295,26 @@ fun lagBehandling(
             resultat = resultat,
             aktiv = aktiv,
             status = status,
-        ).initBehandlingStegTilstand()
+        )
+    behandling.behandlingStegTilstand.addAll(lagBehandlingStegTilstander(behandling))
     behandling.endretTidspunkt = endretTidspunkt
     return behandling
 }
 
 fun lagBehandlingStegTilstand(
     behandling: Behandling,
-    behandlingSteg: BehandlingSteg,
-    behandlingStegStatus: BehandlingStegStatus,
+    behandlingSteg: BehandlingSteg = BehandlingSteg.REGISTRERE_PERSONGRUNNLAG,
+    behandlingStegStatus: BehandlingStegStatus = BehandlingStegStatus.KLAR,
     frist: LocalDate? = null,
     årsak: VenteÅrsak? = null,
-) = behandling.behandlingStegTilstand.add(
+): BehandlingStegTilstand =
     BehandlingStegTilstand(
         behandling = behandling,
         behandlingSteg = behandlingSteg,
         behandlingStegStatus = behandlingStegStatus,
         frist = frist,
         årsak = årsak,
-    ),
-)
+    )
 
 fun lagArbeidsfordelingPåBehandling(
     id: Long = 123,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 import java.time.LocalDateTime
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
 
 class SnikeIKøenServiceTest {
     private val localDateTimeProvider: LocalDateTimeProvider = mockk()
@@ -74,12 +75,16 @@ class SnikeIKøenServiceTest {
                 lagBehandling(
                     id = 1L,
                     status = BehandlingStatus.OPPRETTET,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.REGISTRERE_PERSONGRUNNLAG,
+                                behandlingStegStatus = BehandlingStegStatus.KLAR,
+                            ),
+                        )
+                    },
                 )
-            lagBehandlingStegTilstand(
-                behandling,
-                BehandlingSteg.REGISTRERE_PERSONGRUNNLAG,
-                BehandlingStegStatus.KLAR,
-            )
 
             every { behandlingRepository.hentBehandling(1L) } returns behandling
 
@@ -97,17 +102,28 @@ class SnikeIKøenServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(value = BehandlingStegStatus::class)
-        fun `skal sette behandling på maskinell vent uansett behandlingStegStatus når BehandlingStatus er UTREDES`(
+        @EnumSource(
+            value = BehandlingStegStatus::class,
+            names = ["TILBAKEFØRT"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal sette behandling på maskinell vent for behandlingStegStatus når BehandlingStatus er UTREDES`(
             behandlingStegStatus: BehandlingStegStatus,
         ) {
             // Arrange
-            val behandling = lagBehandling(status = BehandlingStatus.UTREDES)
-            lagBehandlingStegTilstand(
-                behandling,
-                BehandlingSteg.REGISTRERE_SØKNAD,
-                behandlingStegStatus,
-            )
+            val behandling =
+                lagBehandling(
+                    status = BehandlingStatus.UTREDES,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.REGISTRERE_SØKNAD,
+                                behandlingStegStatus = behandlingStegStatus,
+                            ),
+                        )
+                    },
+                )
 
             val årsak = SettPåMaskinellVentÅrsak.SATSENDRING
 
@@ -134,13 +150,19 @@ class SnikeIKøenServiceTest {
             behandlingStatus: BehandlingStatus,
         ) {
             // Arrange
-            val behandling = lagBehandling(status = behandlingStatus)
-            behandling.behandlingStegTilstand.clear()
-            lagBehandlingStegTilstand(
-                behandling,
-                BehandlingSteg.AVSLUTT_BEHANDLING,
-                BehandlingStegStatus.VENTER,
-            )
+            val behandling =
+                lagBehandling(
+                    status = behandlingStatus,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING,
+                                behandlingStegStatus = BehandlingStegStatus.VENTER,
+                            ),
+                        )
+                    },
+                )
 
             val årsak = SettPåMaskinellVentÅrsak.SATSENDRING
 
@@ -418,15 +440,18 @@ class SnikeIKøenServiceTest {
                     fagsak = fagsak,
                     status = BehandlingStatus.SATT_PÅ_MASKINELL_VENT,
                     aktiv = false,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.VILKÅRSVURDERING,
+                                behandlingStegStatus = BehandlingStegStatus.VENTER,
+                                frist = dagensDato,
+                                årsak = VenteÅrsak.AVVENTER_BEHANDLING,
+                            ),
+                        )
+                    },
                 )
-            behandlingPåVent.behandlingStegTilstand.clear()
-            lagBehandlingStegTilstand(
-                behandlingPåVent,
-                BehandlingSteg.VILKÅRSVURDERING,
-                BehandlingStegStatus.VENTER,
-                frist = dagensDato,
-                årsak = VenteÅrsak.AVVENTER_BEHANDLING,
-            )
 
             val behandlingSomSnekIKøen =
                 lagBehandling(
@@ -471,13 +496,18 @@ class SnikeIKøenServiceTest {
         @Test
         fun `skal kunne snike i køen om BehandlingStegStatus er VENTER`() {
             // Arrange
-            val behandling = lagBehandling()
-            behandling.behandlingStegTilstand.clear()
-            lagBehandlingStegTilstand(
-                behandling,
-                BehandlingSteg.VILKÅRSVURDERING,
-                BehandlingStegStatus.VENTER,
-            )
+            val behandling =
+                lagBehandling(
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.VILKÅRSVURDERING,
+                                behandlingStegStatus = BehandlingStegStatus.VENTER,
+                            ),
+                        )
+                    },
+                )
 
             // Act
             val kanSnikeForbi = snikeIKøenService.kanSnikeForbi(behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SnikeIKøenServiceTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 import java.time.LocalDateTime
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
 
 class SnikeIKøenServiceTest {
     private val localDateTimeProvider: LocalDateTimeProvider = mockk()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingControllerTest.kt
@@ -75,7 +75,9 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
                 behandlendeEnhetNavn = "test",
             ),
         )
-        lagBehandlingStegTilstand(behandling, BehandlingSteg.VILKÅRSVURDERING, BehandlingStegStatus.KLAR)
+        behandling.behandlingStegTilstand.add(
+            lagBehandlingStegTilstand(behandling, BehandlingSteg.VILKÅRSVURDERING, BehandlingStegStatus.KLAR),
+        )
         lagreBehandling(behandling)
 
         every { integrasjonClient.hentLand(any()) } returns "Norge"
@@ -140,19 +142,31 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
     fun `endreVilkår - skal endre vilkår og tilbakefører behandling til vilkårsvurdering`() {
         val behandlingForOppdatering = behandlingRepository.hentAktivBehandling(behandling.id)
         behandlingForOppdatering.behandlingStegTilstand.clear()
+        behandlingForOppdatering.behandlingStegTilstand.addAll(
+            setOf(
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.VILKÅRSVURDERING,
+                    BehandlingStegStatus.UTFØRT,
+                ),
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.BEHANDLINGSRESULTAT,
+                    BehandlingStegStatus.UTFØRT,
+                ),
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.SIMULERING,
+                    BehandlingStegStatus.UTFØRT,
+                ),
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.VEDTAK,
+                    BehandlingStegStatus.KLAR,
+                ),
+            ),
+        )
 
-        lagBehandlingStegTilstand(
-            behandlingForOppdatering,
-            BehandlingSteg.VILKÅRSVURDERING,
-            BehandlingStegStatus.UTFØRT,
-        )
-        lagBehandlingStegTilstand(
-            behandlingForOppdatering,
-            BehandlingSteg.BEHANDLINGSRESULTAT,
-            BehandlingStegStatus.UTFØRT,
-        )
-        lagBehandlingStegTilstand(behandlingForOppdatering, BehandlingSteg.SIMULERING, BehandlingStegStatus.UTFØRT)
-        lagBehandlingStegTilstand(behandlingForOppdatering, BehandlingSteg.VEDTAK, BehandlingStegStatus.KLAR)
         lagreBehandling(behandlingForOppdatering)
 
         lagVedtakOgVedtaksperiode()
@@ -281,18 +295,31 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
     fun `opprettNyttVilkår - skal opprette nytt vilkår og tilbakefører behandling til vilkårsvurdering steg`() {
         val behandlingForOppdatering = behandlingRepository.hentAktivBehandling(behandling.id)
         behandlingForOppdatering.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(
-            behandlingForOppdatering,
-            BehandlingSteg.VILKÅRSVURDERING,
-            BehandlingStegStatus.UTFØRT,
+        behandlingForOppdatering.behandlingStegTilstand.addAll(
+            setOf(
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.VILKÅRSVURDERING,
+                    BehandlingStegStatus.UTFØRT,
+                ),
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.BEHANDLINGSRESULTAT,
+                    BehandlingStegStatus.UTFØRT,
+                ),
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.SIMULERING,
+                    BehandlingStegStatus.UTFØRT,
+                ),
+                lagBehandlingStegTilstand(
+                    behandlingForOppdatering,
+                    BehandlingSteg.VEDTAK,
+                    BehandlingStegStatus.KLAR,
+                ),
+            ),
         )
-        lagBehandlingStegTilstand(
-            behandlingForOppdatering,
-            BehandlingSteg.BEHANDLINGSRESULTAT,
-            BehandlingStegStatus.UTFØRT,
-        )
-        lagBehandlingStegTilstand(behandlingForOppdatering, BehandlingSteg.SIMULERING, BehandlingStegStatus.UTFØRT)
-        lagBehandlingStegTilstand(behandlingForOppdatering, BehandlingSteg.VEDTAK, BehandlingStegStatus.KLAR)
+
         lagreBehandling(behandlingForOppdatering)
 
         lagVedtakOgVedtaksperiode()

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -311,8 +311,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `utførSteg skal videresende behandling fra BESLUTTE_VEDTAK til IVERKSETT_MOT_OPPDRAG steg når SB godkjenner`() {
         behandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(behandling, VEDTAK, UTFØRT)
-        lagBehandlingStegTilstand(behandling, BESLUTTE_VEDTAK, KLAR)
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, VEDTAK, UTFØRT))
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, BESLUTTE_VEDTAK, KLAR))
 
         behandling.status = BehandlingStatus.FATTER_VEDTAK
         lagreBehandling(behandling)
@@ -343,7 +343,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @EnumSource(value = BehandlingSteg::class, names = ["BESLUTTE_VEDTAK", "IVERKSETT_MOT_OPPDRAG", "JOURNALFØR_VEDTAKSBREV", "AVSLUTT_BEHANDLING"])
     fun `utførSteg skal kaste feil dersom vi forsøker å utføre et allerede utført steg fra og med BESLUTTE_VEDTAK-steget`(behandlingSteg: BehandlingSteg) {
         behandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(behandling, behandlingSteg, UTFØRT)
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, behandlingSteg, UTFØRT))
 
         lagreBehandling(behandling)
 
@@ -364,7 +364,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         behandling.behandlingStegTilstand.clear()
 
         BehandlingSteg.entries.forEach {
-            lagBehandlingStegTilstand(behandling, it, UTFØRT)
+            behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, it, UTFØRT))
         }
 
         behandling.status = BehandlingStatus.AVSLUTTET
@@ -385,8 +385,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `utførSteg skal tilbakeføre behandling fra BESLUTTE_VEDTAK til VEDTAK steg når SB underkjenner vedtaket`() {
         behandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(behandling, VEDTAK, UTFØRT)
-        lagBehandlingStegTilstand(behandling, BESLUTTE_VEDTAK, KLAR)
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, VEDTAK, UTFØRT))
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, BESLUTTE_VEDTAK, KLAR))
 
         behandling.status = BehandlingStatus.FATTER_VEDTAK
         lagreBehandling(behandling)
@@ -404,8 +404,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     fun `utførStegEtterIverksettelseAutomatisk skal utføre AVSLUTT_BEHANDLING steg automatisk`() {
         val taskSlot = slot<Task>()
         behandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, UTFØRT)
-        lagBehandlingStegTilstand(behandling, AVSLUTT_BEHANDLING, KLAR)
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, UTFØRT))
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, AVSLUTT_BEHANDLING, KLAR))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
         lagreBehandling(behandling)
 
@@ -424,8 +424,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     fun `utførStegEtterIverksettelseAutomatisk skal opprette task for å utføre JOURNALFØR_VEDTAKSBREV steg automatisk`() {
         val taskSlot = slot<Task>()
         behandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT)
-        lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR)
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT))
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
         lagreBehandling(behandling)
         vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now()))
@@ -439,8 +439,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @Test
     fun `utførStegEtterIverksettelseAutomatisk skal opprette tilbakekreving task for revurdering`() {
         behandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT)
-        lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR)
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT))
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
         lagreBehandling(behandling)
         vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now()))
@@ -461,8 +461,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     fun `utførStegEtterIverksettelseAutomatisk skal ikke opprette tilbakekreving task for revurdering med valg IGNORER_TILBAKEKREVING`() {
         val taskSlot = slot<Task>()
         behandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT)
-        lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR)
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT))
+        behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
         lagreBehandling(behandling)
         vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now()))
@@ -490,7 +490,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         tekniskEndringBehandling.resultat = Behandlingsresultat.ENDRET_UTEN_UTBETALING
         tekniskEndringBehandling.status = BehandlingStatus.FATTER_VEDTAK
         tekniskEndringBehandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(tekniskEndringBehandling, BESLUTTE_VEDTAK, KLAR)
+        tekniskEndringBehandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(tekniskEndringBehandling, BESLUTTE_VEDTAK, KLAR))
         lagreBehandling(tekniskEndringBehandling)
         vedtakRepository.saveAndFlush(Vedtak(behandling = tekniskEndringBehandling, vedtaksdato = LocalDateTime.now()))
 
@@ -521,7 +521,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         tekniskEndringBehandling.resultat = Behandlingsresultat.ENDRET_UTBETALING
         tekniskEndringBehandling.status = BehandlingStatus.FATTER_VEDTAK
         tekniskEndringBehandling.behandlingStegTilstand.clear()
-        lagBehandlingStegTilstand(tekniskEndringBehandling, BESLUTTE_VEDTAK, KLAR)
+        tekniskEndringBehandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(tekniskEndringBehandling, BESLUTTE_VEDTAK, KLAR))
         lagreBehandling(tekniskEndringBehandling)
         vedtakRepository.saveAndFlush(Vedtak(behandling = tekniskEndringBehandling, vedtaksdato = LocalDateTime.now()))
 


### PR DESCRIPTION
Samt tilpasser lagBehandling metode for å tillatte lettere å legge til BehandlingStegTilstand. 

Jobbet med denne koden i forbindelse med SnikeIKøenService, men ble aldri tatt med i MRen. Gjorde en siste finish på den nå og lagde en egen PR. 

### 💰 Hva skal gjøres, og hvorfor?
Endrer eksiterende testlogikk for å gjøre det lettere å opprette BehandlingStegTilstand for behandling, samt fjerner side-effects fra metoder

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Endret eksisterende tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
