### PR TITLE
Send overgangsordningandeler til oppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
@@ -8,6 +8,7 @@ import java.time.LocalTime
 import java.time.Month
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 
 val nbLocale = Locale.of("nb", "Norway")
@@ -91,6 +92,8 @@ fun MånedPeriode.overlapperHeltEllerDelvisMed(annenPeriode: MånedPeriode) =
         annenPeriode.inkluderer(this.tom)
 
 fun MånedPeriode.erMellom(annenPeriode: MånedPeriode) = annenPeriode.inkluderer(this.fom) && annenPeriode.inkluderer(this.tom)
+
+fun MånedPeriode.antallMåneder(): Int = fom.until(tom, ChronoUnit.MONTHS).toInt() + 1
 
 fun LocalDate.førsteDagINesteMåned() = this.plusMonths(1).withDayOfMonth(1)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -20,7 +20,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 const val FAGSYSTEM = "KS"
-val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 11) // TODO: SKAL VÆRE 2024-12
+val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 12)
 
 @Component
 class UtbetalingsoppdragGenerator {

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
-import no.nav.familie.ks.sak.kjerne.beregning.domene.overgangsordningAndeler
+import no.nav.familie.ks.sak.kjerne.beregning.domene.overgangsordningAndelerPerAktør
 import no.nav.familie.ks.sak.kjerne.beregning.domene.totalKalkulertUtbetalingsbeløpForPeriode
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -80,12 +80,16 @@ class UtbetalingsoppdragGenerator {
         return ordinæreAndeler + overgangsordningAndeler
     }
 
-    private fun TilkjentYtelse.ordinæreAndelertilAndelDataLongId(): List<AndelDataLongId> = this.ordinæreAndeler().map { it.tilAndelDataLongId() }
+    private fun TilkjentYtelse.ordinæreAndelertilAndelDataLongId(): List<AndelDataLongId> =
+        this
+            .andelerTilkjentYtelse
+            .ordinæreAndeler()
+            .map { it.tilAndelDataLongId() }
 
     private fun TilkjentYtelse.overgangsordningAndelerTilAndelDataLongId(): List<AndelDataLongId> =
         this
-            .overgangsordningAndeler()
-            .groupBy { it.aktør }
+            .andelerTilkjentYtelse
+            .overgangsordningAndelerPerAktør()
             .map { (aktør, overgangsordningAndeler) ->
                 val førsteAndel = overgangsordningAndeler.minBy { it.stønadFom }
                 val kalkulertUtbetalingsbeløp = overgangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -20,7 +20,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 const val FAGSYSTEM = "KS"
-val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 12)
+val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 11) // TODO: skal være 24/12
 
 @Component
 class UtbetalingsoppdragGenerator {

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -31,6 +31,7 @@ class UtbetalingsoppdragGenerator {
         nyTilkjentYtelse: TilkjentYtelse,
         sisteAndelPerKjede: Map<IdentOgType, AndelTilkjentYtelse>,
         erSimulering: Boolean,
+        skalSendeOvergangsordningAndeler: Boolean,
     ): BeregnetUtbetalingsoppdragLongId =
         Utbetalingsgenerator().lagUtbetalingsoppdrag(
             behandlingsinformasjon =
@@ -51,8 +52,8 @@ class UtbetalingsoppdragGenerator {
                     // Ved simulering når migreringsdato er endret, skal vi opphøre fra den nye datoen og ikke fra første utbetaling per kjede.
                     opphørKjederFraFørsteUtbetaling = erSimulering,
                 ),
-            forrigeAndeler = forrigeTilkjentYtelse?.tilAndelDataLongId() ?: emptyList(),
-            nyeAndeler = nyTilkjentYtelse.tilAndelDataLongId(),
+            forrigeAndeler = forrigeTilkjentYtelse?.tilAndelDataLongId(skalSendeOvergangsordningAndeler) ?: emptyList(),
+            nyeAndeler = nyTilkjentYtelse.tilAndelDataLongId(skalSendeOvergangsordningAndeler),
             sisteAndelPerKjede = sisteAndelPerKjede.mapValues { it.value.tilAndelDataLongId() },
         )
 
@@ -69,9 +70,13 @@ class UtbetalingsoppdragGenerator {
             kildeBehandlingId = kildeBehandlingId,
         )
 
-    private fun TilkjentYtelse.tilAndelDataLongId(): List<AndelDataLongId> {
+    private fun TilkjentYtelse.tilAndelDataLongId(skalSendeOvergangsordningAndeler: Boolean): List<AndelDataLongId> {
         val ordinæreAndeler = this.ordinæreAndelertilAndelDataLongId()
-        val overgangsordningAndeler = this.overgangsordningAndelerTilAndelDataLongId()
+        val overgangsordningAndeler =
+            when (skalSendeOvergangsordningAndeler) {
+                true -> this.overgangsordningAndelerTilAndelDataLongId()
+                false -> emptyList()
+            }
         return ordinæreAndeler + overgangsordningAndeler
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
+import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.unleash.UnleashService
 import org.slf4j.Logger
@@ -176,7 +177,12 @@ class UtbetalingsoppdragService(
         tilkjentYtelse: TilkjentYtelse,
         andelerMedPeriodeId: List<AndelMedPeriodeIdLongId>,
     ) {
-        val andelerSomSkalSendesTilOppdrag = tilkjentYtelse.andelerTilkjentYtelse.filtrerAndelerSomSkalSendesTilOppdrag()
+        val andelerSomSkalSendesTilOppdrag =
+            when (unleashService.isEnabled(FeatureToggleConfig.OVERGANGSORDNING)) {
+                true -> tilkjentYtelse.andelerTilkjentYtelse
+                false -> tilkjentYtelse.ordinæreAndeler()
+            }.filtrerAndelerSomSkalSendesTilOppdrag()
+
         if (andelerMedPeriodeId.size != andelerSomSkalSendesTilOppdrag.size) {
             error("Antallet andeler med oppdatert periodeOffset, forrigePeriodeOffset og kildeBehandlingId fra ny generator skal være likt antallet ordinære andeler med kalkulertUtbetalingsbeløp != 0 + antall barn med overgangsordning. Generator gir ${andelerMedPeriodeId.size} andeler men det er ${andelerSomSkalSendesTilOppdrag.size} andeler med kalkulertUtbetalingsbeløp != 0")
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -180,7 +180,7 @@ class UtbetalingsoppdragService(
         val andelerSomSkalSendesTilOppdrag =
             when (unleashService.isEnabled(FeatureToggleConfig.OVERGANGSORDNING)) {
                 true -> tilkjentYtelse.andelerTilkjentYtelse
-                false -> tilkjentYtelse.ordinæreAndeler()
+                false -> tilkjentYtelse.andelerTilkjentYtelse.ordinæreAndeler()
             }.filtrerAndelerSomSkalSendesTilOppdrag()
 
         if (andelerMedPeriodeId.size != andelerSomSkalSendesTilOppdrag.size) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -18,8 +18,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValideringService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
-import no.nav.familie.ks.sak.kjerne.beregning.domene.førsteOvergangsordningAndelForHverAktør
-import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
+import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.unleash.UnleashService
 import org.slf4j.Logger
@@ -177,14 +176,7 @@ class UtbetalingsoppdragService(
         tilkjentYtelse: TilkjentYtelse,
         andelerMedPeriodeId: List<AndelMedPeriodeIdLongId>,
     ) {
-        val ordinæreAndelerTilkjentYtelse = tilkjentYtelse.ordinæreAndeler()
-        val overgangsordningAndeler =
-            when (unleashService.isEnabled(FeatureToggleConfig.OVERGANGSORDNING)) {
-                true -> tilkjentYtelse.førsteOvergangsordningAndelForHverAktør()
-                false -> emptyList()
-            }
-        val andelerSomSkalSendesTilOppdrag =
-            ordinæreAndelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() } + overgangsordningAndeler
+        val andelerSomSkalSendesTilOppdrag = tilkjentYtelse.andelerTilkjentYtelse.filtrerAndelerSomSkalSendesTilOppdrag()
         if (andelerMedPeriodeId.size != andelerSomSkalSendesTilOppdrag.size) {
             error("Antallet andeler med oppdatert periodeOffset, forrigePeriodeOffset og kildeBehandlingId fra ny generator skal være likt antallet ordinære andeler med kalkulertUtbetalingsbeløp != 0 + antall barn med overgangsordning. Generator gir ${andelerMedPeriodeId.size} andeler men det er ${andelerSomSkalSendesTilOppdrag.size} andeler med kalkulertUtbetalingsbeløp != 0")
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.VedtakReposito
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.beregning.domene.overgangsordningAndelerPerAktør
 import no.nav.familie.ks.sak.kjerne.beregning.domene.totalKalkulertUtbetalingsbeløpForPeriode
 import no.nav.familie.ks.sak.kjerne.forrigebehandling.EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
@@ -254,15 +255,16 @@ class StegService(
     ): Boolean {
         val sumOvergangsordningAndelerPerAktør =
             andelerNåværendeBehandling
-                .filter { it.type == YtelseType.OVERGANGSORDNING }
-                .groupBy { it.aktør }
+                .overgangsordningAndelerPerAktør()
                 .mapValues { (_, nåværendeOvergangsordningAndeler) ->
                     nåværendeOvergangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
                 }
 
-        return andelerForrigeBehandling.groupBy { it.aktør }.any { (aktør, forrigeOvergangsordningAndeler) ->
-            sumOvergangsordningAndelerPerAktør[aktør] != forrigeOvergangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
-        }
+        return andelerForrigeBehandling
+            .overgangsordningAndelerPerAktør()
+            .any { (aktør, forrigeOvergangsordningAndeler) ->
+                sumOvergangsordningAndelerPerAktør[aktør] != forrigeOvergangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
+            }
     }
 
     private fun utførStegAutomatisk(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -253,18 +253,21 @@ class StegService(
         andelerNåværendeBehandling: List<AndelTilkjentYtelse>,
         andelerForrigeBehandling: List<AndelTilkjentYtelse>,
     ): Boolean {
-        val sumOvergangsordningAndelerPerAktør =
+        val sumOvergangsordningAndelerPerAktørNåværendeBehandling =
             andelerNåværendeBehandling
                 .overgangsordningAndelerPerAktør()
-                .mapValues { (_, nåværendeOvergangsordningAndeler) ->
-                    nåværendeOvergangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
+                .mapValues { (_, andeler) ->
+                    andeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
                 }
 
-        return andelerForrigeBehandling
-            .overgangsordningAndelerPerAktør()
-            .any { (aktør, forrigeOvergangsordningAndeler) ->
-                sumOvergangsordningAndelerPerAktør[aktør] != forrigeOvergangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
-            }
+        val sumOvergangsordningAndelerPerAktørForrigeBehandling =
+            andelerForrigeBehandling
+                .overgangsordningAndelerPerAktør()
+                .mapValues { (_, andeler) ->
+                    andeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
+                }
+
+        return sumOvergangsordningAndelerPerAktørNåværendeBehandling != sumOvergangsordningAndelerPerAktørForrigeBehandling
     }
 
     private fun utførStegAutomatisk(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegService.kt
@@ -244,7 +244,8 @@ class StegService(
 
         return lagEndringIUtbetalingTidslinje(ordinæreAndelerNåværendeBehandling, ordinæreAndelerForrigeBehandling)
             .tilPerioder()
-            .any { it.verdi == true } || erEndringIOvergangsordningAndeler(overgangsordningAndelerNåværendeBehandling, overgangsordningAndelerForrigeBehandling)
+            .any { it.verdi == true } ||
+            erEndringIOvergangsordningAndeler(overgangsordningAndelerNåværendeBehandling, overgangsordningAndelerForrigeBehandling)
     }
 
     private fun erEndringIOvergangsordningAndeler(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårsvurderingRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
@@ -115,8 +116,6 @@ data class AndelTilkjentYtelseMedEndreteUtbetalinger(
     val kalkulertUtbetalingsbeløp get() = andelTilkjentYtelse.kalkulertUtbetalingsbeløp
     val aktør get() = andelTilkjentYtelse.aktør
 
-    fun erAndelSomSkalSendesTilOppdrag() = andelTilkjentYtelse.erAndelSomSkalSendesTilOppdrag()
-
     fun medTom(tom: YearMonth): AndelTilkjentYtelseMedEndreteUtbetalinger =
         AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse.copy(stønadTom = tom), endreteUtbetalinger)
 
@@ -131,6 +130,11 @@ data class AndelTilkjentYtelseMedEndreteUtbetalinger(
     companion object {
         fun utenEndringer(andelTilkjentYtelse: AndelTilkjentYtelse): AndelTilkjentYtelseMedEndreteUtbetalinger = AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse, emptyList())
     }
+}
+
+fun Iterable<AndelTilkjentYtelseMedEndreteUtbetalinger>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelseMedEndreteUtbetalinger> {
+    val andelerSomskalSendesTilOppdrag = this.map { it.andel }.filtrerAndelerSomSkalSendesTilOppdrag()
+    return this.filter { it.andel in andelerSomskalSendesTilOppdrag }
 }
 
 data class EndretUtbetalingAndelMedAndelerTilkjentYtelse(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
@@ -48,7 +49,7 @@ class BeregningService(
     fun hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandlingId: Long): List<AndelTilkjentYtelse> =
         andelTilkjentYtelseRepository
             .finnAndelerTilkjentYtelseForBehandling(behandlingId)
-            .filter { it.erAndelSomSkalSendesTilOppdrag() }
+            .filtrerAndelerSomSkalSendesTilOppdrag()
 
     fun hentTilkjentYtelseForBehandlingerIverksattMotØkonomi(fagsakId: Long): List<TilkjentYtelse> {
         val iverksatteBehandlinger = behandlingRepository.finnByFagsakAndAvsluttet(fagsakId)
@@ -57,7 +58,7 @@ class BeregningService(
                 .finnByBehandlingAndHasUtbetalingsoppdrag(
                     it.id,
                 )?.takeIf { tilkjentYtelse ->
-                    tilkjentYtelse.andelerTilkjentYtelse.any { aty -> aty.erAndelSomSkalSendesTilOppdrag() }
+                    tilkjentYtelse.andelerTilkjentYtelse.filtrerAndelerSomSkalSendesTilOppdrag().isNotEmpty()
                 }
         }
     }
@@ -185,7 +186,7 @@ class BeregningService(
             .finnLøpendeAndelerTilkjentYtelseForBehandlinger(
                 behandlingIder,
                 avstemmingstidspunkt.toLocalDate().toYearMonth(),
-            ).filter { it.erAndelSomSkalSendesTilOppdrag() }
+            ).filtrerAndelerSomSkalSendesTilOppdrag()
 
     fun slettTilkjentYtelseForBehandling(behandling: Behandling) = tilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
+import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
 import no.nav.familie.ks.sak.kjerne.beregning.domene.tilTidslinjeMedAndeler
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.utledMaksAntallMånederMedUtbetaling
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilBrevTekst
@@ -46,7 +47,7 @@ object TilkjentYtelseValidator {
         val andelerPerAktør = tilkjentYtelse.andelerTilkjentYtelse.groupBy { it.aktør }
 
         andelerPerAktør.filter { it.value.isNotEmpty() }.forEach { (aktør, andeler) ->
-            val ordinæreAndeler = andeler.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
+            val ordinæreAndeler = andeler.ordinæreAndeler()
 
             val stønadFom = ordinæreAndeler.minOf { it.stønadFom }
             val stønadTom = ordinæreAndeler.maxOf { it.stønadTom }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -136,8 +136,11 @@ data class AndelTilkjentYtelse(
     fun overlapperPeriode(måndePeriode: MånedPeriode): Boolean =
         this.stønadFom <= måndePeriode.tom &&
             this.stønadTom >= måndePeriode.fom
+}
 
-    fun erAndelSomSkalSendesTilOppdrag(): Boolean = this.kalkulertUtbetalingsbeløp != 0
+fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> {
+    val (ordinæreAndeler, overgangsordningAndeler) = partition { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
+    return overgangsordningAndeler.groupBy { it.aktør }.map { it.value.minBy { it.stønadFom } } + ordinæreAndeler.filter { it.kalkulertUtbetalingsbeløp != 0 }
 }
 
 fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp(): List<AndelTilkjentYtelse> =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -138,10 +138,8 @@ data class AndelTilkjentYtelse(
             this.stønadTom >= måndePeriode.fom
 }
 
-fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> {
-    val (ordinæreAndeler, overgangsordningAndeler) = partition { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
-    return overgangsordningAndeler.groupBy { it.aktør }.map { it.value.minBy { it.stønadFom } } + ordinæreAndeler.filter { it.kalkulertUtbetalingsbeløp != 0 }
-}
+fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> =
+    overgangsordningAndelerPerAktør().map { it.value.minBy { it.stønadFom } } + ordinæreAndeler().filter { it.kalkulertUtbetalingsbeløp != 0 }
 
 fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp(): List<AndelTilkjentYtelse> =
     this.fold(emptyList()) { acc, andelTilkjentYtelse ->
@@ -159,6 +157,12 @@ fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp():
     }
 
 fun AndelTilkjentYtelse.totalKalkulertUtbetalingsbeløpForPeriode(): Int = kalkulertUtbetalingsbeløp * stønadsPeriode().antallMåneder()
+
+fun Iterable<AndelTilkjentYtelse>.ordinæreAndeler() =
+    this.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
+
+fun Iterable<AndelTilkjentYtelse>.overgangsordningAndelerPerAktør() =
+    this.filter { it.type == YtelseType.OVERGANGSORDNING }.groupBy { it.aktør }
 
 enum class YtelseType(
     val klassifisering: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -20,6 +20,7 @@ import jakarta.persistence.Table
 import no.nav.familie.ks.sak.common.entitet.BaseEntitet
 import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.YearMonthConverter
+import no.nav.familie.ks.sak.common.util.antallMåneder
 import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.YtelsetypeKS
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
@@ -153,6 +154,8 @@ fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp():
             acc + andelTilkjentYtelse
         }
     }
+
+fun AndelTilkjentYtelse.totalKalkulertUtbetalingsbeløpForPeriode(): Int = kalkulertUtbetalingsbeløp * stønadsPeriode().antallMåneder()
 
 enum class YtelseType(
     val klassifisering: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
@@ -89,6 +89,3 @@ fun TilkjentYtelse.ordinæreAndeler() =
 
 fun TilkjentYtelse.overgangsordningAndeler() =
     andelerTilkjentYtelse.filter { it.type == YtelseType.OVERGANGSORDNING }
-
-fun TilkjentYtelse.førsteOvergangsordningAndelForHverAktør() =
-    overgangsordningAndeler().groupBy { it.aktør }.map { it.value.minBy { it.stønadFom } }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
@@ -83,3 +83,12 @@ fun TilkjentYtelse.utbetalingsoppdrag(): Utbetalingsoppdrag? =
 
 fun TilkjentYtelse.skalIverksettesMotOppdrag(): Boolean =
     this.utbetalingsoppdrag()?.utbetalingsperiode?.isNotEmpty() ?: false
+
+fun TilkjentYtelse.ordinæreAndeler() =
+    andelerTilkjentYtelse.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
+
+fun TilkjentYtelse.overgangsordningAndeler() =
+    andelerTilkjentYtelse.filter { it.type == YtelseType.OVERGANGSORDNING }
+
+fun TilkjentYtelse.førsteOvergangsordningAndelForHverAktør() =
+    overgangsordningAndeler().groupBy { it.aktør }.map { it.value.minBy { it.stønadFom } }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/TilkjentYtelse.kt
@@ -83,9 +83,3 @@ fun TilkjentYtelse.utbetalingsoppdrag(): Utbetalingsoppdrag? =
 
 fun TilkjentYtelse.skalIverksettesMotOppdrag(): Boolean =
     this.utbetalingsoppdrag()?.utbetalingsperiode?.isNotEmpty() ?: false
-
-fun TilkjentYtelse.ordinæreAndeler() =
-    andelerTilkjentYtelse.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
-
-fun TilkjentYtelse.overgangsordningAndeler() =
-    andelerTilkjentYtelse.filter { it.type == YtelseType.OVERGANGSORDNING }

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/stønadsstatistikk/StønadsstatistikkService.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.Vilkårsvu
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
+import no.nav.familie.ks.sak.kjerne.beregning.filtrerAndelerSomSkalSendesTilOppdrag
 import no.nav.familie.ks.sak.kjerne.beregning.lagVertikalePerioder
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
@@ -129,7 +130,7 @@ class StønadsstatistikkService(
                 utbetaltPerMnd = sumUtbetalingsbeløp,
                 utbetalingsDetaljer =
                     andelerForPeriode
-                        .filter { andel -> andel.erAndelSomSkalSendesTilOppdrag() }
+                        .filtrerAndelerSomSkalSendesTilOppdrag()
                         .map { andel ->
                             UtbetalingsDetaljDVH(
                                 person =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/OppdragSteg.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/OppdragSteg.kt
@@ -107,6 +107,7 @@ class OppdragSteg {
             sisteAndelPerKjede = sisteAndelPerIdent,
             nyTilkjentYtelse = tilkjentYtelse,
             erSimulering = erSimulering,
+            skalSendeOvergangsordningAndeler = true,
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -4,6 +4,8 @@ import io.mockk.junit5.MockKExtension
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
+import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.data.dato
 import no.nav.familie.ks.sak.data.fnrTilAktør
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
@@ -16,6 +18,9 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.beregning.domene.førsteOvergangsordningAndelForHverAktør
+import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
@@ -551,29 +556,207 @@ internal class UtbetalingsoppdragGeneratorTest {
     }
 
     @Test
-    fun `lagUtbetalingsoppdrag skal summere overgangsordningandeler riktig`() {
+    fun `lagUtbetalingsoppdrag skal ikke generere utbetalingsperioder for overgangsordningAndeler som har uendret sum`() {
+        val tidNå = LocalDate.now()
+
+        val aktør = fnrTilAktør(randomFnr())
+        val fagsak = lagFagsak(aktør)
+
+        val førsteBehandling =
+            lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD, fagsak = fagsak).also {
+                it.behandlingStegTilstand.forEach { behandlingSteg ->
+                    behandlingSteg.behandlingStegStatus = BehandlingStegStatus.UTFØRT
+                }
+            }
+
+        val vedtak = Vedtak(behandling = førsteBehandling)
+
+        val tilkjentYtelseIFørsteBehandling =
+            TilkjentYtelse(behandling = førsteBehandling, opprettetDato = tidNå, endretDato = tidNå)
+
+        val andelTilkjentYtelserIFørsteBehandling =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    id = 0,
+                    tilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                    behandling = førsteBehandling,
+                    aktør = aktør,
+                    stønadFom = årMåned("2020-01"),
+                    stønadTom = årMåned("2024-07"),
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    tilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                    behandling = førsteBehandling,
+                    aktør = aktør,
+                    stønadFom = årMåned("2024-10"),
+                    stønadTom = årMåned("2024-11"),
+                    kalkulertUtbetalingsbeløp = 1000,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    tilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                    behandling = førsteBehandling,
+                    aktør = aktør,
+                    stønadFom = årMåned("2025-01"),
+                    stønadTom = årMåned("2025-02"),
+                    kalkulertUtbetalingsbeløp = 2000,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+            )
+
+        tilkjentYtelseIFørsteBehandling.andelerTilkjentYtelse.addAll(andelTilkjentYtelserIFørsteBehandling)
+
+        val oppdatertTilkjentYtelseIFørsteBehandling =
+            utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
+                saksbehandlerId = "123abc",
+                vedtak = vedtak,
+                forrigeTilkjentYtelse = null,
+                nyTilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                sisteAndelPerKjede = emptyMap(),
+                erSimulering = false,
+                skalSendeOvergangsordningAndeler = true,
+            )
+
+        val oppdaterteAndelerTilkjentYtelseFørsteBehandling = tilkjentYtelseIFørsteBehandling.tilAndelerMedOppdatertOffset(oppdatertTilkjentYtelseIFørsteBehandling.andeler)
+
+        val andreBehandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD, fagsak = fagsak)
+
+        val tilkjentYtelseIAndreBehandling =
+            TilkjentYtelse(behandling = andreBehandling, opprettetDato = tidNå, endretDato = tidNå)
+
+        val andelTilkjentYtelserIAndreBehandling =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    tilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                    behandling = førsteBehandling,
+                    aktør = aktør,
+                    stønadFom = årMåned("2020-01"),
+                    stønadTom = årMåned("2024-07"),
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 4,
+                    tilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                    behandling = førsteBehandling,
+                    aktør = aktør,
+                    stønadFom = årMåned("2024-08"),
+                    stønadTom = årMåned("2024-08"),
+                    kalkulertUtbetalingsbeløp = 4000,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 5,
+                    tilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                    behandling = førsteBehandling,
+                    aktør = aktør,
+                    stønadFom = årMåned("2025-01"),
+                    stønadTom = årMåned("2025-02"),
+                    kalkulertUtbetalingsbeløp = 1000,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+            )
+
+        tilkjentYtelseIAndreBehandling.andelerTilkjentYtelse.addAll(andelTilkjentYtelserIAndreBehandling)
+
+        val beregnetUtbetalingsoppdragLongId =
+            utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
+                saksbehandlerId = "123abc",
+                vedtak = vedtak,
+                forrigeTilkjentYtelse = tilkjentYtelseIFørsteBehandling,
+                nyTilkjentYtelse = tilkjentYtelseIAndreBehandling,
+                sisteAndelPerKjede =
+                    oppdaterteAndelerTilkjentYtelseFørsteBehandling
+                        .groupBy { andelTilkjentYtelse -> IdentOgType(ident = andelTilkjentYtelse.aktør.aktivFødselsnummer(), type = YtelsetypeKS.ORDINÆR_KONTANTSTØTTE) }
+                        .filterValues { andelTilkjentYtelse -> andelTilkjentYtelse.any { it.periodeOffset != null } }
+                        .mapValues { it.value.maxBy { andelTilkjentYtelse -> andelTilkjentYtelse.periodeOffset!! } },
+                erSimulering = false,
+                skalSendeOvergangsordningAndeler = true,
+            )
+
+        val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
+
+        assertThat("Det er uventede utbetalingsperioder: ${utbetalingsoppdrag.utbetalingsperiode}", utbetalingsoppdrag.utbetalingsperiode.size, Is(0))
     }
 
-    // Flere barn
-    // Flere andeler per barn
-    // Perioder som er lengre enn én måned gir riktig sum
-    // Ordinære og overgangsordningandeler fucker ikke opp hverandre
-    // Sjekke riktig offset
+    @Test
+    fun `lagUtbetalingsoppdrag skal generere én utbetalingsperiode for overgangsordning per barn `() {
+        val tidNå = LocalDate.now()
+
+        val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
+        val aktør = fnrTilAktør(randomFnr())
+        val aktør2 = fnrTilAktør(randomFnr())
+        val vedtak = Vedtak(behandling = behandling)
+        val tilkjentYtelse = TilkjentYtelse(behandling = behandling, opprettetDato = tidNå, endretDato = tidNå)
+
+        val andelTilkjentYtelser =
+            listOf(
+                lagAndelTilkjentYtelse(tilkjentYtelse, behandling, aktør, årMåned("2024-05"), årMåned("2024-08"), id = 0),
+                lagAndelTilkjentYtelse(tilkjentYtelse, behandling, aktør, årMåned("2024-09"), årMåned("2024-10"), id = 1, ytelseType = YtelseType.OVERGANGSORDNING),
+                lagAndelTilkjentYtelse(tilkjentYtelse, behandling, aktør, årMåned("2024-12"), årMåned("2024-12"), id = 2, ytelseType = YtelseType.OVERGANGSORDNING),
+                lagAndelTilkjentYtelse(tilkjentYtelse, behandling, aktør2, årMåned("2024-11"), årMåned("2024-12"), id = 3, ytelseType = YtelseType.OVERGANGSORDNING, kalkulertUtbetalingsbeløp = 1000),
+                lagAndelTilkjentYtelse(tilkjentYtelse, behandling, aktør2, årMåned("2025-01"), årMåned("2025-02"), id = 4, ytelseType = YtelseType.OVERGANGSORDNING),
+            )
+
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(andelTilkjentYtelser)
+
+        val beregnetUtbetalingsoppdragLongId =
+            utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
+                saksbehandlerId = "123abc",
+                vedtak = vedtak,
+                forrigeTilkjentYtelse = null,
+                nyTilkjentYtelse = tilkjentYtelse,
+                sisteAndelPerKjede = emptyMap(),
+                erSimulering = false,
+                skalSendeOvergangsordningAndeler = true,
+            )
+
+        val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
+
+        assertThat(utbetalingsoppdrag.kodeEndring, Is(no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.KodeEndring.NY))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(3))
+        assertThat(
+            "Sats på utbetalingsperiode var feil: ${utbetalingsoppdrag.utbetalingsperiode.map { it.sats }}",
+            utbetalingsoppdrag.utbetalingsperiode.map { it.sats.toInt() },
+            Is(listOf(7500, 22500, 17000)),
+        )
+        assertThat(
+            utbetalingsoppdrag.utbetalingsperiode.all { it.utbetalesTil == behandling.fagsak.aktør.aktivFødselsnummer() },
+            Is(true),
+        )
+
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].vedtakdatoFom, Is(dato("2024-05-01")))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].vedtakdatoTom, Is(dato("2024-08-31")))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].periodeId, Is(0))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].forrigePeriodeId, Is(nullValue()))
+
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[1].vedtakdatoFom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().førsteDagIInneværendeMåned()))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[1].vedtakdatoTom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().sisteDagIMåned()))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[1].periodeId, Is(1))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[1].forrigePeriodeId, Is(0))
+
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[2].vedtakdatoFom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().førsteDagIInneværendeMåned()))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[2].vedtakdatoTom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().sisteDagIMåned()))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[2].periodeId, Is(2))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode[2].forrigePeriodeId, Is(nullValue()))
+    }
 
     private fun TilkjentYtelse.tilAndelerMedOppdatertOffset(
         andelerMedPeriodeId: List<AndelMedPeriodeIdLongId>,
     ): MutableSet<AndelTilkjentYtelse> {
-        val andelerPåId = andelerMedPeriodeId.associateBy { it.id }
-        val andelerTilkjentYtelse = this.andelerTilkjentYtelse
+        val ordinæreAndelerTilkjentYtelse = this.ordinæreAndeler()
+        val overgangsordningAndeler = this.førsteOvergangsordningAndelForHverAktør()
+        val andelerSomSkalSendesTilOppdrag =
+            ordinæreAndelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() } + overgangsordningAndeler
 
