### PR TITLE
Fiks logging issues ks sak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/KafkaConfig.kt
@@ -100,7 +100,7 @@ class KafkaConfig(
                 "specific.avro.reader" to true,
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to KafkaAvroDeserializer::class.java,
-                ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ks-sak-2",
+                ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ks-sak-1",
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
             )
         return consumerConfigs.toMap() + securityConfig()
@@ -146,7 +146,7 @@ class KafkaConfig(
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
             ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
             ConsumerConfig.GROUP_ID_CONFIG to "familie-ks-sak",
-            ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ks-sak-1",
+            ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ks-sak-3",
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "latest",
             CommonClientConfigs.RETRIES_CONFIG to 10,
             CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG to 100,
@@ -158,7 +158,7 @@ class KafkaConfig(
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
             ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
             ConsumerConfig.GROUP_ID_CONFIG to "familie-ks-sak",
-            ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ks-sak-1",
+            ConsumerConfig.CLIENT_ID_CONFIG to "consumer-familie-ks-sak-4",
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
             CommonClientConfigs.RETRIES_CONFIG to 10,
             CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG to 100,

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -48,7 +48,6 @@
     <root level="${ROOT_LOG_LEVEL:-INFO}">
         <!-- nais+local -->
         <appender-ref ref="stdout_json"/>
-        <Appender-ref ref="SENTRY"/>
     </root>
 
     <logger name="no.nav" level="WARN"/>


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23564

Logging i familie-ks-sak har vært dårlig en stund, både i prod og preprod.

1. Det spammes masse av disse meldingene (se frekvensen 😱):
<img width="1223" alt="spam" src="https://github.com/user-attachments/assets/0b360130-2f9b-4bc6-8b02-32b066e52d70">

2. Vanlig logging i preprod fungerer ikke.

LØSNING

1. Vi spammes ned av open-telemtry logger siden vi bruker samme kafka clientID på flere topic. Nummerer dem derfor i c2f1c172115a98e2e0352cf804437ee8c42e0c40, og resultatet blir stillhet:
<img width="859" alt="silence" src="https://github.com/user-attachments/assets/b6cb3f69-116b-4a33-9042-d81d8fcc0290">

2. Vanlig logging i preprod fungerer ikke. Greide å finne ut når nøyaktig dette skjedde, og det skjer nøyaktig etter at vi fjerner sentry config fra ks-sak i https://github.com/navikt/familie-ks-sak/pull/949:
<img width="1466" alt="sentry" src="https://github.com/user-attachments/assets/f652e42b-cd3d-443c-85fc-ef1709f10d6d">
Løsningen blir å slette SENTRY som appender i logback fila, da den ikke lenger brukes. Resultatet blir at loggene kommer tilbake i preprod. Utføres i a41678e9d3f663437a6290df6e4581cad6086ca4

<img width="1394" alt="fix" src="https://github.com/user-attachments/assets/194caeb5-3f34-4cbc-a2ac-ebeda16589df">

