### PR TITLE
Bruk fastsatt dato som nådato i tester

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -443,7 +443,8 @@ internal class KompetanseServiceTest {
     fun `tilpassKompetanse skal opprette kompetanseskjema med ingen sluttdato når regelverk-tidslinjer fortsetter etter nåtidspunktet`() {
         every { vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(any()) } returns tomTidslinje()
 
-        val fom = LocalDate.now().minusMonths(3).førsteDagIInneværendeMåned()
+        val nåDato = LocalDate.of(2024, 10, 1)
+        val fom = nåDato.minusMonths(3).førsteDagIInneværendeMåned()
         val tom = fom.plusMonths(10).sisteDagIMåned()
         val tomForBarn2 = fom.plusMonths(6).sisteDagIMåned()
 
@@ -480,7 +481,8 @@ internal class KompetanseServiceTest {
     fun `tilpassKompetanse skal opprette kompetanse med sluttdato når et av barnets regelverk-tidslinjer avsluttes før nåtidspunktet`() {
         every { vilkårsvurderingTidslinjeService.hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(any()) } returns tomTidslinje()
 
-        val fom = LocalDate.now().minusMonths(6).førsteDagIInneværendeMåned()
+        val nåDato = LocalDate.of(2024, 10, 1)
+        val fom = nåDato.minusMonths(6).førsteDagIInneværendeMåned()
         val tom = fom.plusMonths(10).sisteDagIMåned()
         val tomForBarn2 = fom.plusMonths(3).sisteDagIMåned()
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23100

Oppstår siden i november så har man en blanding av regelverk 2024 aug + regelverk 2021, og da blir fom/tom annerledes på kompetansen. Fastsetter dato til oktober 2024 for å holde testen på regelverk 2021.

