### PR TITLE
Valider ingen endring i ordinære andeler i overgangsordningbehandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -58,21 +58,16 @@ class BehandlingsresultatSteg(
 
         if (behandling.erOvergangsordning() && unleashService.isEnabled(FeatureToggleConfig.OVERGANGSORDNING)) {
             val overgangsordningAndeler = overgangsordningAndelService.hentOvergangsordningAndeler(behandlingId)
+            val sisteVedtatteBehandling =
+                behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
+                    ?: throw Feil("Fant ingen iverksatt behandling for fagsak ${behandling.fagsak.id}")
+            val tilkjentYtelseForrigeBehandling = beregningService.hentTilkjentYtelseForBehandling(sisteVedtatteBehandling.id)
 
             OvergangsordningAndelValidator.validerOvergangsordningAndeler(
                 overgangsordningAndeler = overgangsordningAndeler,
-                alleAndelerTilkjentYtelse = tilkjentYtelseNåværendeBehandling.andelerTilkjentYtelse,
+                andelerTilkjentYtelseNåværendeBehandling = tilkjentYtelseNåværendeBehandling.andelerTilkjentYtelse,
+                andelerTilkjentYtelseForrigeBehandling = tilkjentYtelseForrigeBehandling.andelerTilkjentYtelse,
                 personResultaterForBarn = personResultaterForBarn,
-            )
-
-            val sisteIverksatteBehandling =
-                behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
-                    ?: throw Feil("Fant ingen iverksatt behandling for fagsak ${behandling.fagsak.id}")
-            val tilkjentYtelseForrigeBehandling = beregningService.hentTilkjentYtelseForBehandling(sisteIverksatteBehandling.id)
-
-            OvergangsordningAndelValidator.validerIngenEndringIOrdinæreAndelerTilkjentYtelse(
-                andelerNåværendeBehandling = tilkjentYtelseNåværendeBehandling.andelerTilkjentYtelse,
-                andelerForrigeBehandling = tilkjentYtelseForrigeBehandling.andelerTilkjentYtelse,
                 barna = personopplysningGrunnlag.barna,
             )
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -11,9 +11,6 @@ import no.nav.familie.ks.sak.kjerne.beregning.EndretUtbetalingAndelMedAndelerTil
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator
-import no.nav.familie.ks.sak.kjerne.overgangsordning.OvergangsordningAndelValidator
-import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndel
-import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.utfyltePerioder
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 
@@ -36,9 +33,7 @@ object BehandlingsresultatValideringUtils {
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         tilkjentYtelse: TilkjentYtelse,
         endretUtbetalingMedAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
-        overgangsordningAndeler: List<OvergangsordningAndel>,
         personResultaterForBarn: List<PersonResultat>,
-        skalValidereOvergangsordningAndeler: Boolean,
     ) {
         val alleBarnetsAlderVilkårResultater = personResultaterForBarn.flatMap { it.vilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.BARNETS_ALDER } }
         val barnehageplassVilkårPerPerson = personResultaterForBarn.groupBy { it.aktør }.mapValues { it.value.flatMap { it.vilkårResultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS } } }
@@ -49,14 +44,6 @@ object BehandlingsresultatValideringUtils {
         // valider EndretUtbetalingAndel
         EndretUtbetalingAndelValidator.validerAtAlleOpprettedeEndringerErUtfylt(endretUtbetalingMedAndeler.map { it.endretUtbetaling })
         EndretUtbetalingAndelValidator.validerAtEndringerErTilknyttetAndelTilkjentYtelse(endretUtbetalingMedAndeler)
-
-        // valider OvergangsordningAndel
-        if (skalValidereOvergangsordningAndeler) {
-            OvergangsordningAndelValidator.validerAtAlleOpprettedeOvergangsordningAndelerErGyldigUtfylt(overgangsordningAndeler)
-            OvergangsordningAndelValidator.validerAtOvergangsordningAndelerIkkeOverlapperMedOrdinæreAndeler(tilkjentYtelse.andelerTilkjentYtelse)
-            OvergangsordningAndelValidator.validerAndelerErIPeriodenBarnetEr20Til23Måneder(overgangsordningAndeler.utfyltePerioder())
-            OvergangsordningAndelValidator.validerAtBarnehagevilkårErOppfyltForAlleOvergangsordningPerioder(overgangsordningAndeler.utfyltePerioder(), barnehageplassVilkårPerPerson)
-        }
     }
 
     internal fun validerBehandlingsresultat(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -36,7 +36,6 @@ object BehandlingsresultatValideringUtils {
         personResultaterForBarn: List<PersonResultat>,
     ) {
         val alleBarnetsAlderVilkårResultater = personResultaterForBarn.flatMap { it.vilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.BARNETS_ALDER } }
-        val barnehageplassVilkårPerPerson = personResultaterForBarn.groupBy { it.aktør }.mapValues { it.value.flatMap { it.vilkårResultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS } } }
 
         // valider TilkjentYtelse
         TilkjentYtelseValidator.validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(tilkjentYtelse, personopplysningGrunnlag, alleBarnetsAlderVilkårResultater)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -136,6 +136,15 @@ data class AndelTilkjentYtelse(
     fun overlapperPeriode(måndePeriode: MånedPeriode): Boolean =
         this.stønadFom <= måndePeriode.tom &&
             this.stønadTom >= måndePeriode.fom
+
+    fun innholdErLikt(andel: AndelTilkjentYtelse): Boolean =
+        this.type == andel.type &&
+            this.stønadFom == andel.stønadFom &&
+            this.stønadTom == andel.stønadTom &&
+            this.kalkulertUtbetalingsbeløp == andel.kalkulertUtbetalingsbeløp &&
+            this.aktør == andel.aktør &&
+            this.nasjonaltPeriodebeløp == andel.nasjonaltPeriodebeløp &&
+            this.differanseberegnetPeriodebeløp == andel.differanseberegnetPeriodebeløp
 }
 
 fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
@@ -8,7 +8,9 @@ import no.nav.familie.ks.sak.common.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅrKort
 import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.tilMånedÅrKort
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilTidslinje
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -16,10 +18,23 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndel
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.UtfyltOvergangsordningAndel
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.tilPerioder
+import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.utfyltePerioder
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import java.time.YearMonth
 
 object OvergangsordningAndelValidator {
+    fun validerOvergangsordningAndeler(
+        overgangsordningAndeler: List<OvergangsordningAndel>,
+        alleAndelerTilkjentYtelse: Set<AndelTilkjentYtelse>,
+        personResultaterForBarn: List<PersonResultat>,
+    ) {
+        val barnehageplassVilkårPerPerson = personResultaterForBarn.groupBy { it.aktør }.mapValues { it.value.flatMap { it.vilkårResultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS } } }
+        validerAtAlleOpprettedeOvergangsordningAndelerErGyldigUtfylt(overgangsordningAndeler)
+        validerAtOvergangsordningAndelerIkkeOverlapperMedOrdinæreAndeler(alleAndelerTilkjentYtelse)
+        validerAtBarnehagevilkårErOppfyltForAlleOvergangsordningPerioder(overgangsordningAndeler.utfyltePerioder(), barnehageplassVilkårPerPerson)
+        validerAndelerErIPeriodenBarnetEr20Til23Måneder(overgangsordningAndeler.utfyltePerioder())
+    }
+
     fun validerAndelerErIPeriodenBarnetEr20Til23Måneder(
         overgangsordningAndeler: List<UtfyltOvergangsordningAndel>,
     ) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
@@ -30,14 +30,17 @@ import java.time.YearMonth
 object OvergangsordningAndelValidator {
     fun validerOvergangsordningAndeler(
         overgangsordningAndeler: List<OvergangsordningAndel>,
-        alleAndelerTilkjentYtelse: Set<AndelTilkjentYtelse>,
+        andelerTilkjentYtelseNåværendeBehandling: Set<AndelTilkjentYtelse>,
+        andelerTilkjentYtelseForrigeBehandling: Set<AndelTilkjentYtelse>,
         personResultaterForBarn: List<PersonResultat>,
+        barna: List<Person>,
     ) {
         val barnehageplassVilkårPerPerson = personResultaterForBarn.groupBy { it.aktør }.mapValues { it.value.flatMap { it.vilkårResultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS } } }
         validerAtAlleOpprettedeOvergangsordningAndelerErGyldigUtfylt(overgangsordningAndeler)
-        validerAtOvergangsordningAndelerIkkeOverlapperMedOrdinæreAndeler(alleAndelerTilkjentYtelse)
+        validerAtOvergangsordningAndelerIkkeOverlapperMedOrdinæreAndeler(andelerTilkjentYtelseNåværendeBehandling)
         validerAtBarnehagevilkårErOppfyltForAlleOvergangsordningPerioder(overgangsordningAndeler.utfyltePerioder(), barnehageplassVilkårPerPerson)
         validerAndelerErIPeriodenBarnetEr20Til23Måneder(overgangsordningAndeler.utfyltePerioder())
+        validerIngenEndringIOrdinæreAndelerTilkjentYtelse(andelerTilkjentYtelseNåværendeBehandling, andelerTilkjentYtelseForrigeBehandling, barna)
     }
 
     fun validerIngenEndringIOrdinæreAndelerTilkjentYtelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidatorTest.kt
@@ -28,6 +28,37 @@ class OvergangsordningAndelValidatorTest {
         )
 
     @Test
+    fun validerIngenEndringIOrdinæreAndelerTilkjentYtelse() {
+        val nåværendeAndeler =
+            setOf(
+                lagAndelTilkjentYtelse(
+                    aktør = aktør,
+                    fom = YearMonth.of(2024, 1),
+                    tom = YearMonth.of(2024, 5),
+                    ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
+                ),
+            )
+
+        val forrigeAndeler =
+            setOf(
+                lagAndelTilkjentYtelse(
+                    aktør = aktør,
+                    fom = YearMonth.of(2024, 1),
+                    tom = YearMonth.of(2024, 3),
+                    ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
+                ),
+            )
+
+        assertThrows<FunksjonellFeil> {
+            OvergangsordningAndelValidator.validerIngenEndringIOrdinæreAndelerTilkjentYtelse(
+                andelerNåværendeBehandling = nåværendeAndeler,
+                andelerForrigeBehandling = forrigeAndeler,
+                barna = listOf(person),
+            )
+        }
+    }
+
+    @Test
     fun validerAndelerErIPeriodenBarnetEr20Til23Måneder() {
         val andeler = listOf(andel)
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22613

I behandlinger med årsak `OVERGANGSORDNING_2024` skal det ikke være mulig å endre ordinære andeler.
Kaster en feil i behandlingsresultatsteget dersom det er endringer

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

![f89f666ed52e151116d484d27f41bb8d](https://github.com/user-attachments/assets/2b2d11db-b4ac-4509-927f-0188b728e006)