-        andelerTilkjentYtelse.forEach { andel ->
-            if (andel.erAndelSomSkalSendesTilOppdrag()) {
-                val andelMedOffset = andelerPåId[andel.id]
-                andel.periodeOffset = andelMedOffset!!.periodeId
+        return andelerSomSkalSendesTilOppdrag
+            .onEach { andel ->
+                val andelMedOffset =
+                    andelerMedPeriodeId.first { it.id == andel.id }
+                andel.periodeOffset = andelMedOffset.periodeId
                 andel.forrigePeriodeOffset = andelMedOffset.forrigePeriodeId
                 andel.kildeBehandlingId = andelMedOffset.kildeBehandlingId
-            }
-        }
-        return andelerTilkjentYtelse
+            }.toMutableSet()
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -56,6 +56,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = tilkjentYtelse,
                 sisteAndelPerKjede = emptyMap(),
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
@@ -145,6 +146,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = TilkjentYtelse(behandling = behandling, opprettetDato = tidNå, endretDato = tidNå),
                 sisteAndelPerKjede = andelTilkjentYtelser.groupBy { andelTilkjentYtelse -> IdentOgType(ident = andelTilkjentYtelse.aktør.aktivFødselsnummer(), type = YtelsetypeKS.ORDINÆR_KONTANTSTØTTE) }.filterValues { andelTilkjentYtelse -> andelTilkjentYtelse.any { it.periodeOffset != null } }.mapValues { it.value.maxBy { andelTilkjentYtelse -> andelTilkjentYtelse.periodeOffset!! } },
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
@@ -234,6 +236,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = tilkjentYtelseIFørsteBehandling,
                 sisteAndelPerKjede = emptyMap(),
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val oppdaterteAndelerTilkjentYtelseFørsteBehandling = tilkjentYtelseIFørsteBehandling.tilAndelerMedOppdatertOffset(beregnetUtbetalingsoppdragLongId1.andeler)
@@ -281,6 +284,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = tilkjentYtelseIAndreBehandling,
                 sisteAndelPerKjede = oppdaterteAndelerTilkjentYtelseFørsteBehandling.groupBy { andelTilkjentYtelse -> IdentOgType(ident = andelTilkjentYtelse.aktør.aktivFødselsnummer(), type = YtelsetypeKS.ORDINÆR_KONTANTSTØTTE) }.filterValues { andelTilkjentYtelse -> andelTilkjentYtelse.any { it.periodeOffset != null } }.mapValues { it.value.maxBy { andelTilkjentYtelse -> andelTilkjentYtelse.periodeOffset!! } },
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
@@ -361,6 +365,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = tilkjentYtelseIFørsteBehandling,
                 sisteAndelPerKjede = emptyMap(),
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val oppdaterteAndelerTilkjentYtelseFørsteBehandling = tilkjentYtelseIFørsteBehandling.tilAndelerMedOppdatertOffset(oppdatertTilkjentYtelseIFørsteBehandling.andeler)
@@ -401,6 +406,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = tilkjentYtelseIAndreBehandling,
                 sisteAndelPerKjede = oppdaterteAndelerTilkjentYtelseFørsteBehandling.groupBy { andelTilkjentYtelse -> IdentOgType(ident = andelTilkjentYtelse.aktør.aktivFødselsnummer(), type = YtelsetypeKS.ORDINÆR_KONTANTSTØTTE) }.filterValues { andelTilkjentYtelse -> andelTilkjentYtelse.any { it.periodeOffset != null } }.mapValues { it.value.maxBy { andelTilkjentYtelse -> andelTilkjentYtelse.periodeOffset!! } },
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val utbetalingsoppdrag = oppdatertTilkjentYtelseIAndreBehandling.utbetalingsoppdrag
@@ -488,6 +494,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = tilkjentYtelseIFørsteBehandling,
                 sisteAndelPerKjede = emptyMap(),
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val oppdaterteAndelerTilkjentYtelseFørsteBehandling = tilkjentYtelseIFørsteBehandling.tilAndelerMedOppdatertOffset(oppdatertTilkjentYtelseIFørsteBehandling.andeler)
@@ -535,12 +542,23 @@ internal class UtbetalingsoppdragGeneratorTest {
                 nyTilkjentYtelse = tilkjentYtelseIAndreBehandling,
                 sisteAndelPerKjede = oppdaterteAndelerTilkjentYtelseFørsteBehandling.groupBy { andelTilkjentYtelse -> IdentOgType(ident = andelTilkjentYtelse.aktør.aktivFødselsnummer(), type = YtelsetypeKS.ORDINÆR_KONTANTSTØTTE) }.filterValues { andelTilkjentYtelse -> andelTilkjentYtelse.any { it.periodeOffset != null } }.mapValues { it.value.maxBy { andelTilkjentYtelse -> andelTilkjentYtelse.periodeOffset!! } },
                 erSimulering = false,
+                skalSendeOvergangsordningAndeler = false,
             )
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
 
         assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(0))
     }
