### PR TITLE
Lagrer siste sanitybegrunnelser i inmemory cache

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityKlient.kt
@@ -1,10 +1,13 @@
 package no.nav.familie.ks.sak.integrasjon.sanity
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient.Companion.RETRY_BACKOFF_5000MS
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjeneste
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelserResponsDto
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
 import java.net.URI
@@ -15,6 +18,11 @@ class SanityKlient(
     @Value("\${SANITY_BASE_URL}") private val sanityBaseUrl: String,
     restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "sanity") {
+    @Retryable(
+        value = [Exception::class],
+        maxAttempts = 3,
+        backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS),
+    )
     fun hentBegrunnelser(datasett: String = "ks-brev"): List<SanityBegrunnelse> {
         val uri = lagHentUri(datasett, HENT_BEGRUNNELSER)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityServiceTest.kt
@@ -1,0 +1,85 @@
+package no.nav.familie.ks.sak.integrasjon.sanity
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseType
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class SanityServiceTest {
+    @MockK
+    private lateinit var cachedSanityKlient: CachedSanityKlient
+
+    @InjectMockKs
+    private lateinit var sanityService: SanityService
+
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @Test
+    fun `Skal hente SanityBegrunnelser`() {
+        every { cachedSanityKlient.hentSanityBegrunnelserCached() } returns
+            listOf(
+                SanityBegrunnelse(
+                    NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE.sanityApiNavn,
+                    "innvilgetIkkeBarnehage",
+                    SanityBegrunnelseType.STANDARD,
+                    Vilkår.values().toList(),
+                    rolle = emptyList(),
+                    triggere = emptyList(),
+                    utdypendeVilkårsvurderinger = emptyList(),
+                    hjemler = emptyList(),
+                    endretUtbetalingsperiode = emptyList(),
+                    endringsårsaker = emptyList(),
+                    støtterFritekst = false,
+                    skalAlltidVises = false,
+                    resultat = SanityResultat.INNVILGET,
+                ),
+            )
+
+        assertThat(sanityService.hentSanityBegrunnelser()).hasSize(1)
+    }
+
+    @Test
+    fun `Skal kaste feil hvis det ikke er mulig å hente fra Sanity eller finnes i Cache`() {
+        every { cachedSanityKlient.hentSanityBegrunnelserCached() } throws RuntimeException("Feil ved henting av begrunnelser i test")
+
+        val e = assertThrows<RuntimeException> { sanityService.hentSanityBegrunnelser() }
+        assertThat(e.message).isEqualTo("Feil ved henting av begrunnelser i test")
+    }
+
+    @Test
+    fun `Skal bruke allerede lagret cache hvis det feiler mot sanity`() {
+        every { cachedSanityKlient.hentSanityBegrunnelserCached() } returns
+            listOf(
+                SanityBegrunnelse(
+                    NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE.sanityApiNavn,
+                    "innvilgetIkkeBarnehage",
+                    SanityBegrunnelseType.STANDARD,
+                    Vilkår.values().toList(),
+                    rolle = emptyList(),
+                    triggere = emptyList(),
+                    utdypendeVilkårsvurderinger = emptyList(),
+                    hjemler = emptyList(),
+                    endretUtbetalingsperiode = emptyList(),
+                    endringsårsaker = emptyList(),
+                    støtterFritekst = false,
+                    skalAlltidVises = false,
+                    resultat = SanityResultat.INNVILGET,
+                ),
+            ) andThenThrows RuntimeException("Feil får å teste cachet versjon")
+
+        assertThat(sanityService.hentSanityBegrunnelser()).hasSize(1)
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Sanity-begrunnelsene lever i en shortCache. Når de evictes så henter man oppdaterte begrunnelser. Tar vare på siste nedlastede begrunnelse i minne, slik at man ikke går ned hvis Sanity skulle ha midlertidig problemer

Flyttet også Retryable ned til SanityKlient. Den hører mer hjemme der.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

