### PR TITLE
Endre utbetalingsdato for overgangsordning til desember 2024

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -23,7 +23,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 const val FAGSYSTEM = "KS"
-val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 10) // TODO: skal være 24/12
+val OVERGANGSORDNING_UTBETALINGSMÅNED = YearMonth.of(2024, 12)
 
 @Component
 class UtbetalingsoppdragGenerator {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -805,7 +805,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                 ).utbetalingsoppdrag
 
         assertThat(utbetalingsoppdrag.kodeEndring, Is(Utbetalingsoppdrag.KodeEndring.ENDR))
-        assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(1))
+        assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(3))
 
         val forventetUtbetalingsbeløp =
             tilkjentYtelsenyBehandling.andelerTilkjentYtelse.let { andeler ->
@@ -815,18 +815,19 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         assertThat(
             "Sats på utbetalingsperiode var feil: ${utbetalingsoppdrag.utbetalingsperiode.map { it.sats }}",
-            utbetalingsoppdrag.utbetalingsperiode[0].sats.toInt(),
-            Is(forventetUtbetalingsbeløp),
+            utbetalingsoppdrag.utbetalingsperiode.any {
+                it.sats.toInt() == forventetUtbetalingsbeløp
+            },
+            Is(true),
         )
         assertThat(
             utbetalingsoppdrag.utbetalingsperiode.all { it.utbetalesTil == aktør.aktivFødselsnummer() },
             Is(true),
         )
 
-        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].vedtakdatoFom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().førsteDagIInneværendeMåned()))
-        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].vedtakdatoTom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().sisteDagIMåned()))
-        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].periodeId, Is(1))
-        assertThat(utbetalingsoppdrag.utbetalingsperiode[0].forrigePeriodeId, Is(0))
+        val utbetalingOvergangsordning = utbetalingsoppdrag.utbetalingsperiode.first { it.sats.toInt() == forventetUtbetalingsbeløp }
+        assertThat(utbetalingOvergangsordning.vedtakdatoFom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().førsteDagIInneværendeMåned()))
+        assertThat(utbetalingOvergangsordning.vedtakdatoTom, Is(OVERGANGSORDNING_UTBETALINGSMÅNED.toLocalDate().sisteDagIMåned()))
     }
 
     private fun TilkjentYtelse.tilAndelerMedOppdatertOffset(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/stønadsstatistikk/StønadsstatistikkServiceTest.kt
@@ -272,7 +272,7 @@ internal class StønadsstatistikkServiceTest {
                     it.stønadTom in LocalDate.of(2024, 8, 1)..LocalDate.of(2025, 2, 28)
             }
 
-        assertThat(utbetalingsperioderAugTilFeb.size).isEqualTo(3)
+        assertThat(utbetalingsperioderAugTilFeb.size).isEqualTo(4)
 
         val utbetalingerForBarn1IAugTilFeb =
             utbetalingsperioderAugTilFeb.filter {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Utbetalingsmåned for overgangsordning skal være desember 2024
