### PR TITLE
Refaktorer logikk for hjemler til en egen pakke. Forenkler logikken og skriver enhetstester

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -14,5 +14,7 @@ class FeatureToggleConfig {
         const val OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER = "familie-ba-ks-sak.opprett-sak-paa-riktig-enhet-og-saksbehandler"
 
         const val BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER = "familie-ks-sak.bruk-ny-loype-for-generering-av-andeler"
+
+        const val BRUK_OMSKRIVING_AV_HJEMLER_I_BREV = "familie-ks-sak.bruk_omskriving_av_hjemler_i_brev"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/refusjonEøs/RefusjonEøsService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/refusjonEøs/RefusjonEøsService.kt
@@ -78,4 +78,6 @@ class RefusjonEøsService(
             land = it.land,
             refusjonAvklart = it.refusjonAvklart,
         )
+
+    fun harRefusjonEøsPåBehandling(behandlingId: Long): Boolean = refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId).isNotEmpty()
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/Vilkårsvurdering.kt
@@ -47,4 +47,13 @@ data class Vilkårsvurdering(
             .single { it.erSøkersResultater() }
             .andreVurderinger
             .singleOrNull { it.type == AnnenVurderingType.OPPLYSNINGSPLIKT }
+
+    fun erOpplysningspliktVilkårOppfylt(): Boolean {
+        val opplysningspliktVilkår =
+            personResultater
+                .single { it.erSøkersResultater() }
+                .andreVurderinger
+                .singleOrNull { it.type == AnnenVurderingType.OPPLYSNINGSPLIKT }
+        return opplysningspliktVilkår?.resultat == Resultat.OPPFYLT
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ks.sak.common.util.formaterBeløp
 import no.nav.familie.ks.sak.common.util.storForbokstavIAlleNavn
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -49,10 +50,12 @@ import no.nav.familie.ks.sak.kjerne.brev.domene.maler.vedtaksbrev.OpphørMedEndr
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.vedtaksbrev.Opphørt
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.vedtaksbrev.VedtakEndring
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.vedtaksbrev.VedtakOvergangsordning
+import no.nav.familie.ks.sak.kjerne.brev.hjemler.HjemmeltekstUtleder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.korrigertvedtak.KorrigertVedtakService
 import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
+import no.nav.familie.unleash.UnleashService
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 
@@ -76,6 +79,8 @@ class GenererBrevService(
     private val opprettGrunnlagOgSignaturDataService: OpprettGrunnlagOgSignaturDataService,
     private val brevmalService: BrevmalService,
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    private val hjemmeltekstUtleder: HjemmeltekstUtleder,
+    private val unleashService: UnleashService,
 ) {
     fun genererManueltBrev(
         manueltBrevRequest: ManueltBrevDto,
@@ -259,13 +264,21 @@ class GenererBrevService(
         val korrigertVedtak = korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(vedtak.behandling.id)
 
         val hjemler =
-            hentHjemler(
-                behandlingId = vedtak.behandling.id,
-                utvidetVedtaksperioderMedBegrunnelser = oppdatertUtvidetVedtaksperioderMedBegrunnelser,
-                målform = personopplysningsgrunnlagOgSignaturData.grunnlag.søker.målform,
-                sanityBegrunnelser = sanityService.hentSanityBegrunnelser(),
-                vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,
-            )
+            if (unleashService.isEnabled(FeatureToggleConfig.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV, false)) {
+                hjemmeltekstUtleder.utledHjemmeltekst(
+                    behandlingId = vedtak.behandling.id,
+                    vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,
+                    utvidetVedtaksperioderMedBegrunnelser = oppdatertUtvidetVedtaksperioderMedBegrunnelser,
+                )
+            } else {
+                hentHjemler(
+                    behandlingId = vedtak.behandling.id,
+                    utvidetVedtaksperioderMedBegrunnelser = oppdatertUtvidetVedtaksperioderMedBegrunnelser,
+                    målform = personopplysningsgrunnlagOgSignaturData.grunnlag.søker.målform,
+                    sanityBegrunnelser = sanityService.hentSanityBegrunnelser(),
+                    vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,
+                )
+            }
 
         return FellesdataForVedtaksbrev(
             enhet = personopplysningsgrunnlagOgSignaturData.enhet,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen883Hjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen883Hjemler.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+
+fun utledEØSForordningen883Hjemler(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+) = sanityBegrunnelser.flatMap { it.hjemlerEØSForordningen883 }.distinct()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen987Hjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen987Hjemler.kt
@@ -1,0 +1,16 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+
+const val HJEMMEL_60_EØS_FORORDNINGEN_987 = "60"
+
+fun utledEØSForordningen987Hjemler(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    refusjonEøsHjemmelSkalMedIBrev: Boolean,
+): List<String> =
+    sanityBegrunnelser.flatMap { it.hjemlerEØSForordningen987 } +
+        if (refusjonEøsHjemmelSkalMedIBrev) {
+            listOf(HJEMMEL_60_EØS_FORORDNINGEN_987)
+        } else {
+            emptyList()
+        }.distinct()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen987Hjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen987Hjemler.kt
@@ -8,9 +8,12 @@ fun utledEØSForordningen987Hjemler(
     sanityBegrunnelser: List<SanityBegrunnelse>,
     refusjonEøsHjemmelSkalMedIBrev: Boolean,
 ): List<String> =
-    sanityBegrunnelser.flatMap { it.hjemlerEØSForordningen987 } +
-        if (refusjonEøsHjemmelSkalMedIBrev) {
-            listOf(HJEMMEL_60_EØS_FORORDNINGEN_987)
-        } else {
-            emptyList()
-        }.distinct()
+    sanityBegrunnelser
+        .flatMap { it.hjemlerEØSForordningen987 }
+        .plus(
+            if (refusjonEøsHjemmelSkalMedIBrev) {
+                listOf(HJEMMEL_60_EØS_FORORDNINGEN_987)
+            } else {
+                emptyList()
+            },
+        ).distinct()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/ForvaltningsloverHjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/ForvaltningsloverHjemler.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+const val FORVALTINIGSLOVEN_PARAGRAF_35 = "35"
+
+fun utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev: Boolean): List<String> =
+    if (vedtakKorrigertHjemmelSkalMedIBrev) {
+        listOf(FORVALTINIGSLOVEN_PARAGRAF_35)
+    } else {
+        emptyList()
+    }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemlerKombinator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemlerKombinator.kt
@@ -1,0 +1,80 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.util.slåSammen
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
+
+fun kombinerHjemler(
+    målform: Målform,
+    separasjonsavtaleStorbritanniaHjemler: List<String>,
+    ordinæreHjemler: List<String>,
+    eøsForordningen883Hjemler: List<String>,
+    eøsForordningen987Hjemler: List<String>,
+    forvaltningslovenHjemler: List<String>,
+): List<String> {
+    val alleHjemlerForBegrunnelser = mutableListOf<String>()
+
+    // Rekkefølgen her er viktig
+    if (separasjonsavtaleStorbritanniaHjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+                when (målform) {
+                    Målform.NB -> "Separasjonsavtalen mellom Storbritannia og Norge artikkel"
+                    Målform.NN -> "Separasjonsavtalen mellom Storbritannia og Noreg artikkel"
+                }
+            } ${
+                slåSammen(separasjonsavtaleStorbritanniaHjemler)
+            }",
+        )
+    }
+
+    if (ordinæreHjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+                when (målform) {
+                    Målform.NB -> "kontantstøtteloven"
+                    Målform.NN -> "kontantstøttelova"
+                }
+            } ${
+                hjemlerTilHjemmeltekst(
+                    hjemler = ordinæreHjemler,
+                    lovForHjemmel = "kontantstøtteloven",
+                )
+            }",
+        )
+    }
+
+    if (eøsForordningen883Hjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add("EØS-forordning 883/2004 artikkel ${slåSammen(eøsForordningen883Hjemler)}")
+    }
+    if (eøsForordningen987Hjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add("EØS-forordning 987/2009 artikkel ${slåSammen(eøsForordningen987Hjemler)}")
+    }
+
+    if (forvaltningslovenHjemler.isNotEmpty()) {
+        alleHjemlerForBegrunnelser.add(
+            "${
+                when (målform) {
+                    Målform.NB -> "forvaltningsloven"
+                    Målform.NN -> "forvaltningslova"
+                }
+            } ${
+                hjemlerTilHjemmeltekst(hjemler = forvaltningslovenHjemler, lovForHjemmel = "forvaltningsloven")
+            }",
+        )
+    }
+    return alleHjemlerForBegrunnelser
+}
+
+fun hjemlerTilHjemmeltekst(
+    hjemler: List<String>,
+    lovForHjemmel: String,
+): String =
+    when (hjemler.size) {
+        0 -> throw Feil(
+            "Kan ikke lage hjemmeltekst for $lovForHjemmel når ingen begrunnelser har hjemler fra $lovForHjemmel knyttet til seg.",
+        )
+
+        1 -> "§ ${hjemler[0]}"
+        else -> "§§ ${slåSammen(hjemler)}"
+    }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemmeltekstUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemmeltekstUtleder.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøsService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.IBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilSanityBegrunnelse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import org.springframework.stereotype.Component
+
+@Component
+class HjemmeltekstUtleder(
+    private val vilkårsvurderingService: VilkårsvurderingService,
+    private val sanityService: SanityService,
+    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
+    private val refusjonEøsService: RefusjonEøsService,
+) {
+    fun utledHjemmeltekst(
+        behandlingId: Long,
+        vedtakKorrigertHjemmelSkalMedIBrev: Boolean = false,
+        utvidetVedtaksperioderMedBegrunnelser: List<UtvidetVedtaksperiodeMedBegrunnelser>,
+    ): String {
+        val vilkårsvurdering =
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)
+
+        val sanityBegrunnelser =
+            utvidetVedtaksperioderMedBegrunnelser
+                .flatMap<UtvidetVedtaksperiodeMedBegrunnelser, IBegrunnelse> { vedtaksperiode ->
+                    vedtaksperiode.begrunnelser.map { it.nasjonalEllerFellesBegrunnelse } + vedtaksperiode.eøsBegrunnelser.map { it.begrunnelse }
+                }.mapNotNull { it.tilSanityBegrunnelse(sanityService.hentSanityBegrunnelser()) }
+
+        val alleHjemlerForBegrunnelser =
+            kombinerHjemler(
+                ordinæreHjemler = utledOrdinæreHjemler(sanityBegrunnelser = sanityBegrunnelser, opplysningspliktHjemlerSkalMedIBrev = !vilkårsvurdering.erOpplysningspliktVilkårOppfylt()),
+                målform = personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandlingId),
+                forvaltningslovenHjemler = utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev = vedtakKorrigertHjemmelSkalMedIBrev),
+                separasjonsavtaleStorbritanniaHjemler = utledSeprasjonsavtaleStorbritanniaHjemler(sanityBegrunnelser = sanityBegrunnelser),
+                eøsForordningen883Hjemler = utledEØSForordningen883Hjemler(sanityBegrunnelser = sanityBegrunnelser),
+                eøsForordningen987Hjemler = utledEØSForordningen987Hjemler(sanityBegrunnelser = sanityBegrunnelser, refusjonEøsHjemmelSkalMedIBrev = refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId)),
+            )
+
+        return slåSammenHjemlerAvUlikeTyper(alleHjemlerForBegrunnelser)
+    }
+
+    private fun slåSammenHjemlerAvUlikeTyper(hjemler: List<String>) =
+        when (hjemler.size) {
+            0 -> throw FunksjonellFeil("Ingen hjemler var knyttet til begrunnelsen(e) som er valgt. Du må velge minst én begrunnelse som er knyttet til en hjemmel.")
+            1 -> hjemler.single()
+            else -> slåSammenListeMedHjemler(hjemler)
+        }
+
+    private fun slåSammenListeMedHjemler(hjemler: List<String>): String =
+        hjemler.reduceIndexed { index, acc, s ->
+            when (index) {
+                0 -> acc + s
+                hjemler.size - 1 -> "$acc og $s"
+                else -> "$acc, $s"
+            }
+        }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/OrdinæreHjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/OrdinæreHjemler.kt
@@ -1,0 +1,23 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+
+fun utledOrdinæreHjemler(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    opplysningspliktHjemlerSkalMedIBrev: Boolean,
+): List<String> {
+    val ordinæreHjemler = mutableSetOf<String>()
+
+    ordinæreHjemler.addAll(sanityBegrunnelser.flatMap { it.hjemler }.toMutableSet())
+
+    if (opplysningspliktHjemlerSkalMedIBrev) {
+        val hjemlerNårOpplysningspliktIkkeOppfylt = listOf("13", "16")
+        ordinæreHjemler.addAll(hjemlerNårOpplysningspliktIkkeOppfylt)
+    }
+
+    return ordinæreHjemler
+        .map { it.toInt() }
+        .sorted()
+        .map { it.toString() }
+        .distinct()
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemler.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
+
+fun utledSeprasjonsavtaleStorbritanniaHjemler(sanityBegrunnelser: List<SanityBegrunnelse>) =
+    sanityBegrunnelser
+        .flatMap { it.hjemlerSeperasjonsavtalenStorbritannina }
+        .distinct()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -100,6 +100,8 @@ class PersonopplysningGrunnlagService(
 
     fun hentSøker(behandlingId: Long): Person? = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)?.søker
 
+    fun hentSøkerThrows(behandlingId: Long): Person = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId).søker
+
     fun hentBarna(behandlingId: Long): List<Person>? = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)?.barna
 
     fun hentSøkerOgBarnPåFagsak(fagsakId: Long): Set<PersonEnkel>? =
