### PR TITLE
Tillat utbetaling over 100% i én måned mellom august 2024 og januar 2025

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
@@ -95,6 +95,8 @@ fun MånedPeriode.erMellom(annenPeriode: MånedPeriode) = annenPeriode.inkludere
 
 fun MånedPeriode.antallMåneder(): Int = fom.until(tom, ChronoUnit.MONTHS).toInt() + 1
 
+fun MånedPeriode.månederIPeriode(): List<YearMonth> = generateSequence(fom) { it.plusMonths(1) }.takeWhile { it <= tom }.toList()
+
 fun LocalDate.førsteDagINesteMåned() = this.plusMonths(1).withDayOfMonth(1)
 
 fun erBack2BackIMånedsskifte(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -4,6 +4,9 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.exception.KONTAKT_TEAMET_SUFFIX
 import no.nav.familie.ks.sak.common.exception.UtbetalingsikkerhetFeil
+import no.nav.familie.ks.sak.common.util.MånedPeriode
+import no.nav.familie.ks.sak.common.util.inkluderer
+import no.nav.familie.ks.sak.common.util.månederIPeriode
 import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
@@ -144,7 +147,7 @@ object TilkjentYtelseValidator {
                     .flatMap { it.andelerTilkjentYtelse }
                     .filter { it.aktør == barn.aktør }
 
-            if (erOverlappAvAndeler(
+            if (erUgyldigOverlappAvAndeler(
                     andeler = andeler,
                     andelerFraAndreBehandlinger = barnsAndelerFraAndreBehandlinger,
                 )
@@ -164,16 +167,27 @@ object TilkjentYtelseValidator {
         }
     }
 
-    private fun erOverlappAvAndeler(
+    private fun erUgyldigOverlappAvAndeler(
         andeler: List<AndelTilkjentYtelse>,
         andelerFraAndreBehandlinger: List<AndelTilkjentYtelse>,
-    ): Boolean =
-        andeler.any { andelTilkjentYtelse ->
-            andelerFraAndreBehandlinger.any {
-                andelTilkjentYtelse.overlapperMed(it) &&
-                    andelTilkjentYtelse.prosent + it.prosent > BigDecimal(100)
-            }
+    ): Boolean {
+        val overlappendeMåneder =
+            andeler
+                .flatMap { andel -> andel.periode.månederIPeriode().map { it to andel.prosent } }
+                .filter { (måned, prosent) ->
+                    andelerFraAndreBehandlinger.any { andelFraAnnenBehandling ->
+                        andelFraAnnenBehandling.periode.inkluderer(måned) &&
+                            prosent + andelFraAnnenBehandling.prosent > BigDecimal(100)
+                    }
+                }.map { it.first }
+
+        val periodeMedTillatOverlappÉnMåned = MånedPeriode(YearMonth.of(2024, 8), YearMonth.of(2025, 1))
+        return when {
+            overlappendeMåneder.isEmpty() -> false
+            overlappendeMåneder.size > 1 -> true
+            else -> !periodeMedTillatOverlappÉnMåned.inkluderer(overlappendeMåneder.first())
         }
+    }
 
     fun finnAktørIderMedUgyldigEtterbetalingsperiode(
         forrigeAndelerTilkjentYtelse: List<AndelTilkjentYtelse>?,


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23518

I perioden fom august 2024 tom januar 2025 skal det være mulig at begge foreldre har overlappende utbetaling av kontantstøtte i én måned

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
