### PR TITLE
Fix: sørg for at "opprettet av ks-sak"-beskjed alltid kommer med i oppgave-beskrivelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -230,11 +230,7 @@ class OppgaveService(
         fagsakId: Long,
         beskrivelse: String? = null,
     ): String =
-        if (beskrivelse != null) {
-            beskrivelse + "\n"
-        } else {
-            ""
-        } + (
+        beskrivelse?.let { it + "\n" } + (
             "----- Opprettet av familie-ks-sak ${
                 LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
             } --- \n" +

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -230,13 +230,16 @@ class OppgaveService(
         fagsakId: Long,
         beskrivelse: String? = null,
     ): String =
-        beskrivelse?.let { it + "\n" }
-            ?: (
-                "----- Opprettet av familie-ks-sak ${
-                    LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
-                } --- \n" +
-                    "https://ks.intern.nav.no/fagsak/$fagsakId"
-            )
+        if (beskrivelse != null) {
+            beskrivelse + "\n"
+        } else {
+            ""
+        } + (
+            "----- Opprettet av familie-ks-sak ${
+                LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
+            } --- \n" +
+                "https://ks.intern.nav.no/fagsak/$fagsakId"
+        )
 
     companion object {
         private val logger = LoggerFactory.getLogger(OppgaveService::class.java)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23989

Sørger for at beskjed om at oppgaven har blitt opprettet av ks-sak alltid kommer med i oppgave-beskrivelsen. Skriver om koden så den blir helt lik som i ba-sak. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det gir mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
