### PR TITLE
Ikke lag kompetanser til overgangsordningandeler i nasjonale saker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/TilpassKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/TilpassKompetanserService.kt
@@ -102,13 +102,15 @@ class TilpassKompetanserService(
                         .tilPerioder()
                         .tilTidslinje()
                 }
+        val eksistererEøsRegelverkPåBehandling =
+            barnasEøsRegelverkTidslinjer.values.any { it.tilPerioderIkkeNull().isNotEmpty() }
 
         return eksisterendeKompetanser
             .tilSeparateTidslinjerForBarna()
             .outerJoin(barnasEøsRegelverkTidslinjer, overgangsordningAndelerTidslinjer) { kompetanse, regelverk, overgangsordningAndel ->
                 when {
                     regelverk != null -> kompetanse ?: Kompetanse.blankKompetanse
-                    overgangsordningAndel != null -> kompetanse ?: Kompetanse.blankKompetanse
+                    eksistererEøsRegelverkPåBehandling && overgangsordningAndel != null -> kompetanse ?: Kompetanse.blankKompetanse
                     else -> null
                 }
             }.mapValues { (_, value) ->


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-22613

I nasjonale saker skal det ikke genereres tomme kompetanser i perioder med overgangsordning.
Gjør en sjekk på om det eksisterer regelverk for eøs på behandlingen før kompetansen for overgangsordningen genereres.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
