### PR TITLE
Fiks frist feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -156,7 +156,7 @@ class OppgaveService(
         integrasjonClient.ferdigstillOppgave(oppgaveId)
     }
 
-    fun forlengFristÅpneOppgaverPåBehandling(
+    fun settNyFristÅpneOppgaverPåBehandling(
         behandlingId: Long,
         nyFrist: LocalDate,
     ) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -179,7 +179,8 @@ class OppgaveService(
 
                 else -> {
                     val nyFrist = LocalDate.parse(gammelOppgave.fristFerdigstillelse).plus(forlengelse)
-                    val oppgaveOppdatering = gammelOppgave.copy(fristFerdigstillelse = nyFrist?.toString())
+                    logger.info("$nyFrist - $forlengelse - ${gammelOppgave.fristFerdigstillelse}")
+                    val oppgaveOppdatering = gammelOppgave.copy(fristFerdigstillelse = nyFrist.toString())
                     integrasjonClient.oppdaterOppgave(oppgaveOppdatering)
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.Period
 import java.time.format.DateTimeFormatter
 
 @Service
@@ -159,7 +158,7 @@ class OppgaveService(
 
     fun forlengFristÅpneOppgaverPåBehandling(
         behandlingId: Long,
-        forlengelse: Period,
+        nyFrist: LocalDate,
     ) {
         val dbOppgaver = oppgaveRepository.findByBehandlingIdAndIkkeFerdigstilt(behandlingId)
 
@@ -178,8 +177,6 @@ class OppgaveService(
                     logger.warn("Oppgave ${dbOppgave.gsakId} er allerede avsluttet. Frist ikke forlenget.")
 
                 else -> {
-                    val nyFrist = LocalDate.parse(gammelOppgave.fristFerdigstillelse).plus(forlengelse)
-                    logger.info("$nyFrist - $forlengelse - ${gammelOppgave.fristFerdigstillelse}")
                     val oppgaveOppdatering = gammelOppgave.copy(fristFerdigstillelse = nyFrist.toString())
                     integrasjonClient.oppdaterOppgave(oppgaveOppdatering)
                 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentService.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.Period
 
 @Service
 class SettBehandlingPåVentService(
@@ -34,7 +33,7 @@ class SettBehandlingPåVentService(
 
         oppgaveService.forlengFristÅpneOppgaverPåBehandling(
             behandlingId = behandling.id,
-            forlengelse = Period.between(LocalDate.now(), frist),
+            nyFrist = frist,
         )
     }
 
@@ -46,11 +45,11 @@ class SettBehandlingPåVentService(
     ) {
         val behandling = behandlingRepository.hentBehandling(behandlingId)
 
-        val gammelFrist = stegService.oppdaterBehandlingstegFristOgÅrsak(behandling, frist, årsak)
+        stegService.oppdaterBehandlingstegFristOgÅrsak(behandling, frist, årsak)
 
         oppgaveService.forlengFristÅpneOppgaverPåBehandling(
             behandlingId = behandlingId,
-            forlengelse = Period.between(gammelFrist, frist),
+            nyFrist = frist,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentService.kt
@@ -31,7 +31,7 @@ class SettBehandlingPåVentService(
 
         stegService.settBehandlingstegPåVent(behandling, frist, årsak)
 
-        oppgaveService.forlengFristÅpneOppgaverPåBehandling(
+        oppgaveService.settNyFristÅpneOppgaverPåBehandling(
             behandlingId = behandling.id,
             nyFrist = frist,
         )
@@ -47,7 +47,7 @@ class SettBehandlingPåVentService(
 
         stegService.oppdaterBehandlingstegFristOgÅrsak(behandling, frist, årsak)
 
-        oppgaveService.forlengFristÅpneOppgaverPåBehandling(
+        oppgaveService.settNyFristÅpneOppgaverPåBehandling(
             behandlingId = behandlingId,
             nyFrist = frist,
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentServiceTest.kt
@@ -46,7 +46,7 @@ class SettBehandlingPåVentServiceTest {
     fun `settBehandlingPåVent - skal sette behandling på vent og forlenge frist på oppgave`() {
         every { behandlingRepository.hentBehandling(any()) } returns behandling
         every { stegService.settBehandlingstegPåVent(any(), any(), VenteÅrsak.AVVENTER_DOKUMENTASJON) } just runs
-        every { oppgaveService.forlengFristÅpneOppgaverPåBehandling(any(), any()) } just runs
+        every { oppgaveService.settNyFristÅpneOppgaverPåBehandling(any(), any()) } just runs
 
         val frist = LocalDate.now().plusWeeks(1)
         settBehandlingPåVentService.settBehandlingPåVent(
@@ -57,7 +57,7 @@ class SettBehandlingPåVentServiceTest {
 
         verify(exactly = 1) { behandlingRepository.hentBehandling(any()) }
         verify(exactly = 1) { stegService.settBehandlingstegPåVent(any(), any(), VenteÅrsak.AVVENTER_DOKUMENTASJON) }
-        verify(exactly = 1) { oppgaveService.forlengFristÅpneOppgaverPåBehandling(any(), any()) }
+        verify(exactly = 1) { oppgaveService.settNyFristÅpneOppgaverPåBehandling(any(), any()) }
     }
 
     @Test
@@ -159,7 +159,7 @@ class SettBehandlingPåVentServiceTest {
             )
         } returns gammelFrist
 
-        every { oppgaveService.forlengFristÅpneOppgaverPåBehandling(any(), any()) } just runs
+        every { oppgaveService.settNyFristÅpneOppgaverPåBehandling(any(), any()) } just runs
 
         settBehandlingPåVentService.oppdaterFristOgÅrsak(
             behandling.id,
@@ -175,7 +175,7 @@ class SettBehandlingPåVentServiceTest {
                 VenteÅrsak.AVVENTER_DOKUMENTASJON,
             )
         }
-        verify(exactly = 1) { oppgaveService.forlengFristÅpneOppgaverPåBehandling(any(), any()) }
+        verify(exactly = 1) { oppgaveService.settNyFristÅpneOppgaverPåBehandling(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23748



Når man forlenger frist i dag skjer følgende:

Man finner forskjellX som er dagens dato fram til ny frist.
Man plusser gammelfrist med forskjellX.

Kommer vi da i en situasjon der dagensdato er 30 desember, ny frist er 21 januar, og gammelfrist er 20 desember så vil fristen bli satt til 11 januar. (20 des + 21 dager) selvom ønsket frist er 21 jan.