### PR TITLE
NAV-21576: Legger til sonar og jacoco

### DIFF
--- a/.github/workflows/build-and-deploy-preprod-prod.yml
+++ b/.github/workflows/build-and-deploy-preprod-prod.yml
@@ -25,7 +25,10 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build
+          SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: ./gradlew build jacocoTestReport jacocoIntegrationTestReport sonar
 
   bygg-og-push-til-github:
     name: Bygg app/image, push til github

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,6 +21,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
+
   ktlint:
     name: Ktlint
     runs-on: ubuntu-latest
@@ -33,16 +34,15 @@ jobs:
         with:
           java-version: "21"
           distribution: 'temurin'
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
       - name: Kjør ktlint
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew ktlintCheck
+
   enhetstester:
     name: Enhetstester
     runs-on: ubuntu-latest-8-cores
@@ -53,16 +53,21 @@ jobs:
         with:
           java-version: "21"
           distribution: 'temurin'
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
       - name: Kjør enhetstester
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew test
+          ./gradlew test jacocoTestReport
+      - name: Last opp Jacoco enhetstester rapport
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacocoTestReport
+          path: build/reports/jacoco/test/jacocoTestReport.xml
+          retention-days: 1
+          overwrite: true
       - uses: dorny/test-reporter@v1
         if: failure()
         with:
@@ -70,6 +75,7 @@ jobs:
           path: "**/build/test-results/test/TEST-*.xml"
           reporter: java-junit
           token: ${{ secrets.GITHUB_TOKEN }}
+
   integrasjonstester:
     name: Integrasjonstester
     runs-on: ubuntu-latest-8-cores
@@ -80,16 +86,21 @@ jobs:
         with:
           java-version: "21"
           distribution: 'temurin'
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
       - name: Kjør integrasjonstester
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew integrationTest
+          ./gradlew integrationTest jacocoIntegrationTestReport
+      - name: Last opp Jacoco integrasjonstester rapport
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacocoIntegrationTestReport
+          path: build/reports/jacoco/jacocoIntegrationTestReport/jacocoIntegrationTestReport.xml
+          retention-days: 1
+          overwrite: true
       - uses: dorny/test-reporter@v1
         if: failure()
         with:
@@ -97,3 +108,40 @@ jobs:
           path: "**/build/test-results/integrationTest/TEST-*.xml"
           reporter: java-junit
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest-8-cores
+    needs: [ enhetstester, integrasjonstester ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Last ned Jacoco enhetstester rapport
+        uses: actions/download-artifact@v4
+        with:
+          name: jacocoTestReport
+      - name: Last ned Jacoco integrasjonstester rapport
+        uses: actions/download-artifact@v4
+        with:
+          name: jacocoIntegrationTestReport
+      - name: Cache Sonar packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Kjør Sonar
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: |
+          ./gradlew sonar -D "sonar.coverage.jacoco.xmlReportPaths=jacocoTestReport.xml,jacocoIntegrationTestReport.xml"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.allopen") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.noarg") version kotlinVersion
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
+    id("org.sonarqube") version "5.1.0.4882"
+    id("jacoco") // Built in to gradle
 
     // ------------- SLSA -------------- //
     id("org.cyclonedx.bom") version "1.10.0"
@@ -209,6 +211,32 @@ tasks.register<JavaExec>("ktlintFormat") {
     )
 }
 
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    executionData(fileTree(layout.buildDirectory).include("/jacoco/test.exec"))
+    reports {
+        xml.required = true
+    }
+}
+
+tasks.register<JacocoReport>("jacocoIntegrationTestReport") {
+    dependsOn(":integrationTest")
+    sourceSets(sourceSets.main.get())
+    executionData(fileTree(layout.buildDirectory).include("/jacoco/integrationTest.exec"))
+    reports {
+        xml.required = true
+    }
+}
+
+sonar {
+    properties {
+        property("sonar.projectKey", System.getenv("SONAR_PROJECTKEY"))
+        property("sonar.organization", "navikt")
+        property("sonar.host.url", System.getenv("SONAR_HOST_URL"))
+        property("sonar.token", System.getenv("SONAR_TOKEN"))
+    }
+}
+
 allprojects {
     plugins.withId("java") {
         this@allprojects.tasks {
@@ -218,6 +246,7 @@ allprojects {
                     useJUnitPlatform {
                         excludeTags("integrationTest")
                     }
+                    finalizedBy(jacocoTestReport)
                 }
             val integrationTest =
                 register<Test>("integrationTest") {
@@ -225,6 +254,7 @@ allprojects {
                         includeTags("integrationTest")
                     }
                     shouldRunAfter(test)
+                    finalizedBy(":jacocoIntegrationTestReport")
                 }
             "check" {
                 dependsOn(integrationTest)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21576

Legger til sonar og jacoco. 

I `build-pr` GHA blir enhetstester og integrasjonstester kjørt separat. Må defor laste opp jacoco-rapportene som et artifact som kan lastest ned og brukes i sonar-jobben. 

I `build-and-deploy-preprod-prod.yml` GHA blir testene kjørt sammen og kan dermed bare kjøre sonar med en gang da sonar har tilgang til jacoco-rapportene. 

Prosjektet er opprettet i SonarCloud, se her: https://sonarcloud.io/project/overview?id=navikt_familie-ks-sak

Sonar-token er opprettet via https://sonarcloud.io/account/security

Har lagt inn `SONAR_HOST_URL`, `SONAR_PROJECTKEY`, og `SONAR_TOKEN` i secrets her: https://github.com/navikt/familie-ks-sak/settings/secrets/actions

Verdien av `SONAR_PROJECTKEY` finner man her: https://sonarcloud.io/project/information?id=navikt_familie-ks-sak

Målet er å få scannet prosjektet ved merge til main, samt få opp en rapport på PRer som vist under

<img width="930" alt="image" src="https://github.com/user-attachments/assets/1d41675a-f90c-42b0-b9ce-0247541b3e9f">

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

Trenger ikke skrive tester for bygg / github actions

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
