### PR TITLE
Fjerner alle vilkårresultater som ikke er vurdert før forskyvning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFørFebruar2025/ForskyvVilkårFørFebruar2025.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFørFebruar2025/ForskyvVilkårFørFebruar2025.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvni
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning.lovverkFørFebruar2025.lov2021.forskyvEtterLovgivning2021
@@ -19,7 +20,7 @@ object ForskyvVilkårFørFebruar2025 {
     ): Map<Vilkår, List<Periode<VilkårResultat>>> {
         val vilkårResultaterForAktørMap =
             personResultat.vilkårResultater
-                .filter { it.periodeFom != null }
+                .filter { it.resultat != Resultat.IKKE_VURDERT }
                 .groupByTo(mutableMapOf()) { it.vilkårType }
                 .mapValues { if (it.key == Vilkår.BOR_MED_SØKER) it.value.fjernAvslagUtenPeriodeHvisDetFinsAndreVilkårResultat() else it.value }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFørFebruar2025/ForskyvVilkårFørFebruar2025.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFørFebruar2025/ForskyvVilkårFørFebruar2025.kt
@@ -19,6 +19,7 @@ object ForskyvVilkårFørFebruar2025 {
     ): Map<Vilkår, List<Periode<VilkårResultat>>> {
         val vilkårResultaterForAktørMap =
             personResultat.vilkårResultater
+                .filter { it.periodeFom != null }
                 .groupByTo(mutableMapOf()) { it.vilkårType }
                 .mapValues { if (it.key == Vilkår.BOR_MED_SØKER) it.value.fjernAvslagUtenPeriodeHvisDetFinsAndreVilkårResultat() else it.value }
 


### PR DESCRIPTION
Vi får følgende feil: ```[java.lang.IllegalStateException]  En feil har oppstått: Feil med tidslinje. Periode som ikke kommer på slutten har tom=null``` dersom vi forsøker å forskyve. Fjerner her alle vilkårresultater som ikke er vurdert før vi forsøker å forskyve.
