### PR TITLE
Lagt til default exception handler for HttpMessageNotReadableException

### DIFF
--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/ApiExceptionHandlerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/ApiExceptionHandlerTest.kt
@@ -1,0 +1,77 @@
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.api
+
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.hamcrest.CoreMatchers.`is` as Is
+
+class ApiExceptionHandlerTest : OppslagSpringRunnerTest() {
+    private val controllerUrl: String = "/api/forvaltning"
+
+    @BeforeEach
+    fun setUp() {
+        RestAssured.port = port
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails()
+    }
+
+    @Test
+    fun `Skal få en feilmelding om hvilket felt som ikke kan være null, som er null i json`() {
+        // Arrange
+        val gyldigEndretUtbetalingAndelDto =
+            """
+            {
+               "fom": null,
+               "tom": "2021-01-01"
+            }
+            """.trimIndent()
+
+        val token = lokalTestToken(behandlerRolle = BehandlerRolle.SAKSBEHANDLER)
+
+        // Act & assert
+        Given {
+            header("Authorization", "Bearer $token")
+            body(gyldigEndretUtbetalingAndelDto)
+            contentType(ContentType.JSON)
+        } When {
+            post("$controllerUrl/avstemming/send-grensesnittavstemming-manuell")
+        } Then {
+            statusCode(HttpStatus.BAD_REQUEST.value())
+            body("status", Is("FEILET"))
+            body("frontendFeilmelding", Is("Mangler verdi for felt no.nav.familie.ks.sak.common.util.Periode[\"fom\"]"))
+        }
+    }
+
+    @Test
+    fun `Skal få en feilmelding om hvilket felt som ikke kan parses`() {
+        // Arrange
+        val gyldigEndretUtbetalingAndelDto =
+            """
+            {
+               "fom": "2021",
+               "tom": "2021-01-01"
+            }
+            """.trimIndent()
+
+        val token = lokalTestToken(behandlerRolle = BehandlerRolle.SAKSBEHANDLER)
+
+        // Act & assert
+        Given {
+            header("Authorization", "Bearer $token")
+            body(gyldigEndretUtbetalingAndelDto)
+            contentType(ContentType.JSON)
+        } When {
+            post("$controllerUrl/avstemming/send-grensesnittavstemming-manuell")
+        } Then {
+            statusCode(HttpStatus.BAD_REQUEST.value())
+            body("status", Is("FEILET"))
+            body("frontendFeilmelding", Is("Ugyldig verdi 2021 for felt no.nav.familie.ks.sak.common.util.Periode[\"fom\"]"))
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Lagt til default exception handler for HttpMessageNotReadableException

Dette for at det ikke skal logges feil ved brukerfeil og for at man skal kunne gi en bedre feilmelding hvis frontendfeilmeldingen ikke er god nok og likevel blir sendt til backend

Hvis HttpMessageNotReadableException er en MismatchedInputException
<img width="557" alt="image" src="https://github.com/user-attachments/assets/6fc09c65-8e8b-411f-8416-a1814e24f1db">

Hvis HttpMessageNotReadableException er en InvalidFormatException
![image](https://github.com/user-attachments/assets/76644866-39c4-41e4-921a-5bfd793d0b77)


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Feilmeldinger. Det er vanskelig å få de like bra som evt ved frontend, siden det ikke er helt samsvar mellom navn i json og evt felt som vises i frontend, men disse feilmeldingene skal være kun de steder som det mangler frontend-validering, men det likevel sendes til backend

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
