### PR TITLE
NAV-24038: Del 1 av å ta i bruk lovverk ved forskyvning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -12,7 +12,7 @@ class FeatureToggleConfig {
         // Ikke operasjonelle
         const val OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER = "familie-ba-ks-sak.opprett-sak-paa-riktig-enhet-og-saksbehandler"
         const val KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK = "familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"
-        const val BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER = "familie-ks-sak.bruk-ny-loype-for-generering-av-andeler"
+        const val STØTTER_LOVENDRING_2025 = "familie-ks-sak.stotter-lovendring-2025"
 
         const val BRUK_OMSKRIVING_AV_HJEMLER_I_BREV = "familie-ks-sak.bruk_omskriving_av_hjemler_i_brev"
         const val ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK = "familie-ks-sak.allerede-utbetalt"

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
 import no.nav.familie.ks.sak.common.util.nesteMåned
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
-import no.nav.familie.ks.sak.kjerne.beregning.tilAndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.tilAndelerTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.tilPeriode
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
@@ -135,6 +135,6 @@ object BehandlingsresultatOpphørUtils {
                         // Vi ønsker å filtrere bort andeler som har 0 i kalkulertUtbetalingsbeløp
                         if (kalkulertUtbetalingsbeløp == 0) null else andelTilkjentYtelse
                 }
-            }.tilAndelTilkjentYtelse()
+            }.tilAndelerTilkjentYtelse()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.slåSammen
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
@@ -29,6 +30,7 @@ import no.nav.familie.tidslinje.TidslinjePeriodeMedDato
 import no.nav.familie.tidslinje.utvidelser.klipp
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.validerIngenOverlapp
+import no.nav.familie.unleash.UnleashService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -44,6 +46,7 @@ class VilkårsvurderingSteg(
     private val beregningService: BeregningService,
     private val kompetanseService: KompetanseService,
     private val barnetsVilkårValidator: BarnetsVilkårValidator,
+    private val unleashService: UnleashService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.VILKÅRSVURDERING
 
@@ -268,7 +271,7 @@ class VilkårsvurderingSteg(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         vilkårsvurdering: Vilkårsvurdering,
     ) {
-        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag)
+        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER))
         if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
             throw FunksjonellFeil(
                 melding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -58,7 +58,7 @@ class VilkårsvurderingSteg(
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId)
 
         if (personopplysningGrunnlag.barna.any { it.fødselsdato.isAfter(LocalDate.of(2023, 12, 31)) } &&
-            !unleashNextMedContextService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER)
+            !unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025)
         ) {
             throw FunksjonellFeil("Barn født 1.1.24 eller senere kan ikke behandles før nytt regelverk er støttet i løsningen")
         }
