### PR TITLE
NAV-23470: Legger til logikk for overgangsordning i HjemmeltekstUtleder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevUtil.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 const val HJEMMEL_60_EØS_FORORDNINGEN_987 = "60"
 const val FORVALTINIGSLOVEN_PARAGRAF_35 = "35"
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 fun hentHjemmeltekst(
     sanitybegrunnelserBruktIBrev: List<SanityBegrunnelse>,
     opplysningspliktHjemlerSkalMedIBrev: Boolean = false,
@@ -47,6 +48,7 @@ fun hentHjemmeltekst(
     return slåSammenHjemlerAvUlikeTyper(alleHjemlerOgTekstForBegrunnelser)
 }
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 private fun hentHjemlerForEøsForordningen987(
     begrunnelser: List<SanityBegrunnelse>,
     refusjonEøsHjemmelSkalMedIBrev: Boolean,
@@ -62,6 +64,7 @@ private fun hentHjemlerForEøsForordningen987(
     return hjemler.distinct()
 }
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 fun hentForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev: Boolean): List<String> =
     if (vedtakKorrigertHjemmelSkalMedIBrev) {
         listOf(FORVALTINIGSLOVEN_PARAGRAF_35)
@@ -69,6 +72,7 @@ fun hentForvaltningsloverHjemler(vedtakKorrigertHjemmelSkalMedIBrev: Boolean): L
         emptyList()
     }
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 private fun slåSammenHjemlerAvUlikeTyper(hjemler: List<String>) =
     when (hjemler.size) {
         0 -> throw FunksjonellFeil("Ingen hjemler var knyttet til begrunnelsen(e) som er valgt. Du må velge minst én begrunnelse som er knyttet til en hjemmel.")
@@ -76,6 +80,7 @@ private fun slåSammenHjemlerAvUlikeTyper(hjemler: List<String>) =
         else -> slåSammenListeMedHjemler(hjemler)
     }
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 private fun slåSammenListeMedHjemler(hjemler: List<String>): String =
     hjemler.reduceIndexed { index, acc, s ->
         when (index) {
@@ -85,6 +90,7 @@ private fun slåSammenListeMedHjemler(hjemler: List<String>): String =
         }
     }
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 private fun hentAlleTyperHjemler(
     ordinæreHjemler: List<String>,
     målform: Målform,
@@ -147,6 +153,7 @@ private fun hentAlleTyperHjemler(
     return alleHjemlerForBegrunnelser
 }
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 fun hjemlerTilHjemmeltekst(
     hjemler: List<String>,
     lovForHjemmel: String,
@@ -160,6 +167,7 @@ fun hjemlerTilHjemmeltekst(
         else -> "§§ ${slåSammen(hjemler)}"
     }
 
+@Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
 private fun hentOrdinæreHjemler(
     hjemler: MutableSet<String>,
     opplysningspliktHjemlerSkalMedIBrev: Boolean,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -329,6 +329,7 @@ class GenererBrevService(
         )
     }
 
+    @Deprecated("Refaktorert til ny kode med toggle, se HjemmeltekstUtleder")
     private fun hentHjemler(
         behandlingId: Long,
         utvidetVedtaksperioderMedBegrunnelser: List<UtvidetVedtaksperiodeMedBegrunnelser>,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23470

Legger til logikk som har blitt introdusert etter man gjorde refaktoreringen.

Legger til `@Deprectated` for å tydeligjøre at gammel kode er refaktorert og vil bli slettet i fremtiden. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
