### PR TITLE
Endring i endret utbetalingsandel skal ikke trigge endret flagg i behandlingsresultatet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -18,8 +18,7 @@ object EndringIEndretUtbetalingAndelUtil {
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
                 (
                     nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted ||
-                        nåværende?.årsak != forrige?.årsak ||
-                        nåværende?.søknadstidspunkt != forrige?.søknadstidspunkt
+                        nåværende?.årsak != forrige?.årsak
                 )
             }
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22909

Har diskutert med Anna, og endring i søknadstidspunkt gitt i endret utbetalingsandelene skal ikke trigge endring flagg for behandlingsresultatet.