### PR TITLE
Kast funksjonell feil dersom det finnes uoppfylt barnets alder vilkår med ingen fom og tom samtidig som det finnes oppfylte perioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidator.kt
@@ -23,7 +23,10 @@ class BarnetsVilkårValidator(
         val funksjonelleFeil = mutableListOf<String>()
 
         barna.map { barn ->
-            val vilkårsResultaterForBarn = vilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.filter { it.personResultat?.aktør == barn.aktør }
+            val vilkårsResultaterForBarn =
+                vilkårsvurdering.personResultater
+                    .flatMap { it.vilkårResultater }
+                    .filter { it.personResultat?.aktør == barn.aktør }
 
             vilkårsResultaterForBarn.forEach { vilkårResultat ->
                 val fødselsdato = barn.fødselsdato.tilDagMånedÅr()
@@ -33,7 +36,7 @@ class BarnetsVilkårValidator(
                 }
                 if (vilkårResultat.periodeFom != null && vilkårType != Vilkår.MEDLEMSKAP_ANNEN_FORELDER && vilkårResultat.lagOgValiderPeriodeFraVilkår().fom.isBefore(barn.fødselsdato)) {
                     funksjonelleFeil.add(
-                        "Vilkår $vilkårType for barn med fødselsdato $fødselsdato " + "har fom dato før barnets fødselsdato.",
+                        "Vilkår $vilkårType for barn med fødselsdato $fødselsdato har fom dato før barnets fødselsdato.",
                     )
                 }
             }
@@ -42,13 +45,16 @@ class BarnetsVilkårValidator(
 
             val finnesUoppfyltBarnetsAlderVilkårForBarnUtenFomOgTom =
                 barnetsAlderVilkårPåBarn.any {
-                    it.resultat == Resultat.IKKE_OPPFYLT && it.periodeFom == null && it.periodeTom == null && it.vilkårType == Vilkår.BARNETS_ALDER
+                    it.resultat == Resultat.IKKE_OPPFYLT &&
+                        it.periodeFom == null &&
+                        it.periodeTom == null &&
+                        it.vilkårType == Vilkår.BARNETS_ALDER
                 }
+
             val finnesOppfyltBarnetsAlderVilkår =
-                barnetsAlderVilkårPåBarn
-                    .filter {
-                        it.resultat == Resultat.OPPFYLT && it.vilkårType == Vilkår.BARNETS_ALDER
-                    }.isNotEmpty()
+                barnetsAlderVilkårPåBarn.any {
+                    it.resultat == Resultat.OPPFYLT && it.vilkårType == Vilkår.BARNETS_ALDER
+                }
 
             if (finnesUoppfyltBarnetsAlderVilkårForBarnUtenFomOgTom && finnesOppfyltBarnetsAlderVilkår) {
                 throw FunksjonellFeil(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtleder.kt
@@ -15,17 +15,16 @@ fun utledMaksAntallMånederMedUtbetaling(
         VilkårLovverk.LOVVERK_2024,
         VilkårLovverk.LOVVERK_2021_OG_2024,
         -> 7L
+
         VilkårLovverk.LOVVERK_2021 -> {
-            val førsteBarnetsAlderVilkårResultatFom = barnetsAlderVilkårResultater.sortedBy { it.periodeFom }.first().periodeFom!!
+            val førsteBarnetsAlderVilkårResultatFom = barnetsAlderVilkårResultater.sortedBy { it.periodeFom }.firstOrNull()?.periodeFom!!
             val sisteBarnetsAlderVilkårResultatTom = barnetsAlderVilkårResultater.sortedBy { it.periodeTom }.last().periodeTom!!
             val minstAvTomEllerLovEndringDato = minOf(sisteBarnetsAlderVilkårResultatTom, DATO_LOVENDRING_2024)
             val dagenFørLovendring = DATO_LOVENDRING_2024.minusDays(1)
 
             val sisteMuligeUtbetaling =
                 when {
-                    vilkårLovverkInformasjonForBarn.fødselsdato.plusYears(2)
-                        != dagenFørLovendring &&
-                        sisteBarnetsAlderVilkårResultatTom == dagenFørLovendring -> minstAvTomEllerLovEndringDato
+                    vilkårLovverkInformasjonForBarn.fødselsdato.plusYears(2) != dagenFørLovendring && sisteBarnetsAlderVilkårResultatTom == dagenFørLovendring -> minstAvTomEllerLovEndringDato
 
                     else -> minstAvTomEllerLovEndringDato.minusMonths(1)
                 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtleder.kt
@@ -17,14 +17,17 @@ fun utledMaksAntallMånederMedUtbetaling(
         -> 7L
 
         VilkårLovverk.LOVVERK_2021 -> {
-            val førsteBarnetsAlderVilkårResultatFom = barnetsAlderVilkårResultater.sortedBy { it.periodeFom }.firstOrNull()?.periodeFom!!
+            val førsteBarnetsAlderVilkårResultatFom = barnetsAlderVilkårResultater.sortedBy { it.periodeFom }.first().periodeFom!!
             val sisteBarnetsAlderVilkårResultatTom = barnetsAlderVilkårResultater.sortedBy { it.periodeTom }.last().periodeTom!!
             val minstAvTomEllerLovEndringDato = minOf(sisteBarnetsAlderVilkårResultatTom, DATO_LOVENDRING_2024)
             val dagenFørLovendring = DATO_LOVENDRING_2024.minusDays(1)
 
+            val toÅrsdagTilBarnetErIkkeLikDagenFørLovendring = vilkårLovverkInformasjonForBarn.fødselsdato.plusYears(2) != dagenFørLovendring
             val sisteMuligeUtbetaling =
                 when {
-                    vilkårLovverkInformasjonForBarn.fødselsdato.plusYears(2) != dagenFørLovendring && sisteBarnetsAlderVilkårResultatTom == dagenFørLovendring -> minstAvTomEllerLovEndringDato
+                    toÅrsdagTilBarnetErIkkeLikDagenFørLovendring &&
+                        sisteBarnetsAlderVilkårResultatTom
+                        == dagenFørLovendring -> minstAvTomEllerLovEndringDato
 
                     else -> minstAvTomEllerLovEndringDato.minusMonths(1)
                 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22406

Problemstilling:
<img width="925" alt="Screenshot 2024-09-17 at 11 19 55" src="https://github.com/user-attachments/assets/c6ed0339-e231-4715-a829-d8b60591607e">


Validatoren vår feiler når det finnes et barnets alder vilkår som er oppfylt, og samtidig finnes et vilkår som ikke er oppfylt der SB ikke har satt fom og tom. Dette gir da ikke mening, og jeg har derfor lagt til en feilmelding som ber SB å legge inn fom på avslag. Vi kaster funksjonell feil istedenfor å få nullpointere i prod.