### PR TITLE
Man skal kunne velge allerede utbetalt årsak på revurderinger og si at pengene skal utbetales

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -18,7 +18,6 @@ import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilSanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerIngenOverlappendeEndring
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerPeriodeInnenforTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerTomDato
-import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerUtbetalingMotÅrsak
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerÅrsak
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
@@ -27,7 +26,6 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGru
 import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 
 @Service
 class EndretUtbetalingAndelService(
@@ -83,11 +81,6 @@ class EndretUtbetalingAndelService(
             endretUtbetalingAndel = endretUtbetalingAndel,
             vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id),
             kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
-        )
-
-        validerUtbetalingMotÅrsak(
-            årsak = endretUtbetalingAndel.årsak,
-            skalUtbetales = endretUtbetalingAndel.prosent != BigDecimal(0),
         )
 
         validerIngenOverlappendeEndring(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidator.kt
@@ -132,16 +132,6 @@ object EndretUtbetalingAndelValidator {
         }
     }
 
-    fun validerUtbetalingMotÅrsak(
-        årsak: Årsak?,
-        skalUtbetales: Boolean,
-    ) {
-        if (skalUtbetales && årsak == Årsak.ALLEREDE_UTBETALT) {
-            val feilmelding = "Du kan ikke velge denne årsaken og si at kontantstøtten skal utbetales."
-            throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
-        }
-    }
-
     fun validerTomDato(
         tomDato: YearMonth?,
         gyldigTomEtterDagensDato: YearMonth?,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23815
Frontend-PR: https://github.com/navikt/familie-ks-sak-frontend/pull/994

### 💰 Hva skal gjøres, og hvorfor?
Dette vil gjelde for to scenarioer, begge revurderinger:
Scenario 1 er at man i førstegangsvurderingen ser at søker ikke skal ha penger i en periode på grunn av noe, og i revurderingen ser at søker skal ha penger likevel fordi bakgrunnsinformasjonen har endret seg. Da kan man velge Allerede utbetalt og si at pengene skal utbetales for å skape ekstra andeler.

Scenario 2 er at søker har fått all kontantstøtten vedkommende kan få, men likevel søker på nytt for de samme pengene. Da bruker vi samme logikk som ovenfor siden vi ikke ønsker å nulle ut andelene som finnes fra forrige behandling og skape feilutbetalinger. Da sier saksbehandler at ja, perioden skal utbetales men nei, det er et avslag siden pengene allerede er utbetalt.

Slik ser det da ut i frontend:
<img width="563" alt="image" src="https://github.com/user-attachments/assets/bfba9f3f-bd6e-46c1-9789-66cd87fafef0" />


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Setter ingen feature-toggle på denne endringen siden det vil feile tidligere i løpet hvis allerede utbetalt sin toggle ikke er skrudd på.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Jeg har kun slettet kode, ikke skrevet ny funksjonalitet.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
