### PR TITLE
Bare se på personer fra forrige behandling når vi utleder endringsresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -40,13 +40,12 @@ object BehandlingsresultatEndringUtils {
         forrigePersonResultat: Set<PersonResultat>,
         nåværendeEndretAndeler: List<EndretUtbetalingAndel>,
         forrigeEndretAndeler: List<EndretUtbetalingAndel>,
-        personerIBehandling: Set<Person>,
         personerIForrigeBehandling: Set<Person>,
     ): Endringsresultat {
         val logger: Logger = LoggerFactory.getLogger("utledEndringsresultatLogger")
         val secureLogger = LoggerFactory.getLogger("secureLogger")
 
-        val relevantePersoner = (personerIBehandling.map { it.aktør } + personerIForrigeBehandling.map { it.aktør }).distinct()
+        val relevantePersoner = personerIForrigeBehandling.map { it.aktør }
 
         val endringerForRelevantePersoner =
             relevantePersoner.any { aktør ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -48,7 +48,6 @@ class BehandlingsresultatService(
 
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)
 
-        val personerIBehandling = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id).personer.toSet()
         val personerIForrigeBehandling = forrigeBehandling?.let { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = forrigeBehandling.id).personer.toSet() } ?: emptySet()
 
         val forrigeVilkårsvurdering = forrigeBehandling?.id?.let { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = it) }
@@ -95,7 +94,6 @@ class BehandlingsresultatService(
                     nåværendeKompetanser = kompetanser.toList(),
                     forrigeKompetanser = forrigeKompetanser.toList(),
                     personerFremstiltKravFor = personerFremstiltKravFor,
-                    personerIBehandling = personerIBehandling,
                     personerIForrigeBehandling = personerIForrigeBehandling,
                 )
             } else {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -39,7 +39,6 @@ class BehandlingsresultatEndringUtilsTest {
     private val barn1Aktør = randomAktør()
 
     val jan22 = YearMonth.of(2022, 1)
-    val feb22 = YearMonth.of(2022, 2)
     val mai22 = YearMonth.of(2022, 5)
     val aug22 = YearMonth.of(2022, 8)
     val des22 = YearMonth.of(2022, 12)
@@ -57,7 +56,6 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigePersonResultat = emptySet(),
                 nåværendeEndretAndeler = emptyList(),
                 forrigeEndretAndeler = emptyList(),
-                personerIBehandling = emptySet(),
                 personerIForrigeBehandling = emptySet(),
             )
 
@@ -87,7 +85,6 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigePersonResultat = emptySet(),
                 nåværendeEndretAndeler = emptyList(),
                 forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(person),
                 personerIForrigeBehandling = setOf(person),
             )
 
@@ -177,7 +174,6 @@ class BehandlingsresultatEndringUtilsTest {
                 nåværendePersonResultat = setOf(nåværendePersonResultat),
                 nåværendeEndretAndeler = emptyList(),
                 forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(barn),
                 personerIForrigeBehandling = setOf(barn),
             )
 
@@ -221,7 +217,6 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigePersonResultat = emptySet(),
                 nåværendeEndretAndeler = emptyList(),
                 forrigeEndretAndeler = emptyList(),
-                personerIBehandling = setOf(barnPerson),
                 personerIForrigeBehandling = setOf(barnPerson),
             )
 
@@ -253,7 +248,6 @@ class BehandlingsresultatEndringUtilsTest {
                 forrigePersonResultat = emptySet(),
                 forrigeEndretAndeler = listOf(forrigeEndretAndel),
                 nåværendeEndretAndeler = listOf(forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)),
-                personerIBehandling = setOf(barn),
                 personerIForrigeBehandling = setOf(barn),
             )
 

