### PR TITLE
Nye endepunkter for henting av journalpost og dokument

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
@@ -213,7 +213,7 @@ class IntegrasjonClient(
         backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS),
     )
     fun hentJournalpost(journalpostId: String): Journalpost {
-        val uri = URI.create("$integrasjonUri/journalpost?journalpostId=$journalpostId")
+        val uri = URI.create("$integrasjonUri/journalpost/tilgangsstyrt/baks?journalpostId=$journalpostId")
 
         return kallEksternTjenesteRessurs(
             tjeneste = "dokarkiv",
@@ -228,7 +228,7 @@ class IntegrasjonClient(
         dokumentId: String,
         journalpostId: String,
     ): ByteArray {
-        val uri = URI.create("$integrasjonUri/journalpost/hentdokument/$journalpostId/$dokumentId")
+        val uri = URI.create("$integrasjonUri/journalpost/hentdokument/tilgangsstyrt/baks/$journalpostId/$dokumentId")
 
         return kallEksternTjenesteRessurs(
             tjeneste = "dokarkiv",


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Tar i bruk nye endepunkter for henting av journalpost og dokument. De nye endepunktene kjører tilgangskontroll dersom journalposten inneholder eller dokumentet er en digital søknad. Har ikke saksbehandler tilgang til personene i søknaden får vi en 403 - forbidden respons. Grunnen til at vi går over til dette er for å hindre at saksbehandlere som ikke har kode 6, 7 eller 19 tilgang får tilgang til å journalføre innkommende søknader.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
