### PR TITLE
Korriger forskyvning av vilkår slik at man ikke får overlapp av perioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/StandardVilkårForskyver.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/StandardVilkårForskyver.kt
@@ -22,16 +22,12 @@ fun forskyvStandardVilkår2024(
             Periode(
                 verdi = it.gjeldende,
                 fom = it.gjeldende.periodeFom?.førsteDagIInneværendeMåned(),
-                tom =
-                    when (it.gjeldendeSlutterDagenFørNeste()) {
-                        true -> it.gjeldende.periodeTom
-                        false -> it.gjeldende.periodeTom?.sisteDagIMåned()
-                    },
+                tom = it.gjeldende.periodeTom?.sisteDagIMåned(),
             )
         }.filter { (it.fom ?: TIDENES_MORGEN).isBefore(it.tom ?: TIDENES_ENDE) }
         .filtrerBortOverlappendePerioder()
 
 private fun List<Periode<VilkårResultat>>.filtrerBortOverlappendePerioder() =
     map { listOf(it).tilTidslinje() }
-        .kombiner { vilkårResultater -> vilkårResultater.minByOrNull { it.periodeFom ?: TIDENES_MORGEN } }
+        .kombiner { vilkårResultater -> vilkårResultater.maxByOrNull { it.periodeFom ?: TIDENES_MORGEN } }
         .tilPerioderIkkeNull()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/ForskyvVilkår2024KtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/ForskyvVilkår2024KtTest.kt
@@ -115,4 +115,46 @@ class ForskyvVilkår2024KtTest {
             assertThat(it.tom).isEqualTo(desember.atEndOfMonth())
         }
     }
+
+    @Test
+    fun `Ved to oppfylte vilkårresultat i samme måned så skal det seneste vilkåret være gjeldene for måneden etter`() {
+        // Arrange
+        val førstePeriodeBorMedSøker =
+            lagVilkårResultat(
+                vilkårType = Vilkår.BOR_MED_SØKER,
+                periodeFom = august.atDay(15),
+                periodeTom = oktober.atDay(14),
+                resultat = Resultat.OPPFYLT,
+            )
+        val andrePeriodeBorMedSøker =
+            lagVilkårResultat(
+                vilkårType = Vilkår.BOR_MED_SØKER,
+                periodeFom = oktober.atDay(15),
+                periodeTom = desember.atDay(1),
+                resultat = Resultat.OPPFYLT,
+            )
+
+        val vilkårResultater =
+            listOf(
+                førstePeriodeBorMedSøker,
+                andrePeriodeBorMedSøker,
+            )
+
+        // Act
+        val forskjøvedeVilkårResultater =
+            forskyvEtterLovgivning2024(
+                Vilkår.BOR_MED_SØKER,
+                vilkårResultater,
+            )
+
+        assertThat(forskjøvedeVilkårResultater).hasSize(2)
+
+        assertThat(forskjøvedeVilkårResultater[0].fom).isEqualTo(august.atDay(1))
+        assertThat(forskjøvedeVilkårResultater[0].tom).isEqualTo(september.atDay(30))
+        assertThat(forskjøvedeVilkårResultater[0].verdi).isEqualTo(førstePeriodeBorMedSøker)
+
+        assertThat(forskjøvedeVilkårResultater[1].fom).isEqualTo(oktober.atDay(1))
+        assertThat(forskjøvedeVilkårResultater[1].tom).isEqualTo(desember.atDay(31))
+        assertThat(forskjøvedeVilkårResultater[1].verdi).isEqualTo(andrePeriodeBorMedSøker)
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/ForskyvVilkår2024KtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/ForskyvVilkår2024KtTest.kt
@@ -117,7 +117,7 @@ class ForskyvVilkår2024KtTest {
     }
 
     @Test
-    fun `Ved to oppfylte vilkårresultat i samme måned så skal det seneste vilkåret være gjeldene for måneden etter`() {
+    fun `Ved to oppfylte vilkårresultat i samme måned så skal det seneste vilkåret være gjeldende for måneden`() {
         // Arrange
         val førstePeriodeBorMedSøker =
             lagVilkårResultat(
@@ -147,6 +147,7 @@ class ForskyvVilkår2024KtTest {
                 vilkårResultater,
             )
 
+        // Assert
         assertThat(forskjøvedeVilkårResultater).hasSize(2)
 
         assertThat(forskjøvedeVilkårResultater[0].fom).isEqualTo(august.atDay(1))


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23408

Se følgende scenario:
Vilkår 1 m/ fom-tom:  01.08.2024 - 14.09.2024
Vilkår 2 m/ fom-tom: 15.09.2024 -> 30.11.2024

Etter forskyvning med dagens logikk vil man få to perioder.
Man vil få en periode 01.08.2024 - 14.09.2024 og en periode 15.09.2024 -> 30.11.2024.
I tidslinja vil man derfor ha 2 perioder, og når man da oppretter andel, så vil man få to andeler som overlappes i september.

Jeg korrigerer nå derfor slik at vi får to perioder
Man vil få en periode 01.08.2024 - 31.08.2024 og en periode 01.09.2024 -> 30.11.2024.
Første periode vil hva vilkår 1 som verdi
Andre periode vil ha vilkår 2 som verdi.

Tester OK.