### PR TITLE
Fiks enhetstest etter overgang til 2025

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/ClockProvider.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/ClockProvider.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.ks.sak.common
+
+import java.time.Clock
+
+fun interface ClockProvider {
+    fun get(): Clock
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/ClockProviderConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/ClockProviderConfig.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ks.sak.config
+
+import no.nav.familie.ks.sak.common.ClockProvider
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class ClockProviderConfig {
+    @Bean
+    fun clockProvider(): ClockProvider =
+        ClockProvider {
+            Clock.systemDefaultZone()
+        }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/TestClockProvider.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/TestClockProvider.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.ks.sak
+
+import no.nav.familie.ks.sak.common.ClockProvider
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class TestClockProvider(
+    private val clock: Clock = Clock.systemDefaultZone(),
+) : ClockProvider {
+    override fun get(): Clock = clock
+
+    companion object {
+        private val zoneId = ZoneId.of("Europe/Oslo")
+
+        fun lagClockProviderMedFastTidspunkt(localDateTime: ZonedDateTime): TestClockProvider = TestClockProvider(Clock.fixed(localDateTime.toInstant(), zoneId))
+
+        fun lagClockProviderMedFastTidspunkt(localDate: LocalDate): TestClockProvider = lagClockProviderMedFastTidspunkt(localDate.atStartOfDay(zoneId))
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/ClockProviderConfigTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/ClockProviderConfigTest.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ks.sak.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+class ClockProviderConfigTest {
+    @Test
+    fun `skal returnere system default zone clock fra clock provider`() {
+        // Arrange
+        val clockProvider = ClockProviderConfig().clockProvider()
+
+        // Act
+        val clock = clockProvider.get()
+
+        // Assert
+        assertThat(clock).isEqualTo(Clock.systemDefaultZone())
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.eøs.kompetanse
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
+import no.nav.familie.ks.sak.TestClockProvider
 import no.nav.familie.ks.sak.api.dto.tilKompetanseDto
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.Periode
@@ -71,6 +72,7 @@ internal class KompetanseServiceTest {
             endretUtbetalingAndelRepository = endretUtbetalingAndelRepository,
             overgangsordningAndelRepository = overgangsordningAndelRepository,
             unleashService = unleashService,
+            clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(LocalDate.of(2024, 10, 1)),
         )
 
     private val kompetanseService: KompetanseService =


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23775

Fiks feilende enhetstest etter at vi har bevegd oss inn til 2025.
Bruker clockprovider.