@@ -278,7 +278,7 @@ class VilkårsvurderingSteg(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         vilkårsvurdering: Vilkårsvurdering,
     ) {
-        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER))
+        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025))
         if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
             throw FunksjonellFeil(
                 melding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkår.kt
@@ -51,8 +51,9 @@ private fun Collection<PersonResultat>.tilForskjøvetVilkårResultatTidslinjeFor
 
 fun Collection<PersonResultat>.tilForskjøvetVilkårResultatTidslinjeDerVilkårErOppfyltForPerson(
     person: Person,
+    lovverk: Lovverk = Lovverk.FØR_LOVENDRING_2025,
 ): Tidslinje<List<VilkårResultat>> {
-    val forskjøvedeVilkårResultater = this.find { it.aktør == person.aktør }?.forskyvVilkårResultater() ?: emptyMap()
+    val forskjøvedeVilkårResultater = this.find { it.aktør == person.aktør }?.forskyvVilkårResultater(lovverk = lovverk) ?: emptyMap()
 
     return forskjøvedeVilkårResultater
         .map { it.value.tilTidslinje() }
@@ -61,7 +62,9 @@ fun Collection<PersonResultat>.tilForskjøvetVilkårResultatTidslinjeDerVilkårE
         .tilTidslinje()
 }
 
-fun PersonResultat.forskyvVilkårResultater(lovverk: Lovverk = Lovverk.FØR_LOVENDRING_2025): Map<Vilkår, List<Periode<VilkårResultat>>> =
+fun PersonResultat.forskyvVilkårResultater(
+    lovverk: Lovverk = Lovverk.FØR_LOVENDRING_2025,
+): Map<Vilkår, List<Periode<VilkårResultat>>> =
     when (lovverk) {
         Lovverk.FØR_LOVENDRING_2025 -> ForskyvVilkårFørFebruar2025.forskyvVilkårResultater(personResultat = this)
         Lovverk.LOVENDRING_FEBRUAR_2025 -> TODO()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelGenerator.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
-import no.nav.familie.ks.sak.kjerne.beregning.lovverkFørFebruar2025.tilAndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelTilkjentYtelseTidslinjeUtil.kt
@@ -18,11 +18,9 @@ fun Iterable<AndelTilkjentYtelse>.tilSeparateTidslinjerForBarna(): Map<Aktør, T
         .groupBy { it.aktør }
         .mapValues { (_, andeler) -> andeler.map { it.tilPeriode() }.tilTidslinje() }
 
-fun Map<Aktør, Tidslinje<AndelTilkjentYtelse>>.tilAndelerTilkjentYtelse(): List<AndelTilkjentYtelse> = this.values.flatMap { it.tilAndelTilkjentYtelse() }
+fun Map<Aktør, Tidslinje<AndelTilkjentYtelse>>.tilAndelerTilkjentYtelse(): List<AndelTilkjentYtelse> = this.values.flatMap { it.tilAndelerTilkjentYtelse() }
 
-fun Iterable<Tidslinje<AndelTilkjentYtelse>>.tilAndelerTilkjentYtelse(): List<AndelTilkjentYtelse> = this.flatMap { it.tilAndelTilkjentYtelse() }
-
-fun Tidslinje<AndelTilkjentYtelse>.tilAndelTilkjentYtelse(): List<AndelTilkjentYtelse> =
+fun Tidslinje<AndelTilkjentYtelse>.tilAndelerTilkjentYtelse(): List<AndelTilkjentYtelse> =
     this
         .tilPerioder()
         .map {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
@@ -1,19 +1,19 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.lovverk.LovverkUtleder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 
 @Service
 class BeregnAndelTilkjentYtelseService(
     private val andelGeneratorLookup: AndelGenerator.Lookup,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     fun beregnAndelerTilkjentYtelse(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
@@ -38,7 +38,7 @@ class BeregnAndelTilkjentYtelseService(
         val regelverk =
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = barn.fødselsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025, false),
+                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
             )
         val andelGenerator = andelGeneratorLookup.hentGeneratorForLovverk(regelverk)
         val andeler = andelGenerator.beregnAndelerForBarn(søker = søker, barn = barn, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
@@ -38,7 +38,7 @@ class BeregnAndelTilkjentYtelseService(
         val regelverk =
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = barn.fødselsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER, false),
+                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025, false),
             )
         val andelGenerator = andelGeneratorLookup.hentGeneratorForLovverk(regelverk)
         val andeler = andelGenerator.beregnAndelerForBarn(søker = søker, barn = barn, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/VilkårResultaterTilAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/VilkårResultaterTilAndelTilkjentYtelseMapper.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ks.sak.kjerne.beregning.lovverkFørFebruar2025
+package no.nav.familie.ks.sak.kjerne.beregning
 
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.toYearMonth

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/lovverkFebruar2025/LovverkFebruar2025AndelGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/lovverkFebruar2025/LovverkFebruar2025AndelGenerator.kt
@@ -1,7 +1,10 @@
 package no.nav.familie.ks.sak.kjerne.beregning.lovverkFebruar2025
 
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning.tilForskjøvetVilkårResultatTidslinjeDerVilkårErOppfyltForPerson
 import no.nav.familie.ks.sak.kjerne.beregning.AndelGenerator
+import no.nav.familie.ks.sak.kjerne.beregning.AndelGenerator.Companion.kombinerForskjøvedeTidslinjerTilOppfyltTidslinje
+import no.nav.familie.ks.sak.kjerne.beregning.AndelGenerator.Companion.lagAndelerTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
@@ -18,7 +21,24 @@ class LovverkFebruar2025AndelGenerator : AndelGenerator {
         vilkårsvurdering: Vilkårsvurdering,
         tilkjentYtelse: TilkjentYtelse,
     ): List<AndelTilkjentYtelse> {
-        // TODO: Skrive logikk for å generere andeler etter nytt regelverk
-        return emptyList()
+        val søkersVilkårResultaterForskjøvetTidslinje =
+            vilkårsvurdering.personResultater.tilForskjøvetVilkårResultatTidslinjeDerVilkårErOppfyltForPerson(
+                person = søker,
+                lovverk = lovverk,
+            )
+
+        val barnetsVilkårResultaterForskjøvetTidslinje =
+            vilkårsvurdering.personResultater.tilForskjøvetVilkårResultatTidslinjeDerVilkårErOppfyltForPerson(
+                person = barn,
+                lovverk = lovverk,
+            )
+
+        val oppfyltTidslinje = kombinerForskjøvedeTidslinjerTilOppfyltTidslinje(søkersVilkårResultaterForskjøvetTidslinje, barnetsVilkårResultaterForskjøvetTidslinje)
+
+        return lagAndelerTilkjentYtelse(
+            oppfyltTidslinje = oppfyltTidslinje,
+            tilkjentYtelse = tilkjentYtelse,
+            barnAktør = barn.aktør,
+        )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/lovverkFørFebruar2025/LovverkFørFebruar2025AndelGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/lovverkFørFebruar2025/LovverkFørFebruar2025AndelGenerator.kt
@@ -23,11 +23,15 @@ class LovverkFørFebruar2025AndelGenerator : AndelGenerator {
     ): List<AndelTilkjentYtelse> {
         val søkersVilkårResultaterForskjøvetTidslinje =
             vilkårsvurdering.personResultater.tilForskjøvetVilkårResultatTidslinjeDerVilkårErOppfyltForPerson(
-                søker,
+                person = søker,
+                lovverk = lovverk,
             )
 
         val barnetsVilkårResultaterForskjøvetTidslinje =
-            vilkårsvurdering.personResultater.tilForskjøvetVilkårResultatTidslinjeDerVilkårErOppfyltForPerson(barn)
+            vilkårsvurdering.personResultater.tilForskjøvetVilkårResultatTidslinjeDerVilkårErOppfyltForPerson(
+                person = barn,
+                lovverk = lovverk,
+            )
 
         val oppfyltTidslinje = kombinerForskjøvedeTidslinjerTilOppfyltTidslinje(søkersVilkårResultaterForskjøvetTidslinje, barnetsVilkårResultaterForskjøvetTidslinje)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårResultatTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårResultatTidslinje.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning.forskyvVilkårResultater
+import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
@@ -13,9 +14,9 @@ import no.nav.familie.tidslinje.tilTidslinje
  * Antakelsen er at IKKE_OPPFYLT i ALLE tilfeller kan ignoreres for beregning,
  * og evt bare brukes for info i brev
  */
-fun PersonResultat.tilVilkårRegelverkResultatTidslinje(): List<Tidslinje<VilkårRegelverkResultat>> =
+fun PersonResultat.tilVilkårRegelverkResultatTidslinje(lovverk: Lovverk): List<Tidslinje<VilkårRegelverkResultat>> =
     this
-        .forskyvVilkårResultater()
+        .forskyvVilkårResultater(lovverk = lovverk)
         .values
         .map {
             it
@@ -33,3 +34,10 @@ fun Periode<VilkårResultat>.tilVilkårRegelverkResultatPeriode(): Periode<Vilk�
         verdi = VilkårRegelverkResultat(vilkårResultat.vilkårType, vilkårResultat.tilRegelverkResultat(), utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger),
     )
 }
+
+fun VilkårResultat.tilVilkårRegelverkResultatPeriode(): Periode<VilkårRegelverkResultat> =
+    Periode(
+        fom = this.periodeFom,
+        tom = this.periodeTom,
+        verdi = VilkårRegelverkResultat(this.vilkårType, this.tilRegelverkResultat(), utdypendeVilkårsvurderinger = this.utdypendeVilkårsvurderinger),
+    )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårResultatTidslinje.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårResultatTidslinje.kt
@@ -34,10 +34,3 @@ fun Periode<VilkårResultat>.tilVilkårRegelverkResultatPeriode(): Periode<Vilk�
         verdi = VilkårRegelverkResultat(vilkårResultat.vilkårType, vilkårResultat.tilRegelverkResultat(), utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger),
     )
 }
-
-fun VilkårResultat.tilVilkårRegelverkResultatPeriode(): Periode<VilkårRegelverkResultat> =
-    Periode(
-        fom = this.periodeFom,
-        tom = this.periodeTom,
-        verdi = VilkårRegelverkResultat(this.vilkårType, this.tilRegelverkResultat(), utdypendeVilkårsvurderinger = this.utdypendeVilkårsvurderinger),
-    )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
@@ -13,14 +14,13 @@ import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.filtrerIkkeNull
 import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 
 @Service
 class VilkårsvurderingTidslinjeService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     fun lagVilkårsvurderingTidslinjer(behandlingId: Long): VilkårsvurderingTidslinjer {
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -26,7 +26,7 @@ class VilkårsvurderingTidslinjeService(
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId)
 
-        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER))
+        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025))
     }
 
     fun hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId: Long): Tidslinje<Boolean> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
