### PR TITLE
Fjerner gammel validering av behandlingsresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -200,41 +200,39 @@ data class Behandling(
  */
 enum class Behandlingsresultat(
     val displayName: String,
-    val gyldigeBehandlingstyper: List<BehandlingType>,
 ) {
     // Søknad
-    INNVILGET(displayName = "Innvilget", BehandlingType.values().toList()),
-    INNVILGET_OG_OPPHØRT(displayName = "Innvilget og opphørt", BehandlingType.values().toList()),
-    INNVILGET_OG_ENDRET(displayName = "Innvilget og endret", BehandlingType.values().toList()),
-    INNVILGET_ENDRET_OG_OPPHØRT(displayName = "Innvilget, endret og opphørt", BehandlingType.values().toList()),
+    INNVILGET(displayName = "Innvilget"),
+    INNVILGET_OG_OPPHØRT(displayName = "Innvilget og opphørt"),
+    INNVILGET_OG_ENDRET(displayName = "Innvilget og endret"),
+    INNVILGET_ENDRET_OG_OPPHØRT(displayName = "Innvilget, endret og opphørt"),
 
-    DELVIS_INNVILGET(displayName = "Delvis innvilget", BehandlingType.values().toList()),
-    DELVIS_INNVILGET_OG_OPPHØRT(displayName = "Delvis innvilget og opphørt", BehandlingType.values().toList()),
-    DELVIS_INNVILGET_OG_ENDRET(displayName = "Delvis innvilget og endret", BehandlingType.values().toList()),
+    DELVIS_INNVILGET(displayName = "Delvis innvilget"),
+    DELVIS_INNVILGET_OG_OPPHØRT(displayName = "Delvis innvilget og opphørt"),
+    DELVIS_INNVILGET_OG_ENDRET(displayName = "Delvis innvilget og endret"),
     DELVIS_INNVILGET_ENDRET_OG_OPPHØRT(
         displayName = "Delvis innvilget, endret og opphørt",
-        BehandlingType.values().toList(),
     ),
 
-    AVSLÅTT(displayName = "Avslått", BehandlingType.values().toList()),
-    AVSLÅTT_OG_OPPHØRT(displayName = "Avslått og opphørt", listOf(REVURDERING, TEKNISK_ENDRING)),
-    AVSLÅTT_OG_ENDRET(displayName = "Avslått og endret", listOf(REVURDERING, TEKNISK_ENDRING)),
-    AVSLÅTT_ENDRET_OG_OPPHØRT(displayName = "Avslått, endret og opphørt", listOf(REVURDERING, TEKNISK_ENDRING)),
+    AVSLÅTT(displayName = "Avslått"),
+    AVSLÅTT_OG_OPPHØRT(displayName = "Avslått og opphørt"),
+    AVSLÅTT_OG_ENDRET(displayName = "Avslått og endret"),
+    AVSLÅTT_ENDRET_OG_OPPHØRT(displayName = "Avslått, endret og opphørt"),
 
     // Revurdering uten søknad
-    ENDRET_UTBETALING(displayName = "Endret utbetaling", listOf(REVURDERING, TEKNISK_ENDRING)),
-    ENDRET_UTEN_UTBETALING(displayName = "Endret, uten endret utbetaling", listOf(REVURDERING, TEKNISK_ENDRING)),
-    ENDRET_OG_OPPHØRT(displayName = "Endret og opphørt", listOf(REVURDERING, TEKNISK_ENDRING)),
-    OPPHØRT(displayName = "Opphørt", BehandlingType.values().toList()),
-    FORTSATT_OPPHØRT(displayName = "Fortsatt opphørt", listOf(REVURDERING, TEKNISK_ENDRING)),
-    FORTSATT_INNVILGET(displayName = "Fortsatt innvilget", listOf(REVURDERING, TEKNISK_ENDRING)),
+    ENDRET_UTBETALING(displayName = "Endret utbetaling"),
+    ENDRET_UTEN_UTBETALING(displayName = "Endret, uten endret utbetaling"),
+    ENDRET_OG_OPPHØRT(displayName = "Endret og opphørt"),
+    OPPHØRT(displayName = "Opphørt"),
+    FORTSATT_OPPHØRT(displayName = "Fortsatt opphørt"),
+    FORTSATT_INNVILGET(displayName = "Fortsatt innvilget"),
 
     // Henlagt
-    HENLAGT_FEILAKTIG_OPPRETTET(displayName = "Henlagt feilaktig opprettet", BehandlingType.values().toList()),
-    HENLAGT_SØKNAD_TRUKKET(displayName = "Henlagt søknad trukket", BehandlingType.values().toList()),
-    HENLAGT_TEKNISK_VEDLIKEHOLD(displayName = "Henlagt teknisk vedlikehold", BehandlingType.values().toList()),
+    HENLAGT_FEILAKTIG_OPPRETTET(displayName = "Henlagt feilaktig opprettet"),
+    HENLAGT_SØKNAD_TRUKKET(displayName = "Henlagt søknad trukket"),
+    HENLAGT_TEKNISK_VEDLIKEHOLD(displayName = "Henlagt teknisk vedlikehold"),
 
-    IKKE_VURDERT(displayName = "Ikke vurdert", emptyList()),
+    IKKE_VURDERT(displayName = "Ikke vurdert"),
     ;
 
     fun kanIkkeSendesTilOppdrag(): Boolean = this in listOf(FORTSATT_INNVILGET, AVSLÅTT, FORTSATT_OPPHØRT, ENDRET_UTEN_UTBETALING)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -56,8 +56,6 @@ class BehandlingsresultatSteg(
 
         val resultat = behandlingsresultatService.utledBehandlingsresultat(behandling.id)
 
-        // valider om behandlingsresultat samsvarer med Behandlingstype
-        BehandlingsresultatValideringUtils.validerUtledetBehandlingsresultat(behandling, resultat)
         val behandlingMedOppdatertResultat = behandlingService.oppdaterBehandlingsresultat(behandlingId, resultat)
 
         val erLovendringOgFremtidigOpphørOgNyAndelIAugust2024 = behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(behandling)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -80,25 +80,4 @@ object BehandlingsresultatValideringUtils {
             throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
         }
     }
-
-    fun validerUtledetBehandlingsresultat(
-        behandling: Behandling,
-        behandlingsresultat: Behandlingsresultat,
-    ) {
-        when {
-            behandling.type !in behandlingsresultat.gyldigeBehandlingstyper -> {
-                val feilmelding =
-                    "Behandlingsresultatet ${behandlingsresultat.displayName.lowercase()} " +
-                        "er ugyldig i kombinasjon med behandlingstype '${behandling.type.visningsnavn}'."
-                throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
-            }
-
-            behandlingsresultat.erAvslått() && behandling.erKlage() -> {
-                val feilmelding =
-                    "Behandlingsårsak ${behandling.opprettetÅrsak.visningsnavn.lowercase()} " +
-                        "er ugyldig i kombinasjon med resultat '${behandlingsresultat.displayName.lowercase()}'."
-                throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
-            }
-        }
-    }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22909

Fjerner gammel validering av behandlingsresultat.
Den gamle logikken er feil og avviker fra BA, så jeg tenker det er greit å fjerne den da den uansett ikke lenger trengs siden vi har en ny validering.

Nytt validering skjer allerede i `validerBehandlingsresultat` i `BehandlingsresultatValideringUtils`.