### PR TITLE
NAV-23641: Endringer i barnets alder vilkår skal ikke automatisk føre til endringer i behandlingsresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -17,7 +17,7 @@ object EndringIVilkårsvurderingUtil {
         forrigePersonResultater: Set<PersonResultat>,
     ): Tidslinje<Boolean> {
         val tidslinjePerVilkår =
-            Vilkår.entries.map { vilkår ->
+            Vilkår.entries.filter { it != Vilkår.BARNETS_ALDER }.map { vilkår ->
                 val vilkårTidslinje =
                     lagEndringIVilkårsvurderingForPersonOgVilkårTidslinje(
                         nåværendeOppfylteVilkårResultaterForPerson =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
@@ -238,6 +238,62 @@ class EndringIVilkårsvurderingUtilTest {
     }
 
     @Test
+    fun `Endring i vilkårsvurdering - skal ikke lage periode med endring hvis det er barnets alder som er endret`() {
+        val nåværendeVilkårResultat =
+            setOf(
+                VilkårResultat(
+                    behandlingId = 0,
+                    personResultat = null,
+                    vilkårType = Vilkår.BARNETS_ALDER,
+                    resultat = Resultat.OPPFYLT,
+                    periodeFom = LocalDate.of(2024, 5, 9),
+                    periodeTom = LocalDate.of(2024, 7, 31),
+                    begrunnelse = "Test",
+                    utdypendeVilkårsvurderinger = emptyList(),
+                    vurderesEtter = Regelverk.NASJONALE_REGLER,
+                ),
+                VilkårResultat(
+                    behandlingId = 0,
+                    personResultat = null,
+                    vilkårType = Vilkår.BARNETS_ALDER,
+                    resultat = Resultat.OPPFYLT,
+                    periodeFom = LocalDate.of(2024, 8, 1),
+                    periodeTom = LocalDate.of(2024, 12, 9),
+                    begrunnelse = "Test",
+                    utdypendeVilkårsvurderinger = emptyList(),
+                    vurderesEtter = Regelverk.NASJONALE_REGLER,
+                ),
+            )
+
+        val forrigeVilkårResultat =
+            setOf(
+                VilkårResultat(
+                    behandlingId = 0,
+                    personResultat = null,
+                    vilkårType = Vilkår.BARNETS_ALDER,
+                    resultat = Resultat.OPPFYLT,
+                    periodeFom = LocalDate.of(2024, 5, 9),
+                    periodeTom = LocalDate.of(2025, 5, 9),
+                    begrunnelse = "Test",
+                    utdypendeVilkårsvurderinger = emptyList(),
+                    vurderesEtter = Regelverk.NASJONALE_REGLER,
+                ),
+            )
+
+        val aktør = randomAktør()
+
+        val perioderMedEndring =
+            EndringIVilkårsvurderingUtil
+                .lagEndringIVilkårsvurderingTidslinje(
+                    nåværendePersonResultaterForPerson = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
+                    forrigePersonResultater = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
+                ).tilPerioder()
+                .filter { it.verdi == true }
+
+        Assertions.assertTrue(perioderMedEndring.isEmpty())
+    }
+
+    @Test
     fun `Endring i vilkårsvurdering - skal ikke lage periode med endring hvis eneste endring er å sette obligatoriske utdypende vilkårsvurderinger`() {
         val fødselsdato = LocalDate.of(2015, 1, 1)
         val forrigeVilkårResultat =

--- a/src/test/resources/cucumber/behandlingsresultat/endret-utbetaling-andel.feature
+++ b/src/test/resources/cucumber/behandlingsresultat/endret-utbetaling-andel.feature
@@ -1,9 +1,10 @@
+
 # language: no
 # encoding: UTF-8
 
-Egenskap: Behandlingsresultat ved bruk av endret utbetaling andel
+Egenskap: Behandlingsresultat ved endret utbetaling
 
-  Scenario: Opphørsperioder som starter og slutter samtidig som avslagsperioder skal bli filtrert ut.
+  Scenario: Behandlingsresultat skal bli Avslått dersom den eneste endringen er i Barnets alder vilkåret og man har brukt endret utbetalingsårsak FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024.
     Gitt følgende fagsaker
       | FagsakId |
       | 1        |
@@ -15,63 +16,46 @@ Egenskap: Behandlingsresultat ved bruk av endret utbetaling andel
 
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
-      | 1            | 1       | SØKER      | 21.03.1997  |
-      | 1            | 2       | BARN       | 18.01.2023  |
-      | 2            | 1       | SØKER      | 21.03.1997  |
-      | 2            | 2       | BARN       | 18.01.2023  |
-
-
-    Og følgende dagens dato 07.12.2024
+      | 1            | 1       | SØKER      | 20.03.1995  |
+      | 1            | 2       | BARN       | 09.05.2023  |
+      | 2            | 1       | SØKER      | 20.03.1995  |
+      | 2            | 2       | BARN       | 09.05.2023  |
+    Og følgende dagens dato 10.12.2024
 
     Og følgende vilkårresultater for behandling 1
-      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
-      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 21.03.1997 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 20.03.1995 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 20.03.2000 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
 
-      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
-      | 2       | BARNEHAGEPLASS                                         |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
-      | 2       | BARNETS_ALDER                                          |                  | 18.01.2024 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
-      | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 18.08.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 08.05.2000 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 09.05.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 09.05.2023 | 14.08.2024 | OPPFYLT  | Nei                  |                      |                  | Ja                                    |              |
+      | 2       | BARNETS_ALDER                |                  | 09.05.2024 | 09.05.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
 
     Og følgende vilkårresultater for behandling 2
-      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
-      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 21.03.1997 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 20.03.1995 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 20.03.2000 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
 
-      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET,MEDLEMSKAP_ANNEN_FORELDER |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
-      | 2       | BARNEHAGEPLASS                                         |                  | 18.01.2023 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
-      | 2       | BARNETS_ALDER                                          |                  | 18.01.2024 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
-      | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 18.08.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 08.05.2000 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 09.05.2023 | 14.08.2024 | OPPFYLT  | Nei                  |                      |                  | Ja                                    |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 09.05.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 09.05.2024 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 01.08.2024 | 09.12.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
 
     Og følgende endrede utbetalinger
       | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak                                 | Prosent | Søknadstidspunkt | Avtaletidspunkt delt bosted | Er eksplisitt avslag |
-      | 2       | 2            | 01.08.2024 | 31.08.2024 | FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 | 0       | 04.12.2024       |                             | Ja                   |
-
-    Og andeler er beregnet for behandling 1
+      | 2       | 2            | 01.08.2024 | 31.08.2024 | FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 | 0       | 17.06.2024       |                             | Ja                   |
 
     Og med følgende andeler tilkjent ytelse for behandling 1
       | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
-      | 2       | 01.02.2024 | 31.07.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+      | 2       | 01.06.2024 | 31.07.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
 
     Og andeler er beregnet for behandling 2
 
     Så forvent følgende andeler tilkjent ytelse for behandling 2
       | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
-      | 2       | 01.02.2024 | 31.07.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+      | 2       | 01.06.2024 | 31.07.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
       | 2       | 01.08.2024 | 31.08.2024 | 0     | ORDINÆR_KONTANTSTØTTE | 0       | 7500 | 0                      |                          |
     Og når behandlingsresultatet er utledet for behandling 2
-
     Så forvent at behandlingsresultatet er AVSLÅTT på behandling 2
-
-    Og vedtaksperioder er laget for behandling 2
-
-    Så forvent følgende vedtaksperioder på behandling 2
-      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
-      | 01.08.2024 |          | AVSLAG             |           |
-
-    Så forvent at følgende begrunnelser er gyldige for behandling 2
-      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                         | Ugyldige begrunnelser |
-      | 01.08.2024 |          | AVSLAG             |                                | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 |                       |
-
-    Og når disse begrunnelsene er valgt for behandling 2
-      | Fra dato   | Til dato | Standardbegrunnelser                         | Eøsbegrunnelser | Fritekster |
-      | 01.08.2024 |          |                                              |                 |            |
-      | 01.08.2024 |          | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 |                 |            |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi opplever at behandlingsresultatet blir "Endret" i tilfeller hvor det ikke skulle blitt det, grunnet endringer i barnets alder vilkåret. Vi fjerner her barnets alder vilkåret fra endrings-sjekken, da endringene i vilkåret vil føre til endringer i andelene dersom det er snakk om en reell endring.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
