### PR TITLE
NAV-23734: Endrer fra "reduksjon til full barnehageplass" til "reduksjon til gradert barnehageplass" når man utleder graderingsforskjell mellom forrige og denne perioden

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/FomForskyver.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/FomForskyver.kt
@@ -13,7 +13,7 @@ fun forskyvFomBasertPåGraderingsforskjell2024(
     return when (graderingsforskjellMellomDenneOgForrigePeriode) {
         Graderingsforskjell.LIK,
         Graderingsforskjell.ØKNING,
-        Graderingsforskjell.REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
+        Graderingsforskjell.REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
         -> fomDato.førsteDagIInneværendeMåned()
 
         Graderingsforskjell.REDUKSJON,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/Graderingsforskjell.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/Graderingsforskjell.kt
@@ -10,7 +10,7 @@ enum class Graderingsforskjell {
     ØKNING,
     REDUKSJON,
     ØKNING_FRA_FULL_BARNEHAGEPLASS,
-    REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
+    REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
     LIK,
 }
 
@@ -43,8 +43,8 @@ fun finnGraderingsforskjellMellomDenneOgForrigePeriode2024(
             vilkårResultatForrigePerioden != null
 
     return when {
-        graderingForrigePeriode > graderingDennePerioden && graderingDennePerioden.equals(BigDecimal(0)) && fomDennePeriodenErSammeMånedSomAlleAndreVilkårBlirOppfylt
-        -> Graderingsforskjell.REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT
+        graderingForrigePeriode > graderingDennePerioden && graderingForrigePeriode.equals(BigDecimal(100)) && fomDennePeriodenErSammeMånedSomAlleAndreVilkårBlirOppfylt
+        -> Graderingsforskjell.REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT
 
         harSluttetIFulltidBarnehageDennePerioden
         -> Graderingsforskjell.ØKNING_FRA_FULL_BARNEHAGEPLASS

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/TomForskyver.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/TomForskyver.kt
@@ -13,7 +13,7 @@ fun forskyvTomBasertPåGraderingsforskjell2024(
     }
     return when (graderingsforskjellMellomDenneOgNestePeriode) {
         Graderingsforskjell.LIK,
-        Graderingsforskjell.REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
+        Graderingsforskjell.REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
         -> tomDato.plusDays(1).minusMonths(1).sisteDagIMåned()
 
         Graderingsforskjell.ØKNING,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/GraderingsforskjellKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/GraderingsforskjellKtTest.kt
@@ -10,21 +10,21 @@ import java.time.YearMonth
 
 class GraderingsforskjellKtTest {
     @Test
-    fun `skal utlede REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT når det er en reduksjon til full barnehageplass i graderingen til vilkårsresultatet fra forrige og denne perioden og alle andre vilkår er oppfylt samme måned`() {
+    fun `skal utlede REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT når det er en reduksjon til deltid barnehageplass i graderingen til vilkårsresultatet fra forrige og denne perioden og alle andre vilkår er oppfylt samme måned`() {
         // Arrange
         val vilkårResultatForrigePeriode =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNEHAGEPLASS,
                 periodeFom = null,
                 periodeTom = LocalDate.of(2024, 1, 15),
-                antallTimer = BigDecimal(20),
+                antallTimer = BigDecimal(0),
             )
         val vilkårResultatDennePeriode =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNEHAGEPLASS,
                 periodeFom = LocalDate.of(2024, 1, 16),
                 periodeTom = null,
-                antallTimer = BigDecimal(40),
+                antallTimer = BigDecimal(20),
             )
 
         val tidligsteÅrMånedAlleAndreVilkårErOppfylt = YearMonth.of(2024, 1)
@@ -39,7 +39,7 @@ class GraderingsforskjellKtTest {
 
         // Assert
         assertThat(graderingsforskjell).isEqualTo(
-            Graderingsforskjell.REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
+            Graderingsforskjell.REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/TomForskyverKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/regelsett/lov2024/barnehageplass/TomForskyverKtTest.kt
@@ -132,7 +132,7 @@ class TomForskyverKtTest {
             val forskjøvetTom =
                 forskyvTomBasertPåGraderingsforskjell2024(
                     tomDato,
-                    Graderingsforskjell.REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
+                    Graderingsforskjell.REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
                 )
 
             // Assert
@@ -148,7 +148,7 @@ class TomForskyverKtTest {
             val forskjøvetTom =
                 forskyvTomBasertPåGraderingsforskjell2024(
                     tomDato,
-                    Graderingsforskjell.REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
+                    Graderingsforskjell.REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
                 )
 
             // Assert
@@ -164,7 +164,7 @@ class TomForskyverKtTest {
             val forskjøvetTom =
                 forskyvTomBasertPåGraderingsforskjell2024(
                     tomDato,
-                    Graderingsforskjell.REDUKSJON_TIL_FULL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
+                    Graderingsforskjell.REDUKSJON_TIL_BARNEHAGEPLASS_SAMME_MÅNED_SOM_ANDRE_VILKÅR_FØRST_BLIR_OPPFYLT,
                 )
 
             // Assert

--- a/src/test/resources/cucumber/vilkår/barnehageplass/overgang_til_barnehageplass.feature
+++ b/src/test/resources/cucumber/vilkår/barnehageplass/overgang_til_barnehageplass.feature
@@ -231,3 +231,28 @@ Egenskap: Overgang til barnehageplass
     Så forvent følgende andeler tilkjent ytelse for behandling 1
       | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
       | 2       | 01.10.2024 | 05.03.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 |
+
+  Scenario: Det skal innvilges gradert kontantstøtte dersom man starter i deltid barnehage samme måned som man blir 13 måned gammel i august 2024
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 05.07.2023  |
+
+    Og følgende dagens dato 11.06.2024
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 19.06.1988 |            | OPPFYLT  | Nei                  |                      |                |              |
+      | 1       | LOVLIG_OPPHOLD                                         |                  | 19.06.1988 |            | OPPFYLT  | Nei                  |                      |                |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 05.01.2023 |            | OPPFYLT  | Nei                  |                      |                |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 05.07.2023 | 14.08.2024 | OPPFYLT  | Nei                  |                      |                |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 15.08.2024 |            | OPPFYLT  | Nei                  |                      |                | 20           |
+      | 2       | BARNETS_ALDER                                          |                  | 04.07.2024 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                |              |
+      | 2       | BARNETS_ALDER                                          |                  | 01.08.2024 | 04.02.2025 | OPPFYLT  | Nei                  |                      |                |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
+      | 2       | 01.08.2024 | 05.02.2025 | 3000  | ORDINÆR_KONTANTSTØTTE | 40      | 7500 |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23734

Tidligere har vi spesialhåndtert tilfeller hvor innvilgelse har funnet sted samtidig som det er en reduksjon til full barnehageplass. Dette er nå endret til å være en reduksjon til barnehageplass (dvs. ikke nødvendigvis fulltid). 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
