### PR TITLE
Generer AndelTilkjentYtelse når KompensasjonAndeler endres

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/KompensasjonAndelController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/KompensasjonAndelController.kt
@@ -80,7 +80,7 @@ class KompensasjonAndelController(
 
         val behandling = behandlingService.hentBehandling(behandlingId)
 
-        kompensasjonAndelService.fjernKompensasjongAndelOgOppdaterTilkjentYtelse(
+        kompensasjonAndelService.fjernKompensasjonAndelOgOppdaterTilkjentYtelse(
             behandling,
             kompensasjonAndelId,
         )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ks.sak.kjerne.eøs.EøsSkjemaerForNyBehandlingService
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -19,6 +20,7 @@ class RegistrerPersonGrunnlagSteg(
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
+    private val kompensasjonAndelService: KompensasjonAndelService,
     private val eøsSkjemaerForNyBehandlingService: EøsSkjemaerForNyBehandlingService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.REGISTRERE_PERSONGRUNNLAG
@@ -38,6 +40,11 @@ class RegistrerPersonGrunnlagSteg(
 
         if (sisteVedtattBehandling != null) {
             endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling,
+                sisteVedtattBehandling,
+            )
+
+            kompensasjonAndelService.kopierKompensasjonAndelFraForrigeBehandling(
                 behandling,
                 sisteVedtattBehandling,
             )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
@@ -40,13 +40,13 @@ class RegistrerPersonGrunnlagSteg(
 
         if (sisteVedtattBehandling != null) {
             endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
-                behandling,
-                sisteVedtattBehandling,
+                behandling = behandling,
+                forrigeBehandling = sisteVedtattBehandling,
             )
 
             kompensasjonAndelService.kopierKompensasjonAndelFraForrigeBehandling(
-                behandling,
-                sisteVedtattBehandling,
+                behandling = behandling,
+                forrigeBehandling = sisteVedtattBehandling,
             )
 
             eøsSkjemaerForNyBehandlingService.kopierEøsSkjemaer(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
-import no.nav.familie.ba.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje
 import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
 import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
 import no.nav.familie.ks.sak.api.dto.BesluttVedtakDto
@@ -22,6 +21,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.iverksettmotoppdrag.Iverkset
 import no.nav.familie.ks.sak.kjerne.behandling.steg.journalførvedtaksbrev.JournalførVedtaksbrevTask
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.SendOpprettTilbakekrevingsbehandlingRequestTask
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.TilbakekrevingRepository

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -43,28 +43,37 @@ class TilkjentYtelseService(
             )
 
         val kompensasjonAndelerSomAndelTilkjentYtelse =
-            kompensasjonAndelRepository
-                .hentKompensasjonAndelerForBehandling(vilkårsvurdering.behandling.id)
-                .map { it.tilIKompensasjonAndel() }
-                .filterIsInstance<UtfyltKompensasjonAndel>()
-                .map { kompensasjonAndel ->
-                    AndelTilkjentYtelse(
-                        behandlingId = vilkårsvurdering.behandling.id,
-                        tilkjentYtelse = tilkjentYtelse,
-                        aktør = kompensasjonAndel.person.aktør,
-                        prosent = kompensasjonAndel.prosent,
-                        stønadFom = kompensasjonAndel.fom,
-                        stønadTom = kompensasjonAndel.tom,
-                        kalkulertUtbetalingsbeløp = maksBeløp().prosent(kompensasjonAndel.prosent),
-                        nasjonaltPeriodebeløp = maksBeløp().prosent(kompensasjonAndel.prosent),
-                        type = YtelseType.KOMPENSASJONSORDNING_2024,
-                        sats = maksBeløp(),
-                    )
-                }
+            genererAndelerTilkjentYtelseFraKompensasjonAndeler(
+                behandlingId = vilkårsvurdering.behandling.id,
+                tilkjentYtelse = tilkjentYtelse,
+            )
 
         val alleAndelerTilkjentYtelse = andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel } + kompensasjonAndelerSomAndelTilkjentYtelse
 
         tilkjentYtelse.andelerTilkjentYtelse.addAll(alleAndelerTilkjentYtelse)
         return tilkjentYtelse
     }
+
+    private fun genererAndelerTilkjentYtelseFraKompensasjonAndeler(
+        behandlingId: Long,
+        tilkjentYtelse: TilkjentYtelse,
+    ): List<AndelTilkjentYtelse> =
+        kompensasjonAndelRepository
+            .hentKompensasjonAndelerForBehandling(behandlingId)
+            .map { it.tilIKompensasjonAndel() }
+            .filterIsInstance<UtfyltKompensasjonAndel>()
+            .map { kompensasjonAndel ->
+                AndelTilkjentYtelse(
+                    behandlingId = behandlingId,
+                    tilkjentYtelse = tilkjentYtelse,
+                    aktør = kompensasjonAndel.person.aktør,
+                    prosent = kompensasjonAndel.prosent,
+                    stønadFom = kompensasjonAndel.fom,
+                    stønadTom = kompensasjonAndel.tom,
+                    kalkulertUtbetalingsbeløp = maksBeløp().prosent(kompensasjonAndel.prosent),
+                    nasjonaltPeriodebeløp = maksBeløp().prosent(kompensasjonAndel.prosent),
+                    type = YtelseType.KOMPENSASJONSORDNING_2024,
+                    sats = maksBeløp(),
+                )
+            }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.beregning.domene.prosent
 import no.nav.familie.ks.sak.kjerne.beregning.endretUtbetaling.AndelTilkjentYtelseMedEndretUtbetalingBehandler
-import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
 import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.erObligatoriskeFelterUtfylt
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
@@ -17,7 +17,7 @@ import java.time.LocalDate
 @Service
 class TilkjentYtelseService(
     private val beregnAndelTilkjentYtelseService: BeregnAndelTilkjentYtelseService,
-    private val kompensasjonAndelService: KompensasjonAndelService,
+    private val kompensasjonAndelRepository: KompensasjonAndelRepository,
 ) {
     fun beregnTilkjentYtelse(
         vilkårsvurdering: Vilkårsvurdering,
@@ -42,8 +42,8 @@ class TilkjentYtelseService(
             )
 
         val kompensasjonAndelerSomAndelTilkjentYtelse =
-            kompensasjonAndelService
-                .hentKompensasjonAndeler(vilkårsvurdering.behandling.id)
+            kompensasjonAndelRepository
+                .hentKompensasjonAndelerForBehandling(vilkårsvurdering.behandling.id)
                 .filter { it.erObligatoriskeFelterUtfylt() }
                 .map { kompensasjonAndel ->
                     AndelTilkjentYtelse(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig.Companion.KOMPENSASJONSORDNING
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -12,6 +13,7 @@ import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.UtfyltKompensasj
 import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.tilIKompensasjonAndel
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -19,6 +21,7 @@ import java.time.LocalDate
 class TilkjentYtelseService(
     private val beregnAndelTilkjentYtelseService: BeregnAndelTilkjentYtelseService,
     private val kompensasjonAndelRepository: KompensasjonAndelRepository,
+    private val unleashService: UnleashService,
 ) {
     fun beregnTilkjentYtelse(
         vilkårsvurdering: Vilkårsvurdering,
@@ -43,10 +46,14 @@ class TilkjentYtelseService(
             )
 
         val kompensasjonAndelerSomAndelTilkjentYtelse =
-            genererAndelerTilkjentYtelseFraKompensasjonAndeler(
-                behandlingId = vilkårsvurdering.behandling.id,
-                tilkjentYtelse = tilkjentYtelse,
-            )
+            if (unleashService.isEnabled(KOMPENSASJONSORDNING)) {
+                genererAndelerTilkjentYtelseFraKompensasjonAndeler(
+                    behandlingId = vilkårsvurdering.behandling.id,
+                    tilkjentYtelse = tilkjentYtelse,
+                )
+            } else {
+                emptyList()
+            }
 
         val alleAndelerTilkjentYtelse = andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel } + kompensasjonAndelerSomAndelTilkjentYtelse
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -1,8 +1,14 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
+import no.nav.familie.ks.sak.kjerne.beregning.domene.prosent
 import no.nav.familie.ks.sak.kjerne.beregning.endretUtbetaling.AndelTilkjentYtelseMedEndretUtbetalingBehandler
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.erObligatoriskeFelterUtfylt
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import org.springframework.stereotype.Service
@@ -11,6 +17,7 @@ import java.time.LocalDate
 @Service
 class TilkjentYtelseService(
     private val beregnAndelTilkjentYtelseService: BeregnAndelTilkjentYtelseService,
+    private val kompensasjonAndelService: KompensasjonAndelService,
 ) {
     fun beregnTilkjentYtelse(
         vilkårsvurdering: Vilkårsvurdering,
@@ -33,7 +40,29 @@ class TilkjentYtelseService(
                 andelTilkjentYtelserUtenEndringer = andelerTilkjentYtelseBarnaUtenEndringer,
                 endretUtbetalingAndeler = endretUtbetalingAndelerBarna,
             )
-        tilkjentYtelse.andelerTilkjentYtelse.addAll(andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel })
+
+        val kompensasjonAndelerSomAndelTilkjentYtelse =
+            kompensasjonAndelService
+                .hentKompensasjonAndeler(vilkårsvurdering.behandling.id)
+                .filter { it.erObligatoriskeFelterUtfylt() }
+                .map { kompensasjonAndel ->
+                    AndelTilkjentYtelse(
+                        behandlingId = vilkårsvurdering.behandling.id,
+                        tilkjentYtelse = tilkjentYtelse,
+                        aktør = kompensasjonAndel.person!!.aktør,
+                        prosent = kompensasjonAndel.prosent!!,
+                        stønadFom = kompensasjonAndel.fom!!,
+                        stønadTom = kompensasjonAndel.tom!!,
+                        kalkulertUtbetalingsbeløp = maksBeløp().prosent(kompensasjonAndel.prosent!!),
+                        nasjonaltPeriodebeløp = maksBeløp().prosent(kompensasjonAndel.prosent!!), // TODO: se på om dette er riktig
+                        type = YtelseType.KOMPENSASJONSORDNING_2024,
+                        sats = maksBeløp(),
+                    )
+                }
+
+        val alleAndelerTilkjentYtelse = andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel } + kompensasjonAndelerSomAndelTilkjentYtelse
+
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(alleAndelerTilkjentYtelse)
         return tilkjentYtelse
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -8,7 +8,8 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.beregning.domene.prosent
 import no.nav.familie.ks.sak.kjerne.beregning.endretUtbetaling.AndelTilkjentYtelseMedEndretUtbetalingBehandler
 import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
-import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.erObligatoriskeFelterUtfylt
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.UtfyltKompensasjonAndel
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.tilIKompensasjonAndel
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import org.springframework.stereotype.Service
@@ -44,17 +45,18 @@ class TilkjentYtelseService(
         val kompensasjonAndelerSomAndelTilkjentYtelse =
             kompensasjonAndelRepository
                 .hentKompensasjonAndelerForBehandling(vilkårsvurdering.behandling.id)
-                .filter { it.erObligatoriskeFelterUtfylt() }
+                .map { it.tilIKompensasjonAndel() }
+                .filterIsInstance<UtfyltKompensasjonAndel>()
                 .map { kompensasjonAndel ->
                     AndelTilkjentYtelse(
                         behandlingId = vilkårsvurdering.behandling.id,
                         tilkjentYtelse = tilkjentYtelse,
-                        aktør = kompensasjonAndel.person!!.aktør,
-                        prosent = kompensasjonAndel.prosent!!,
-                        stønadFom = kompensasjonAndel.fom!!,
-                        stønadTom = kompensasjonAndel.tom!!,
-                        kalkulertUtbetalingsbeløp = maksBeløp().prosent(kompensasjonAndel.prosent!!),
-                        nasjonaltPeriodebeløp = maksBeløp().prosent(kompensasjonAndel.prosent!!), // TODO: se på om dette er riktig
+                        aktør = kompensasjonAndel.person.aktør,
+                        prosent = kompensasjonAndel.prosent,
+                        stønadFom = kompensasjonAndel.fom,
+                        stønadTom = kompensasjonAndel.tom,
+                        kalkulertUtbetalingsbeløp = maksBeløp().prosent(kompensasjonAndel.prosent),
+                        nasjonaltPeriodebeløp = maksBeløp().prosent(kompensasjonAndel.prosent),
                         type = YtelseType.KOMPENSASJONSORDNING_2024,
                         sats = maksBeløp(),
                     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -47,8 +47,12 @@ object TilkjentYtelseValidator {
 
         andelerPerAktør.filter { it.value.isNotEmpty() }.forEach { (aktør, andeler) ->
 
-            val stønadFom = andeler.minOf { it.stønadFom }
-            val stønadTom = andeler.maxOf { it.stønadTom }
+            // TODO: Valider KOMPENSASJONSORDNING
+
+            val ordinæreAndeler = andeler.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
+
+            val stønadFom = ordinæreAndeler.minOf { it.stønadFom }
+            val stønadTom = ordinæreAndeler.maxOf { it.stønadTom }
 
             val relevantBarn = barna.single { it.aktør == aktør }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIUtbetalingUtil.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.kjerne.forrigebehandling
+package no.nav.familie.ks.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
 import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelService.kt
@@ -58,7 +58,7 @@ class KompensasjonAndelService(
     }
 
     @Transactional
-    fun fjernKompensasjongAndelOgOppdaterTilkjentYtelse(
+    fun fjernKompensasjonAndelOgOppdaterTilkjentYtelse(
         behandling: Behandling,
         kompensasjonAndelId: Long,
     ) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelService.kt
@@ -51,9 +51,9 @@ class KompensasjonAndelService(
         slåSammenOgOppdaterKompensasjonAndeler(behandling)
 
         beregningService.oppdaterTilkjentYtelsePåBehandling(
-            behandling,
-            personopplysningGrunnlag,
-            vilkårsvurdering,
+            behandling = behandling,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            vilkårsvurdering = vilkårsvurdering,
         )
     }
 
@@ -68,9 +68,9 @@ class KompensasjonAndelService(
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id)
 
         beregningService.oppdaterTilkjentYtelsePåBehandling(
-            behandling,
-            personopplysningGrunnlag,
-            vilkårsvurdering,
+            behandling = behandling,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            vilkårsvurdering = vilkårsvurdering,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelService.kt
@@ -33,14 +33,21 @@ class KompensasjonAndelService(
         val kompensasjonAndel = finnKompensasjonAndel(kompensasjonAndelId)
         val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
         val person = personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == kompensasjonAndelRequestDto.personIdent }
+        val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id)
 
         kompensasjonAndel.fraKompenasjonAndelDto(kompensasjonAndelRequestDto, person)
 
         // TODO: Validering
 
+        // TODO: Slå sammen kompensasjonAndeler som er like og etterfølgende
+
         kompensasjonAndelRepository.saveAndFlush(kompensasjonAndel)
 
-        // TODO: Oppdater tilkjent ytelse med endret kompensasjonsandel
+        beregningService.oppdaterTilkjentYtelsePåBehandling(
+            behandling,
+            personopplysningGrunnlag,
+            vilkårsvurdering,
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/domene/KompensasjonAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/domene/KompensasjonAndel.kt
@@ -63,6 +63,12 @@ data class KompensasjonAndel(
     override fun hashCode(): Int = id.hashCode()
 }
 
+fun KompensasjonAndel.erObligatoriskeFelterUtfylt(): Boolean =
+    this.person != null &&
+        this.fom != null &&
+        this.tom != null &&
+        this.prosent != null
+
 fun KompensasjonAndel.tilKompensasjonAndelDto(): KompensasjonAndelDto =
     KompensasjonAndelDto(
         id = this.id,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -66,6 +66,7 @@ import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.tilIKompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
 import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.domene.Valutakurs
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndel
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
@@ -88,6 +89,7 @@ class StepDefinition {
     var valutakurs = mutableMapOf<Long, List<Valutakurs>>()
     var utenlandskPeriodebeløp = mutableMapOf<Long, List<UtenlandskPeriodebeløp>>()
     var endredeUtbetalinger = mutableMapOf<Long, List<EndretUtbetalingAndel>>()
+    var kompensasjonAndeler = mutableMapOf<Long, List<KompensasjonAndel>>()
     var andelerTilkjentYtelse = mutableMapOf<Long, List<AndelTilkjentYtelse>>()
     var overstyrteEndringstidspunkt = mutableMapOf<Long, LocalDate>()
     var uregistrerteBarn = mutableMapOf<Long, List<BarnMedOpplysningerDto>>()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.cucumber.mocking
 import io.mockk.mockk
 import no.nav.familie.ba.sak.cucumber.mock.mockEndretUtbetalingAndelRepository
 import no.nav.familie.ba.sak.cucumber.mock.mockFagsakRepository
+import no.nav.familie.ba.sak.cucumber.mock.mockKompensasjonAndelRepository
 import no.nav.familie.ba.sak.cucumber.mock.mockLoggService
 import no.nav.familie.ba.sak.cucumber.mock.mockPersonopplysningGrunnlagRepository
 import no.nav.familie.ba.sak.cucumber.mock.mockTaskService
@@ -27,7 +28,6 @@ import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.Regelverk
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterTilkjentYtelseService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
 import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -49,6 +49,7 @@ class CucumberMock(
     val tilkjentYtelseRepositoryMock = mockTilkjentYtelseRepository(stepDefinition)
     val personopplysningGrunnlagRepositoryMock = mockPersonopplysningGrunnlagRepository(stepDefinition)
     val endretUtbetalingAndelRepositoryMock = mockEndretUtbetalingAndelRepository(stepDefinition)
+    val kompensasjonAndelRepositoryMock = mockKompensasjonAndelRepository(stepDefinition)
     val fagsakRepositoryMock = mockFagsakRepository(stepDefinition)
     val vedtakRepositoryMock = mockVedtakRepository(stepDefinition)
     val taskServiceMock = mockTaskService()
@@ -64,7 +65,6 @@ class CucumberMock(
     val personRepository = mockk<PersonRepository>()
     val tilbakekrevingsbehandlingHentService = mockk<TilbakekrevingsbehandlingHentService>()
     val arbeidsfordelingServiceMock = mockk<ArbeidsfordelingService>()
-    val kompensasjonAndelRepositoryMock = mockk<KompensasjonAndelRepository>()
 
     val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -1,16 +1,6 @@
 package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.mockk
-import no.nav.familie.ba.sak.cucumber.mock.mockEndretUtbetalingAndelRepository
-import no.nav.familie.ba.sak.cucumber.mock.mockFagsakRepository
-import no.nav.familie.ba.sak.cucumber.mock.mockKompensasjonAndelRepository
-import no.nav.familie.ba.sak.cucumber.mock.mockLoggService
-import no.nav.familie.ba.sak.cucumber.mock.mockPersonopplysningGrunnlagRepository
-import no.nav.familie.ba.sak.cucumber.mock.mockTaskService
-import no.nav.familie.ba.sak.cucumber.mock.mockTilkjentYtelseRepository
-import no.nav.familie.ba.sak.cucumber.mock.mockUtenlandskPeriodebeløpRepository
-import no.nav.familie.ba.sak.cucumber.mock.mockValutakursRepository
-import no.nav.familie.ba.sak.cucumber.mock.mockVedtakRepository
 import no.nav.familie.ks.sak.common.util.LocalDateProvider
 import no.nav.familie.ks.sak.cucumber.StepDefinition
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -27,7 +27,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.Regelverk
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterTilkjentYtelseService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
 import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -64,14 +64,14 @@ class CucumberMock(
     val personRepository = mockk<PersonRepository>()
     val tilbakekrevingsbehandlingHentService = mockk<TilbakekrevingsbehandlingHentService>()
     val arbeidsfordelingServiceMock = mockk<ArbeidsfordelingService>()
-    val kompensasjonAndelServiceMock = mockk<KompensasjonAndelService>()
+    val kompensasjonAndelRepositoryMock = mockk<KompensasjonAndelRepository>()
 
     val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
             unleashService = mockUnleashService(isEnabledDefault = false),
         )
-    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelServiceMock)
+    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelRepositoryMock)
 
     val tilpassDifferanseberegningEtterTilkjentYtelseService =
         TilpassDifferanseberegningEtterTilkjentYtelseService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -71,7 +71,7 @@ class CucumberMock(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
             unleashService = mockUnleashService(isEnabledDefault = false),
         )
-    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelRepositoryMock)
+    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelRepositoryMock, mockUnleashService())
 
     val tilpassDifferanseberegningEtterTilkjentYtelseService =
         TilpassDifferanseberegningEtterTilkjentYtelseService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.Regelverk
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.eøs.differanseberegning.TilpassDifferanseberegningEtterTilkjentYtelseService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
 import no.nav.familie.ks.sak.kjerne.personident.AktørRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -63,13 +64,14 @@ class CucumberMock(
     val personRepository = mockk<PersonRepository>()
     val tilbakekrevingsbehandlingHentService = mockk<TilbakekrevingsbehandlingHentService>()
     val arbeidsfordelingServiceMock = mockk<ArbeidsfordelingService>()
+    val kompensasjonAndelServiceMock = mockk<KompensasjonAndelService>()
 
     val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
             unleashService = mockUnleashService(isEnabledDefault = false),
         )
-    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService)
+    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelServiceMock)
 
     val tilpassDifferanseberegningEtterTilkjentYtelseService =
         TilpassDifferanseberegningEtterTilkjentYtelseService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockEndretUtbetalingAndelRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockEndretUtbetalingAndelRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockFagsakRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockFagsakRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompensasjonAndelRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompensasjonAndelRepository.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.ba.sak.cucumber.mock
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.cucumber.StepDefinition
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
+
+fun mockKompensasjonAndelRepository(stepDefinition: StepDefinition): KompensasjonAndelRepository =
+    mockk<KompensasjonAndelRepository>().apply {
+        every { hentKompensasjonAndelerForBehandling(any()) } answers {
+            val behandlingId = firstArg<Long>()
+            stepDefinition.kompensasjonAndeler[behandlingId] ?: emptyList()
+        }
+    }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompensasjonAndelRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompensasjonAndelRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ba.sak.cucumber.mock
+package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompetanseRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockKompetanseRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockLoggService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockLoggService.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.just

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPersonopplysningGrunnlagRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPersonopplysningGrunnlagRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTaskService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTaskService.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTilkjentYtelseRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockTilkjentYtelseRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUtenlandskPeriodebeløpRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUtenlandskPeriodebeløpRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockValutakursRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockValutakursRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockVedtakRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockVedtakRepository.kt
@@ -1,4 +1,4 @@
-﻿package no.nav.familie.ba.sak.cucumber.mock
+﻿package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersongrunnlagEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersongrunnlagEnhetTest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ks.sak.kjerne.eøs.EøsSkjemaerForNyBehandlingService
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService
 import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.ValutakursService
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import org.junit.jupiter.api.Test
 
@@ -22,6 +23,7 @@ class RegistrerPersongrunnlagEnhetTest {
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk(relaxed = true)
     private val vilkårsvurderingService: VilkårsvurderingService = mockk(relaxed = true)
     private val endretUtbetalingAndelService: EndretUtbetalingAndelService = mockk(relaxed = true)
+    private val kompensasjonAndelService: KompensasjonAndelService = mockk(relaxed = true)
     private val kompetanseService: KompetanseService = mockk(relaxed = true)
     private val valutakursService: ValutakursService = mockk(relaxed = true)
     private val utenlandskPeriodebeløpService: UtenlandskPeriodebeløpService = mockk(relaxed = true)
@@ -32,6 +34,7 @@ class RegistrerPersongrunnlagEnhetTest {
             vilkårsvurderingService = vilkårsvurderingService,
             personopplysningGrunnlagService = personopplysningGrunnlagService,
             endretUtbetalingAndelService = endretUtbetalingAndelService,
+            kompensasjonAndelService = kompensasjonAndelService,
             eøsSkjemaerForNyBehandlingService =
                 EøsSkjemaerForNyBehandlingService(
                     kompetanseService = kompetanseService,
@@ -42,11 +45,11 @@ class RegistrerPersongrunnlagEnhetTest {
 
     @Test
     fun `Kopierer kompetanser, valutakurser og utenlandsk periodebeløp til ny behandling`() {
-        val sisteVedtatteBehandling = lagBehandling()
+        val sisteVedtatteBehandling = lagBehandling(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
         val behandling2 = lagBehandling()
 
         every { behandlingRepository.hentBehandling(behandling2.id) } returns behandling2
-        every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling.copy(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET))
+        every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling)
 
         registrerPersongrunnlagSteg.utførSteg(behandlingId = behandling2.id)
 
@@ -63,16 +66,24 @@ class RegistrerPersongrunnlagEnhetTest {
                 BehandlingId(sisteVedtatteBehandling.id),
                 BehandlingId(behandling2.id),
             )
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling = behandling2,
+                forrigeBehandling = sisteVedtatteBehandling,
+            )
+            kompensasjonAndelService.kopierKompensasjonAndelFraForrigeBehandling(
+                behandling = behandling2,
+                forrigeBehandling = sisteVedtatteBehandling,
+            )
         }
     }
 
     @Test
     fun `Skal ikke kopierer kompetanser, valutakurser og utenlandsk periodebeløp for man ikke har noen siste behandling er henlagt`() {
-        val sisteVedtatteBehandling = lagBehandling()
+        val sisteVedtatteBehandling = lagBehandling(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET)
         val behandling2 = lagBehandling()
 
         every { behandlingRepository.hentBehandling(behandling2.id) } returns behandling2
-        every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling.copy(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET))
+        every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling)
 
         registrerPersongrunnlagSteg.utførSteg(behandlingId = behandling2.id)
 
@@ -88,6 +99,14 @@ class RegistrerPersongrunnlagEnhetTest {
             utenlandskPeriodebeløpService.kopierOgErstattUtenlandskPeriodebeløp(
                 BehandlingId(sisteVedtatteBehandling.id),
                 BehandlingId(behandling2.id),
+            )
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(
+                behandling = behandling2,
+                forrigeBehandling = sisteVedtatteBehandling,
+            )
+            kompensasjonAndelService.kopierKompensasjonAndelFraForrigeBehandling(
+                behandling = behandling2,
+                forrigeBehandling = sisteVedtatteBehandling,
             )
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.utbetalingsperiodeMedBegrunnelser
 
 import apr
+import io.mockk.mockk
 import mars
 import no.nav.familie.ks.sak.common.tidslinje.Periode
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
@@ -329,10 +330,12 @@ internal class UtbetalingsperiodeUtilTest {
 
         val tilkjentYtelseService =
             TilkjentYtelseService(
-                BeregnAndelTilkjentYtelseService(
-                    andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
-                    unleashService = mockUnleashService(false),
-                ),
+                beregnAndelTilkjentYtelseService =
+                    BeregnAndelTilkjentYtelseService(
+                        andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
+                        unleashService = mockUnleashService(false),
+                    ),
+                kompensasjonAndelService = mockk(),
             )
 
         val tilkjentYtelse =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -335,7 +335,7 @@ internal class UtbetalingsperiodeUtilTest {
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
                         unleashService = mockUnleashService(false),
                     ),
-                kompensasjonAndelService = mockk(),
+                kompensasjonAndelRepository = mockk(),
             )
 
         val tilkjentYtelse =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -338,6 +338,7 @@ internal class UtbetalingsperiodeUtilTest {
                         unleashService = mockUnleashService(false),
                     ),
                 kompensasjonAndelRepository = mockKompensasjonAndelRepository(),
+                unleashService = mockUnleashService(true),
             )
 
         val tilkjentYtelse =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.utbetalingsperiodeMedBegrunnelser
 
 import apr
+import io.mockk.every
 import io.mockk.mockk
 import mars
 import no.nav.familie.ks.sak.common.tidslinje.Periode
@@ -30,6 +31,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.RegelverkFørFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
@@ -335,7 +337,7 @@ internal class UtbetalingsperiodeUtilTest {
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
                         unleashService = mockUnleashService(false),
                     ),
-                kompensasjonAndelRepository = mockk(),
+                kompensasjonAndelRepository = mockKompensasjonAndelRepository(),
             )
 
         val tilkjentYtelse =
@@ -367,4 +369,9 @@ internal class UtbetalingsperiodeUtilTest {
             lagFullstendigVilkårResultat = true,
             personType = PersonType.SØKER,
         )
+
+    private fun mockKompensasjonAndelRepository(): KompensasjonAndelRepository =
+        mockk<KompensasjonAndelRepository>().apply {
+            every { hentKompensasjonAndelerForBehandling(any()) } returns emptyList()
+        }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -66,7 +66,7 @@ internal class TilkjentYtelseServiceTest {
 
     private val kompensasjonAndelRepositoryMock: KompensasjonAndelRepository = mockk()
 
-    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelRepositoryMock)
+    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelRepositoryMock, mockUnleashService(true))
 
     @BeforeEach
     fun init() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -1,8 +1,11 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.familie.ks.sak.common.util.NullablePeriode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashService
 import no.nav.familie.ks.sak.data.lagBehandling
@@ -24,6 +27,8 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.beregning.domene.prosent
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.RegelverkFørFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndel
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -31,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
 
 internal class TilkjentYtelseServiceTest {
     private val søker = randomAktør()
@@ -57,7 +63,10 @@ internal class TilkjentYtelseServiceTest {
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
             unleashService = mockUnleashService(false),
         )
-    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService)
+
+    private val kompensasjonAndelService: KompensasjonAndelService = mockk()
+
+    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelService)
 
     @BeforeEach
     fun init() {
@@ -69,6 +78,82 @@ internal class TilkjentYtelseServiceTest {
                 søkerPeriodeFom = LocalDate.of(1987, 1, 1),
                 søkerPeriodeTom = null,
             )
+
+        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns emptyList()
+    }
+
+    @Test
+    fun `beregnTilkjentYtelse skal generere kompensasjonAndeler`() {
+        // arrange
+        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns
+            listOf(
+                KompensasjonAndel(
+                    id = 1,
+                    behandlingId = behandling.id,
+                    person = barnPerson,
+                    prosent = BigDecimal(100),
+                    fom = YearMonth.of(2024, 9),
+                    tom = YearMonth.of(2024, 10),
+                ),
+                KompensasjonAndel(
+                    id = 2,
+                    behandlingId = behandling.id,
+                    person = barnPerson,
+                    prosent = BigDecimal(50),
+                    fom = YearMonth.of(2024, 12),
+                    tom = YearMonth.of(2025, 1),
+                ),
+            )
+
+        // act
+        val tilkjentYtelse =
+            tilkjentYtelseService.beregnTilkjentYtelse(
+                vilkårsvurdering = vilkårsvurdering,
+                personopplysningGrunnlag = personopplysningGrunnlag,
+            )
+
+        // assert
+        assertTilkjentYtelse(tilkjentYtelse, 2)
+        assertAndelTilkjentYtelse(
+            andelTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.first { it.stønadFom == YearMonth.of(2024, 9) },
+            prosent = BigDecimal(100),
+            periodeFom = YearMonth.of(2024, 9).toLocalDate(),
+            periodeTom = YearMonth.of(2024, 10).toLocalDate(),
+            type = YtelseType.KOMPENSASJONSORDNING_2024,
+        )
+        assertAndelTilkjentYtelse(
+            andelTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.first { it.stønadFom == YearMonth.of(2024, 12) },
+            prosent = BigDecimal(50),
+            periodeFom = YearMonth.of(2024, 12).toLocalDate(),
+            periodeTom = YearMonth.of(2025, 1).toLocalDate(),
+            type = YtelseType.KOMPENSASJONSORDNING_2024,
+        )
+    }
+
+    @Test
+    fun `beregnTilkjentYtelse tar ikke med tom kompensasjonandel`() {
+        // arrange
+        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns
+            listOf(
+                KompensasjonAndel(
+                    id = 1,
+                    behandlingId = behandling.id,
+                    person = null,
+                    prosent = null,
+                    fom = null,
+                    tom = null,
+                ),
+            )
+
+        // act
+        val tilkjentYtelse =
+            tilkjentYtelseService.beregnTilkjentYtelse(
+                vilkårsvurdering = vilkårsvurdering,
+                personopplysningGrunnlag = personopplysningGrunnlag,
+            )
+
+        // assert
+        assertTrue(tilkjentYtelse.andelerTilkjentYtelse.isEmpty())
     }
 
     @Test
@@ -533,9 +618,10 @@ internal class TilkjentYtelseServiceTest {
         prosent: BigDecimal,
         periodeFom: LocalDate,
         periodeTom: LocalDate,
+        type: YtelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
     ) {
         assertEquals(barn1, andelTilkjentYtelse.aktør)
-        assertEquals(YtelseType.ORDINÆR_KONTANTSTØTTE, andelTilkjentYtelse.type)
+        assertEquals(type, andelTilkjentYtelse.type)
         assertEquals(prosent, andelTilkjentYtelse.prosent)
         assertEquals(periodeFom.toYearMonth(), andelTilkjentYtelse.stønadFom)
         assertEquals(periodeTom.toYearMonth(), andelTilkjentYtelse.stønadTom)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -27,8 +27,8 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.beregning.domene.prosent
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.RegelverkFørFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
-import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
 import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndel
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -64,9 +64,9 @@ internal class TilkjentYtelseServiceTest {
             unleashService = mockUnleashService(false),
         )
 
-    private val kompensasjonAndelService: KompensasjonAndelService = mockk()
+    private val kompensasjonAndelRepositoryMock: KompensasjonAndelRepository = mockk()
 
-    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelService)
+    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelRepositoryMock)
 
     @BeforeEach
     fun init() {
@@ -79,13 +79,13 @@ internal class TilkjentYtelseServiceTest {
                 søkerPeriodeTom = null,
             )
 
-        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns emptyList()
+        every { kompensasjonAndelRepositoryMock.hentKompensasjonAndelerForBehandling(any()) } returns emptyList()
     }
 
     @Test
     fun `beregnTilkjentYtelse skal generere kompensasjonAndeler`() {
         // arrange
-        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns
+        every { kompensasjonAndelRepositoryMock.hentKompensasjonAndelerForBehandling(any()) } returns
             listOf(
                 KompensasjonAndel(
                     id = 1,
@@ -133,7 +133,7 @@ internal class TilkjentYtelseServiceTest {
     @Test
     fun `beregnTilkjentYtelse tar ikke med tom kompensasjonandel`() {
         // arrange
-        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns
+        every { kompensasjonAndelRepositoryMock.hentKompensasjonAndelerForBehandling(any()) } returns
             listOf(
                 KompensasjonAndel(
                     id = 1,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -27,8 +27,8 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.beregning.domene.prosent
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.RegelverkFørFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
-import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.KompensasjonAndelService
 import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndel
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -64,9 +64,9 @@ internal class TilkjentYtelseServiceTest {
             unleashService = mockUnleashService(false),
         )
 
-    private val kompensasjonAndelService: KompensasjonAndelService = mockk()
+    private val kompensasjonAndelRepository: KompensasjonAndelRepository = mockk()
 
-    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelService)
+    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, kompensasjonAndelRepository)
 
     @BeforeEach
     fun init() {
@@ -79,13 +79,13 @@ internal class TilkjentYtelseServiceTest {
                 søkerPeriodeTom = null,
             )
 
-        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns emptyList()
+        every { kompensasjonAndelRepository.hentKompensasjonAndelerForBehandling(any()) } returns emptyList()
     }
 
     @Test
     fun `beregnTilkjentYtelse skal generere kompensasjonAndeler`() {
         // arrange
-        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns
+        every { kompensasjonAndelRepository.hentKompensasjonAndelerForBehandling(any()) } returns
             listOf(
                 KompensasjonAndel(
                     id = 1,
@@ -133,7 +133,7 @@ internal class TilkjentYtelseServiceTest {
     @Test
     fun `beregnTilkjentYtelse tar ikke med tom kompensasjonandel`() {
         // arrange
-        every { kompensasjonAndelService.hentKompensasjonAndeler(any()) } returns
+        every { kompensasjonAndelRepository.hentKompensasjonAndelerForBehandling(any()) } returns
             listOf(
                 KompensasjonAndel(
                     id = 1,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -107,6 +107,7 @@ data class VilkårsvurderingBuilder(
                         unleashService = mockUnleashService(false),
                     ),
                 kompensasjonAndelRepository = mockKompensasjonAndelRepository(),
+                unleashService = mockUnleashService(true),
             )
 
         return tilkjentYtelseService.beregnTilkjentYtelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.eøs.util
 
+import io.mockk.mockk
 import no.nav.familie.ks.sak.common.tidslinje.Periode
 import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
 import no.nav.familie.ks.sak.common.tidslinje.filtrerIkkeNull
@@ -98,10 +99,12 @@ data class VilkårsvurderingBuilder(
     fun byggTilkjentYtelse(): TilkjentYtelse {
         val tilkjentYtelseService =
             TilkjentYtelseService(
-                BeregnAndelTilkjentYtelseService(
-                    andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
-                    unleashService = mockUnleashService(false),
-                ),
+                beregnAndelTilkjentYtelseService =
+                    BeregnAndelTilkjentYtelseService(
+                        andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
+                        unleashService = mockUnleashService(false),
+                    ),
+                kompensasjonAndelService = mockk(),
             )
 
         return tilkjentYtelseService.beregnTilkjentYtelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -104,7 +104,7 @@ data class VilkårsvurderingBuilder(
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
                         unleashService = mockUnleashService(false),
                     ),
-                kompensasjonAndelService = mockk(),
+                kompensasjonAndelRepository = mockk(),
             )
 
         return tilkjentYtelseService.beregnTilkjentYtelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.eøs.util
 
+import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ks.sak.common.tidslinje.Periode
 import no.nav.familie.ks.sak.common.tidslinje.Tidslinje
@@ -29,6 +30,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.RegelverkFørFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
+import no.nav.familie.ks.sak.kjerne.kompensasjonsordning.domene.KompensasjonAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import java.time.YearMonth
@@ -104,7 +106,7 @@ data class VilkårsvurderingBuilder(
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(RegelverkLovendringFebruar2025AndelGenerator(), RegelverkFørFebruar2025AndelGenerator())),
                         unleashService = mockUnleashService(false),
                     ),
-                kompensasjonAndelRepository = mockk(),
+                kompensasjonAndelRepository = mockKompensasjonAndelRepository(),
             )
 
         return tilkjentYtelseService.beregnTilkjentYtelse(
@@ -112,6 +114,11 @@ data class VilkårsvurderingBuilder(
             personopplysningGrunnlag = this.byggPersonopplysningGrunnlag(),
         )
     }
+
+    private fun mockKompensasjonAndelRepository(): KompensasjonAndelRepository =
+        mockk<KompensasjonAndelRepository>().apply {
+            every { hentKompensasjonAndelerForBehandling(any()) } returns emptyList()
+        }
 }
 
 internal fun Periode<UtdypendeVilkårRegelverkResultat>.tilVilkårResultater(personResultat: PersonResultat): Collection<VilkårResultat> =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/kompensasjonsordning/KompensasjonAndelServiceTest.kt
@@ -130,7 +130,7 @@ class KompensasjonAndelServiceTest {
 
         every { kompensasjonAndelRepository.hentKompensasjonAndelerForBehandling(any()) } returns emptyList()
 
-        kompensasjonAndelService.fjernKompensasjongAndelOgOppdaterTilkjentYtelse(behandling, 200)
+        kompensasjonAndelService.fjernKompensasjonAndelOgOppdaterTilkjentYtelse(behandling, 200)
 
         verify(exactly = 1) { kompensasjonAndelRepository.deleteById(200) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -6,10 +6,10 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.verify
-import no.nav.familie.ba.sak.cucumber.mock.mockTaskService
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.config.PersonInfoQuery
+import no.nav.familie.ks.sak.cucumber.mocking.mockTaskService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.randomAktør


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: NAV-22613

Vi ønsker at kompensasjonsandeler skal inkluderes i AndelTilkjentYtelse for en behandling.
Løser dette ved å slå sammen like perioder og generere tilkjent ytelse på nytt hver gang kompensasjonsandeler oppdateres

Validering og vedtaksperiode genering tas i andre PR'er

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