--- a/src/test/resources/cucumber/behandlingsresultat/nytt-barn.feature
+++ b/src/test/resources/cucumber/behandlingsresultat/nytt-barn.feature
@@ -1,0 +1,72 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Behandlingsresultat ved nytt barn
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | SØKNAD           | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 25.03.1994  |
+      | 1            | 2       | BARN       | 14.05.2022  |
+      | 2            | 1       | SØKER      | 25.03.1994  |
+      | 2            | 2       | BARN       | 14.05.2022  |
+      | 2            | 3       | BARN       | 28.06.2023  |
+
+  Scenario: Skal bli AVSLÅTT dersom det er et nytt barn med avslag i behandling 2, og ingen endring for annet barn fra behandling 1
+    Og følgende dagens dato 14.01.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               | 25.03.1994 |            | OPPFYLT      | Nei                  | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   | 25.03.1999 |            | OPPFYLT      | Nei                  | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    | 02.11.1999 |            | OPPFYLT      | Nei                  | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               | 14.05.2022 | 31.07.2023 | OPPFYLT      | Nei                  |                  | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER | 14.05.2022 |            | OPPFYLT      | Nei                  | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNETS_ALDER                | 14.05.2023 | 14.05.2024 | OPPFYLT      | Nei                  |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               | 01.08.2023 |            | IKKE_OPPFYLT | Nei                  |                  | Nei                                   | 50           |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser                           | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               | 25.03.1994 |            | OPPFYLT      | Nei                  |                                                | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   | 25.03.1999 |            | OPPFYLT      | Nei                  |                                                | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    | 02.11.1999 |            | OPPFYLT      | Nei                  |                                                | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER | 14.05.2022 |            | OPPFYLT      | Nei                  |                                                | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               | 14.05.2022 | 31.07.2023 | OPPFYLT      | Nei                  |                                                |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                | 14.05.2023 | 14.05.2024 | OPPFYLT      | Nei                  |                                                |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               | 01.08.2023 |            | IKKE_OPPFYLT | Nei                  | AVSLAG_BRUKER_MELDER_FULLTIDSPLASS_I_BARNEHAGE |                  | Nei                                   | 50           |
+
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER    | 02.11.1999 |            | OPPFYLT      | Nei                  |                                                | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BOSATT_I_RIKET,BOR_MED_SØKER | 28.06.2023 |            | OPPFYLT      | Nei                  |                                                | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               | 28.06.2023 | 31.07.2024 | OPPFYLT      | Nei                  |                                                |                  | Nei                                   |              |
+      | 3       | BARNETS_ALDER                | 28.06.2024 | 31.07.2024 | OPPFYLT      | Nei                  |                                                |                  | Nei                                   |              |
+      | 3       | BARNETS_ALDER                | 01.08.2024 | 28.01.2025 | OPPFYLT      | Nei                  |                                                |                  | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               | 01.08.2024 |            | IKKE_OPPFYLT | Nei                  | AVSLAG_BRUKER_MELDER_FULLTIDSPLASS_I_BARNEHAGE |                  | Nei                                   | 45           |
+
+    Og følgende endrede utbetalinger
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak                                 | Prosent | Søknadstidspunkt | Er eksplisitt avslag |
+      | 3       | 2            | 01.07.2024 | 31.07.2024 | ETTERBETALING_3MND                    | 0       | 09.11.2024       | Ja                   |
+      | 3       | 2            | 01.08.2024 | 31.08.2024 | FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 | 0       | 09.11.2024       | Ja                   |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp |
+      | 2       | 01.06.2023 | 31.07.2023 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |
+      | 3       | 01.07.2024 | 31.08.2024 | 0     | ORDINÆR_KONTANTSTØTTE | 0       | 7500 | 0                      |
+
+    Og når behandlingsresultatet er utledet for behandling 2
+
+    Så forvent at behandlingsresultatet er AVSLÅTT på behandling 2


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-23824

Når vi utleder endringsresultat for en behandling, er det feil å se på personer som ikke var inkludert i forrige behandling, ettersom de uansett ikke har noen endringer

Utleder derfor behandlingsresultat bare basert på personer som var en del av forrige behandling

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
