### PR TITLE
Chore: Fjerner bruk av toggle ved henting av journalposter for bruker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/JournalføringController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/JournalføringController.kt
@@ -3,13 +3,12 @@ package no.nav.familie.ks.sak.api
 import jakarta.validation.Valid
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.journalpost.TilgangsstyrtJournalpost
 import no.nav.familie.ks.sak.api.dto.JournalføringRequestDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.integrasjon.journalføring.InnkommendeJournalføringService
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
-import no.nav.familie.unleash.UnleashService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -28,24 +27,18 @@ import org.springframework.web.bind.annotation.RestController
 class JournalføringController(
     private val innkommendeJournalføringService: InnkommendeJournalføringService,
     private val tilgangService: TilgangService,
-    private val unleashService: UnleashService,
 ) {
     @PostMapping(path = ["/bruker"])
     fun hentJournalposterForBruker(
         @RequestBody personIdentBody: PersonIdent,
-    ): ResponseEntity<Ressurs<List<Any>>> {
-        val tilgangsstyrteJournalposter =
-            innkommendeJournalføringService.hentJournalposterForBruker(
-                personIdentBody.ident,
-            )
-        val response =
-            if (unleashService.isEnabled(FeatureToggleConfig.BRUK_NYTT_RETUR_OBJEKT_FOR_JOURNALPOSTER, false)) {
-                tilgangsstyrteJournalposter
-            } else {
-                tilgangsstyrteJournalposter.map { it.journalpost }
-            }
-        return ResponseEntity.ok(Ressurs.success(response))
-    }
+    ): ResponseEntity<Ressurs<List<TilgangsstyrtJournalpost>>> =
+        ResponseEntity.ok(
+            Ressurs.success(
+                innkommendeJournalføringService.hentJournalposterForBruker(
+                    personIdentBody.ident,
+                ),
+            ),
+        )
 
     @GetMapping("/{journalpostId}/dokument/{dokumentId}")
     fun hentDokumentIJournalpost(

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -14,8 +14,5 @@ class FeatureToggleConfig {
         const val OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER = "familie-ba-ks-sak.opprett-sak-paa-riktig-enhet-og-saksbehandler"
 
         const val BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER = "familie-ks-sak.bruk-ny-loype-for-generering-av-andeler"
-
-        // NAV-22361
-        const val BRUK_NYTT_RETUR_OBJEKT_FOR_JOURNALPOSTER = "familie-ba-ks-sak.bruk-nytt-retur-objekt-for-journalposter"
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/JournalføringControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/JournalføringControllerTest.kt
@@ -3,13 +3,9 @@ package no.nav.familie.ks.sak.api
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.kontrakter.felles.PersonIdent
-import no.nav.familie.kontrakter.felles.journalpost.Journalpost
-import no.nav.familie.kontrakter.felles.journalpost.TilgangsstyrtJournalpost
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.integrasjon.journalføring.InnkommendeJournalføringService
 import no.nav.familie.ks.sak.integrasjon.lagTilgangsstyrtJournalpost
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
-import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,47 +14,21 @@ import org.springframework.http.HttpStatus
 class JournalføringControllerTest {
     private val innkommendeJournalføringService: InnkommendeJournalføringService = mockk()
     private val tilgangService: TilgangService = mockk()
-    private val unleashService: UnleashService = mockk()
     private val journalføringController: JournalføringController =
         JournalføringController(
             innkommendeJournalføringService = innkommendeJournalføringService,
             tilgangService = tilgangService,
-            unleashService = unleashService,
         )
 
     @Nested
     inner class HentJournalposterForBruker {
         @Test
-        fun `skal returnere liste av journalposter når toggle er av`() {
-            // Arrange
-            val personIdent = PersonIdent("123")
-            val journalpostId = "1"
-
-            every { innkommendeJournalføringService.hentJournalposterForBruker(personIdent.ident) } returns listOf(lagTilgangsstyrtJournalpost(personIdent.ident, journalpostId = journalpostId))
-            every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NYTT_RETUR_OBJEKT_FOR_JOURNALPOSTER, false) } returns false
-
-            // Act
-            val responseEntity = journalføringController.hentJournalposterForBruker(personIdentBody = personIdent)
-
-            // Assert
-            assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
-            assertThat(responseEntity.body).isNotNull
-            assertThat(responseEntity.body!!.data).isNotNull
-            val journalposter = responseEntity.body!!.data!!
-            assertThat(journalposter).hasSize(1)
-            assertThat(journalposter.single()).isInstanceOf(Journalpost::class.java)
-            val journalpost = journalposter.single() as Journalpost
-            assertThat(journalpost.journalpostId).isEqualTo("1")
-        }
-
-        @Test
-        fun `skal returnere liste av tilgangsstyrte journalposter når toggle er på`() {
+        fun `skal returnere liste av tilgangsstyrte journalposter`() {
             // Arrange
             val personIdent = PersonIdent("123")
             val journalpostId = "1"
 
             every { innkommendeJournalføringService.hentJournalposterForBruker(personIdent.ident) } returns listOf(lagTilgangsstyrtJournalpost(personIdent.ident, journalpostId = journalpostId, harTilgang = true))
-            every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NYTT_RETUR_OBJEKT_FOR_JOURNALPOSTER, false) } returns true
 
             // Act
             val responseEntity = journalføringController.hentJournalposterForBruker(personIdentBody = personIdent)
@@ -69,8 +39,7 @@ class JournalføringControllerTest {
             assertThat(responseEntity.body!!.data).isNotNull
             val journalposter = responseEntity.body!!.data!!
             assertThat(journalposter).hasSize(1)
-            assertThat(journalposter.single()).isInstanceOf(TilgangsstyrtJournalpost::class.java)
-            val tilgangsstyrtJournalpost = journalposter.single() as TilgangsstyrtJournalpost
+            val tilgangsstyrtJournalpost = journalposter.single()
             assertThat(tilgangsstyrtJournalpost.journalpost.journalpostId).isEqualTo("1")
             assertThat(tilgangsstyrtJournalpost.harTilgang).isTrue
         }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi har endret returtype ved henting av journalposter for bruker. I overgangen til ny type brukte vi en toggle for å bestemme om vi skulle bruke gammel eller ny type. Nå er vi helt over på den nye typen `TilgangsstyrteJournalposter` og kan trygt fjerne toggle.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

Ingen nye tester da jeg bare har fjernet kode.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
