### PR TITLE
Håndter feil utfylt valutakursdato som en funksjonell feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/ecb/ECBService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/ecb/ECBService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.integrasjon.ecb
 
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.del
 import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.integrasjon.ecb.domene.ECBValutakursCache
@@ -8,7 +9,8 @@ import no.nav.familie.valutakurs.Frequency
 import no.nav.familie.valutakurs.ValutakursRestClient
 import no.nav.familie.valutakurs.domene.ExchangeRate
 import no.nav.familie.valutakurs.domene.exchangeRateForCurrency
-import no.nav.familie.valutakurs.exception.ValutakursClientException
+import no.nav.familie.valutakurs.exception.IngenValutakursException
+import no.nav.familie.valutakurs.exception.ValutakursException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Import
@@ -59,8 +61,10 @@ class ECBService(
                     ),
                 )
                 return beregnValutakurs(valutakursUtenlandskValuta.exchangeRate, valutakursNOK.exchangeRate)
-            } catch (e: ValutakursClientException) {
+            } catch (e: ValutakursException) {
                 throw ECBServiceException(e.message, e)
+            } catch (e: IngenValutakursException) {
+                throw FunksjonellFeil(e.message)
             }
         }
         logger.info("Valutakurs ble hentet fra cache for $utenlandskValuta på $kursDato")


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22522

Når saksbehandler fyller inn en ugyldig dato i frontend logges det en error med `NullpointerException`.
Utvider feilhåndtering av kall til `ValutakursRestClient`, så koden skiller på serverfeil og funksjonell feil

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
