### PR TITLE
Vedtakbegrunnelser istedenfor begrunnelser i endret utbetaling andel

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
@@ -19,7 +19,7 @@ data class EndretUtbetalingAndelRequestDto(
     val begrunnelse: String,
     val erEksplisittAvslagPåSøknad: Boolean?,
     @JsonDeserialize(using = IBegrunnelseDeserializer::class)
-    val begrunnelser: List<NasjonalEllerFellesBegrunnelse>,
+    val vedtakbegrunnelser: List<NasjonalEllerFellesBegrunnelse>,
 )
 
 fun EndretUtbetalingAndelRequestDto.mapTilBegrunnelser(): List<NasjonalEllerFellesBegrunnelse> {
@@ -32,7 +32,7 @@ fun EndretUtbetalingAndelRequestDto.mapTilBegrunnelser(): List<NasjonalEllerFell
 
         Årsak.ALLEREDE_UTBETALT,
         ->
-            this.begrunnelser
+            this.vedtakbegrunnelser
 
         Årsak.FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024,
         -> listOf(NasjonalEllerFellesBegrunnelse.AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024)

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
@@ -19,7 +19,7 @@ data class EndretUtbetalingAndelRequestDto(
     val begrunnelse: String,
     val erEksplisittAvslagPåSøknad: Boolean?,
     @JsonDeserialize(using = IBegrunnelseDeserializer::class)
-    val vedtakbegrunnelser: List<NasjonalEllerFellesBegrunnelse>,
+    val vedtaksbegrunnelser: List<NasjonalEllerFellesBegrunnelse>,
 )
 
 fun EndretUtbetalingAndelRequestDto.mapTilBegrunnelser(): List<NasjonalEllerFellesBegrunnelse> {
@@ -32,7 +32,7 @@ fun EndretUtbetalingAndelRequestDto.mapTilBegrunnelser(): List<NasjonalEllerFell
 
         Årsak.ALLEREDE_UTBETALT,
         ->
-            this.vedtakbegrunnelser
+            this.vedtaksbegrunnelser
 
         Årsak.FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024,
         -> listOf(NasjonalEllerFellesBegrunnelse.AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024)

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelResponsDto.kt
@@ -17,5 +17,5 @@ data class EndretUtbetalingAndelResponsDto(
     val begrunnelse: String?,
     val erEksplisittAvslagPåSøknad: Boolean?,
     val erTilknyttetAndeler: Boolean,
-    val vedtakbegrunnelser: List<NasjonalEllerFellesBegrunnelse>,
+    val vedtaksbegrunnelser: List<NasjonalEllerFellesBegrunnelse>,
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelResponsDto.kt
@@ -17,5 +17,5 @@ data class EndretUtbetalingAndelResponsDto(
     val begrunnelse: String?,
     val erEksplisittAvslagPåSøknad: Boolean?,
     val erTilknyttetAndeler: Boolean,
-    val begrunnelser: List<NasjonalEllerFellesBegrunnelse>,
+    val vedtakbegrunnelser: List<NasjonalEllerFellesBegrunnelse>,
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
@@ -109,7 +109,7 @@ class BeslutteVedtakSteg(
 
             vedtakService.opprettOgInitierNyttVedtakForBehandling(
                 behandling = behandling,
-                kopierVedtakBegrunnelser = true,
+                kopiervedtaksbegrunnelser = true,
             )
 
             val behandleUnderkjentVedtakTask =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakService.kt
@@ -42,7 +42,7 @@ class VedtakService(
 
     fun opprettOgInitierNyttVedtakForBehandling(
         behandling: Behandling,
-        kopierVedtakBegrunnelser: Boolean = false,
+        kopiervedtaksbegrunnelser: Boolean = false,
     ) {
         behandling.steg.takeUnless { it !== BehandlingSteg.BESLUTTE_VEDTAK && it !== BehandlingSteg.REGISTRERE_PERSONGRUNNLAG }
             ?: throw Feil("Forsøker å initiere vedtak på steg ${behandling.steg}")
@@ -54,7 +54,7 @@ class VedtakService(
 
         val nyttVedtak = Vedtak(behandling = behandling)
 
-        if (kopierVedtakBegrunnelser && deaktivertVedtak != null) {
+        if (kopiervedtaksbegrunnelser && deaktivertVedtak != null) {
             vedtaksperiodeService.kopierOverVedtaksperioder(
                 deaktivertVedtak = deaktivertVedtak,
                 aktivtVedtak = nyttVedtak,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -521,7 +521,7 @@ class VedtaksperiodeService(
 
                     val avslagsbegrunnelser =
                         endretUtbetalinger
-                            .map { it.begrunnelser }
+                            .map { it.vedtakbegrunnelser }
                             .flatten()
                             .toSet()
                             .toList()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -521,7 +521,7 @@ class VedtaksperiodeService(
 
                     val avslagsbegrunnelser =
                         endretUtbetalinger
-                            .map { it.vedtakbegrunnelser }
+                            .map { it.vedtaksbegrunnelser }
                             .flatten()
                             .toSet()
                             .toList()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -144,7 +144,7 @@ data class EndretUtbetalingAndelMedAndelerTilkjentYtelse(
     val periode get() = endretUtbetalingAndel.periode
     val person get() = endretUtbetalingAndel.person
     val begrunnelse get() = endretUtbetalingAndel.begrunnelse
-    val begrunnelser get() = endretUtbetalingAndel.begrunnelser
+    val vedtakbegrunnelser get() = endretUtbetalingAndel.vedtakbegrunnelser
     val søknadstidspunkt get() = endretUtbetalingAndel.søknadstidspunkt
     val prosent get() = endretUtbetalingAndel.prosent
     val aktivtFødselsnummer get() = endretUtbetalingAndel.person?.aktør?.aktivFødselsnummer()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -144,7 +144,7 @@ data class EndretUtbetalingAndelMedAndelerTilkjentYtelse(
     val periode get() = endretUtbetalingAndel.periode
     val person get() = endretUtbetalingAndel.person
     val begrunnelse get() = endretUtbetalingAndel.begrunnelse
-    val vedtakbegrunnelser get() = endretUtbetalingAndel.vedtakbegrunnelser
+    val vedtaksbegrunnelser get() = endretUtbetalingAndel.vedtaksbegrunnelser
     val søknadstidspunkt get() = endretUtbetalingAndel.søknadstidspunkt
     val prosent get() = endretUtbetalingAndel.prosent
     val aktivtFødselsnummer get() = endretUtbetalingAndel.person?.aktør?.aktivFødselsnummer()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -18,7 +18,6 @@ import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilSanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerIngenOverlappendeEndring
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerPeriodeInnenforTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerTomDato
-import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerUtbetalingMotÅrsak
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator.validerÅrsak
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
@@ -27,7 +26,6 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGru
 import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.math.BigDecimal
 
 @Service
 class EndretUtbetalingAndelService(
@@ -83,11 +81,6 @@ class EndretUtbetalingAndelService(
             endretUtbetalingAndel = endretUtbetalingAndel,
             vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id),
             kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
-        )
-
-        validerUtbetalingMotÅrsak(
-            årsak = endretUtbetalingAndel.årsak,
-            skalUtbetales = endretUtbetalingAndel.prosent != BigDecimal(0),
         )
 
         validerIngenOverlappendeEndring(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -141,7 +141,7 @@ class EndretUtbetalingAndelService(
         forrigeBehandling: Behandling,
     ) = hentEndredeUtbetalingAndeler(forrigeBehandling.id).forEach {
         val kopiertOverEndretUtbetalingAndel =
-            it.copy(id = 0, behandlingId = behandling.id, erEksplisittAvslagPåSøknad = false, vedtakbegrunnelser = emptyList())
+            it.copy(id = 0, behandlingId = behandling.id, erEksplisittAvslagPåSøknad = false, vedtaksbegrunnelser = emptyList())
         endretUtbetalingAndelRepository.save(kopiertOverEndretUtbetalingAndel)
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -148,7 +148,7 @@ class EndretUtbetalingAndelService(
         forrigeBehandling: Behandling,
     ) = hentEndredeUtbetalingAndeler(forrigeBehandling.id).forEach {
         val kopiertOverEndretUtbetalingAndel =
-            it.copy(id = 0, behandlingId = behandling.id, erEksplisittAvslagPåSøknad = false, begrunnelser = emptyList())
+            it.copy(id = 0, behandlingId = behandling.id, erEksplisittAvslagPåSøknad = false, vedtakbegrunnelser = emptyList())
         endretUtbetalingAndelRepository.save(kopiertOverEndretUtbetalingAndel)
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelValidator.kt
@@ -132,16 +132,6 @@ object EndretUtbetalingAndelValidator {
         }
     }
 
-    fun validerUtbetalingMotÅrsak(
-        årsak: Årsak?,
-        skalUtbetales: Boolean,
-    ) {
-        if (skalUtbetales && årsak == Årsak.ALLEREDE_UTBETALT) {
-            val feilmelding = "Du kan ikke velge denne årsaken og si at kontantstøtten skal utbetales."
-            throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
-        }
-    }
-
     fun validerTomDato(
         tomDato: YearMonth?,
         gyldigTomEtterDagensDato: YearMonth?,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -61,7 +61,7 @@ data class EndretUtbetalingAndel(
     var begrunnelse: String? = null,
     @Column(name = "vedtak_begrunnelse_spesifikasjoner")
     @Convert(converter = IBegrunnelseListConverter::class)
-    var vedtakbegrunnelser: List<NasjonalEllerFellesBegrunnelse> = emptyList(),
+    var vedtaksbegrunnelser: List<NasjonalEllerFellesBegrunnelse> = emptyList(),
     @Column(name = "er_eksplisitt_avslag_paa_soknad")
     var erEksplisittAvslagPåSøknad: Boolean? = null,
 ) : BaseEntitet() {
@@ -110,7 +110,7 @@ fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilEndretUtbetalingAndelRespon
         årsak = this.årsak,
         søknadstidspunkt = this.søknadstidspunkt,
         begrunnelse = this.begrunnelse,
-        vedtakbegrunnelser = this.vedtakbegrunnelser,
+        vedtaksbegrunnelser = this.vedtaksbegrunnelser,
         erEksplisittAvslagPåSøknad = this.erEksplisittAvslagPåSøknad,
         erTilknyttetAndeler = this.andelerTilkjentYtelse.isNotEmpty(),
     )
@@ -126,7 +126,7 @@ fun EndretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(
     this.årsak = endretUtbetalingAndelRequestDto.årsak
     this.søknadstidspunkt = endretUtbetalingAndelRequestDto.søknadstidspunkt
     this.begrunnelse = endretUtbetalingAndelRequestDto.begrunnelse
-    this.vedtakbegrunnelser = endretUtbetalingAndelRequestDto.mapTilBegrunnelser()
+    this.vedtaksbegrunnelser = endretUtbetalingAndelRequestDto.mapTilBegrunnelser()
     this.erEksplisittAvslagPåSøknad = endretUtbetalingAndelRequestDto.erEksplisittAvslagPåSøknad
     return this
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndel.kt
@@ -61,7 +61,7 @@ data class EndretUtbetalingAndel(
     var begrunnelse: String? = null,
     @Column(name = "vedtak_begrunnelse_spesifikasjoner")
     @Convert(converter = IBegrunnelseListConverter::class)
-    var begrunnelser: List<NasjonalEllerFellesBegrunnelse> = emptyList(),
+    var vedtakbegrunnelser: List<NasjonalEllerFellesBegrunnelse> = emptyList(),
     @Column(name = "er_eksplisitt_avslag_paa_soknad")
     var erEksplisittAvslagPåSøknad: Boolean? = null,
 ) : BaseEntitet() {
@@ -110,7 +110,7 @@ fun EndretUtbetalingAndelMedAndelerTilkjentYtelse.tilEndretUtbetalingAndelRespon
         årsak = this.årsak,
         søknadstidspunkt = this.søknadstidspunkt,
         begrunnelse = this.begrunnelse,
-        begrunnelser = this.begrunnelser,
+        vedtakbegrunnelser = this.vedtakbegrunnelser,
         erEksplisittAvslagPåSøknad = this.erEksplisittAvslagPåSøknad,
         erTilknyttetAndeler = this.andelerTilkjentYtelse.isNotEmpty(),
     )
@@ -126,7 +126,7 @@ fun EndretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(
     this.årsak = endretUtbetalingAndelRequestDto.årsak
     this.søknadstidspunkt = endretUtbetalingAndelRequestDto.søknadstidspunkt
     this.begrunnelse = endretUtbetalingAndelRequestDto.begrunnelse
-    this.begrunnelser = endretUtbetalingAndelRequestDto.mapTilBegrunnelser()
+    this.vedtakbegrunnelser = endretUtbetalingAndelRequestDto.mapTilBegrunnelser()
     this.erEksplisittAvslagPåSøknad = endretUtbetalingAndelRequestDto.erEksplisittAvslagPåSøknad
     return this
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -721,7 +721,7 @@ fun lagEndretUtbetalingAndel(
         årsak = årsak,
         søknadstidspunkt = søknadstidspunkt,
         begrunnelse = begrunnelse,
-        vedtakbegrunnelser = begrunnelser,
+        vedtaksbegrunnelser = begrunnelser,
         erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
     )
 

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -721,7 +721,7 @@ fun lagEndretUtbetalingAndel(
         årsak = årsak,
         søknadstidspunkt = søknadstidspunkt,
         begrunnelse = begrunnelse,
-        begrunnelser = begrunnelser,
+        vedtakbegrunnelser = begrunnelser,
         erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
     )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -105,7 +105,7 @@ class EndretUtbetalingAndelServiceTest {
 
         val lagretEndretUtbetalingAndel = lagretEndretUtbetalingAndelSlot.captured
 
-        assertThat(lagretEndretUtbetalingAndel.vedtakbegrunnelser, Is(emptyList()))
+        assertThat(lagretEndretUtbetalingAndel.vedtaksbegrunnelser, Is(emptyList()))
         assertThat(lagretEndretUtbetalingAndel.erEksplisittAvslagPåSøknad, Is(false))
         assertThat(lagretEndretUtbetalingAndel.årsak, Is(Årsak.ETTERBETALING_3MND))
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -105,7 +105,7 @@ class EndretUtbetalingAndelServiceTest {
 
         val lagretEndretUtbetalingAndel = lagretEndretUtbetalingAndelSlot.captured
 
-        assertThat(lagretEndretUtbetalingAndel.begrunnelser, Is(emptyList()))
+        assertThat(lagretEndretUtbetalingAndel.vedtakbegrunnelser, Is(emptyList()))
         assertThat(lagretEndretUtbetalingAndel.erEksplisittAvslagPåSøknad, Is(false))
         assertThat(lagretEndretUtbetalingAndel.årsak, Is(Årsak.ETTERBETALING_3MND))
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelKtTest.kt
@@ -59,7 +59,7 @@ class EndretUtbetalingAndelKtTest {
             assertThat(oppdatertEndretUtbetalingAndel.årsak).isEqualTo(endretUtbetalingAndelRequestDto.årsak)
             assertThat(oppdatertEndretUtbetalingAndel.søknadstidspunkt).isEqualTo(endretUtbetalingAndelRequestDto.søknadstidspunkt)
             assertThat(oppdatertEndretUtbetalingAndel.begrunnelse).isEqualTo(endretUtbetalingAndelRequestDto.begrunnelse)
-            assertThat(oppdatertEndretUtbetalingAndel.vedtakbegrunnelser).containsOnly()
+            assertThat(oppdatertEndretUtbetalingAndel.vedtaksbegrunnelser).containsOnly()
             assertThat(oppdatertEndretUtbetalingAndel.erEksplisittAvslagPåSøknad).isEqualTo(endretUtbetalingAndelRequestDto.erEksplisittAvslagPåSøknad)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelKtTest.kt
@@ -59,7 +59,7 @@ class EndretUtbetalingAndelKtTest {
             assertThat(oppdatertEndretUtbetalingAndel.årsak).isEqualTo(endretUtbetalingAndelRequestDto.årsak)
             assertThat(oppdatertEndretUtbetalingAndel.søknadstidspunkt).isEqualTo(endretUtbetalingAndelRequestDto.søknadstidspunkt)
             assertThat(oppdatertEndretUtbetalingAndel.begrunnelse).isEqualTo(endretUtbetalingAndelRequestDto.begrunnelse)
-            assertThat(oppdatertEndretUtbetalingAndel.begrunnelser).containsOnly()
+            assertThat(oppdatertEndretUtbetalingAndel.vedtakbegrunnelser).containsOnly()
             assertThat(oppdatertEndretUtbetalingAndel.erEksplisittAvslagPåSøknad).isEqualTo(endretUtbetalingAndelRequestDto.erEksplisittAvslagPåSøknad)
         }
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
@@ -91,7 +91,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                     "årsak": "FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024",
                     "søknadstidspunkt": "2024-08-20",
                     "begrunnelse": "gyldig request",
-                    "begrunnelser": []
+                    "vedtaksbegrunnelser": []
                 }
                 """.trimIndent()
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
@@ -156,7 +156,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                     "årsak": "FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024",
                     "søknadstidspunkt": "2024-08-20",
                     "begrunnelse": "gyldig request",
-                    "vedtakbegrunnelser": []
+                    "vedtaksbegrunnelser": []
                 }
                 """.trimIndent()
 
@@ -227,7 +227,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                     "årsak": "FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024",
                     "søknadstidspunkt": "2024-08-20",
                     "begrunnelse": "gyldig request",
-                    "vedtakbegrunnelser": []
+                    "vedtaksbegrunnelser": []
                 }
                 """.trimIndent()
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
@@ -156,7 +156,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                     "årsak": "FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024",
                     "søknadstidspunkt": "2024-08-20",
                     "begrunnelse": "gyldig request",
-                    "begrunnelser": []
+                    "vedtakbegrunnelser": []
                 }
                 """.trimIndent()
 
@@ -227,7 +227,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                     "årsak": "FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024",
                     "søknadstidspunkt": "2024-08-20",
                     "begrunnelse": "gyldig request",
-                    "begrunnelser": []
+                    "vedtakbegrunnelser": []
                 }
                 """.trimIndent()
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23583

I EndretUtbetalingAndel har vi både feltet "begrunnelse" og "begrunnelser", som er noe forvirrende. Sistnevnte burde døpes om til å bli "vedtakbegrunnelser" i stedet. Det er snakk om Sanity-begrunnelsene som saksbehandler velger som vises i brevet.