### PR TITLE
Bruk av barnehageplass 2024 endret utbetaling årsak skal ikke trigge resultatet endring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -21,7 +21,7 @@ object EndringIEndretUtbetalingAndelUtil {
                 (
                     nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted ||
                         nåværende?.årsak != forrige?.årsak &&
-                            erIkkeFulltidsplassIBarnehageAugust2024MedEksplisittAvslag
+                        erIkkeFulltidsplassIBarnehageAugust2024MedEksplisittAvslag
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat.tilPeriode
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
+import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
@@ -18,7 +19,8 @@ object EndringIEndretUtbetalingAndelUtil {
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
                 (
                     nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted ||
-                        nåværende?.årsak != forrige?.årsak
+                        nåværende?.årsak != forrige?.årsak &&
+                        nåværende?.årsak != Årsak.FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -17,11 +17,11 @@ object EndringIEndretUtbetalingAndelUtil {
 
         val endringerTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
-                val erIkkeFulltidsplassIBarnehageAugust2024MedEksplisittAvslag = nåværende?.årsak != Årsak.FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 && nåværende?.erEksplisittAvslagPåSøknad == true
+                val erFulltidsplassIBarnehageAugust2024MedEksplisittAvslag = nåværende?.årsak == Årsak.FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 && nåværende.erEksplisittAvslagPåSøknad == true
                 (
                     nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted ||
                         nåværende?.årsak != forrige?.årsak &&
-                        erIkkeFulltidsplassIBarnehageAugust2024MedEksplisittAvslag
+                        !erFulltidsplassIBarnehageAugust2024MedEksplisittAvslag
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -17,10 +17,11 @@ object EndringIEndretUtbetalingAndelUtil {
 
         val endringerTidslinje =
             nåværendeTidslinje.kombinerMed(forrigeTidslinje) { nåværende, forrige ->
+                val erIkkeFulltidsplassIBarnehageAugust2024MedEksplisittAvslag = nåværende?.årsak != Årsak.FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 && nåværende?.erEksplisittAvslagPåSøknad == true
                 (
                     nåværende?.avtaletidspunktDeltBosted != forrige?.avtaletidspunktDeltBosted ||
                         nåværende?.årsak != forrige?.årsak &&
-                        nåværende?.årsak != Årsak.FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024
+                            erIkkeFulltidsplassIBarnehageAugust2024MedEksplisittAvslag
                 )
             }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -236,8 +236,19 @@ class StepDefinition {
     /**
      * Mulige verdier: | AktørId | Fra dato | Til dato | Beløp | Ytelse type | Prosent | Sats |
      */
-    @Så("forvent følgende andeler tilkjent ytelse for behandling {}")
+    @Så("med følgende andeler tilkjent ytelse for behandling {}")
     fun `med andeler tilkjent ytelse`(
+        behandlingId: Long,
+        dataTable: DataTable,
+    ) {
+        andelerTilkjentYtelse[behandlingId] = lagAndelerTilkjentYtelse(dataTable, behandlingId, behandlinger, persongrunnlag)
+    }
+
+    /**
+     * Mulige verdier: | AktørId | Fra dato | Til dato | Beløp | Ytelse type | Prosent | Sats |
+     */
+    @Så("forvent følgende andeler tilkjent ytelse for behandling {}")
+    fun `forvent følgende andeler tilkjent ytelse`(
         behandlingId: Long,
         dataTable: DataTable,
     ) {

--- a/src/test/resources/cucumber/behandlingsresultat/endret-utbetaling-andel.feature
+++ b/src/test/resources/cucumber/behandlingsresultat/endret-utbetaling-andel.feature
@@ -1,0 +1,77 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Behandlingsresultat ved bruk av endret utbetaling andel
+
+  Scenario: Opphørsperioder som starter og slutter samtidig som avslagsperioder skal bli filtrert ut.
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | SØKNAD           | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 21.03.1997  |
+      | 1            | 2       | BARN       | 18.01.2023  |
+      | 2            | 1       | SØKER      | 21.03.1997  |
+      | 2            | 2       | BARN       | 18.01.2023  |
+
+
+    Og følgende dagens dato 07.12.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 21.03.1997 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                                          |                  | 18.01.2024 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 18.08.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 21.03.1997 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                                          |                  | 18.01.2024 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 18.08.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende endrede utbetalinger
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak                                 | Prosent | Søknadstidspunkt | Avtaletidspunkt delt bosted | Er eksplisitt avslag |
+      | 2       | 2            | 01.08.2024 | 31.08.2024 | FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 | 0       | 04.12.2024       |                             | Ja                   |
+
+    Og andeler er beregnet for behandling 1
+
+    Og med følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.02.2024 | 31.07.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.02.2024 | 31.07.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+      | 2       | 01.08.2024 | 31.08.2024 | 0     | ORDINÆR_KONTANTSTØTTE | 0       | 7500 | 0                      |                          |
+    Og når behandlingsresultatet er utledet for behandling 2
+
+    Så forvent at behandlingsresultatet er AVSLÅTT på behandling 2
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
+      | 01.08.2024 |          | AVSLAG             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                         | Ugyldige begrunnelser |
+      | 01.08.2024 |          | AVSLAG             |                                | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato | Standardbegrunnelser                         | Eøsbegrunnelser | Fritekster |
+      | 01.08.2024 |          |                                              |                 |            |
+      | 01.08.2024 |          | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 |                 |            |


### PR DESCRIPTION
Slack: https://nav-it.slack.com/archives/C01G9BA8JKZ/p1733809577227329

Vi ønsker ikke at behandlingen får ENDRET grunnet at man har lagt til en endret utbetaling årsak for august 2024 gruppa med avslag. Dette skal bare lede til en avslag, men nå trigger den at det blir endring grunnet at man har lagt på ny endretutbetalingandel.