### PR TITLE
Skrur ned til å kun kjøre grensesnittavstemming 1 gang ved feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingTask.kt
@@ -16,8 +16,8 @@ import java.util.UUID
 @TaskStepBeskrivelse(
     taskStepType = GrensesnittavstemmingTask.TASK_STEP_TYPE,
     beskrivelse = "Grensesnittavstemming mot oppdrag",
-    // Rekjører kun 1 gang siden avstemming kan ha kjørt OK selv om tasken har feilet, så en autoretry kan trigge flere like grensesnittavstemminger. Som kan skape problemer hvis de kjøres umiddelbart etter hverandre.
-    maxAntallFeil = 1,
+    maxAntallFeil = 2,
+    triggerTidVedFeilISekunder = 60 * 5,
 )
 class GrensesnittavstemmingTask(
     private val avstemmingService: AvstemmingService,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Leste litt logger, og så at grensesnittavstemming trigget alarmer når et kall mot familie-oppdrag timet ut, og task umiddelbart ble rekjørt med retry. Da ble det kjørende 2 grensesnittavstemminger. Siden maks feil var 3 ganger. Som skapte litt krøll. 

Skrur ned til å kun kjøre grensesnittavstemming 2 gang ved feil, med en delay på 5 min. Da vil tasken ikke kjøres umiddelbart. Også lagt til beskrivelse om hva man skal sjekke for hvis tasken feiler. 
