### PR TITLE
Gjør oppslag på kommunenavn i Barnehagebarn-tabellen ikke case-sensitiv

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnInfotrygdDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnInfotrygdDto.kt
@@ -8,7 +8,7 @@ data class BarnehagebarnInfotrygdDto(
     val fom: LocalDate,
     val tom: LocalDate?,
     val antallTimerIBarnehage: Double,
-    val endringstype: String,
+    val endringstype: String?,
     val kommuneNavn: String,
     val kommuneNr: String,
     val harFagsak: Boolean,

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -60,7 +60,7 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
             INNER JOIN po_person pp ON p.fk_aktoer_id = pp.fk_aktoer_id
             INNER JOIN gr_personopplysninger go ON pp.fk_gr_personopplysninger_id = go.id
             INNER JOIN behandling b ON go.fk_behandling_id = b.id AND b.aktiv = true
-            INNER JOIN fagsak f ON b.fk_fagsak_id = f.id AND f.arkivert = false WHERE bb.kommune_navn = :kommuneNavn
+            INNER JOIN fagsak f ON b.fk_fagsak_id = f.id AND f.arkivert = false WHERE UPPER(bb.kommune_navn) = UPPER(:kommuneNavn)
             AND f.status IN (:fagsakStatuser)
             GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr, f.id, f.status""",
         nativeQuery = true,
@@ -118,7 +118,7 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
             LEFT OUTER JOIN gr_personopplysninger go ON pp.fk_gr_personopplysninger_id = go.id
             LEFT OUTER JOIN  behandling b ON go.fk_behandling_id = b.id AND b.aktiv = true
             LEFT OUTER JOIN fagsak f ON b.fk_fagsak_id = f.id and f.arkivert = false 
-            WHERE bb.kommune_navn = :kommuneNavn
+            WHERE UPPER(bb.kommune_navn) = UPPER(:kommuneNavn)
             GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr, f.id, f.status""",
         nativeQuery = true,
     )
@@ -132,7 +132,7 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
             SELECT bb.ident as ident, bb.fom as fom, bb.tom as tom, bb.antall_timer_i_barnehage as antallTimerIBarnehage, 
             bb.endringstype as endringstype, bb.kommune_navn as kommuneNavn, bb.kommune_nr as kommuneNr, MAX(bb.endret_tid) as endretTid
             FROM barnehagebarn bb
-            WHERE bb.ident in (:barna) AND bb.kommune_navn = :kommuneNavn
+            WHERE bb.ident in (:barna) AND UPPER(bb.kommune_navn) = UPPER(:kommuneNavn)
             GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr""",
         nativeQuery = true,
     )
@@ -147,7 +147,7 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
             SELECT bb.ident as ident, bb.fom as fom, bb.tom as tom, bb.antall_timer_i_barnehage as antallTimerIBarnehage, 
             bb.endringstype as endringstype, bb.kommune_navn as kommuneNavn, bb.kommune_nr as kommuneNr, MAX(bb.endret_tid) as endretTid
             FROM barnehagebarn bb
-            WHERE bb.kommune_navn = :kommuneNavn
+            WHERE UPPER(bb.kommune_navn) = UPPER(:kommuneNavn)
             GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr""",
         nativeQuery = true,
     )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24097

Søket i barnehagelisten i KS-sak krever at kommunenavnet man søker på er identisk med det som står i tabellen.
Endrer uttrekket slik at oppslag gjøres med store bokstaver slik at søket ikke lenger er case-sensitivt

Gjør også `BarnehagebarnInfotrygdDto::endringstype` nullable, ettersom verdien i tabellen kan være `null`: #1032 