### PR TITLE
Fix: endre maks differanse til å være 6mnd for adopsjon på barnets alder-vilkåret

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2024.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2024.kt
@@ -30,8 +30,8 @@ class BarnetsAlderVilkårValidator2024 {
                         ) ->
                         "Du kan ikke sette en t.o.m dato på barnets alder vilkåret som er etter august året barnet fyller 6 år."
 
-                    it.verdi.erAdopsjonOppfylt() && it.fom.plusMonths(7) < it.tom ->
-                        "Differansen mellom f.o.m datoen og t.o.m datoen på barnets alder vilkåret kan ikke være mer enn 7 måneder."
+                    it.verdi.erAdopsjonOppfylt() && it.fom.plusMonths(6) < it.tom ->
+                        "Differansen mellom f.o.m datoen og t.o.m datoen på barnets alder vilkåret kan ikke være mer enn 6 måneder."
 
                     !it.verdi.erAdopsjonOppfylt() && !it.fom.isEqual(maxOf(periodeFomBarnetsAlderLov2024, DATO_LOVENDRING_2024)) ->
                         "F.o.m datoen på barnets alder vilkåret må være lik datoen barnet fyller 13 måneder eller 01.08.24 dersom barnet fyller 13 måneder før 01.08.24."

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2024Test.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2024Test.kt
@@ -85,7 +85,7 @@ class BarnetsAlderVilkårValidator2024Test {
     }
 
     @Test
-    fun `skal returnere feil om differansen mellom fom og tom er mer enn syv måneder for barn som er adoptert`() {
+    fun `skal returnere feil om differansen mellom fom og tom er mer enn seks måneder for barn som er adoptert`() {
         // Arrange
         val fødselsdato = LocalDate.of(2023, 10, 17)
 
@@ -108,7 +108,7 @@ class BarnetsAlderVilkårValidator2024Test {
                             resultat = Resultat.OPPFYLT,
                         ),
                     fom = fødselsdato.plusYears(1),
-                    tom = fødselsdato.plusYears(2),
+                    tom = fødselsdato.plusYears(1).plusMonths(7),
                 ),
             )
 
@@ -124,7 +124,7 @@ class BarnetsAlderVilkårValidator2024Test {
         // Assert
         assertThat(validerBarnetsAlderVilkår).hasSize(1)
         assertThat(validerBarnetsAlderVilkår).contains(
-            "Differansen mellom f.o.m datoen og t.o.m datoen på barnets alder vilkåret kan ikke være mer enn 7 måneder.",
+            "Differansen mellom f.o.m datoen og t.o.m datoen på barnets alder vilkåret kan ikke være mer enn 6 måneder.",
         )
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23940

For barnets alder-vilkåret har vi tillatt en måned for mye for adopsjonssaker, så de har fått generert andeler i 8 måneder i stedet for 7. Som man kan se i favro-kortet så blir man stoppet av en feilmelding på behandlingsresultat-siden, men dette burde ikke vært tillatt å legge inn i vilkåret, slik at saksbehandler får feilmeldingen tidligere. For vanlige saker er det 6 måneder diff som tillates i vilkåret (fom=13mnd og tom=16mnd = 6mnd diff).

Tilhørende frontend PR: https://github.com/navikt/familie-ks-sak-frontend/pull/1005

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