@@ -107,7 +109,7 @@ class PersonopplysningGrunnlagService(
             .finnSøkerOgBarnAktørerTilFagsak(fagsakId)
             .takeIf { it.isNotEmpty() }
 
-    fun hentSøkersMålform(behandlingId: Long) = hentSøker(behandlingId)?.målform ?: Målform.NB
+    fun hentSøkersMålform(behandlingId: Long) = hentSøkerThrows(behandlingId).målform
 
     fun lagreOgDeaktiverGammel(personopplysningGrunnlag: PersonopplysningGrunnlag): PersonopplysningGrunnlag {
         finnAktivPersonopplysningGrunnlag(personopplysningGrunnlag.behandlingId)?.let {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/refusjonEøs/RefusjonEøsServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/refusjonEøs/RefusjonEøsServiceTest.kt
@@ -1,0 +1,56 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagRefusjonEøs
+import no.nav.familie.ks.sak.kjerne.logg.LoggService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RefusjonEøsServiceTest {
+    private val refusjonEøsRepository = mockk<RefusjonEøsRepository>()
+    private val loggService = mockk<LoggService>()
+
+    private val refusjonEøsService: RefusjonEøsService =
+        RefusjonEøsService(
+            refusjonEøsRepository = refusjonEøsRepository,
+            loggService = loggService,
+        )
+
+    @Nested
+    inner class HarRefusjonEøsPåBehandlingTest {
+        @Test
+        fun `skal returnere false om refusjon eøs på behandling er tom`() {
+            // Arrange
+            val behandling = lagBehandling()
+
+            every {
+                refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId = behandling.id)
+            } returns emptyList()
+
+            // Act
+            val harRefusjonEøsPåBehandling = refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id)
+
+            // Assert
+            assertThat(harRefusjonEøsPåBehandling).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om refusjon eøs på behandling ikke er tom`() {
+            // Arrange
+            val behandling = lagBehandling()
+
+            every {
+                refusjonEøsRepository.finnRefusjonEøsForBehandling(behandlingId = behandling.id)
+            } returns listOf(lagRefusjonEøs())
+
+            // Act
+            val harRefusjonEøsPåBehandling = refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id)
+
+            // Assert
+            assertThat(harRefusjonEøsPåBehandling).isTrue()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårsvurderingTest.kt
@@ -1,0 +1,153 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene
+
+import no.nav.familie.ks.sak.data.lagPersonResultat
+import no.nav.familie.ks.sak.data.lagVilkårResultat
+import no.nav.familie.ks.sak.data.lagVilkårsvurdering
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class VilkårsvurderingTest {
+    @Nested
+    inner class ErOpplysningspliktVilkårOppfyltTest {
+        @Test
+        fun `skal exception om personresultater er tom`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering().also { it.personResultater = emptySet() }
+
+            // Act & assert
+            val exception =
+                assertThrows<NoSuchElementException> {
+                    vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+                }
+            assertThat(exception.message).isEqualTo("Collection contains no element matching the predicate.")
+        }
+
+        @Test
+        fun `skal kaste exception om ingen vilkår er for søker`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultat = { vilkårsvurdering ->
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagVilkårResultat(
+                                        personResultat = personResultat,
+                                        vilkårType = Vilkår.BARNETS_ALDER,
+                                    ),
+                                )
+                            },
+                            lagAnnenVurdering = { emptySet() },
+                        )
+                    },
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<NoSuchElementException> {
+                    vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+                }
+            assertThat(exception.message).isEqualTo("Collection contains no element matching the predicate.")
+        }
+
+        @Test
+        fun `skal returnere false om annen vurdering er tom`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultat = { vilkårsvurdering ->
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagVilkårResultat(
+                                        personResultat = personResultat,
+                                        vilkårType = Vilkår.BOSATT_I_RIKET,
+                                    ),
+                                )
+                            },
+                            lagAnnenVurdering = { emptySet() },
+                        )
+                    },
+                )
+
+            // Act
+            val erOpplysningspliktVilkårOppfylt = vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+
+            // Assert
+            assertThat(erOpplysningspliktVilkårOppfylt).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om annen vurdering opplysningsplikt ikke er oppfylt`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultat = { vilkårsvurdering ->
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagVilkårResultat(
+                                        personResultat = personResultat,
+                                        vilkårType = Vilkår.BOSATT_I_RIKET,
+                                    ),
+                                )
+                            },
+                            lagAnnenVurdering = {
+                                setOf(
+                                    AnnenVurdering(personResultat = it, type = AnnenVurderingType.OPPLYSNINGSPLIKT, resultat = Resultat.IKKE_OPPFYLT),
+                                )
+                            },
+                        )
+                    },
+                )
+
+            // Act
+            val erOpplysningspliktVilkårOppfylt = vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+
+            // Assert
+            assertThat(erOpplysningspliktVilkårOppfylt).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om annen vurdering opplysningsplikt er oppfylt`() {
+            // Arrange
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    lagPersonResultat = { vilkårsvurdering ->
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = vilkårsvurdering.behandling.fagsak.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagVilkårResultat(
+                                        personResultat = personResultat,
+                                        vilkårType = Vilkår.BOSATT_I_RIKET,
+                                    ),
+                                )
+                            },
+                            lagAnnenVurdering = {
+                                setOf(
+                                    AnnenVurdering(personResultat = it, type = AnnenVurderingType.OPPLYSNINGSPLIKT, resultat = Resultat.OPPFYLT),
+                                )
+                            },
+                        )
+                    },
+                )
+
+            // Act
+            val erOpplysningspliktVilkårOppfylt = vilkårsvurdering.erOpplysningspliktVilkårOppfylt()
+
+            // Assert
+            assertThat(erOpplysningspliktVilkårOppfylt).isTrue()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
@@ -23,9 +23,11 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.Brevmal
+import no.nav.familie.ks.sak.kjerne.brev.hjemler.HjemmeltekstUtleder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.korrigertvedtak.KorrigertVedtakService
 import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
+import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -39,6 +41,7 @@ class GenererBrevServiceTest {
     val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk()
     val saksbehandlerContext: SaksbehandlerContext = mockk()
     val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
+    val unleashService = mockk<UnleashService>()
 
     val genererBrevService =
         GenererBrevService(
@@ -60,6 +63,8 @@ class GenererBrevServiceTest {
             opprettSammensattKontrollsakBrevDtoService = mockk<OpprettSammensattKontrollsakBrevDtoService>(),
             brevmalService = mockk<BrevmalService>(),
             andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>(),
+            hjemmeltekstUtleder = mockk<HjemmeltekstUtleder>(),
+            unleashService = unleashService,
         )
 
     private val søker = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen883HjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen883HjemlerKtTest.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.data.lagSanityBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EØSForordningen883HjemlerKtTest {
+    @Test
+    fun `skal returnere en tom liste om input er en tom liste`() {
+        // Act
+        val eøsForordningen883Hjemler = utledEØSForordningen883Hjemler(sanityBegrunnelser = emptyList())
+
+        // Assert
+        assertThat(eøsForordningen883Hjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal utlede EØS forordningen 883 hjemler`() {
+        // Arrange
+        val sanityEøsBegrunnelse1 =
+            lagSanityBegrunnelse(
+                apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.name,
+                hjemlerEøsForordningen883 = listOf("6", "4", "3"),
+            )
+
+        val sanityEøsBegrunnelse2 =
+            lagSanityBegrunnelse(
+                apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.name,
+                hjemlerEøsForordningen883 = listOf("2", "1", "6"),
+            )
+
+        val sanityBegrunnelser = listOf(sanityEøsBegrunnelse1, sanityEøsBegrunnelse2)
+
+        // Act
+        val eøsForordningen883Hjemler = utledEØSForordningen883Hjemler(sanityBegrunnelser = sanityBegrunnelser)
+
+        // Assert
+        assertThat(eøsForordningen883Hjemler).containsOnly("6", "4", "3", "2", "1")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen987HjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/EØSForordningen987HjemlerKtTest.kt
@@ -1,0 +1,96 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.data.lagSanityBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EØSForordningen987HjemlerKtTest {
+    @Test
+    fun `skal retunere en tom liste om sanity EØS begrunnelsene er en tom liste og refusjon EØS hjemmel ikke skal være med i brevet`() {
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityBegrunnelser = emptyList(),
+                refusjonEøsHjemmelSkalMedIBrev = false,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).isEmpty()
+    }
+
+    @Test
+    fun `skal retunere liste med refusjon EØS hjemmel som eneste innslag da sanity EØS begrunnelser er en tom liste`() {
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityBegrunnelser = emptyList(),
+                refusjonEøsHjemmelSkalMedIBrev = true,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).containsOnly("60")
+    }
+
+    @Test
+    fun `skal retunere en liste av hjemler uten refusjon EØS hjemmel `() {
+        // Arrange
+        val sanityEøsBegrunnelse1 =
+            lagSanityBegrunnelse(
+                apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.name,
+                hjemlerEøsForordningen987 = listOf("1", "3", "5"),
+            )
+        val sanityEøsBegrunnelse2 =
+            lagSanityBegrunnelse(
+                apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.name,
+                hjemlerEøsForordningen987 = listOf("4", "3", "6"),
+            )
+
+        val sanityEøsBegrunnelser =
+            listOf(
+                sanityEøsBegrunnelse1,
+                sanityEøsBegrunnelse2,
+            )
+
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityBegrunnelser = sanityEøsBegrunnelser,
+                refusjonEøsHjemmelSkalMedIBrev = false,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).containsOnly("1", "3", "5", "4", "6")
+    }
+
+    @Test
+    fun `skal retunere en liste av hjemler med refusjon EØS hjemmel `() {
+        // Arrange
+        val sanityEøsBegrunnelse1 =
+            lagSanityBegrunnelse(
+                apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.name,
+                hjemlerEøsForordningen987 = listOf("1", "3", "5"),
+            )
+        val sanityEøsBegrunnelse2 =
+            lagSanityBegrunnelse(
+                apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.name,
+                hjemlerEøsForordningen987 = listOf("4", "3", "6"),
+            )
+
+        val sanityEøsBegrunnelser =
+            listOf(
+                sanityEøsBegrunnelse1,
+                sanityEøsBegrunnelse2,
+            )
+
+        // Act
+        val hjemlerForEøsForordningen987 =
+            utledEØSForordningen987Hjemler(
+                sanityBegrunnelser = sanityEøsBegrunnelser,
+                refusjonEøsHjemmelSkalMedIBrev = true,
+            )
+
+        // Assert
+        assertThat(hjemlerForEøsForordningen987).containsOnly("1", "3", "5", "4", "6", "60")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/ForvaltningsloverHjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/ForvaltningsloverHjemlerKtTest.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ForvaltningsloverHjemlerKtTest {
+    @Test
+    fun `skal utlede forvaltningslover hjemler om vedtak korrigert hjemmel skal med i brev`() {
+        // Act
+        val forvaltningsloverHjemler = utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev = true)
+
+        // Assert
+        assertThat(forvaltningsloverHjemler).containsOnly("35")
+    }
+
+    @Test
+    fun `skal utlede forvaltningslover hjemler om vedtak korrigert hjemmel ikke skal med i brev`() {
+        // Act
+        val forvaltningsloverHjemler = utledForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev = false)
+
+        // Assert
+        assertThat(forvaltningsloverHjemler).isEmpty()
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemlerKombinatorKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemlerKombinatorKtTest.kt
@@ -1,0 +1,284 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class HjemlerKombinatorKtTest {
+    @Test
+    fun `skal retunere en tom liste om ingen hjemler blir sendt inn for kombinering`() {
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal kombinere hjemler kun separasjonsavtale storbritannia på bokmål`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("Separasjonsavtalen mellom Storbritannia og Norge artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere hjemler kun separasjonsavtale storbritannia på nynorsk`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun ordinære hjemler på bokmål`() {
+        // Arrange
+        val ordinæreHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = ordinæreHjemler,
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("kontantstøtteloven §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun ordinære hjemler på nynorsk`() {
+        // Arrange
+        val ordinæreHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = ordinæreHjemler,
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("kontantstøttelova §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 883 hjemler på bokmål`() {
+        // Arrange
+        val eøsForordningen883Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 883/2004 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 883 hjemler på nynorsk`() {
+        // Arrange
+        val eøsForordningen883Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 883/2004 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 987 hjemler på bokmål`() {
+        // Arrange
+        val eøsForordningen987Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 987/2009 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun eøs forordningen 987 hjemler på nynorsk`() {
+        // Arrange
+        val eøsForordningen987Hjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = emptyList(),
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("EØS-forordning 987/2009 artikkel 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun forvaltningsloven hjemler på bokmål`() {
+        // Arrange
+        val forvaltningslovenHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("forvaltningsloven §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere kun forvaltningsloven hjemler på nynorsk`() {
+        // Arrange
+        val forvaltningslovenHjemler = listOf("1", "3", "2")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = emptyList(),
+                ordinæreHjemler = emptyList(),
+                eøsForordningen883Hjemler = emptyList(),
+                eøsForordningen987Hjemler = emptyList(),
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsOnly("forvaltningslova §§ 1, 3 og 2")
+    }
+
+    @Test
+    fun `skal kombinere alle hjemler på bokmål`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "12")
+        val ordinæreHjemler = listOf("12")
+        val eøsForordningen883Hjemler = listOf("6")
+        val eøsForordningen987Hjemler = listOf("9000")
+        val forvaltningslovenHjemler = listOf("1337", "322", "644")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NB,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = ordinæreHjemler,
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsExactly(
+            "Separasjonsavtalen mellom Storbritannia og Norge artikkel 1, 3 og 12",
+            "kontantstøtteloven § 12",
+            "EØS-forordning 883/2004 artikkel 6",
+            "EØS-forordning 987/2009 artikkel 9000",
+            "forvaltningsloven §§ 1337, 322 og 644",
+        )
+    }
+
+    @Test
+    fun `skal kombinere alle hjemler på nynorsk`() {
+        // Arrange
+        val separasjonsavtaleStorbritanniaHjemler = listOf("1", "3", "12")
+        val ordinæreHjemler = listOf("12")
+        val eøsForordningen883Hjemler = listOf("6")
+        val eøsForordningen987Hjemler = listOf("9000")
+        val forvaltningslovenHjemler = listOf("1337", "322", "644")
+
+        // Act
+        val kombinerteHjemler =
+            kombinerHjemler(
+                målform = Målform.NN,
+                separasjonsavtaleStorbritanniaHjemler = separasjonsavtaleStorbritanniaHjemler,
+                ordinæreHjemler = ordinæreHjemler,
+                eøsForordningen883Hjemler = eøsForordningen883Hjemler,
+                eøsForordningen987Hjemler = eøsForordningen987Hjemler,
+                forvaltningslovenHjemler = forvaltningslovenHjemler,
+            )
+
+        // Assert
+        assertThat(kombinerteHjemler).containsExactly(
+            "Separasjonsavtalen mellom Storbritannia og Noreg artikkel 1, 3 og 12",
+            "kontantstøttelova § 12",
+            "EØS-forordning 883/2004 artikkel 6",
+            "EØS-forordning 987/2009 artikkel 9000",
+            "forvaltningslova §§ 1337, 322 og 644",
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemmeltekstUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/HjemmeltekstUtlederTest.kt
@@ -1,0 +1,735 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagEØSVedtaksbegrunnelse
+import no.nav.familie.ks.sak.data.lagSanityBegrunnelse
+import no.nav.familie.ks.sak.data.lagUtvidetVedtaksperiodeMedBegrunnelser
+import no.nav.familie.ks.sak.data.lagVedtaksbegrunnelse
+import no.nav.familie.ks.sak.data.lagVilkårsvurdering
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøsService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class HjemmeltekstUtlederTest {
+    private val vilkårsvurderingService = mockk<VilkårsvurderingService>()
+    private val personopplysningGrunnlagService = mockk<PersonopplysningGrunnlagService>()
+    private val refusjonEøsService = mockk<RefusjonEøsService>()
+    private val sanityService = mockk<SanityService>()
+    private val hjemmeltekstUtleder: HjemmeltekstUtleder =
+        HjemmeltekstUtleder(
+            vilkårsvurderingService = vilkårsvurderingService,
+            sanityService = sanityService,
+            personopplysningGrunnlagService = personopplysningGrunnlagService,
+            refusjonEøsService = refusjonEøsService,
+        )
+
+    @Test
+    fun `skal returnere sorterte hjemler`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4", "2", "10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+            )
+
+        // Act
+        val hentHjemmeltekst =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat("kontantstøtteloven §§ 2, 4, 10 og 11").isEqualTo(hentHjemmeltekst)
+    }
+
+    @Test
+    fun `skal ikke inkludere hjemmel 13 og 16 hvis opplysningsplikt er oppfylt`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4", "2", "10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("kontantstøtteloven §§ 2, 4, 10 og 11")
+    }
+
+    @Test
+    fun `skal inkludere hjemmel 13 og 16 hvis opplysningsplikt ikke er oppfylt`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.IKKE_OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4", "2", "10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("kontantstøtteloven §§ 2, 4, 10, 11, 13 og 16")
+    }
+
+    @Test
+    fun `skal inkludere EØS-forordning 987 artikkel 60 hvis det eksisterer eøs refusjon på behandlingen`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns true
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns emptyList()
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = emptyList(),
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("EØS-forordning 987/2009 artikkel 60")
+    }
+
+    @Test
+    fun `skal gi riktig formattering ved hjemler fra kontantstøtteloven og 2 EØS-forordninger`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                    hjemler = listOf("4"),
+                    hjemlerEøsForordningen883 = listOf("11-16"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11"),
+                    hjemlerEøsForordningen987 = listOf("58", "60"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("kontantstøtteloven §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 11-16 og EØS-forordning 987/2009 artikkel 58 og 60")
+    }
+
+    @Test
+    fun `skal gi riktig formattering ved hjemler fra Separasjonsavtale og to EØS-forordninger`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                    hjemler = listOf("4"),
+                    hjemlerEøsForordningen883 = listOf("11-16"),
+                    hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11"),
+                    hjemlerEøsForordningen987 = listOf("58", "60"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Arrange
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Norge artikkel 29, kontantstøtteloven §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 11-16 og EØS-forordning 987/2009 artikkel 58 og 60")
+    }
+
+    @Test
+    fun `skal gi riktig formattering ved nynorsk og hjemler fra Separasjonsavtale og to EØS-forordninger`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                    hjemler = listOf("4"),
+                    hjemlerEøsForordningen883 = listOf("11-16"),
+                    hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11"),
+                    hjemlerEøsForordningen987 = listOf("58", "60"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, kontantstøttelova §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 11-16 og EØS-forordning 987/2009 artikkel 58 og 60")
+    }
+
+    @Test
+    fun `skal slå sammen hjemlene riktig når det er 3 eller flere hjemler på 'siste' hjemmeltype`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                    hjemler = listOf("4"),
+                    hjemlerEøsForordningen883 = listOf("2", "11-16", "67", "68"),
+                    hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, kontantstøttelova §§ 4, 10 og 11 og EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68")
+    }
+
+    @Test
+    fun `skal kun ta med en hjemmel 1 gang hvis flere begrunnelser er knyttet til samme hjemmel`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_SATSENDRING.sanityApiNavn,
+                    hjemler = listOf("10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_ALENEANSVAR.sanityApiNavn,
+                    hjemler = listOf("4"),
+                    hjemlerEøsForordningen883 = listOf("2", "11-16", "67", "68"),
+                    hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                    hjemlerEøsForordningen987 = listOf("58"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BEGGE_FORELDRE_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11"),
+                    hjemlerEøsForordningen883 = listOf("2", "67", "68"),
+                    hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                    hjemlerEøsForordningen987 = listOf("58"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = false,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo("Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, kontantstøttelova §§ 4, 10 og 11, EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68 og EØS-forordning 987/2009 artikkel 58")
+    }
+
+    @Test
+    fun `skal utlede hjemmeltekst for alle hjemler på bokmål`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns true
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4", "2", "10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.sanityApiNavn,
+                    hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                    hjemler = listOf("1"),
+                    hjemlerEøsForordningen883 = listOf("2", "11-16", "67", "68"),
+                    hjemlerEøsForordningen987 = listOf("58"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = true,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo(
+            "Separasjonsavtalen mellom Storbritannia og Norge artikkel 29, " +
+                "kontantstøtteloven §§ 1, 2, 4, 10 og 11, " +
+                "EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68, " +
+                "EØS-forordning 987/2009 artikkel 58 og 60 og forvaltningsloven § 35",
+        )
+    }
+
+    @Test
+    fun `skal utlede hjemmeltekst for alle hjemler på nynorsk`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        val vedtaksperioderMedBegrunnelser =
+            listOf(
+                lagUtvidetVedtaksperiodeMedBegrunnelser(
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE).map { lagVedtaksbegrunnelse(it) },
+                    eøsBegrunnelser = listOf(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD).map { lagEØSVedtaksbegrunnelse(it) },
+                ),
+            )
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns true
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NN
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every {
+            sanityService.hentSanityBegrunnelser()
+        } returns
+            listOf(
+                lagSanityBegrunnelse(
+                    apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
+                    hjemler = listOf("11", "4", "2", "10"),
+                ),
+                lagSanityBegrunnelse(
+                    apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.sanityApiNavn,
+                    hjemlerSeperasjonsavtalenStorbritannina = listOf("29"),
+                    hjemler = listOf("1"),
+                    hjemlerEøsForordningen883 = listOf("2", "11-16", "67", "68"),
+                    hjemlerEøsForordningen987 = listOf("58"),
+                ),
+            )
+
+        // Act
+        val hjemler =
+            hjemmeltekstUtleder.utledHjemmeltekst(
+                behandlingId = behandling.id,
+                vedtakKorrigertHjemmelSkalMedIBrev = true,
+                utvidetVedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser,
+            )
+
+        // Assert
+        assertThat(hjemler).isEqualTo(
+            "Separasjonsavtalen mellom Storbritannia og Noreg artikkel 29, " +
+                "kontantstøttelova §§ 1, 2, 4, 10 og 11, " +
+                "EØS-forordning 883/2004 artikkel 2, 11-16, 67 og 68, " +
+                "EØS-forordning 987/2009 artikkel 58 og 60 og forvaltningslova § 35",
+        )
+    }
+
+    @Test
+    fun `skal kaste exception om ingen hjemmeltekst blir utledet`() {
+        // Arrange
+        val søker = randomAktør()
+
+        val behandling = lagBehandling()
+
+        every { refusjonEøsService.harRefusjonEøsPåBehandling(behandlingId = behandling.id) } returns false
+        every { personopplysningGrunnlagService.hentSøkersMålform(behandlingId = behandling.id) } returns Målform.NB
+
+        every {
+            vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id)
+        } returns
+            lagVilkårsvurdering(
+                søkerAktør = søker,
+                behandling = behandling,
+                resultat = Resultat.OPPFYLT,
+            )
+
+        every { sanityService.hentSanityBegrunnelser() } returns emptyList()
+
+        // Act & assert
+        val exception =
+            assertThrows<FunksjonellFeil> {
+                hjemmeltekstUtleder.utledHjemmeltekst(
+                    behandlingId = behandling.id,
+                    utvidetVedtaksperioderMedBegrunnelser = emptyList(),
+                )
+            }
+        assertThat(exception.message).isEqualTo(
+            "Ingen hjemler var knyttet til begrunnelsen(e) som er valgt. " +
+                "Du må velge minst én begrunnelse som er knyttet til en hjemmel.",
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/OrdinæreHjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/OrdinæreHjemlerKtTest.kt
@@ -1,0 +1,89 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.data.lagSanityBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OrdinæreHjemlerKtTest {
+    @Test
+    fun `skal utlede en tom liste om ingen hjemler skal inkluderes`() {
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = emptyList(),
+                opplysningspliktHjemlerSkalMedIBrev = false,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal utlede ordinære hjemler for sanity begrunnelser`() {
+        // Arrange
+        val sanityBegrunnelse = lagSanityBegrunnelse(apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.name, hjemler = listOf("1", "3", "2"))
+
+        val sanityBegrunnelser = listOf(sanityBegrunnelse)
+
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = sanityBegrunnelser,
+                opplysningspliktHjemlerSkalMedIBrev = false,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("1", "3", "2")
+    }
+
+    @Test
+    fun `skal utlede ordinære hjemler for sanity eøs begrunnelser`() {
+        // Arrange
+        val sanityBegrunnelse = lagSanityBegrunnelse(apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.name, hjemler = listOf("1", "3", "2"))
+
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = listOf(sanityBegrunnelse),
+                opplysningspliktHjemlerSkalMedIBrev = false,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("1", "3", "2")
+    }
+
+    @Test
+    fun `skal utlede opplysningsplikt hjemmel`() {
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = emptyList(),
+                opplysningspliktHjemlerSkalMedIBrev = true,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("13", "16")
+    }
+
+    @Test
+    fun `skal utlede alle ordinære hjemler`() {
+        // Arrange
+        val sanityBegrunnelse = lagSanityBegrunnelse(apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.name, hjemler = listOf("1", "3", "2"))
+
+        val sanityEøsBegrunnelse = lagSanityBegrunnelse(apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.name, hjemler = listOf("1", "6", "2"))
+
+        val sanityBegrunnelser = listOf(sanityBegrunnelse, sanityEøsBegrunnelse)
+
+        // Act
+        val ordinæreHjemler =
+            utledOrdinæreHjemler(
+                sanityBegrunnelser = sanityBegrunnelser,
+                opplysningspliktHjemlerSkalMedIBrev = true,
+            )
+
+        // Assert
+        assertThat(ordinæreHjemler).containsOnly("1", "2", "3", "6", "13", "16")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemlerKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/hjemler/SeparasjonsavtaleStorbritanniaHjemlerKtTest.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ks.sak.kjerne.brev.hjemler
+
+import no.nav.familie.ks.sak.data.lagSanityBegrunnelse
+import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.EØSBegrunnelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SeparasjonsavtaleStorbritanniaHjemlerKtTest {
+    @Test
+    fun `skal returnere en tom liste når sanity eøs begrunnelser er tom`() {
+        // Act
+        val seprasjonsavtaleStorbritanniaHjemler =
+            utledSeprasjonsavtaleStorbritanniaHjemler(
+                sanityBegrunnelser = emptyList(),
+            )
+
+        // Assert
+        assertThat(seprasjonsavtaleStorbritanniaHjemler).isEmpty()
+    }
+
+    @Test
+    fun `skal utlede seprasjonsavtale for storbritannia hjemler`() {
+        // Arrange
+        val sanityEøsBegrunnelse =
+            lagSanityBegrunnelse(
+                apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_STANDARD.name,
+                hjemlerSeperasjonsavtalenStorbritannina = listOf("1", "4", "3", "4"),
+            )
+
+        val sanityEØSBegrunnelser = listOf(sanityEøsBegrunnelse)
+
+        // Act
+        val seprasjonsavtaleStorbritanniaHjemler =
+            utledSeprasjonsavtaleStorbritanniaHjemler(
+                sanityBegrunnelser = sanityEØSBegrunnelser,
+            )
+
+        // Assert
+        assertThat(seprasjonsavtaleStorbritanniaHjemler).containsOnly("1", "4", "3")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagServiceTest.kt
@@ -115,6 +115,7 @@ internal class PersonopplysningGrunnlagServiceTest {
                 barnAktør = listOf(barnAktør),
                 barnasIdenter = listOf(barnAktør.aktivFødselsnummer()),
             )
+        every { personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(any()) } returns personopplysningGrunnlag
         every { personopplysningGrunnlagRepository.findByBehandlingAndAktiv(any()) } returns personopplysningGrunnlag
         every { personopplysningGrunnlagRepository.save(any()) } returns personopplysningGrunnlag
         every { personopplysningGrunnlagRepository.saveAndFlush(any()) } returns personopplysningGrunnlag


### PR DESCRIPTION
Favro: [NAV-23470](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23470)

### 💰 Hva skal gjøres, og hvorfor?
Forenkler logikken ved å trekke ut hjemler i en egen pakke. Fordeler logikken ut over flere filer. Skriver enhetstester for den "nye" logikken. Den "nye" logikken skal i teorien produsere samme resultat som den forrige. Hensikten her er utelukkende å gjøre koden mer oversiktlig og lettere å teste. 

Toggle for å skru av/på refaktorert logikk slik at det kan merges uten å testes først. 

Toggle: https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-sak.bruk_omskriving_av_hjemler_i_brev

Når toggle fjernes kan man fjerne mye "gammel" kode.

Tilsvarende PR i ba-sak: https://github.com/navikt/familie-ba-sak/pull/4928

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

