### PR TITLE
Endrer tittel på journalpost og tilhørende dokument i henhold til ønsket tabell

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     val sentryVersion = "7.14.0"
     val navFellesVersion = "3.20240913110742_adb42f8"
     val eksterneKontrakterBisysVersion = "2.0_20230214104704_706e9c0"
-    val fellesKontrakterVersion = "3.0_20240919121839_57daa74"
+    val fellesKontrakterVersion = "3.0_20241002091252_adfb53f"
     val familieKontrakterSaksstatistikkVersion = "2.0_20230214104704_706e9c0"
     val familieKontrakterStønadsstatistikkKsVersion = "2.0_20240806120744_a042aa1"
     val tokenValidationSpringVersion = "5.0.5"

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -261,7 +261,7 @@ fun Behandlingsresultat.tilDokumenttype() =
         Behandlingsresultat.ENDRET_UTBETALING,
         Behandlingsresultat.ENDRET_UTEN_UTBETALING,
         Behandlingsresultat.ENDRET_OG_OPPHØRT,
-        -> Dokumenttype.KONTANTSTØTTE_VEDTAK_AVSLAG
+        -> Dokumenttype.KONTANTSTØTTE_VEDTAK_ENDRET
 
         Behandlingsresultat.OPPHØRT,
         Behandlingsresultat.FORTSATT_OPPHØRT,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -242,9 +242,36 @@ enum class Behandlingsresultat(
 
 fun Behandlingsresultat.tilDokumenttype() =
     when (this) {
+        Behandlingsresultat.INNVILGET,
+        Behandlingsresultat.INNVILGET_OG_OPPHØRT,
+        Behandlingsresultat.INNVILGET_OG_ENDRET,
+        Behandlingsresultat.INNVILGET_ENDRET_OG_OPPHØRT,
+        Behandlingsresultat.DELVIS_INNVILGET,
+        Behandlingsresultat.DELVIS_INNVILGET_OG_OPPHØRT,
+        Behandlingsresultat.DELVIS_INNVILGET_OG_ENDRET,
+        Behandlingsresultat.DELVIS_INNVILGET_ENDRET_OG_OPPHØRT,
+        Behandlingsresultat.AVSLÅTT_OG_OPPHØRT,
+        Behandlingsresultat.AVSLÅTT_OG_ENDRET,
+        Behandlingsresultat.AVSLÅTT_ENDRET_OG_OPPHØRT,
+        Behandlingsresultat.FORTSATT_INNVILGET,
+        -> Dokumenttype.KONTANTSTØTTE_VEDTAK
+
         Behandlingsresultat.AVSLÅTT -> Dokumenttype.KONTANTSTØTTE_VEDTAK_AVSLAG
-        Behandlingsresultat.OPPHØRT -> Dokumenttype.KONTANTSTØTTE_OPPHØR
-        else -> Dokumenttype.KONTANTSTØTTE_VEDTAK_INNVILGELSE
+
+        Behandlingsresultat.ENDRET_UTBETALING,
+        Behandlingsresultat.ENDRET_UTEN_UTBETALING,
+        Behandlingsresultat.ENDRET_OG_OPPHØRT,
+        -> Dokumenttype.KONTANTSTØTTE_VEDTAK_AVSLAG
+
+        Behandlingsresultat.OPPHØRT,
+        Behandlingsresultat.FORTSATT_OPPHØRT,
+        -> Dokumenttype.KONTANTSTØTTE_OPPHØR
+
+        HENLAGT_FEILAKTIG_OPPRETTET,
+        HENLAGT_SØKNAD_TRUKKET,
+        HENLAGT_TEKNISK_VEDLIKEHOLD,
+        IKKE_VURDERT,
+        -> throw Feil("Behandlingsresultat $this støtter ikke utsendelse av journalpost.")
     }
 
 /**

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/journalførvedtaksbrev/JournalførVedtaksbrevSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/journalførvedtaksbrev/JournalførVedtaksbrevSteg.kt
@@ -14,9 +14,6 @@ import no.nav.familie.ks.sak.integrasjon.distribuering.DistribuerBrevTask
 import no.nav.familie.ks.sak.integrasjon.distribuering.DistribuerVedtaksbrevTilVergeEllerFullmektigTask
 import no.nav.familie.ks.sak.integrasjon.journalføring.UtgåendeJournalføringService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.tilDokumenttype
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.IBehandlingSteg
@@ -117,22 +114,21 @@ class JournalførVedtaksbrevSteg(
                 if (søkersMålform == Målform.NB) KONTANTSTØTTE_VEDTAK_BOKMÅL_VEDLEGG_FILNAVN else KONTANTSTØTTE_VEDTAK_NYNORSK_VEDLEGG_FILNAVN,
             )
 
+        val dokumenttype = vedtak.behandling.resultat.tilDokumenttype()
+
         val brev =
             listOf(
                 Dokument(
                     vedtak.stønadBrevPdf!!,
                     filtype = Filtype.PDFA,
-                    dokumenttype = vedtak.behandling.resultat.tilDokumenttype(),
-                    tittel = hentOverstyrtDokumenttittel(vedtak.behandling),
+                    dokumenttype = dokumenttype,
                 ),
             )
 
         logger.info(
             "Journalfører vedtaksbrev ${
                 if (tilVergeEllerFullmektig) "til verge/fullmektig" else ""
-            } for behandling ${vedtak.behandling.id} med tittel ${
-                hentOverstyrtDokumenttittel(vedtak.behandling)
-            }",
+            } for behandling ${vedtak.behandling.id} med dokumenttype $dokumenttype",
         )
 
         val vedlegg =
@@ -156,25 +152,6 @@ class JournalførVedtaksbrevSteg(
             avsenderMottaker = avsenderMottaker,
         )
     }
-
-    fun hentOverstyrtDokumenttittel(behandling: Behandling): String? =
-        if (behandling.type == BehandlingType.REVURDERING) {
-            when (behandling.resultat) {
-                Behandlingsresultat.INNVILGET, Behandlingsresultat.DELVIS_INNVILGET,
-                Behandlingsresultat.INNVILGET_OG_ENDRET,
-                -> "Vedtak om endret kontantstøtte"
-
-                Behandlingsresultat.INNVILGET_OG_OPPHØRT,
-                Behandlingsresultat.DELVIS_INNVILGET_OG_OPPHØRT,
-                Behandlingsresultat.ENDRET_OG_OPPHØRT,
-                -> "Vedtak om opphørt kontantstøtte"
-
-                Behandlingsresultat.FORTSATT_INNVILGET -> "Vedtak om fortsatt kontantstøtte"
-                else -> null
-            }
-        } else {
-            null
-        }
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(JournalførVedtaksbrevSteg::class.java)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/journalførvedtaksbrev/JournalførVedtaksbrevStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/journalførvedtaksbrev/JournalførVedtaksbrevStegTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.data.randomFnr
 import no.nav.familie.ks.sak.integrasjon.journalføring.UtgåendeJournalføringService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.journalførvedtaksbrev.JournalførVedtaksbrevSteg.Companion.KONTANTSTØTTE_VEDTAK_BOKMÅL_VEDLEGG_FILNAVN
 import no.nav.familie.ks.sak.kjerne.behandling.steg.journalførvedtaksbrev.JournalførVedtaksbrevSteg.Companion.KONTANTSTØTTE_VEDTAK_NYNORSK_VEDLEGG_FILNAVN
 import no.nav.familie.ks.sak.kjerne.behandling.steg.journalførvedtaksbrev.JournalførVedtaksbrevSteg.Companion.KONTANTSTØTTE_VEDTAK_VEDLEGG_TITTEL
@@ -64,7 +65,7 @@ class JournalførVedtaksbrevStegTest {
         every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = any()) } returns Målform.NB
         every { utgåendeJournalføringService.journalførDokument(any(), any(), any(), any(), capture(dokumentListeSlot), any(), any(), any(), any()) } returns "Test"
 
-        val vedtak = lagVedtak(behandling = lagBehandling(), stønadBrevPdF = ByteArray(5))
+        val vedtak = lagVedtak(behandling = lagBehandling(resultat = Behandlingsresultat.INNVILGET), stønadBrevPdF = ByteArray(5))
         val bokmålDokument = hentDokument(KONTANTSTØTTE_VEDTAK_BOKMÅL_VEDLEGG_FILNAVN)
 
         // Act
@@ -92,7 +93,7 @@ class JournalførVedtaksbrevStegTest {
         every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = any()) } returns Målform.NN
         every { utgåendeJournalføringService.journalførDokument(any(), any(), any(), any(), capture(dokumentListeSlot), any(), any(), any(), any()) } returns "Test"
 
-        val vedtak = lagVedtak(behandling = lagBehandling(), stønadBrevPdF = ByteArray(5))
+        val vedtak = lagVedtak(behandling = lagBehandling(resultat = Behandlingsresultat.INNVILGET), stønadBrevPdF = ByteArray(5))
 
         // Act
         journalførVedtaksbrevSteg.journalførVedtaksbrev(


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543

Endrer navn på dokument og journalpost i henhold til ønsker i favrokort.
Fjerner også hentOverstyrtDokumenttittel da vi ikke lenger skal ha forskjell på førstegangsbehandlinger + revurderinger.

Avhengig av https://github.com/navikt/familie-kontrakter/pull/945
