### PR TITLE
Bare valider ingen overlapp i utfylte overgangsordningandeler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelService.kt
@@ -50,7 +50,9 @@ class OvergangsordningAndelService(
         val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
         val person = personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == overgangsordningAndelRequestDto.personIdent }
         val vilkårsvurdering by lazy { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) }
-        val andreOvergangsordningAndelerPåBehandling by lazy { hentOvergangsordningAndeler(behandling.id).filter { it.id != overgangsordningAndelId } }
+        val andreUtfylteOvergangsordningAndelerPåBehandling by lazy {
+            hentOvergangsordningAndeler(behandling.id).filter { it.id != overgangsordningAndelId }.utfyltePerioder()
+        }
 
         val utfyltOvergangsordningAndel =
             overgangsordningAndel
@@ -74,7 +76,7 @@ class OvergangsordningAndelService(
 
         validerIngenOverlappMedEksisterendeOvergangsordningAndeler(
             nyOvergangsordningAndel = utfyltOvergangsordningAndel,
-            eksisterendeOvergangsordningAndeler = andreOvergangsordningAndelerPåBehandling,
+            eksisterendeUtfylteOvergangsordningAndeler = andreUtfylteOvergangsordningAndelerPåBehandling,
         )
 
         validerAtBarnehagevilkårErOppfyltIOvergangsordningAndelPeriode(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
@@ -80,8 +80,8 @@ object OvergangsordningAndelValidator {
             andelerTidslinje.kombinerMed(barnehagevilkårTidslinje) { andel, vilkår ->
                 if (andel != null && vilkår?.resultat != Resultat.OPPFYLT) {
                     throw FunksjonellFeil(
-                        melding = "Barnehagevilkåret må være oppfylt for alle periodene du prøver å legge til periode for overgangsordning.",
-                        frontendFeilmelding = "Barnehagevilkåret for barnet må være oppfylt for alle periodene det er overgangsordning.",
+                        melding = "Barnehagevilkåret må være oppfylt for alle periodene det er overgangsordning.",
+                        frontendFeilmelding = "Barnehagevilkåret for barn født ${andel.person.fødselsdato.tilKortString()} må være oppfylt for alle periodene det er overgangsordning.",
                     )
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ks.sak.common.tidslinje.tilTidslinje
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅrKort
+import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.tilMånedÅrKort
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
@@ -89,11 +90,10 @@ object OvergangsordningAndelValidator {
 
     fun validerIngenOverlappMedEksisterendeOvergangsordningAndeler(
         nyOvergangsordningAndel: UtfyltOvergangsordningAndel,
-        eksisterendeOvergangsordningAndeler: List<OvergangsordningAndel>,
+        eksisterendeUtfylteOvergangsordningAndeler: List<UtfyltOvergangsordningAndel>,
     ) {
-        if (eksisterendeOvergangsordningAndeler.any {
-                it.overlapperMed(nyOvergangsordningAndel.periode) &&
-                    it.person == nyOvergangsordningAndel.person
+        if (eksisterendeUtfylteOvergangsordningAndeler.any {
+                it.overlapperMed(nyOvergangsordningAndel) && it.person == nyOvergangsordningAndel.person
             }
         ) {
             throw FunksjonellFeil(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/domene/OvergangsordningAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/domene/OvergangsordningAndel.kt
@@ -75,8 +75,6 @@ data class OvergangsordningAndel(
 
     override fun hashCode(): Int = id.hashCode()
 
-    fun overlapperMed(periode: MånedPeriode) = periode.overlapperHeltEllerDelvisMed(this.periode)
-
     fun erObligatoriskeFelterUtfylt(): Boolean =
         this.person != null &&
             this.fom != null &&
@@ -174,6 +172,9 @@ data class UtfyltOvergangsordningAndel(
             fom = fom.atDay(1),
             tom = tom.atEndOfMonth(),
         )
+
+    fun overlapperMed(overgangsordningAndel: UtfyltOvergangsordningAndel) =
+        overgangsordningAndel.periode.overlapperHeltEllerDelvisMed(this.periode)
 }
 
 fun List<UtfyltOvergangsordningAndel>.tilPerioder(): List<Periode<OvergangsordningAndelPeriode>> = map { it.tilPeriode() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidatorTest.kt
@@ -106,9 +106,10 @@ class OvergangsordningAndelValidatorTest {
             listOf(
                 OvergangsordningAndel(
                     behandlingId = 1,
+                    person = person,
                     fom = YearMonth.now(),
                     tom = YearMonth.now(),
-                ),
+                ).tilUtfyltOvergangsordningAndel(),
             )
 
         assertThrows<FunksjonellFeil> {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Når man oppdaterer én overgangsordningandel gjøres det en validering på at den ikke overlapper med andre perioder.
Det gir ikke mening å validere ingen overlapp i perioder der `fom` og/eller `tom` ikke er utfylt.

På et senere tidspunkt valideres det at alle felter er utfylt, og da gjøres ingen overlapp-valideringen igjen, så det er ikke mulig å lage perioder med overlapp.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
