### PR TITLE
Legg til kalkulert utbetalingsbeløp for ordinær andel i utbetalingsmåned for overgangsordning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -9,12 +9,15 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.kontrakter.felles.oppdrag.Opphør
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.ks.sak.common.util.MånedPeriode
+import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
 import no.nav.familie.ks.sak.kjerne.beregning.domene.overgangsordningAndelerPerAktør
 import no.nav.familie.ks.sak.kjerne.beregning.domene.totalKalkulertUtbetalingsbeløpForPeriode
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.time.YearMonth
@@ -74,7 +77,7 @@ class UtbetalingsoppdragGenerator {
         val ordinæreAndeler = this.ordinæreAndelertilAndelDataLongId()
         val overgangsordningAndeler =
             when (skalSendeOvergangsordningAndeler) {
-                true -> this.overgangsordningAndelerTilAndelDataLongId()
+                true -> this.overgangsordningAndelerOgOrdinærForOvergangsordningUtbetalingsmånedTilAndelDataLongId()
                 false -> emptyList()
             }
         return ordinæreAndeler + overgangsordningAndeler
@@ -86,13 +89,17 @@ class UtbetalingsoppdragGenerator {
             .ordinæreAndeler()
             .map { it.tilAndelDataLongId() }
 
-    private fun TilkjentYtelse.overgangsordningAndelerTilAndelDataLongId(): List<AndelDataLongId> =
-        this
+    private fun TilkjentYtelse.overgangsordningAndelerOgOrdinærForOvergangsordningUtbetalingsmånedTilAndelDataLongId(): List<AndelDataLongId> {
+        val ordinærAndelerPerBarnIOvergangsordningUtbetalingsmåned =
+            ordinæreAndelerPerBarnIOvergangsordningUtbetalingMåned()
+        return this
             .andelerTilkjentYtelse
             .overgangsordningAndelerPerAktør()
             .map { (aktør, overgangsordningAndeler) ->
                 val førsteAndel = overgangsordningAndeler.minBy { it.stønadFom }
-                val kalkulertUtbetalingsbeløp = overgangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() }
+                val kalkulertUtbetalingsbeløp =
+                    overgangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() } +
+                        (ordinærAndelerPerBarnIOvergangsordningUtbetalingsmåned[aktør]?.kalkulertUtbetalingsbeløp ?: 0)
                 AndelDataLongId(
                     id = førsteAndel.id,
                     fom = OVERGANGSORDNING_UTBETALINGSMÅNED,
@@ -104,6 +111,17 @@ class UtbetalingsoppdragGenerator {
                     forrigePeriodeId = førsteAndel.forrigePeriodeOffset,
                     kildeBehandlingId = førsteAndel.kildeBehandlingId,
                 )
+            }
+    }
+
+    private fun TilkjentYtelse.ordinæreAndelerPerBarnIOvergangsordningUtbetalingMåned(): Map<Aktør, AndelTilkjentYtelse?> =
+        andelerTilkjentYtelse
+            .ordinæreAndeler()
+            .groupBy { it.aktør }
+            .mapValues { (_, andeler) ->
+                andeler.find { andel ->
+                    andel.periode.overlapperHeltEllerDelvisMed(MånedPeriode(OVERGANGSORDNING_UTBETALINGSMÅNED, OVERGANGSORDNING_UTBETALINGSMÅNED))
+                }
             }
 }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Det ble oppdaget en bug i behandlinger for overgangsordning der utbetalingsoppdraget for overgangsordning overskriver ordinær utbetalingsoppdrag i utbetalingsmåneden for overgangsordningen. Fikser dette ved å inkludere `kalkulertUtbetalingsbeløp` for ordinær andel i utbetalingsandelen til overgangsordning.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
