### PR TITLE
Vi legger til mekanisme for å filtrere ut begrunnelser som ikke er i bruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityService.kt
@@ -15,7 +15,10 @@ class SanityService(
         try {
             cachedSanityKlient
                 .hentSanityBegrunnelserCached()
-                .also { sanityBegrunnelse -> sanityBegrunnelseCache = sanityBegrunnelse }
+                .filter { !it.ikkeIBruk }
+                .also { sanityBegrunnelse ->
+                    sanityBegrunnelseCache = sanityBegrunnelse
+                }
         } catch (e: Exception) {
             if (sanityBegrunnelseCache.isEmpty()) {
                 throw e

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/domene/SanityBegrunnelse.kt
@@ -27,6 +27,7 @@ data class SanityBegrunnelse(
     val endretUtbetalingsperiode: List<EndretUtbetalingsperiodeTrigger>,
     val støtterFritekst: Boolean,
     val skalAlltidVises: Boolean,
+    val ikkeIBruk: Boolean,
     // EØS
     val annenForeldersAktivitet: List<KompetanseAktivitet> = emptyList(),
     val barnetsBostedsland: List<BarnetsBostedsland> = emptyList(),
@@ -121,6 +122,7 @@ data class SanityBegrunnelseDto(
     val hjemler: List<String> = emptyList(),
     val stotterFritekst: Boolean?,
     val skalAlltidVises: Boolean?,
+    val ikkeIBruk: Boolean?,
     val annenForeldersAktivitet: List<String> = emptyList(),
     val barnetsBostedsland: List<String> = emptyList(),
     val kompetanseResultat: List<String> = emptyList(),
@@ -157,6 +159,7 @@ data class SanityBegrunnelseDto(
                 },
             støtterFritekst = stotterFritekst ?: false,
             skalAlltidVises = skalAlltidVises ?: false,
+            ikkeIBruk = ikkeIBruk ?: false,
             annenForeldersAktivitet = annenForeldersAktivitet.mapNotNull { finnEnumverdi(it, KompetanseAktivitet.entries, apiNavn) },
             barnetsBostedsland = barnetsBostedsland.mapNotNull { finnEnumverdi(it, BarnetsBostedsland.entries, apiNavn) },
             kompetanseResultat = kompetanseResultat.mapNotNull { finnEnumverdi(it, KompetanseResultat.entries, apiNavn) },

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -1287,6 +1287,7 @@ fun lagSanityBegrunnelse(
         endretUtbetalingsperiode = emptyList(),
         støtterFritekst = støtterFritekst,
         skalAlltidVises = false,
+        ikkeIBruk = false,
         resultat = resultat,
         hjemlerEØSForordningen883 = hjemlerEøsForordningen883,
         hjemlerEØSForordningen987 = hjemlerEøsForordningen987,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityServiceTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -23,10 +22,6 @@ class SanityServiceTest {
     @InjectMockKs
     private lateinit var sanityService: SanityService
 
-    @BeforeEach
-    fun setUp() {
-    }
-
     @Test
     fun `Skal hente SanityBegrunnelser`() {
         every { cachedSanityKlient.hentSanityBegrunnelserCached() } returns
@@ -35,7 +30,7 @@ class SanityServiceTest {
                     NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE.sanityApiNavn,
                     "innvilgetIkkeBarnehage",
                     SanityBegrunnelseType.STANDARD,
-                    Vilkår.values().toList(),
+                    Vilkår.entries,
                     rolle = emptyList(),
                     triggere = emptyList(),
                     utdypendeVilkårsvurderinger = emptyList(),
@@ -44,11 +39,37 @@ class SanityServiceTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     resultat = SanityResultat.INNVILGET,
                 ),
             )
 
         assertThat(sanityService.hentSanityBegrunnelser()).hasSize(1)
+    }
+
+    @Test
+    fun `Skal ikke returnere SanityBegrunnelser som er markert ikke i bruk`() {
+        every { cachedSanityKlient.hentSanityBegrunnelserCached() } returns
+            listOf(
+                SanityBegrunnelse(
+                    NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE.sanityApiNavn,
+                    "innvilgetIkkeBarnehage",
+                    SanityBegrunnelseType.STANDARD,
+                    Vilkår.entries,
+                    rolle = emptyList(),
+                    triggere = emptyList(),
+                    utdypendeVilkårsvurderinger = emptyList(),
+                    hjemler = emptyList(),
+                    endretUtbetalingsperiode = emptyList(),
+                    endringsårsaker = emptyList(),
+                    støtterFritekst = false,
+                    skalAlltidVises = false,
+                    ikkeIBruk = true,
+                    resultat = SanityResultat.INNVILGET,
+                ),
+            )
+
+        assertThat(sanityService.hentSanityBegrunnelser()).isEmpty()
     }
 
     @Test
@@ -67,7 +88,7 @@ class SanityServiceTest {
                     NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE.sanityApiNavn,
                     "innvilgetIkkeBarnehage",
                     SanityBegrunnelseType.STANDARD,
-                    Vilkår.values().toList(),
+                    Vilkår.entries,
                     rolle = emptyList(),
                     triggere = emptyList(),
                     utdypendeVilkårsvurderinger = emptyList(),
@@ -76,6 +97,7 @@ class SanityServiceTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     resultat = SanityResultat.INNVILGET,
                 ),
             ) andThenThrows RuntimeException("Feil får å teste cachet versjon")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -193,6 +193,7 @@ class VilkårsvurderingServiceTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     resultat = SanityResultat.INNVILGET,
                 ),
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -288,6 +288,7 @@ class BegrunnelserForPeriodeContextTest {
                 endringsårsaker = emptyList(),
                 støtterFritekst = false,
                 skalAlltidVises = false,
+                ikkeIBruk = false,
                 resultat = SanityResultat.INNVILGET,
             )
         val personResultatBarn =
@@ -365,6 +366,7 @@ class BegrunnelserForPeriodeContextTest {
                     endretUtbetalingsperiode = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     resultat = SanityResultat.INNVILGET,
                 ),
             )
@@ -443,6 +445,7 @@ class BegrunnelserForPeriodeContextTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     annenForeldersAktivitet = listOf(KompetanseAktivitet.ARBEIDER),
                     barnetsBostedsland = listOf(BarnetsBostedsland.NORGE),
                     kompetanseResultat = listOf(KompetanseResultat.NORGE_ER_PRIMÆRLAND),
@@ -483,6 +486,7 @@ class BegrunnelserForPeriodeContextTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     annenForeldersAktivitet = listOf(KompetanseAktivitet.ARBEIDER),
                     barnetsBostedsland = listOf(BarnetsBostedsland.NORGE),
                     kompetanseResultat = listOf(KompetanseResultat.NORGE_ER_PRIMÆRLAND),
@@ -523,6 +527,7 @@ class BegrunnelserForPeriodeContextTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     annenForeldersAktivitet = listOf(KompetanseAktivitet.ARBEIDER),
                     barnetsBostedsland = listOf(BarnetsBostedsland.NORGE),
                     kompetanseResultat = listOf(KompetanseResultat.NORGE_ER_PRIMÆRLAND),
@@ -564,6 +569,7 @@ class BegrunnelserForPeriodeContextTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     annenForeldersAktivitet = listOf(KompetanseAktivitet.ARBEIDER),
                     barnetsBostedsland = listOf(BarnetsBostedsland.NORGE),
                     kompetanseResultat = listOf(KompetanseResultat.NORGE_ER_PRIMÆRLAND),
@@ -609,6 +615,7 @@ class BegrunnelserForPeriodeContextTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     annenForeldersAktivitet = listOf(KompetanseAktivitet.ARBEIDER),
                     barnetsBostedsland = listOf(BarnetsBostedsland.NORGE),
                     kompetanseResultat = listOf(KompetanseResultat.NORGE_ER_PRIMÆRLAND),
@@ -653,6 +660,7 @@ class BegrunnelserForPeriodeContextTest {
                     endringsårsaker = emptyList(),
                     støtterFritekst = false,
                     skalAlltidVises = false,
+                    ikkeIBruk = false,
                     annenForeldersAktivitet = listOf(KompetanseAktivitet.ARBEIDER),
                     barnetsBostedsland = listOf(BarnetsBostedsland.NORGE),
                     kompetanseResultat = listOf(KompetanseResultat.NORGE_ER_PRIMÆRLAND),
@@ -694,6 +702,7 @@ class BegrunnelserForPeriodeContextTest {
                 endringsårsaker = emptyList(),
                 støtterFritekst = false,
                 skalAlltidVises = false,
+                ikkeIBruk = false,
                 resultat = SanityResultat.INNVILGET,
             ),
             SanityBegrunnelse(
@@ -709,6 +718,7 @@ class BegrunnelserForPeriodeContextTest {
                 endringsårsaker = emptyList(),
                 støtterFritekst = false,
                 skalAlltidVises = false,
+                ikkeIBruk = false,
                 resultat = SanityResultat.INNVILGET,
             ),
             SanityBegrunnelse(
@@ -724,6 +734,7 @@ class BegrunnelserForPeriodeContextTest {
                 endringsårsaker = emptyList(),
                 støtterFritekst = false,
                 skalAlltidVises = false,
+                ikkeIBruk = false,
                 resultat = SanityResultat.INNVILGET,
             ),
             SanityBegrunnelse(
@@ -739,6 +750,7 @@ class BegrunnelserForPeriodeContextTest {
                 endringsårsaker = emptyList(),
                 støtterFritekst = false,
                 skalAlltidVises = false,
+                ikkeIBruk = false,
                 resultat = SanityResultat.INNVILGET,
             ),
         )


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23619

Denne funksjonaliteten finnes i ba, vi ønsker å overføre den over.
PR i familie-sanity-brev ligger her: https://github.com/navikt/familie-sanity-brev/pull/670