### PR TITLE
NAV-21576: Legger til fetch-depth 0 og caching hvor det manglet

### DIFF
--- a/.github/workflows/build-and-deploy-preprod-prod.yml
+++ b/.github/workflows/build-and-deploy-preprod-prod.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           java-version: "21"
           distribution: 'temurin'
-
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
       - name: Bygg med gradle
         env:
           GITHUB_USERNAME: x-access-token

--- a/.github/workflows/build-and-deploy-preprod-prod.yml
+++ b/.github/workflows/build-and-deploy-preprod-prod.yml
@@ -15,6 +15,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: gradle/actions/wrapper-validation@v4
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -115,6 +115,8 @@ jobs:
     needs: [ enhetstester, integrasjonstester ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: gradle/actions/wrapper-validation@v4
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Legger til caching av sonar i `build-and-deploy-preprod-prod.yml`. 

Får warning uten shallow-depth satt til 0. Se under.

<img width="581" alt="image" src="https://github.com/user-attachments/assets/4ba4bd3f-ecfc-43cd-893e-b1b6541a4986">

Teksten som står der er:

> Last analysis has warnings
> 
> Shallow clone detected during the analysis. Some files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.


På https://github.com/actions/checkout siden står det om `fetch-depth`:

> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags. 

og

```    
# Number of commits to fetch. 0 indicates all history for all branches and tags.
# Default: 1
fetch-depth: ''
```

Står også som anbefalt her:

https://sonarcloud.io/project/configuration/GitHubActions?id=navikt_familie-ks-sak

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/3c0e791e-21b6-4add-94a1-8d6f40982c63">

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
