### PR TITLE
Bare slå sammen overgangsordningandeler per barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelService.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAnde
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.tilPerioder
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.utfyltePerioder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -30,6 +31,11 @@ class OvergangsordningAndelService(
     private val vilkårsvurderingService: VilkårsvurderingService,
 ) {
     fun hentOvergangsordningAndeler(behandlingId: Long) = overgangsordningAndelRepository.hentOvergangsordningAndelerForBehandling(behandlingId)
+
+    fun hentOvergangsordningAndelerForPerson(
+        behandlingId: Long,
+        person: Person,
+    ): List<OvergangsordningAndel> = hentOvergangsordningAndeler(behandlingId).filter { it.person == person }
 
     @Transactional
     fun opprettTomOvergangsordningAndel(behandling: Behandling): OvergangsordningAndel {
@@ -51,7 +57,7 @@ class OvergangsordningAndelService(
         val person = personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == overgangsordningAndelRequestDto.personIdent }
         val vilkårsvurdering by lazy { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) }
         val andreUtfylteOvergangsordningAndelerPåBehandling by lazy {
-            hentOvergangsordningAndeler(behandling.id).filter { it.id != overgangsordningAndelId }.utfyltePerioder()
+            hentOvergangsordningAndelerForPerson(behandling.id, person).filter { it.id != overgangsordningAndelId }.utfyltePerioder()
         }
 
         val utfyltOvergangsordningAndel =
@@ -84,7 +90,7 @@ class OvergangsordningAndelService(
             barnehageplassVilkår = barnehageplassVilkår,
         )
 
-        slåSammenOgOppdaterOvergangsordningAndeler(behandling)
+        slåSammenOgOppdaterOvergangsordningAndeler(behandling, person)
 
         beregningService.oppdaterTilkjentYtelsePåBehandling(
             behandling = behandling,
@@ -122,8 +128,11 @@ class OvergangsordningAndelService(
         overgangsordningAndelRepository.finnOvergangsordningAndel(overgangsordningAndelId)
             ?: throw FunksjonellFeil(melding = "Fant ikke overgangsordningandel med id $overgangsordningAndelId")
 
-    private fun slåSammenOgOppdaterOvergangsordningAndeler(behandling: Behandling) {
-        val overgangsordningAndeler = hentOvergangsordningAndeler(behandling.id)
+    private fun slåSammenOgOppdaterOvergangsordningAndeler(
+        behandling: Behandling,
+        person: Person,
+    ) {
+        val overgangsordningAndeler = hentOvergangsordningAndelerForPerson(behandling.id, person)
         val sammenslåtteOvergangsordningAndeler = overgangsordningAndeler.slåSammenLikePerioder()
         val utfyltePerioder = overgangsordningAndeler.filter { it.erObligatoriskeFelterUtfylt() }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
@@ -72,19 +72,14 @@ object OvergangsordningAndelValidator {
         overgangsordningAndeler: List<UtfyltOvergangsordningAndel>,
         barnehageplassVilkårPerPerson: Map<Aktør, List<VilkårResultat>>,
     ) {
-        val andelerTidslinjePerAktør = overgangsordningAndeler.groupBy { it.person.aktør }.mapValues { it.value.tilPerioder().tilTidslinje() }
-        val barnehagevilkårTidslinjePerAktør = barnehageplassVilkårPerPerson.mapValues { it.value.tilTidslinje() }
-
-        andelerTidslinjePerAktør.forEach { (aktør, andelerTidslinje) ->
-            val barnehagevilkårTidslinje = barnehagevilkårTidslinjePerAktør[aktør] ?: throw FunksjonellFeil("Fant ikke barnehagevilkår for aktør $aktør")
-            andelerTidslinje.kombinerMed(barnehagevilkårTidslinje) { andel, vilkår ->
-                if (andel != null && vilkår?.resultat != Resultat.OPPFYLT) {
-                    throw FunksjonellFeil(
-                        melding = "Barnehagevilkåret må være oppfylt for alle periodene det er overgangsordning.",
-                        frontendFeilmelding = "Barnehagevilkåret for barn født ${andel.person.fødselsdato.tilKortString()} må være oppfylt for alle periodene det er overgangsordning.",
-                    )
-                }
-            }
+        overgangsordningAndeler.forEach { overgangsordningAndel ->
+            val barnehagevilkår =
+                barnehageplassVilkårPerPerson[overgangsordningAndel.person.aktør]
+                    ?: throw FunksjonellFeil("Fant ikke barnehagevilkår for barn født ${overgangsordningAndel.person.fødselsdato.tilKortString()}")
+            validerAtBarnehagevilkårErOppfyltIOvergangsordningAndelPeriode(
+                overgangsordningAndel = overgangsordningAndel,
+                barnehageplassVilkår = barnehagevilkår,
+            )
         }
     }
 
@@ -120,14 +115,14 @@ object OvergangsordningAndelValidator {
 
         if (perioderBarnehagevilkårIkkeErOppfylt.isNotEmpty()) {
             val feilmelding =
-                "Barnehagevilkåret må være oppfylt alle periodene det er overgangsordning. " +
+                "Barnehageplassvilkåret må være oppfylt alle periodene det er overgangsordning for barn født ${overgangsordningAndel.person.fødselsdato.tilKortString()}. " +
                     "Vilkåret er ikke oppfylt i " +
                     when (perioderBarnehagevilkårIkkeErOppfylt.size) {
                         1 -> "perioden ${perioderBarnehagevilkårIkkeErOppfylt.first()}."
                         else -> "periodene ${perioderBarnehagevilkårIkkeErOppfylt.dropLast(1).joinToString()} og ${perioderBarnehagevilkårIkkeErOppfylt.last()}."
                     }
             throw FunksjonellFeil(
-                melding = "Barnehagevilkåret er ikke oppfylt i perioden som blir forsøkt lagt til.",
+                melding = "Barnehageplassvilkåret er ikke oppfylt i perioden som blir forsøkt lagt til.",
                 frontendFeilmelding = feilmelding,
             )
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -227,8 +228,8 @@ class OvergangsordningAndelServiceTest {
                     overgangsordningAndelService.oppdaterOvergangsordningAndelOgOppdaterTilkjentYtelse(behandling, 0, overgangsordningAndelDto)
                 }
 
-            assertThat(funksjonellFeil.melding).isEqualTo("Barnehagevilkåret er ikke oppfylt i perioden som blir forsøkt lagt til.")
-            assertThat(funksjonellFeil.frontendFeilmelding).isEqualTo("Barnehagevilkåret må være oppfylt alle periodene det er overgangsordning. Vilkåret er ikke oppfylt i perioden 15. des. 24 til 31. jan. 25.")
+            assertThat(funksjonellFeil.melding).isEqualTo("Barnehageplassvilkåret er ikke oppfylt i perioden som blir forsøkt lagt til.")
+            assertThat(funksjonellFeil.frontendFeilmelding).isEqualTo("Barnehageplassvilkåret må være oppfylt alle periodene det er overgangsordning for barn født ${barn.fødselsdato.tilKortString()}. Vilkåret er ikke oppfylt i perioden 15. des. 24 til 31. jan. 25.")
         }
 
         @Test
@@ -277,8 +278,8 @@ class OvergangsordningAndelServiceTest {
                     overgangsordningAndelService.oppdaterOvergangsordningAndelOgOppdaterTilkjentYtelse(behandling, 0, overgangsordningAndelDto)
                 }
 
-            assertThat(funksjonellFeil.melding).isEqualTo("Barnehagevilkåret er ikke oppfylt i perioden som blir forsøkt lagt til.")
-            assertThat(funksjonellFeil.frontendFeilmelding).isEqualTo("Barnehagevilkåret må være oppfylt alle periodene det er overgangsordning. Vilkåret er ikke oppfylt i periodene 1. okt. 24 til 14. nov. 24 og 15. des. 24 til 31. jan. 25.")
+            assertThat(funksjonellFeil.melding).isEqualTo("Barnehageplassvilkåret er ikke oppfylt i perioden som blir forsøkt lagt til.")
+            assertThat(funksjonellFeil.frontendFeilmelding).isEqualTo("Barnehageplassvilkåret må være oppfylt alle periodene det er overgangsordning for barn født ${barn.fødselsdato.tilKortString()}. Vilkåret er ikke oppfylt i periodene 1. okt. 24 til 14. nov. 24 og 15. des. 24 til 31. jan. 25.")
         }
 
         @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/OvergangsordningAndelControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/OvergangsordningAndelControllerTest.kt
@@ -4,6 +4,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
+import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
@@ -14,6 +15,7 @@ import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig.Companion.OVERGANGSORDNING
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
@@ -23,6 +25,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakStatus
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndel
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndelRepository
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.core.IsNull
 import org.junit.jupiter.api.BeforeEach
@@ -115,18 +119,55 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
         }
 
         @Test
-        fun `skal oppdatere OvergangsordningAndel`() {
-            val overgangsordningAndel = OvergangsordningAndel(id = 0, behandlingId = behandling.id)
-            overgangsordningAndelRepository.saveAndFlush(overgangsordningAndel)
+        fun `skal oppdatere og slå sammen overgangsordningandeler`() {
+            val barn1 = personopplysningGrunnlag.personer.first { it.aktør == barn }
+            val barn2 =
+                lagrePerson(
+                    lagPerson(
+                        aktør = lagreAktør(randomAktør(randomFnr(barnFødselsdato.plusMonths(2)))),
+                        personType = PersonType.BARN,
+                        personopplysningGrunnlag = personopplysningGrunnlag,
+                    ),
+                )
 
+            val gamleOvergangsordningAndeler =
+                listOf(
+                    OvergangsordningAndel(
+                        id = 0,
+                        behandlingId = behandling.id,
+                        person = barn1,
+                        antallTimer = BigDecimal(20),
+                        fom = barn1.fødselsdato.plusMonths(20).toYearMonth(),
+                        tom = barn1.fødselsdato.plusMonths(21).toYearMonth(),
+                    ),
+                    OvergangsordningAndel(
+                        id = 1,
+                        behandlingId = behandling.id,
+                        person = barn1,
+                        antallTimer = BigDecimal.ZERO,
+                        fom = barn1.fødselsdato.plusMonths(22).toYearMonth(),
+                        tom = barn1.fødselsdato.plusMonths(23).toYearMonth(),
+                    ),
+                    OvergangsordningAndel(
+                        id = 2,
+                        behandlingId = behandling.id,
+                        person = barn2,
+                        fom = barn2.fødselsdato.plusMonths(20).toYearMonth(),
+                        tom = barn2.fødselsdato.plusMonths(23).toYearMonth(),
+                    ),
+                )
+
+            overgangsordningAndelRepository.saveAllAndFlush(gamleOvergangsordningAndeler)
+
+            // Sett antall timer til 0 i første overgangsordningandel
             val overgangsordningAndelDto =
                 OvergangsordningAndelDto(
-                    id = overgangsordningAndel.id,
-                    personIdent = barn.aktivFødselsnummer(),
+                    id = gamleOvergangsordningAndeler.first().id,
+                    personIdent = barn1.aktør.aktivFødselsnummer(),
                     antallTimer = BigDecimal.ZERO,
                     deltBosted = false,
                     fom = barnFødselsdato.plusMonths(20).toYearMonth(),
-                    tom = barnFødselsdato.plusMonths(23).toYearMonth(),
+                    tom = barnFødselsdato.plusMonths(21).toYearMonth(),
                 )
 
             Given {
@@ -134,19 +175,33 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
                 contentType(ContentType.JSON)
                 body(objectMapper.writeValueAsString(overgangsordningAndelDto))
             } When {
-                put("$overgangsordningAndelControllerUrl/${behandling.id}/${overgangsordningAndel.id}")
+                put("$overgangsordningAndelControllerUrl/${behandling.id}/${gamleOvergangsordningAndeler.first().id}")
             } Then {
                 statusCode(200)
                 body("status", Is("SUKSESS"))
-                body("data.overgangsordningAndeler[0].personIdent", Is(barn.aktivFødselsnummer()))
-                body("data.overgangsordningAndeler[0].antallTimer", Is(0))
-                body("data.overgangsordningAndeler[0].deltBosted", Is(false))
-                body("data.overgangsordningAndeler[0].fom", Is("2025-09"))
-                body("data.overgangsordningAndeler[0].tom", Is("2025-12"))
                 // Valideringsfunksjoner skal ikke være med i responsen
                 body("data.overgangsordningAndeler[0].isTomSameOrAfterFom", Is(nullValue()))
                 body("data.overgangsordningAndeler[0].isPersonidentValid", Is(nullValue()))
                 body("data.overgangsordningAndeler[0].isAntallTimerAndDeltBostedValid", Is(nullValue()))
+            } Extract {
+                val overgangsordningAndeler =
+                    path<List<Map<String, Any>>>("data.overgangsordningAndeler")
+                        .map { objectMapper.convertValue(it, OvergangsordningAndelDto::class.java) }
+                assertThat(overgangsordningAndeler)
+                    .hasSize(2)
+                    .anySatisfy {
+                        // Forvent at overgangsordningandeler for barn 1 er slått sammen
+                        assertThat(it.personIdent).isEqualTo(barn1.aktør.aktivFødselsnummer())
+                        assertThat(it.antallTimer).isEqualTo(BigDecimal.ZERO)
+                        assertThat(it.fom).isEqualTo(barn1.fødselsdato.plusMonths(20).toYearMonth())
+                        assertThat(it.tom).isEqualTo(barn1.fødselsdato.plusMonths(23).toYearMonth())
+                    }.anySatisfy {
+                        // Forvent at overgangsordningandel for barn 2 er uendret
+                        assertThat(it.personIdent).isEqualTo(barn2.aktør.aktivFødselsnummer())
+                        assertThat(it.antallTimer).isEqualTo(BigDecimal.ZERO)
+                        assertThat(it.fom).isEqualTo(barn2.fødselsdato.plusMonths(20).toYearMonth())
+                        assertThat(it.tom).isEqualTo(barn2.fødselsdato.plusMonths(23).toYearMonth())
+                    }
             }
         }
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22613

Når en overgangsordning oppdateres prøver backend å slå sammen perioder. Dette skal bare gjøres med pvergangsordningandeler for samme person.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
