### PR TITLE
Nav 22524/reduserer log nivå for bad request

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.ks.sak.kjerne.brev
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjeneste
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseDtoMedData
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.BrevDto
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestOperations
 import java.net.URI
 
@@ -25,18 +27,36 @@ class BrevKlient(
         val uri = URI.create("$familieBrevUri/api/$sanityDataset/dokument/$målform/${brev.mal.apiNavn}/pdf")
 
         secureLogger.info("Kaller familie brev($uri) med data ${brev.data.toBrevString()}")
-        return kallEksternTjeneste(FAMILIE_BREV_TJENESTENAVN, uri, "Hente pdf for vedtaksbrev") {
+
+        return kallEksternTjeneste(
+            FAMILIE_BREV_TJENESTENAVN,
+            uri,
+            "Hente pdf for vedtaksbrev",
+        ) {
             postForEntity(uri, brev.data)
         }
     }
 
     @Cacheable("begrunnelsestekst", cacheManager = "shortCache")
     fun hentBegrunnelsestekst(begrunnelseData: BegrunnelseDtoMedData): String {
-        val uri = URI.create("$familieBrevUri/ks-sak/begrunnelser/${begrunnelseData.apiNavn}/tekst/")
-        secureLogger.info("Kaller familie brev($uri) med data $begrunnelseData")
+        try {
+            val uri = URI.create("$familieBrevUri/ks-sak/begrunnelser/${begrunnelseData.apiNavn}/tekst/")
 
-        return kallEksternTjeneste(FAMILIE_BREV_TJENESTENAVN, uri, "Henter begrunnelsestekst") {
-            postForEntity(uri, begrunnelseData)
+            secureLogger.info("Kaller familie brev($uri) med data $begrunnelseData")
+
+            return kallEksternTjeneste(
+                FAMILIE_BREV_TJENESTENAVN,
+                uri,
+                "Henter begrunnelsestekst",
+            ) {
+                postForEntity(uri, begrunnelseData)
+            }
+        } catch (exception: HttpClientErrorException.BadRequest) {
+            log.warn("En bad request oppstod ved henting av begrunnelsestekst. Se SecureLogs for detaljer.")
+            secureLogger.warn("En bad request oppstod ved henting av begrunnelsestekst", exception)
+            throw FunksjonellFeil(
+                "Begrunnelsen passer ikke vedtaksperiode. Hvis du mener dette er feil ta kontakt med team BAKS.",
+            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
@@ -55,7 +55,7 @@ class BrevKlient(
             log.warn("En bad request oppstod ved henting av begrunnelsestekst. Se SecureLogs for detaljer.")
             secureLogger.warn("En bad request oppstod ved henting av begrunnelsestekst", exception)
             throw FunksjonellFeil(
-                "Begrunnelsen passer ikke vedtaksperioden. Hvis du mener dette er feil ta kontakt med team BAKS.",
+                "Begrunnelsen '${begrunnelseData.apiNavn}' passer ikke vedtaksperioden. Hvis du mener dette er feil ta kontakt med team BAKS.",
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
@@ -55,7 +55,7 @@ class BrevKlient(
             log.warn("En bad request oppstod ved henting av begrunnelsestekst. Se SecureLogs for detaljer.")
             secureLogger.warn("En bad request oppstod ved henting av begrunnelsestekst", exception)
             throw FunksjonellFeil(
-                "Begrunnelsen passer ikke vedtaksperiode. Hvis du mener dette er feil ta kontakt med team BAKS.",
+                "Begrunnelsen passer ikke vedtaksperioden. Hvis du mener dette er feil ta kontakt med team BAKS.",
             )
         }
     }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -29,6 +29,7 @@ import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.common.util.NullablePeriode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
@@ -68,7 +69,9 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseType
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.VedtakFellesfelterSammensattKontrollsakDto
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
@@ -1348,3 +1351,32 @@ fun lagPersonResultat(
     personResultat.andreVurderinger.addAll(lagAnnenVurdering(personResultat))
     return personResultat
 }
+
+fun lagNasjonalOgFellesBegrunnelseDataDto(
+    vedtakBegrunnelseType: BegrunnelseType = BegrunnelseType.INNVILGET,
+    apiNavn: String = "innvilgetIkkeBarnehage",
+    sanityBegrunnelseType: SanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
+    gjelderSoker: Boolean = false,
+    gjelderAndreForelder: Boolean = true,
+    barnasFodselsdatoer: LocalDate = LocalDate.now(),
+    antallBarn: Int = 1,
+    maanedOgAarBegrunnelsenGjelderFor: YearMonth = YearMonth.now(),
+    maalform: String = "bokmaal",
+    belop: Int = 7500,
+    antallTimerBarnehageplass: Int = 0,
+    soknadstidspunkt: LocalDate = LocalDate.now(),
+): NasjonalOgFellesBegrunnelseDataDto =
+    NasjonalOgFellesBegrunnelseDataDto(
+        vedtakBegrunnelseType = vedtakBegrunnelseType,
+        apiNavn = apiNavn,
+        sanityBegrunnelseType = sanityBegrunnelseType,
+        gjelderSoker = gjelderSoker,
+        gjelderAndreForelder = gjelderAndreForelder,
+        barnasFodselsdatoer = barnasFodselsdatoer.tilKortString(),
+        antallBarn = antallBarn,
+        maanedOgAarBegrunnelsenGjelderFor = maanedOgAarBegrunnelsenGjelderFor.tilKortString(),
+        maalform = maalform,
+        belop = belop.toString(),
+        antallTimerBarnehageplass = antallTimerBarnehageplass.toString(),
+        soknadstidspunkt = soknadstidspunkt.tilKortString(),
+    )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
@@ -1,0 +1,116 @@
+package no.nav.familie.ks.sak.kjerne.brev
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.data.lagNasjonalOgFellesBegrunnelseDataDto
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
+
+class BrevKlientTest {
+    private val mockedRestOperations: RestOperations = mockk()
+    private val baseUri = "http://localhost:8080"
+    private val brevKlient: BrevKlient =
+        BrevKlient(
+            baseUri,
+            "dataset",
+            mockedRestOperations,
+        )
+
+    @Nested
+    inner class HentBegrunnelsestekstTest {
+        @Test
+        fun `skal hente begrunnelsestekst`() {
+            // Arrange
+            val nasjonalOgFellesBegrunnelseDataDto = lagNasjonalOgFellesBegrunnelseDataDto()
+
+            every {
+                mockedRestOperations.exchange<String>(
+                    eq(URI("$baseUri/ks-sak/begrunnelser/${nasjonalOgFellesBegrunnelseDataDto.apiNavn}/tekst/")),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<NasjonalOgFellesBegrunnelseDataDto>>(),
+                )
+            } returns
+                ResponseEntity<String>(
+                    "bla bla bla",
+                    HttpStatus.OK,
+                )
+
+            // Act
+            val begrunnelsestekst = brevKlient.hentBegrunnelsestekst(nasjonalOgFellesBegrunnelseDataDto)
+
+            // Assert
+            assertThat(begrunnelsestekst).isEqualTo("bla bla bla")
+        }
+
+        @Test
+        fun `skal kaste funksjonell feil ved bad request exception`() {
+            // Arrange
+            val nasjonalOgFellesBegrunnelseDataDto = lagNasjonalOgFellesBegrunnelseDataDto()
+
+            every {
+                mockedRestOperations.exchange<String>(
+                    eq(URI("$baseUri/ks-sak/begrunnelser/${nasjonalOgFellesBegrunnelseDataDto.apiNavn}/tekst/")),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<NasjonalOgFellesBegrunnelseDataDto>>(),
+                )
+            } throws
+                HttpClientErrorException.create(
+                    HttpStatus.BAD_REQUEST,
+                    "text",
+                    HttpHeaders.EMPTY,
+                    "msg".toByteArray(),
+                    null,
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    brevKlient.hentBegrunnelsestekst(nasjonalOgFellesBegrunnelseDataDto)
+                }
+            assertThat(exception.message).isEqualTo(
+                "Begrunnelsen passer ikke vedtaksperiode. Hvis du mener dette er feil ta kontakt med team BAKS.",
+            )
+        }
+
+        @Test
+        fun `skal ikke konvertere andre exceptions enn bad request exception til funksjonell feil`() {
+            // Arrange
+            val nasjonalOgFellesBegrunnelseDataDto = lagNasjonalOgFellesBegrunnelseDataDto()
+
+            every {
+                mockedRestOperations.exchange<String>(
+                    eq(URI("$baseUri/ks-sak/begrunnelser/${nasjonalOgFellesBegrunnelseDataDto.apiNavn}/tekst/")),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<NasjonalOgFellesBegrunnelseDataDto>>(),
+                )
+            } throws
+                HttpClientErrorException.create(
+                    HttpStatus.FORBIDDEN,
+                    "text",
+                    HttpHeaders.EMPTY,
+                    "msg".toByteArray(),
+                    null,
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<HttpClientErrorException.Forbidden> {
+                    brevKlient.hentBegrunnelsestekst(nasjonalOgFellesBegrunnelseDataDto)
+                }
+            assertThat(exception.message).isEqualTo("403 text")
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
@@ -81,7 +81,7 @@ class BrevKlientTest {
                     brevKlient.hentBegrunnelsestekst(nasjonalOgFellesBegrunnelseDataDto)
                 }
             assertThat(exception.message).isEqualTo(
-                "Begrunnelsen passer ikke vedtaksperiode. Hvis du mener dette er feil ta kontakt med team BAKS.",
+                "Begrunnelsen passer ikke vedtaksperioden. Hvis du mener dette er feil ta kontakt med team BAKS.",
             )
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
@@ -81,7 +81,7 @@ class BrevKlientTest {
                     brevKlient.hentBegrunnelsestekst(nasjonalOgFellesBegrunnelseDataDto)
                 }
             assertThat(exception.message).isEqualTo(
-                "Begrunnelsen passer ikke vedtaksperioden. Hvis du mener dette er feil ta kontakt med team BAKS.",
+                "Begrunnelsen '${nasjonalOgFellesBegrunnelseDataDto.apiNavn}' passer ikke vedtaksperioden. Hvis du mener dette er feil ta kontakt med team BAKS.",
             )
         }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22524

Innslaget skaper støy i loggene så setter nivået på loggingen fra `error` til `warn`/`ìnfo`. 

`BrevKlient` sender en request til familie-brev som returnerer en 400 bad request. I familie-ks-sak blir dette fanget opp i `kallEksternTjeneste` metoden som en `HttpClientErrorException.BadRequest` exception men kastes bare videre. I `ApiExceptionHandler` blir så fanget opp som en vanlig `Exception` og logget som `error`. Endringen fanger `HttpClientErrorException.BadRequest` i `BrevKlient` i en `try-catch` og endrer det til en `FunksjonellFeil`. `FunksjonellFeil` blir også fanget opp i `ApiExceptionHandler` men da logget med log level `info`. I `BrevKlient` blir `HttpClientErrorException.BadRequest` også logget som `warn`. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
