### PR TITLE
Sørger for at vi aldri gjør oppslag mot Axsys dersom navIdent er SYST…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import org.springframework.stereotype.Service
 
 @Service
@@ -23,13 +24,16 @@ class TilpassArbeidsfordelingService(
     fun bestemTilordnetRessursPåOppgave(
         arbeidsfordelingsenhet: Arbeidsfordelingsenhet,
         navIdent: NavIdent?,
-    ): NavIdent? =
-        if (harSaksbehandlerTilgangTilEnhet(enhetId = arbeidsfordelingsenhet.enhetId, navIdent = navIdent)
-        ) {
+    ): NavIdent? {
+        if (navIdent?.erSystemIdent() == true) {
+            return null
+        }
+        return if (harSaksbehandlerTilgangTilEnhet(enhetId = arbeidsfordelingsenhet.enhetId, navIdent = navIdent)) {
             navIdent
         } else {
             null
         }
+    }
 
     private fun harSaksbehandlerTilgangTilEnhet(
         enhetId: String,
@@ -78,7 +82,7 @@ class TilpassArbeidsfordelingService(
         navIdent: NavIdent?,
         arbeidsfordelingsenhet: Arbeidsfordelingsenhet,
     ): Arbeidsfordelingsenhet {
-        if (navIdent == null) {
+        if (navIdent == null || navIdent.erSystemIdent()) {
             // navIdent er null ved automatisk journalføring
             return Arbeidsfordelingsenhet(
                 arbeidsfordelingsenhet.enhetId,
@@ -109,4 +113,6 @@ class TilpassArbeidsfordelingService(
             arbeidsfordelingsenhet.enhetNavn,
         )
     }
+
+    private fun NavIdent.erSystemIdent(): Boolean = this.ident == SYSTEM_FORKORTELSE
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.data.lagEnhet
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +24,7 @@ class TilpassArbeidsfordelingServiceTest {
     @Nested
     inner class TilpassArbeidsfordelingsenhetTilSaksbehandlerTest {
         @Test
-        fun `skal kaste feil om arbeidsfordeling returnerer midlertidig enhet 4863 og NAV-ident er null`() {
+        fun `skal kaste feil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident er null`() {
             // Arrange
             val arbeidsfordelingsenhet =
                 Arbeidsfordelingsenhet(
@@ -43,7 +44,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal kaste feil om arbeidsfordeling returnerer midlertidig enhet 4863 og NAV-ident ikke har tilgang til noen andre enheter enn 4863 og 2103`() {
+        fun `skal kaste feil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident ikke har tilgang til noen andre enheter enn 4863 og 2103`() {
             // Arrange
             val navIdent = NavIdent("1")
             val enhetNavIdentHarTilgangTil1 = KontantstøtteEnhet.MIDLERTIDIG_ENHET
@@ -79,7 +80,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal returnere NAV-ident og første enhetsnummer som NAV-identen har tilgang til når arbeidsfordeling returnerer midlertidig enhet 4863`() {
+        fun `skal returnere første enhetsnummer som NAV-identen har tilgang til når arbeidsfordeling er midlertidig enhet 4863`() {
             // Arrange
             val navIdent = NavIdent("1")
             val enhetNavIdentHarTilgangTil2 = KontantstøtteEnhet.VIKAFOSSEN
@@ -125,7 +126,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal kaste feil hvis arbeidsfordeling returnerer Vikafossen 2103 og NAV-ident er null`() {
+        fun `skal kaste feil hvis arbeidsfordeling er Vikafossen 2103 og NAV-ident er null`() {
             // Arrange
             val arbeidsfordelingsenhet =
                 Arbeidsfordelingsenhet(
@@ -145,7 +146,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal returnere Vikafossen 2103 uten NAV-ident om arbeidsfordeling returnerer Vikafossen 2103 og NAV-ident ikke har tilgang til Vikafossen 2103`() {
+        fun `skal returnere Vikafossen 2103 dersom arbeidsfordeling er Vikafossen 2103 og NAV-ident ikke har tilgang til Vikafossen 2103`() {
             // Arrange
             val navIdent = NavIdent("1")
             val enhetNavIdentHarTilgangTil1 = KontantstøtteEnhet.STEINKJER
@@ -186,7 +187,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal returnere Vikafossen 2103 med NAV-ident om arbeidsfordeling returnerer Vikafossen 2103 og NAV-ident har tilgang til Vikafossen 2103`() {
+        fun `skal returnere Vikafossen 2103 dersom arbeidsfordeling er Vikafossen 2103 og NAV-ident har tilgang til Vikafossen 2103`() {
             // Arrange
             val navIdent = NavIdent("1")
             val enhetNavIdentHarTilgangTil1 = KontantstøtteEnhet.BERGEN
@@ -227,7 +228,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal returnere enhetId uten NAV-ident om arbeidsfordeling ikke returnere 2103 eller 4863 og NAV-ident er null`() {
+        fun `skal returnere enhetId dersom arbeidsfordeling ikke er 2103 eller 4863 og NAV-ident er null`() {
             // Arrange
             val arbeidsfordelingsenhet =
                 Arbeidsfordelingsenhet(
@@ -248,7 +249,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal kaste feil om arbeidsfordeling ikke returnerer 2103 eller 4863 og NAV-ident ikke har tilgang til noen enheter`() {
+        fun `skal kaste feil om arbeidsfordeling ikke er 2103 eller 4863 og NAV-ident ikke har tilgang til noen enheter`() {
             // Arrange
             val navIdent = NavIdent("1")
             val enhetNavIdentHarTilgangTil2 = KontantstøtteEnhet.VIKAFOSSEN
@@ -283,7 +284,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal returnere NAV-ident og første enhet NAV-ident har tilgang om arbeidsfordeling ikke returnere 2103 eller 4863 og NAV-ident ikke har tilgang arbeidsfordeling enheten`() {
+        fun `skal returnere første enhet NAV-ident har tilgang om arbeidsfordeling ikke er 2103 eller 4863 og NAV-ident ikke har tilgang arbeidsfordeling enheten`() {
             // Arrange
             val navIdent = NavIdent("1")
 
@@ -325,7 +326,7 @@ class TilpassArbeidsfordelingServiceTest {
         }
 
         @Test
-        fun `skal returnere NAV-ident og arbeidsfordeling enhetsnummer om arbeidsfordeling ikke returnere 2103 eller 4863 og NAV-ident har tilgang arbeidsfordeling enheten`() {
+        fun `skal returnere arbeidsfordeling dersom arbeidsfordeling ikke er 2103 eller 4863 og NAV-ident har tilgang arbeidsfordeling enheten`() {
             // Arrange
             val navIdent = NavIdent("1")
 
@@ -367,6 +368,27 @@ class TilpassArbeidsfordelingServiceTest {
             // Assert
             assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(arbeidsfordelingEnhet.enhetsnummer)
             assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(arbeidsfordelingEnhet.enhetsnavn)
+        }
+
+        @Test
+        fun `skal returnere behandlendeEnhetId og behandlendeEnhetNavn dersom arbeidsfordeling ikke er 2103 eller 4863 og NAV-ident er SYSTEM_FORKORTELSE`() {
+            // Arrange
+            val arbeidsfordelingsenhet =
+                Arbeidsfordelingsenhet(
+                    enhetId = "1234",
+                    enhetNavn = "Fiktiv enhet",
+                )
+
+            // Act
+            val tilpassetArbeidsfordelingsenhet =
+                tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(
+                    arbeidsfordelingsenhet = arbeidsfordelingsenhet,
+                    navIdent = NavIdent(SYSTEM_FORKORTELSE),
+                )
+
+            // Assert
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(arbeidsfordelingsenhet.enhetId)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(arbeidsfordelingsenhet.enhetNavn)
         }
     }
 
@@ -422,6 +444,24 @@ class TilpassArbeidsfordelingServiceTest {
 
             // Act
             val tilordnetRessurs = tilpassArbeidsfordelingService.bestemTilordnetRessursPåOppgave(arbeidsfordelingsenhet, navIdent)
+
+            // Assert
+            assertThat(tilordnetRessurs).isNull()
+        }
+
+        @Test
+        fun `skal returnere null dersom vi er i systemkontekst`() {
+            // Arrange
+            val arbeidsfordelingsenhet =
+                Arbeidsfordelingsenhet(
+                    enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
+                    enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
+                )
+            val navIdent = NavIdent(SYSTEM_FORKORTELSE)
+
+            // Act
+            val tilordnetRessurs =
+                tilpassArbeidsfordelingService.bestemTilordnetRessursPåOppgave(arbeidsfordelingsenhet, navIdent)
 
             // Assert
             assertThat(tilordnetRessurs).isNull()


### PR DESCRIPTION
Fikser bug i forbindelse med fødselshendelser og oppslag på enheter `NavIdent` har tilgang på. Dersom `NavIdent` er SYSTEM_FORKORTELSE feiler kall mot Axsys. Sørger her for at vi aldri gjør oppslag mot Axsys dersom `NavIdent` er SYSTEM_FORKORTELSE.

Lagt inn to enkle tester som validerer dette.