### PR TITLE
legg til ytelseType i UtbetalingsperiodeDetaljDto

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/UtbetalingsperiodeResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/UtbetalingsperiodeResponsDto.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.UtbetalingsperiodeDetalj
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbetalinger
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.lagVertikalePerioder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import java.math.BigDecimal
@@ -26,6 +27,7 @@ data class UtbetalingsperiodeDetaljDto(
     val utbetaltPerMnd: Int,
     val erPåvirketAvEndring: Boolean,
     val prosent: BigDecimal,
+    val ytelseType: YtelseType,
 )
 
 fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalingsperiodeResponsDto(
@@ -61,6 +63,7 @@ private fun Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilUtbetalings
             utbetaltPerMnd = andel.kalkulertUtbetalingsbeløp,
             erPåvirketAvEndring = andel.endreteUtbetalinger.isNotEmpty(),
             prosent = andel.prosent,
+            ytelseType = andel.type,
         )
     }
 
@@ -70,4 +73,5 @@ fun UtbetalingsperiodeDetalj.tilUtbetalingsperiodeDetaljDto() =
         utbetaltPerMnd = this.utbetaltPerMnd,
         erPåvirketAvEndring = this.erPåvirketAvEndring,
         prosent = this.prosent,
+        ytelseType = this.ytelseType,
     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -20,7 +20,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 const val FAGSYSTEM = "KS"
-val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 11) // TODO: skal være 24/12
+val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 10) // TODO: skal være 24/12
 
 @Component
 class UtbetalingsoppdragGenerator {


### PR DESCRIPTION
sett OVERGANGSORDNING_UTBETALINGSMÅNED til oktober for testing

### 💰 Hva skal gjøres, og hvorfor?
Fikk ikke opp riktig ytelseType i frontend siden vi ikke sendte med det feltet fra backend. Legger det derfor til.

Setter også OVERGANGSORDNING_UTBETALINGSMÅNED til oktober slik at vi kan teste med en dato som ligger i fortiden siden det blir mer likt slik det blir når vi går gjennom overgangsordning. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
