### PR TITLE
Ikke feil tilgangsservice hvis aktør ikke har fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/exception/ApiExceptionHandler.kt
@@ -29,6 +29,8 @@ class ApiExceptionHandler {
     @ExceptionHandler(Exception::class)
     fun handleException(exception: Exception): ResponseEntity<Ressurs<Nothing>> {
         val mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(exception)
+        // log stacktrace med den generelle feilen
+        secureLogger.info("Mottok en ukjent exception. Original stacktrace er:", exception)
 
         return RessursUtils.illegalState(mostSpecificCause.message.toString(), mostSpecificCause)
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
@@ -152,8 +152,10 @@ class TilgangService(
         handling: String,
     ) {
         val aktør = personidentService.hentOgLagreAktør(personIdent, true)
-        val fagsakId = fagsakService.hentFagsakForPerson(aktør).id
-        validerTilgangTilHandlingOgFagsak(fagsakId, event, minimumBehandlerRolle, handling)
+        val fagsakId = fagsakRepository.finnFagsakForAktør(aktør)?.id
+        if (fagsakId != null) {
+            validerTilgangTilHandlingOgFagsak(fagsakId, event, minimumBehandlerRolle, handling)
+        }
     }
 
     private fun harTilgangTilPersoner(personIdenter: List<String>): Boolean =

--- a/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.config.RolleConfig
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Service
 
 @Service
 class TilgangService(
-    private val fagsakService: FagsakService,
     private val behandlingRepository: BehandlingRepository,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val rolleConfig: RolleConfig,

--- a/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangService.kt
@@ -153,6 +153,8 @@ class TilgangService(
         val fagsakId = fagsakRepository.finnFagsakForAktør(aktør)?.id
         if (fagsakId != null) {
             validerTilgangTilHandlingOgFagsak(fagsakId, event, minimumBehandlerRolle, handling)
+        } else {
+            validerTilgangTilHandlingOgPersoner(listOf(personIdent), event, minimumBehandlerRolle, handling)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangServiceTest.kt
@@ -18,7 +18,6 @@ import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.Personident
@@ -52,9 +51,6 @@ class TilgangServiceTest {
 
     @MockK
     private lateinit var mockBehandlingRepository: BehandlingRepository
-
-    @MockK
-    private lateinit var mockFagsakService: FagsakService
 
     @MockK
     private lateinit var mockFagsakRepository: FagsakRepository
@@ -97,7 +93,6 @@ class TilgangServiceTest {
                 integrasjonService = mockIntegrasjonService,
                 behandlingRepository = mockBehandlingRepository,
                 personopplysningGrunnlagRepository = mockPersonopplysningGrunnlagRepository,
-                fagsakService = mockFagsakService,
                 rolleConfig = rolleConfig,
                 cacheManager = cacheManager,
                 auditLogger = auditLogger,
@@ -536,7 +531,7 @@ class TilgangServiceTest {
                 ),
             )
         every { personidentService.hentOgLagreAktør("12345678910", any()) } returns aktør
-        every { mockFagsakService.hentFagsakForPerson(aktør) } returns fagsak
+        every { mockFagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
 
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
@@ -561,7 +556,7 @@ class TilgangServiceTest {
                 ),
             )
         every { personidentService.hentOgLagreAktør("12345678910", any()) } returns aktør
-        every { mockFagsakService.hentFagsakForPerson(aktør) } returns fagsak
+        every { mockFagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
 
         tilgangService.validerTilgangTilHandlingOgFagsakForPerson(
             "12345678910",
@@ -573,7 +568,6 @@ class TilgangServiceTest {
 
     @Test
     fun `validerTilgangTilFagsak - skal kaste feil dersom søker eller et eller flere av barna har diskresjonskode og saksbehandler mangler tilgang`() {
-        every { mockFagsakService.hentFagsak(fagsak.id) }.returns(fagsak)
         every { mockBehandlingRepository.finnBehandlinger(fagsak.id) }.returns(listOf(behandling))
         every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) }.returns(
             PersonopplysningGrunnlag(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tilgangservice feiler når man ikke finner fagsak på aktøren. Det vil da komme en alarm:
En håndtert feil har oppstått(200 OK): Fant ikke fagsak på person

Denne feilen kastes fra tilgangsservicen, så feilhåndteringen senere i koden for `POST /api/hent-fagsak-paa-person`  kjører dermed ikke fordi den havner i ApiExceptionHandler

Skrevet om til at Tilgangservicen ikke feile hvis aktøren ikke har fagsak.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Egentlig ikke en tilbakemelding på akkurat dette, men jeg lurer jo på hvorfor man havner i den situasjonen at frontend kaller `POST /api/hent-fagsak-paa-person` uten at identen har fagsak i databasen.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