@@ -12,18 +13,20 @@ import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.filtrerIkkeNull
 import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 
 @Service
 class VilkårsvurderingTidslinjeService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
+    private val unleashService: UnleashService,
 ) {
     fun lagVilkårsvurderingTidslinjer(behandlingId: Long): VilkårsvurderingTidslinjer {
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId)
 
-        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag)
+        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER))
     }
 
     fun hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId: Long): Tidslinje<Boolean> {
@@ -54,6 +57,6 @@ class VilkårsvurderingTidslinjeService(
         lagVilkårsvurderingTidslinjer(behandlingId.id)
             .barnasTidslinjer()
             .mapValues { (_, tidslinjer) ->
-                tidslinjer.regelverkResultatTidslinje
+                tidslinjer.kombinertRegelverkResultatTidslinje
             }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -1,69 +1,61 @@
 package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.lovverk.LovverkUtleder
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import no.nav.familie.tidslinje.beskjærEtter
 import no.nav.familie.tidslinje.inneholder
-import no.nav.familie.tidslinje.tomTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 
 class VilkårsvurderingTidslinjer(
     vilkårsvurdering: Vilkårsvurdering,
     personopplysningGrunnlag: PersonopplysningGrunnlag,
+    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ) {
-    private val barna: List<Aktør> = personopplysningGrunnlag.barna.map { it.aktør }
-    private val søker: Aktør = personopplysningGrunnlag.søker.aktør
-
-    private val aktørTilPersonResultater = vilkårsvurdering.personResultater.associateBy { it.aktør }
-
-    private val vilkårResultaterTidslinjeMap =
-        aktørTilPersonResultater.entries.associate { (aktør, personResultat) ->
-            aktør to
-                personResultat.tilVilkårRegelverkResultatTidslinje()
+    private val barnasTidslinjer: Map<Person, BarnetsTidslinjer> =
+        personopplysningGrunnlag.barna.associateWith { barn ->
+            BarnetsTidslinjer(
+                barn = barn,
+                personResultater = vilkårsvurdering.personResultater,
+                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+            )
         }
 
-    private val søkersTidslinje: SøkersTidslinjer = SøkersTidslinjer(this, søker)
-
-    private val barnasTidslinjer: Map<Aktør, BarnetsTidslinjer> =
-        barna.associateWith { BarnetsTidslinjer(this, it) }
-
-    fun barnasTidslinjer(): Map<Aktør, BarnetsTidslinjer> = barnasTidslinjer.entries.associate { it.key to it.value }
-
-    class SøkersTidslinjer(
-        tidslinjer: VilkårsvurderingTidslinjer,
-        aktør: Aktør,
-    ) {
-        val vilkårResultatTidslinjer = tidslinjer.vilkårResultaterTidslinjeMap[aktør] ?: listOf(tomTidslinje())
-        val regelverkResultatTidslinje =
-            vilkårResultatTidslinjer.kombiner {
-                kombinerVilkårResultaterTilRegelverkResultat(PersonType.SØKER, it)
-            }
-    }
+    fun barnasTidslinjer(): Map<Aktør, BarnetsTidslinjer> = barnasTidslinjer.entries.associate { it.key.aktør to it.value }
 
     class BarnetsTidslinjer(
-        tidslinjer: VilkårsvurderingTidslinjer,
-        aktør: Aktør,
+        barn: Person,
+        personResultater: Set<PersonResultat>,
+        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ) {
-        private val søkersTidslinje = tidslinjer.søkersTidslinje
+        private val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = barn.fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+        private val søkersTidslinje = personResultater.single { it.erSøkersResultater() }.tilVilkårRegelverkResultatTidslinje(lovverk = lovverk)
+        private val barnetsTidslinje = personResultater.single { it.aktør == barn.aktør }.tilVilkårRegelverkResultatTidslinje(lovverk = lovverk)
 
-        val vilkårResultatTidslinjer = tidslinjer.vilkårResultaterTidslinjeMap[aktør] ?: listOf(tomTidslinje())
-        val egetRegelverkResultatTidslinje =
-            vilkårResultatTidslinjer.kombiner {
+        val barnetsRegelverkResultatTidslinje =
+            barnetsTidslinje.kombiner {
                 kombinerVilkårResultaterTilRegelverkResultat(PersonType.BARN, it)
             }
-        val regelverkResultatTidslinje =
-            egetRegelverkResultatTidslinje
-                .kombinerMed(søkersTidslinje.regelverkResultatTidslinje) { barnetsResultat, søkersResultat ->
+
+        val søkersRegelverkResultatTidslinje =
+            søkersTidslinje.kombiner {
+                kombinerVilkårResultaterTilRegelverkResultat(PersonType.SØKER, it)
+            }
+        val kombinertRegelverkResultatTidslinje =
+            barnetsRegelverkResultatTidslinje
+                .kombinerMed(søkersRegelverkResultatTidslinje) { barnetsResultat, søkersResultat ->
                     barnetsResultat.kombinerMed(søkersResultat)
-                }.beskjærEtter(søkersTidslinje.regelverkResultatTidslinje)
+                }.beskjærEtter(søkersRegelverkResultatTidslinje)
     }
 
     fun harBlandetRegelverk(): Boolean =
-        søkersTidslinje.regelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
-            barnasTidslinjer().values.any {
-                it.egetRegelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK)
-            }
+        barnasTidslinjer().values.any {
+            it.barnetsRegelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK) ||
+                it.søkersRegelverkResultatTidslinje.inneholder(RegelverkResultat.OPPFYLT_BLANDET_REGELVERK)
+        }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -4,9 +4,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Per
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning.forskyvVilkårResultater
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilTidslinje
 import no.nav.familie.tidslinje.Tidslinje
-import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.tomTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
@@ -16,14 +15,11 @@ object EndringIVilkårsvurderingUtil {
         nåværendePersonResultat: PersonResultat?,
         forrigePersonResultat: PersonResultat?,
     ): Tidslinje<Boolean> {
-        val nåværendeForskjøvedeVilkårTidslinjer = nåværendePersonResultat?.forskyvVilkårResultater()?.mapValues { it.value.filter { periode -> periode.verdi.erOppfylt() }.tilTidslinje() } ?: emptyMap()
-        val tidligereForskjøvedeVilkårTidslinjer = forrigePersonResultat?.forskyvVilkårResultater()?.mapValues { it.value.filter { periode -> periode.verdi.erOppfylt() }.tilTidslinje() } ?: emptyMap()
-
         val tidslinjePerVilkår =
             Vilkår.entries.filter { it != Vilkår.BARNETS_ALDER }.map { vilkår ->
                 lagEndringIVilkårsvurderingForPersonOgVilkårTidslinje(
-                    nåværendeForskjøvetVilkårTidslinje = nåværendeForskjøvedeVilkårTidslinjer.getOrDefault(vilkår, tomTidslinje()),
-                    tidligereForskjøvetVilkårTidslinje = tidligereForskjøvedeVilkårTidslinjer.getOrDefault(vilkår, tomTidslinje()),
+                    nåværendeVilkårTidslinje = nåværendePersonResultat?.vilkårResultater?.filter { it.erOppfylt() && it.vilkårType == vilkår }?.tilTidslinje() ?: tomTidslinje(),
+                    tidligereVilkårTidslinje = forrigePersonResultat?.vilkårResultater?.filter { it.erOppfylt() && it.vilkårType == vilkår }?.tilTidslinje() ?: tomTidslinje(),
                 )
             }
 
@@ -39,11 +35,11 @@ object EndringIVilkårsvurderingUtil {
     // 2. Endringer i regelverk
     // 3. Splitt i vilkårsvurderingen
     private fun lagEndringIVilkårsvurderingForPersonOgVilkårTidslinje(
-        nåværendeForskjøvetVilkårTidslinje: Tidslinje<VilkårResultat>,
-        tidligereForskjøvetVilkårTidslinje: Tidslinje<VilkårResultat>,
+        nåværendeVilkårTidslinje: Tidslinje<VilkårResultat>,
+        tidligereVilkårTidslinje: Tidslinje<VilkårResultat>,
     ): Tidslinje<Boolean> {
         val endringIVilkårResultat =
-            nåværendeForskjøvetVilkårTidslinje.kombinerMed(tidligereForskjøvetVilkårTidslinje) { nåværende, forrige ->
+            nåværendeVilkårTidslinje.kombinerMed(tidligereVilkårTidslinje) { nåværende, forrige ->
                 if (nåværende == null || forrige == null) return@kombinerMed false
 
                 val erEndringerIUtdypendeVilkårsvurdering =

--- a/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.unleash.UnleashService
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -30,6 +31,7 @@ import org.hamcrest.CoreMatchers.`is` as Is
 internal class VilkårsvurderingTidslinjeServiceTest {
     val personopplysningGrunnlagRepository = mockk<PersonopplysningGrunnlagRepository>()
     val vilkårsvurderingService = mockk<VilkårsvurderingService>()
+    val unleashService = mockk<UnleashService>()
 
     private lateinit var vilkårsvurderingTidslinjeService: VilkårsvurderingTidslinjeService
 
@@ -39,6 +41,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
             VilkårsvurderingTidslinjeService(
                 personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
                 vilkårsvurderingService = vilkårsvurderingService,
+                unleashService = unleashService,
             )
     }
 

--- a/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -21,7 +22,6 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.unleash.UnleashService
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -31,7 +31,7 @@ import org.hamcrest.CoreMatchers.`is` as Is
 internal class VilkårsvurderingTidslinjeServiceTest {
     val personopplysningGrunnlagRepository = mockk<PersonopplysningGrunnlagRepository>()
     val vilkårsvurderingService = mockk<VilkårsvurderingService>()
-    val unleashService = mockk<UnleashService>()
+    val unleashService = mockk<UnleashNextMedContextService>()
 
     private lateinit var vilkårsvurderingTidslinjeService: VilkårsvurderingTidslinjeService
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -59,7 +59,7 @@ class CucumberMock(
     val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-            unleashService = mockUnleashService(isEnabledDefault = false),
+            unleashService = mockUnleashNextMedContextService(),
         )
     val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, overgangsordningAndelRepositoryMock)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashService
+import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagKompetanse
@@ -563,7 +563,7 @@ internal class UtbetalingsperiodeUtilTest {
                 beregnAndelTilkjentYtelseService =
                     BeregnAndelTilkjentYtelseService(
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-                        unleashService = mockUnleashService(false),
+                        unleashService = mockUnleashNextMedContextService(),
                     ),
                 overgangsordningAndelRepository = mockOvergangsordningAndelRepository(),
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -13,8 +13,10 @@ import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.NullablePeriode
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.lagVilkårResultaterForBarn
@@ -40,6 +42,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.validering
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.unleash.UnleashService
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -56,6 +60,7 @@ class VilkårsvurderingStegTest {
     private val søknadGrunnlagService: SøknadGrunnlagService = mockk()
     private val beregningService: BeregningService = mockk()
     private val kompetanseService: KompetanseService = mockk()
+    private val unleashService: UnleashService = mockk()
 
     private val barnetsAlderVilkårValidator2021 = BarnetsAlderVilkårValidator2021()
     private val barnetsAlderVilkårValidator2024 = BarnetsAlderVilkårValidator2024()
@@ -79,12 +84,13 @@ class VilkårsvurderingStegTest {
             beregningService,
             kompetanseService,
             barnetsVilkårValidator,
+            unleashService,
         )
 
-    private val søker = randomAktør()
-    private val barn = randomAktør()
+    private val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+    private val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2022, 2, 10))
 
-    private val fagsak = lagFagsak(søker)
+    private val fagsak = lagFagsak(søker.aktør)
 
     private val behandling = lagBehandling(id = 1, fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
@@ -107,15 +113,17 @@ class VilkårsvurderingStegTest {
         val personopplysningGrunnlag =
             lagPersonopplysningGrunnlag(
                 behandlingId = behandling.id,
-                søkerPersonIdent = søker.aktivFødselsnummer(),
-                søkerAktør = søker,
-                barnasIdenter = listOf(barn.aktivFødselsnummer()),
+                søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+                søkerAktør = søker.aktør,
+                barnAktør = listOf(barn.aktør),
+                barnasFødselsdatoer = listOf(barn.fødselsdato),
             )
 
         every { søknadGrunnlagService.finnAktiv(behandling.id) } returns søknadGrunnlagMock
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(any(), any(), any()) } just runs
+        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER) } returns true
     }
 
     @Test
@@ -127,14 +135,14 @@ class VilkårsvurderingStegTest {
         val personopplysningGrunnlag =
             lagPersonopplysningGrunnlag(
                 behandlingId = behandling.id,
-                søkerPersonIdent = søker.aktivFødselsnummer(),
-                søkerAktør = søker,
+                søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+                søkerAktør = søker.aktør,
                 søkerDødsDato = LocalDate.of(2020, 12, 12),
                 barnasIdenter = listOf(barn.aktivFødselsnummer()),
             )
 
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
 
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
@@ -175,8 +183,8 @@ class VilkårsvurderingStegTest {
     @Test
     fun `utførSteg - skal kaste funksjonell feil hvis det er periode overlapp mellom delt bosted og gradert barnehageplass vilkår`() {
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker)
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
@@ -253,12 +261,12 @@ class VilkårsvurderingStegTest {
         val personopplysningGrunnlag =
             lagPersonopplysningGrunnlag(
                 behandlingId = behandling.id,
-                søkerPersonIdent = søker.aktivFødselsnummer(),
-                søkerAktør = søker,
+                søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+                søkerAktør = søker.aktør,
             )
 
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
 
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
@@ -305,12 +313,12 @@ class VilkårsvurderingStegTest {
     fun `utførSteg - skal kaste feil hvis barnehageplass perioder ikke dekker perioder i barnets alder vilkår`() {
         val vilkårsvurdering =
             lagVilkårsvurderingMedSøkersVilkår(
-                søkerAktør = søker,
+                søkerAktør = søker.aktør,
                 behandling = behandling,
             )
         val søkerPersonResultat = vilkårsvurdering.personResultater.first()
 
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val barnFødselsDato = LocalDate.of(2020, 4, 1)
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
@@ -343,12 +351,12 @@ class VilkårsvurderingStegTest {
     fun `utførSteg - skal kaste feil hvis barnehageplass perioder starter etter siste dato i barnets alder vilkår`() {
         val vilkårsvurdering =
             lagVilkårsvurderingMedSøkersVilkår(
-                søkerAktør = søker,
+                søkerAktør = søker.aktør,
                 behandling = behandling,
             )
         val søkerPersonResultat = vilkårsvurdering.personResultater.first()
 
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val barnFødselsDato = LocalDate.of(2020, 4, 1)
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
@@ -386,12 +394,12 @@ class VilkårsvurderingStegTest {
     fun `utførSteg - skal kaste feil hvis det finnes mer enn 2 barnehageplass vilkår i en måned`() {
         val vilkårsvurdering =
             lagVilkårsvurderingMedSøkersVilkår(
-                søkerAktør = søker,
+                søkerAktør = søker.aktør,
                 behandling = behandling,
             )
         val søkerPersonResultat = vilkårsvurdering.personResultater.first()
 
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val barnFødselsDato = LocalDate.of(2020, 4, 1)
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
@@ -430,7 +438,7 @@ class VilkårsvurderingStegTest {
     @Test
     fun `utførSteg - skal kaste feil når det er blanding av regelverk på vilkårene for barnet`() {
         val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = søker)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = søker.aktør)
         // BOSATT I RIKET er vurdert etter både NASJONALE_REGLER og EØS_FORORDNINGEN
         // mens MEDLEMSKAP er vurdert etter kun NASJONALE_REGLER
         søkerPersonResultat.setSortedVilkårResultater(
@@ -473,13 +481,12 @@ class VilkårsvurderingStegTest {
             ),
         )
 
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn)
-        val barnFødselsDato = LocalDate.of(2021, 3, 17)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
                 personResultat = barnPersonResultat,
-                barnFødselsdato = barnFødselsDato,
-                barnehageplassPerioder = listOf(NullablePeriode(fom = barnFødselsDato.plusYears(1), tom = null) to null),
+                barnFødselsdato = barn.fødselsdato,
+                barnehageplassPerioder = listOf(NullablePeriode(fom = barn.fødselsdato.plusYears(1), tom = null) to null),
                 regelverk = Regelverk.EØS_FORORDNINGEN,
                 behandlingId = behandling.id,
             )
@@ -498,8 +505,8 @@ class VilkårsvurderingStegTest {
     @Test
     fun `utførSteg - skal validere vilkårsvurderingen`() {
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker)
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
@@ -514,14 +521,13 @@ class VilkårsvurderingStegTest {
                 ),
             ),
         )
-        val barnFødselsDato = LocalDate.now().minusYears(2)
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
                 personResultat = barnPersonResultat,
-                barnFødselsdato = barnFødselsDato,
+                barnFødselsdato = barn.fødselsdato,
                 barnehageplassPerioder =
                     listOf(
-                        NullablePeriode(barnFødselsDato.plusYears(1), barnFødselsDato.plusYears(2)) to null,
+                        NullablePeriode(barn.fødselsdato.plusYears(1), barn.fødselsdato.plusYears(2)) to null,
                     ),
                 behandlingId = behandling.id,
             )
@@ -550,8 +556,8 @@ class VilkårsvurderingStegTest {
     @Test
     fun `utførSteg - skal oppdatere behandlingstema med EØS hvis nåværende behandling inneholder vilkår vurdert etter EØS ordningen`() {
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker)
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
@@ -571,10 +577,10 @@ class VilkårsvurderingStegTest {
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
                 personResultat = barnPersonResultat,
-                barnFødselsdato = barnFødselsDato,
+                barnFødselsdato = barn.fødselsdato,
                 barnehageplassPerioder =
                     listOf(
-                        NullablePeriode(barnFødselsDato.plusYears(1), barnFødselsDato.plusYears(2)) to null,
+                        NullablePeriode(barn.fødselsdato.plusYears(1), barn.fødselsdato.plusYears(2)) to null,
                     ),
                 behandlingId = behandling.id,
             )
@@ -599,8 +605,8 @@ class VilkårsvurderingStegTest {
     @Test
     fun `utførSteg - skal oppdatere behandlingstema med EØS hvis forrige behandling inneholder løpende vilkår vurdert etter EØS ordningen`() {
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker)
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
@@ -616,14 +622,13 @@ class VilkårsvurderingStegTest {
                 ),
             ),
         )
-        val barnFødselsDato = LocalDate.now().minusYears(2)
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
                 personResultat = barnPersonResultat,
-                barnFødselsdato = barnFødselsDato,
+                barnFødselsdato = barn.fødselsdato,
                 barnehageplassPerioder =
                     listOf(
-                        NullablePeriode(barnFødselsDato.plusYears(1), barnFødselsDato.plusYears(2)) to null,
+                        NullablePeriode(barn.fødselsdato.plusYears(1), barn.fødselsdato.plusYears(2)) to null,
                     ),
                 behandlingId = behandling.id,
             )
@@ -633,9 +638,9 @@ class VilkårsvurderingStegTest {
         val forrigeBehandling = lagBehandling(id = 0, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val forrigeVilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultatIForrigeVilkårsvurdering =
-            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = søker)
+            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultatIForrigeVilkårsvurdering =
-            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = barn)
+            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = barn.aktør)
 
         søkerPersonResultatIForrigeVilkårsvurdering.setSortedVilkårResultater(
             setOf(
@@ -692,8 +697,8 @@ class VilkårsvurderingStegTest {
     @Test
     fun `utførSteg - skal ikke oppdatere behandlingstema med EØS hvis forrige behandling inneholder løpende vilkår vurdert etter EØS ordningen men som er utløpt`() {
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
-        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker)
-        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn)
+        val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
+        val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
@@ -713,10 +718,10 @@ class VilkårsvurderingStegTest {
         val vilkårResultaterForBarn =
             lagVilkårResultaterForBarn(
                 personResultat = barnPersonResultat,
-                barnFødselsdato = barnFødselsDato,
+                barnFødselsdato = barn.fødselsdato,
                 barnehageplassPerioder =
                     listOf(
-                        NullablePeriode(barnFødselsDato.plusYears(1), barnFødselsDato.plusYears(2)) to null,
+                        NullablePeriode(barn.fødselsdato.plusYears(1), barn.fødselsdato.plusYears(2)) to null,
                     ),
                 behandlingId = behandling.id,
             )
@@ -726,9 +731,9 @@ class VilkårsvurderingStegTest {
         val forrigeBehandling = lagBehandling(id = 0, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val forrigeVilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultatIForrigeVilkårsvurdering =
-            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = søker)
+            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultatIForrigeVilkårsvurdering =
-            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = barn)
+            PersonResultat(vilkårsvurdering = forrigeVilkårsvurderingForSøker, aktør = barn.aktør)
 
         søkerPersonResultatIForrigeVilkårsvurdering.setSortedVilkårResultater(
             setOf(
@@ -749,12 +754,12 @@ class VilkårsvurderingStegTest {
         val vilkårResultaterForBarnIForrigeVilkårsvurdering =
             lagVilkårResultaterForBarn(
                 personResultat = barnPersonResultatIForrigeVilkårsvurdering,
-                barnFødselsdato = barnIForrigeVilkårsvurderingFødselsDato,
+                barnFødselsdato = barn.fødselsdato,
                 barnehageplassPerioder =
                     listOf(
                         NullablePeriode(
-                            barnIForrigeVilkårsvurderingFødselsDato.plusYears(1),
-                            barnIForrigeVilkårsvurderingFødselsDato.plusYears(2),
+                            barn.fødselsdato.plusYears(1),
+                            barn.fødselsdato.plusYears(2),
                         ) to null,
                     ),
                 behandlingId = forrigeBehandling.id,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -123,7 +123,7 @@ class VilkårsvurderingStegTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(any(), any(), any()) } just runs
-        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
@@ -31,7 +31,7 @@ class BeregnAndelTilkjentYtelseServiceTest {
         every { personopplysningGrunnlag.søker } returns lagPerson(aktør = randomAktør())
         every { personopplysningGrunnlag.barna } returns listOf(lagPerson(aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 12, 31)))
 
-        every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER, false) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025, false) } returns true
         every { andelGeneratorLookup.hentGeneratorForLovverk(any()) } returns andelGenerator
         every { andelGenerator.beregnAndelerForBarn(any(), any(), any(), any()) } returns emptyList()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
@@ -4,17 +4,17 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
-import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class BeregnAndelTilkjentYtelseServiceTest {
-    private val unleashService: UnleashService = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
     private val andelGeneratorLookup: AndelGenerator.Lookup = mockk()
     private val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
@@ -31,7 +31,7 @@ class BeregnAndelTilkjentYtelseServiceTest {
         every { personopplysningGrunnlag.søker } returns lagPerson(aktør = randomAktør())
         every { personopplysningGrunnlag.barna } returns listOf(lagPerson(aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 12, 31)))
 
-        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025, false) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
         every { andelGeneratorLookup.hentGeneratorForLovverk(any()) } returns andelGenerator
         every { andelGenerator.beregnAndelerForBarn(any(), any(), any(), any()) } returns emptyList()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashService
+import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -61,7 +61,7 @@ internal class TilkjentYtelseServiceTest {
     private val beregnAndelTilkjentYtelseService: BeregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-            unleashService = mockUnleashService(false),
+            unleashService = mockUnleashNextMedContextService(),
         )
 
     private val overgangsordningAndelRepositoryMock: OvergangsordningAndelRepository = mockk()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashService
+import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVedtaksbegrunnelse
 import no.nav.familie.ks.sak.data.lagVedtaksperiodeMedBegrunnelser
@@ -463,7 +463,7 @@ fun lagBrevPeriodeContext(
     val andelerTilkjentYtelse =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFørFebruar2025AndelGenerator(), LovverkFebruar2025AndelGenerator())),
-            unleashService = mockUnleashService(false),
+            unleashService = mockUnleashNextMedContextService(),
         ).beregnAndelerTilkjentYtelse(personopplysningGrunnlag = persongrunnlag, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)
 
     val vedtaksperiodeMedBegrunnelser =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.common.util.Periode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagKompetanse
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -38,6 +39,7 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
+import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -55,11 +57,13 @@ internal class KompetanseServiceTest {
     private val overgangsordningAndelRepository: OvergangsordningAndelRepository = mockk()
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository = mockk()
     private val vilkårsvurderingService: VilkårsvurderingService = mockk()
+    private val unleashService: UnleashService = mockk()
 
     private val vilkårsvurderingTidslinjeService =
         VilkårsvurderingTidslinjeService(
             vilkårsvurderingService = vilkårsvurderingService,
             personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
+            unleashService = unleashService,
         )
     private val tilpassKompetanserService =
         TilpassKompetanserService(
@@ -472,6 +476,7 @@ internal class KompetanseServiceTest {
                     barnasIdenter = listOf(barn1, barn2).map { it.aktivFødselsnummer() },
                     barnAktør = listOf(barn1, barn2),
                 )
+            every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER) } returns true
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -476,7 +476,7 @@ internal class KompetanseServiceTest {
                     barnasIdenter = listOf(barn1, barn2).map { it.aktivFødselsnummer() },
                     barnAktør = listOf(barn1, barn2),
                 )
-            every { unleashService.isEnabled(FeatureToggleConfig.BRUK_NY_LØYPE_FOR_GENERERING_AV_ANDELER) } returns true
+            every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagKompetanse
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -39,7 +40,6 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
-import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -57,7 +57,7 @@ internal class KompetanseServiceTest {
     private val overgangsordningAndelRepository: OvergangsordningAndelRepository = mockk()
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository = mockk()
     private val vilkårsvurderingService: VilkårsvurderingService = mockk()
-    private val unleashService: UnleashService = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
 
     private val vilkårsvurderingTidslinjeService =
         VilkårsvurderingTidslinjeService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/TilkjentYtelseBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/TilkjentYtelseBuilder.kt
@@ -104,7 +104,7 @@ class TilkjentYtelseBuilder(
                             )
                         }
                     }
-                }.tilAndelerTilkjentYtelse()
+                }.flatMap { it.tilAndelerTilkjentYtelse() }
 
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andeler)
         return this

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ks.sak.kjerne.eøs.util
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashService
+import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.tilfeldigPerson
@@ -104,7 +104,7 @@ data class VilkårsvurderingBuilder(
                 beregnAndelTilkjentYtelseService =
                     BeregnAndelTilkjentYtelseService(
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-                        unleashService = mockUnleashService(false),
+                        unleashService = mockUnleashNextMedContextService(),
                     ),
                 overgangsordningAndelRepository = mockOvergangsordningAndelRepository(),
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
@@ -123,8 +123,8 @@ class EndringIVilkårsvurderingUtilTest {
                 .filter { it.verdi == true }
 
         Assertions.assertEquals(1, perioderMedEndring.size)
-        Assertions.assertEquals(feb22.førsteDagIInneværendeMåned(), perioderMedEndring.single().fom)
-        Assertions.assertEquals(apr22.sisteDagIInneværendeMåned(), perioderMedEndring.single().tom)
+        Assertions.assertEquals(fødselsdato, perioderMedEndring.single().fom)
+        Assertions.assertEquals(mai22.sisteDagIInneværendeMåned(), perioderMedEndring.single().tom)
     }
 
     @Test
@@ -182,7 +182,7 @@ class EndringIVilkårsvurderingUtilTest {
                 .filter { it.verdi == true }
 
         Assertions.assertEquals(1, perioderMedEndring.size)
-        Assertions.assertEquals(jun22.førsteDagIInneværendeMåned(), perioderMedEndring.single().fom)
+        Assertions.assertEquals(mai22.atDay(8), perioderMedEndring.single().fom)
     }
 
     @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/OvergangsordningAndelControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/OvergangsordningAndelControllerTest.kt
@@ -13,7 +13,6 @@ import no.nav.familie.ks.sak.OppslagSpringRunnerTest
 import no.nav.familie.ks.sak.api.dto.OvergangsordningAndelDto
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.config.BehandlerRolle
-import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
@@ -23,7 +22,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakStatus
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndel
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndelRepository
-import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.core.IsNull
@@ -115,14 +113,6 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
         @Test
         fun `skal oppdatere og slå sammen overgangsordningandeler`() {
             val barn1 = personopplysningGrunnlag.personer.first { it.aktør == barn }
-            val barn2 =
-                lagrePerson(
-                    lagPerson(
-                        aktør = lagreAktør(randomAktør(randomFnr(barnFødselsdato.plusMonths(2)))),
-                        personType = PersonType.BARN,
-                        personopplysningGrunnlag = personopplysningGrunnlag,
-                    ),
-                )
 
             val gamleOvergangsordningAndeler =
                 listOf(
@@ -139,12 +129,6 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
                         antallTimer = BigDecimal.ZERO,
                         fom = barn1.fødselsdato.plusMonths(22).toYearMonth(),
                         tom = barn1.fødselsdato.plusMonths(23).toYearMonth(),
-                    ),
-                    OvergangsordningAndel(
-                        behandlingId = behandling.id,
-                        person = barn2,
-                        fom = barn2.fødselsdato.plusMonths(20).toYearMonth(),
-                        tom = barn2.fødselsdato.plusMonths(23).toYearMonth(),
                     ),
                 )
 
@@ -179,19 +163,13 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
                     path<List<Map<String, Any>>>("data.overgangsordningAndeler")
                         .map { objectMapper.convertValue(it, OvergangsordningAndelDto::class.java) }
                 assertThat(overgangsordningAndeler)
-                    .hasSize(2)
+                    .hasSize(1)
                     .anySatisfy {
                         // Forvent at overgangsordningandeler for barn 1 er slått sammen
                         assertThat(it.personIdent).isEqualTo(barn1.aktør.aktivFødselsnummer())
                         assertThat(it.antallTimer).isEqualTo(BigDecimal.ZERO)
                         assertThat(it.fom).isEqualTo(barn1.fødselsdato.plusMonths(20).toYearMonth())
                         assertThat(it.tom).isEqualTo(barn1.fødselsdato.plusMonths(23).toYearMonth())
-                    }.anySatisfy {
-                        // Forvent at overgangsordningandel for barn 2 er uendret
-                        assertThat(it.personIdent).isEqualTo(barn2.aktør.aktivFødselsnummer())
-                        assertThat(it.antallTimer).isEqualTo(BigDecimal.ZERO)
-                        assertThat(it.fom).isEqualTo(barn2.fødselsdato.plusMonths(20).toYearMonth())
-                        assertThat(it.tom).isEqualTo(barn2.fødselsdato.plusMonths(23).toYearMonth())
                     }
             }
         }


### PR DESCRIPTION
Favro: [NAV-24038](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24038)

### 💰 Hva skal gjøres, og hvorfor?
Begynner å utlede lovverk for barn og styre forskyvning for barn og søker etter dette. Foreløpig har vi implementert dette for beregning av andeler samt når man skal forskyve vilkårresultater for å finne regelverk (EØS/Nasjonal).

Når vi skal finne ut om vilkårsvurderingen er endret siden forrige behandling fjerner vi forskyvningen. Dette for å unngå store omskrivninger for å kunne forskyve søkers vilkår riktig. Kan ikke forskyve søkers vilkår alene lenger.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

Jeg har ikke skrevet tester fordi: eksisterende tester er dekkende foreløpig.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
