### PR TITLE
Fjern toggle familie-ks-sak.allerede-utbetalt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -18,6 +18,5 @@ class FeatureToggleConfig {
         const val BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER = "familie-ks-sak.bruk-ny-loype-for-generering-av-andeler"
 
         const val BRUK_OMSKRIVING_AV_HJEMLER_I_BREV = "familie-ks-sak.bruk_omskriving_av_hjemler_i_brev"
-        const val ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK = "familie-ks-sak.allerede-utbetalt"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårsvurderingRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -15,7 +14,6 @@ import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.slåSammen
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -26,7 +24,6 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
-    private val unleashService: UnleashService,
 ) {
     @Transactional
     fun finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId: Long): List<AndelTilkjentYtelseMedEndreteUtbetalinger> =
@@ -46,7 +43,6 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
                         årsak = endretUtbetalingAndelMedAndelTilkjentYtelse.årsak,
                         endretUtbetalingAndel = endretUtbetalingAndelMedAndelTilkjentYtelse.endretUtbetaling,
                         vilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandlingId),
-                        kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
                     )
                 }
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ks.sak.kjerne.endretutbetaling
 import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.api.dto.SanityBegrunnelseMedEndringsårsakResponseDto
 import no.nav.familie.ks.sak.common.BehandlingId
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -24,7 +23,6 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAnde
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.fraEndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -38,7 +36,6 @@ class EndretUtbetalingAndelService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val endretUtbetalingAndelOppdatertAbonnementer: List<EndretUtbetalingAndelerOppdatertAbonnent> = emptyList(),
     private val sanityService: SanityService,
-    private val unleashService: UnleashService,
 ) {
     fun hentEndredeUtbetalingAndeler(behandlingId: Long) = endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(behandlingId)
 
@@ -82,7 +79,6 @@ class EndretUtbetalingAndelService(
             årsak = endretUtbetalingAndel.årsak,
             endretUtbetalingAndel = endretUtbetalingAndel,
             vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id),
-            kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
         )
 
         validerUtbetalingMotÅrsak(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidator.kt
@@ -61,7 +61,6 @@ object EndretUtbetalingAndelValidator {
         årsak: Årsak?,
         endretUtbetalingAndel: EndretUtbetalingAndel,
         vilkårsvurdering: Vilkårsvurdering?,
-        kanBrukeÅrsakAlleredeUtbetalt: Boolean = false,
     ) {
         checkNotNull(årsak) { "Årsak kan ikke være null" }
         when (årsak) {
@@ -90,7 +89,7 @@ object EndretUtbetalingAndelValidator {
                 )
             }
 
-            Årsak.ALLEREDE_UTBETALT -> validerAlleredeUtbetalt(endretUtbetalingAndel = endretUtbetalingAndel, kanBrukeÅrsakAlleredeUtbetalt)
+            Årsak.ALLEREDE_UTBETALT -> validerAlleredeUtbetalt(endretUtbetalingAndel = endretUtbetalingAndel)
 
             Årsak.ENDRE_MOTTAKER,
             ->
@@ -110,11 +109,7 @@ object EndretUtbetalingAndelValidator {
 
     private fun validerAlleredeUtbetalt(
         endretUtbetalingAndel: EndretUtbetalingAndel,
-        kanBrukeÅrsakAlleredeUtbetalt: Boolean,
     ) {
-        if (!kanBrukeÅrsakAlleredeUtbetalt) {
-            throw FunksjonellFeil("Årsak Allerede utbetalt er ikke implementert enda!!")
-        }
         if (endretUtbetalingAndel.tom?.isAfter(YearMonth.now()) == true) {
             throw FunksjonellFeil("Du har valgt årsaken allerede utbetalt. Du kan ikke velge denne årsaken og en til og med dato frem i tid. Ta kontakt med superbruker om du er usikker på hva du skal gjøre.")
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -75,7 +75,6 @@ class CucumberMock(
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
             endretUtbetalingAndelRepository = endretUtbetalingAndelRepositoryMock,
             vilkårsvurderingRepository = vilkårsvurderingRepositoryMock,
-            unleashService = mockUnleashService(isEnabledDefault = false),
         )
 
     val personidentService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -21,11 +21,9 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseReposito
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
-import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.math.BigDecimal
@@ -42,16 +40,8 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
     @MockK
     private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
 
-    @MockK
-    private lateinit var unleashService: UnleashService
-
     @InjectMockKs
     private lateinit var andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
-
-    @BeforeEach
-    fun setup() {
-        every { unleashService.isEnabled(any()) } returns false
-    }
 
     val søker = randomAktør()
     private val barn1 = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/EndretUtbetalingAndelValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/EndretUtbetalingAndelValidatorTest.kt
@@ -767,30 +767,6 @@ class EndretUtbetalingAndelValidatorTest {
         }
 
         @Test
-        fun `skal kaste feil når årsak er ALLEREDE_UTBETALT og unleash-togglen er skrudd av`() {
-            // Arrange
-            val endretUtbetalingAndel =
-                lagEndretUtbetalingAndel(
-                    periodeFom = YearMonth.of(2024, 8),
-                    periodeTom = YearMonth.of(2024, 8),
-                    årsak = Årsak.ALLEREDE_UTBETALT,
-                )
-
-            // Act & assert
-            val exception =
-                assertThrows<FunksjonellFeil> {
-                    EndretUtbetalingAndelValidator.validerÅrsak(
-                        Årsak.ALLEREDE_UTBETALT,
-                        endretUtbetalingAndel,
-                        null,
-                        kanBrukeÅrsakAlleredeUtbetalt = false,
-                    )
-                }
-
-            assertThat(exception.message).isEqualTo("Årsak Allerede utbetalt er ikke implementert enda!!")
-        }
-
-        @Test
         fun `skal ikke kaste feil når årsak er ALLEREDE_UTBETALT`() {
             // Arrange
             val endretUtbetalingAndel =
@@ -806,7 +782,6 @@ class EndretUtbetalingAndelValidatorTest {
                     Årsak.ALLEREDE_UTBETALT,
                     endretUtbetalingAndel,
                     null,
-                    kanBrukeÅrsakAlleredeUtbetalt = true,
                 )
             }
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -25,7 +25,6 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAnde
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
-import no.nav.familie.unleash.UnleashService
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
@@ -54,9 +53,6 @@ class EndretUtbetalingAndelServiceTest {
 
     @MockK
     private lateinit var sanityService: SanityService
-
-    @MockK
-    private lateinit var unleashService: UnleashService
 
     @Test
     fun `kopierEndretUtbetalingAndelFraForrigeBehandling - skal kopiere over endrete utbetaling i forrige behandling og lagre disse på ny`() {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner bruk av feature toggle for allerede utbetalt. I bunn og grunn en revert av [denne committen](https://github.com/navikt/familie-ks-sak/pull/982/commits/97a6bb5be54371d5d5a535812e3b5efd984bd348).

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Ikke noe spesielt.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
