### PR TITLE
Fix: Fjern trailing skråstrek i klage-endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
@@ -50,7 +50,7 @@ class EksternKlageController(
         return Ressurs.success(opprettBehandlingService.kanOppretteRevurdering(fagsakId))
     }
 
-    @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage/")
+    @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage")
     fun opprettRevurderingKlage(
         @PathVariable fagsakId: Long,
     ): Ressurs<OpprettRevurderingResponse> {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Samme som i ba: https://github.com/navikt/familie-ba-sak/pull/4925

I test av klageløsningen har Viktor og jeg oppdaget at funksjonalitet for å opprette revurdering med årsak klage ikke funker som det skal. Får feilmeldingen at man ikke finner endepunktet. Vi tror det er pga en skråstrek for mye. Prøver å fjerne og se om funksjonaliteten funker som ønsket.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
