### PR TITLE
Legg til delt bosted begrunnelse og fiks autovalg bug

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ks.sak.kjerne.brev.begrunnelser
 
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.Periode
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.erDagenFør
+import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
@@ -208,9 +210,10 @@ class BegrunnelserForPeriodeContext(
                 erFørsteVedtaksperiodeOgBegrunnelseInneholderGjelderFørstePeriodeTrigger,
             )
 
-        val overgangsordningsAndelerSomStarterOgSlutterSamtidigSomVedtaksperiode = overgangsordningAndeler.filter { it.fom == vedtaksperiode.fom.toYearMonth() && it.tom == vedtaksperiode.tom.toYearMonth() }
-
-        val personerMedOvergangsordningAndel = overgangsordningsAndelerSomStarterOgSlutterSamtidigSomVedtaksperiode.mapNotNull { it.person }
+        val personerMedOvergangsordningAndel =
+            overgangsordningAndeler
+                .filter { it.periode.overlapperHeltEllerDelvisMed(MånedPeriode(vedtaksperiode.fom.toYearMonth(), vedtaksperiode.tom.toYearMonth())) }
+                .mapNotNull { it.person }
 
         val filtrerPersonerUtenUtbetalingVedInnvilget =
             hentVilkårResultaterSomOverlapperVedtaksperiode

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
@@ -19,6 +19,10 @@ enum class NasjonalEllerFellesBegrunnelse : IBegrunnelse {
         override val begrunnelseType = BegrunnelseType.INNVILGET
         override val sanityApiNavn = "innvilgetOvergangsordningGradertUtbetaling"
     },
+    INNVILGET_OVERGANGSORDNING_DELT_BOSTED {
+        override val begrunnelseType = BegrunnelseType.INNVILGET
+        override val sanityApiNavn = "innvilgetOvergangsordningDeltBosted"
+    },
     INNVILGET_DELTID_BARNEHAGE {
         override val begrunnelseType = BegrunnelseType.INNVILGET
         override val sanityApiNavn = "innvilgetDeltidBarnehage"

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -27,8 +27,10 @@ import no.nav.familie.ks.sak.kjerne.beregning.AndelTilkjentYtelseMedEndreteUtbet
 import no.nav.familie.ks.sak.kjerne.beregning.BeregnAndelTilkjentYtelseService
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkFørFebruar2025.RegelverkFørFebruar2025AndelGenerator
 import no.nav.familie.ks.sak.kjerne.beregning.regelverkLovendringFebruar2025.RegelverkLovendringFebruar2025AndelGenerator
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
@@ -38,6 +40,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 
 internal class UtbetalingsperiodeUtilTest {
@@ -312,6 +316,230 @@ internal class UtbetalingsperiodeUtilTest {
                 )
 
             assertThat(vedtaksperioderMedKompetanse.size).isEqualTo(4)
+        }
+    }
+
+    @Nested
+    inner class HentBegrunnelserForOvergangsordningPerioder {
+        @Test
+        fun `skal ikke returnere noe begrunnelser dersom det ikke finnes noe overgangsordningandeler i perioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 8), stønadTom = YearMonth.of(2024, 12)),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).isEmpty()
+        }
+
+        @Test
+        fun `skal ikke returnere noe begrunnelser dersom overgangsordning andelene ikke overlapper med vedtaksperioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 6), stønadTom = YearMonth.of(2024, 7), ytelseType = YtelseType.OVERGANGSORDNING),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere noe begrunnelser dersom overgangsordning andelene ikke overlapper med vedtaksperioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 6), stønadTom = YearMonth.of(2024, 7), ytelseType = YtelseType.OVERGANGSORDNING),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).isEmpty()
+        }
+
+        @Test
+        fun `skal returnere INNVILGET_OVERGANGSORDNING begrunnelse dersom det eksisterer overgangsordning andeler med full sats som overlapper med vedtak perioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 7), stønadTom = YearMonth.of(2024, 9), ytelseType = YtelseType.OVERGANGSORDNING),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).size().isEqualTo(1)
+            assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING)
+        }
+
+        @Test
+        fun `skal returnere INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING begrunnelse dersom det eksisterer overgangsordning andeler med gradert sats som overlapper med vedtak perioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 7), stønadTom = YearMonth.of(2024, 9), ytelseType = YtelseType.OVERGANGSORDNING, prosent = BigDecimal(60)),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).size().isEqualTo(1)
+            assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING)
+        }
+
+        @Test
+        fun `skal returnere INNVILGET_OVERGANGSORDNING_DELT_BOSTED begrunnelse dersom det eksisterer overgangsordning andeler med halv sats som overlapper med vedtak perioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 7), stønadTom = YearMonth.of(2024, 9), ytelseType = YtelseType.OVERGANGSORDNING, prosent = BigDecimal(50)),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).size().isEqualTo(1)
+            assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED)
+        }
+
+        @Test
+        fun `skal returnere INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING begrunnelse dersom det både eksisterer overgangsordning andeler med gradert sats og full sats som overlapper med vedtak perioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 7), stønadTom = YearMonth.of(2024, 9), ytelseType = YtelseType.OVERGANGSORDNING, prosent = BigDecimal(100)),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 7), stønadTom = YearMonth.of(2024, 9), ytelseType = YtelseType.OVERGANGSORDNING, prosent = BigDecimal(60)),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).size().isEqualTo(1)
+            assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING)
+        }
+
+        @Test
+        fun `skal returnere INNVILGET_OVERGANGSORDNING_DELT_BOSTED begrunnelse dersom det både eksisterer overgangsordning andeler med halv sats og full sats som overlapper med vedtak perioden`() {
+            val andeler =
+                listOf(
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 7), stønadTom = YearMonth.of(2024, 9), ytelseType = YtelseType.OVERGANGSORDNING, prosent = BigDecimal(100)),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                    AndelTilkjentYtelseMedEndreteUtbetalinger(
+                        andelTilkjentYtelse = lagAndelTilkjentYtelse(stønadFom = YearMonth.of(2024, 7), stønadTom = YearMonth.of(2024, 9), ytelseType = YtelseType.OVERGANGSORDNING, prosent = BigDecimal(50)),
+                        endreteUtbetalingerAndeler = emptyList(),
+                    ),
+                )
+
+            val splittKriteriePeriode =
+                Periode(
+                    SplittkriterierForVedtaksperiode(
+                        andelerTilkjentYtelse = andeler,
+                        splittkriterierForVilkår = emptyMap(),
+                        splittkriterierForKompetanse = emptyMap(),
+                    ),
+                    fom = LocalDate.of(2024, 8, 1),
+                    tom = LocalDate.of(2024, 12, 31),
+                )
+
+            val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
+
+            assertThat(begrunnelser).size().isEqualTo(1)
+            assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED)
         }
     }
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23420

Man har antatt at vedtaksperiodene som opprettes i overgangsordning behandlingene stemmer overens med andelene.
Dette stemmer, men bare for nasjonal.

For EØS behandlinger sekunderland vil det genereres perioder som bare overlapper delvis, og da må logikken justeres.
Legger også til delt bosted begrunnelse som velges automatisk for SB hvis sats er 50% i perioden.