### PR TITLE
Legger til gradle.properties fil med høyere minne grense ved kompilering

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.daemon.jvmargs=-Xmx2048m


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22648

Det er noen tilfeller der man går out of memory ved kompilering.
Det er stort sett kompilering gjennom intellij som fører til dette.

Øker derfor minne grensa ved kompilering av ks-sak.