+
+    @Test
+    fun `lagUtbetalingsoppdrag skal summere overgangsordningandeler riktig`() {
+    }
+
+    // Flere barn
+    // Flere andeler per barn
+    // Perioder som er lengre enn én måned gir riktig sum
+    // Ordinære og overgangsordningandeler fucker ikke opp hverandre
+    // Sjekke riktig offset
 
     private fun TilkjentYtelse.tilAndelerMedOppdatertOffset(
         andelerMedPeriodeId: List<AndelMedPeriodeIdLongId>,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -19,8 +19,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ks.sak.kjerne.beregning.domene.førsteOvergangsordningAndelForHverAktør
-import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
+import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
@@ -744,19 +743,13 @@ internal class UtbetalingsoppdragGeneratorTest {
 
     private fun TilkjentYtelse.tilAndelerMedOppdatertOffset(
         andelerMedPeriodeId: List<AndelMedPeriodeIdLongId>,
-    ): MutableSet<AndelTilkjentYtelse> {
-        val ordinæreAndelerTilkjentYtelse = this.ordinæreAndeler()
-        val overgangsordningAndeler = this.førsteOvergangsordningAndelForHverAktør()
-        val andelerSomSkalSendesTilOppdrag =
-            ordinæreAndelerTilkjentYtelse.filter { it.erAndelSomSkalSendesTilOppdrag() } + overgangsordningAndeler
-
-        return andelerSomSkalSendesTilOppdrag
+    ): MutableSet<AndelTilkjentYtelse> =
+        andelerTilkjentYtelse
+            .filtrerAndelerSomSkalSendesTilOppdrag()
             .onEach { andel ->
-                val andelMedOffset =
-                    andelerMedPeriodeId.first { it.id == andel.id }
+                val andelMedOffset = andelerMedPeriodeId.first { it.id == andel.id }
                 andel.periodeOffset = andelMedOffset.periodeId
                 andel.forrigePeriodeOffset = andelMedOffset.forrigePeriodeId
                 andel.kildeBehandlingId = andelMedOffset.kildeBehandlingId
             }.toMutableSet()
-    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -25,6 +25,8 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
 import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -678,7 +680,7 @@ internal class UtbetalingsperiodeServiceTest {
 
             every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(behandling.fagsak.id) } returns
                 forrigeTilkjentYtelse.andelerTilkjentYtelse
-                    .filter { it.erAndelSomSkalSendesTilOppdrag() }
+                    .filtrerAndelerSomSkalSendesTilOppdrag()
                     .groupBy { it.aktør.aktivFødselsnummer() }
                     .mapValues { it.value.maxBy { it.periodeOffset!! } }
                     .values

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -462,6 +462,123 @@ internal class UtbetalingsperiodeServiceTest {
     }
 
     @Test
+    fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset for 2 personer og tidligere behandling for overgangsordning`() {
+        val vedtak = lagVedtak()
+        val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
+        val person = tilfeldigPerson()
+        val barn = tilfeldigPerson()
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 6,
+                    fom = YearMonth.of(2024, 1),
+                    tom = YearMonth.of(2024, 8),
+                    beløp = 250,
+                    person = person,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 7,
+                    fom = YearMonth.of(2024, 1),
+                    tom = YearMonth.of(2024, 10),
+                    beløp = 350,
+                    person = barn,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 8,
+                    fom = YearMonth.of(2024, 11),
+                    tom = YearMonth.of(2025, 2),
+                    beløp = 350,
+                    person = barn,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+            ),
+        )
+
+        val forrigeBehandling = lagBehandling()
+        val forrigeTilkjentYtelse = lagInitiellTilkjentYtelse(forrigeBehandling)
+        forrigeTilkjentYtelse.andelerTilkjentYtelse.addAll(
+            mutableSetOf(
+                lagAndelTilkjentYtelse(
+                    id = 1,
+                    fom = YearMonth.of(2024, 1),
+                    tom = YearMonth.of(2024, 3),
+                    beløp = 250,
+                    person = person,
+                    periodeIdOffset = 0L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 2,
+                    fom = YearMonth.of(2024, 4),
+                    tom = YearMonth.of(2024, 8),
+                    beløp = 350,
+                    person = person,
+                    periodeIdOffset = 1L,
+                    forrigeperiodeIdOffset = 0L,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 3,
+                    fom = YearMonth.of(2024, 1),
+                    tom = YearMonth.of(2024, 10),
+                    beløp = 250,
+                    person = barn,
+                    periodeIdOffset = 2L,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 4,
+                    fom = YearMonth.of(2024, 11),
+                    tom = YearMonth.of(2024, 11),
+                    beløp = 350,
+                    person = barn,
+                    periodeIdOffset = 3L,
+                    forrigeperiodeIdOffset = 2L,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+                lagAndelTilkjentYtelse(
+                    id = 5,
+                    fom = YearMonth.of(2024, 12),
+                    tom = YearMonth.of(2025, 2),
+                    beløp = 250,
+                    person = barn,
+                    periodeIdOffset = null, // Bare første overgangsordningandel per person får offset
+                    forrigeperiodeIdOffset = null,
+                    ytelseType = YtelseType.OVERGANGSORDNING,
+                ),
+            ),
+        )
+        val tilkjentYtelseSlot = slot<TilkjentYtelse>()
+        setUpMocks(
+            behandling = vedtak.behandling,
+            tilkjentYtelse = tilkjentYtelse,
+            tilkjentYtelseSlot = tilkjentYtelseSlot,
+            forrigeTilkjentYtelse = forrigeTilkjentYtelse,
+        )
+
+        val beregnetUtbetalingsoppdrag =
+            utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                vedtak = vedtak,
+                "abc123",
+            )
+
+        val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
+
+        verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
+
+        validerBeregnetUtbetalingsoppdragOgAndeler(
+            beregnetUtbetalingsoppdrag = beregnetUtbetalingsoppdrag,
+            andelerTilkjentYtelse = lagredeAndeler,
+            forventetAntallAndeler = 3,
+            forventetAntallUtbetalingsperioder = 3,
+            forventedeOffsets =
+                listOf(
+                    Pair(4L, 1L),
+                    Pair(5L, 3L),
+                    Pair(6L, 5L),
+                ),
+        )
+    }
+
+    @Test
     fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag for simulering med en eksisterende kjede og en ny kjede`() {
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
@@ -631,9 +748,9 @@ internal class UtbetalingsperiodeServiceTest {
         forventetAntallUtbetalingsperioder: Int,
     ) {
         assertThat(beregnetUtbetalingsoppdrag.utbetalingsoppdrag).isNotNull
-        assertThat(beregnetUtbetalingsoppdrag.utbetalingsoppdrag.utbetalingsperiode.size).isEqualTo(
-            forventetAntallUtbetalingsperioder,
-        )
+        assertThat(beregnetUtbetalingsoppdrag.utbetalingsoppdrag.utbetalingsperiode.size)
+            .`as`("Feil antall beregnede utbetalingsperioder: ${beregnetUtbetalingsoppdrag.utbetalingsoppdrag.utbetalingsperiode}")
+            .isEqualTo(forventetAntallUtbetalingsperioder)
 
         assertThat(beregnetUtbetalingsoppdrag.andeler).isNotEmpty
         assertThat(beregnetUtbetalingsoppdrag.andeler.size).isEqualTo(forventetAntallAndeler)
@@ -693,6 +810,6 @@ internal class UtbetalingsperiodeServiceTest {
 
         every { tilkjentYtelseRepository.save(capture(tilkjentYtelseSlot)) } returns mockk()
 
-        every { unleashService.isEnabled(any()) } returns false
+        every { unleashService.isEnabled(any()) } returns true
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -25,6 +25,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
+import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -49,6 +50,9 @@ internal class UtbetalingsperiodeServiceTest {
 
     @MockK
     private lateinit var andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository
+
+    @MockK
+    private lateinit var unleashService: UnleashService
 
     @InjectMockKs
     private lateinit var utbetalingsoppdragGenerator: UtbetalingsoppdragGenerator
@@ -686,5 +690,7 @@ internal class UtbetalingsperiodeServiceTest {
         every { behandlingService.hentBehandlingerPåFagsak(behandling.fagsak.id) } returns listOf(behandling)
 
         every { tilkjentYtelseRepository.save(capture(tilkjentYtelseSlot)) } returns mockk()
+
+        every { unleashService.isEnabled(any()) } returns false
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22613)

* Når vi lager et utbetalingsoppdrag for overgangsordningandeler ønsker vi at alle andelene summeres opp per person og sendes som én andel i desember 2024. 
* PeriodeOffset oppdateres bare i første overgangsordningAndel for hver person det lages utbetalingsoppdrag for. 
* Dersom totalsummen av overgangsordningandeler for en person er uendret hopper vi over IVERKSETT_MOT_OPPDRAG - steget. 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
