### PR TITLE
Legg til funksjon for å generere aldersvilkår som følger nytt regelverk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ks.sak.api.dto.NyttVilkårDto
 import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -21,7 +22,6 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
-import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,7 +32,7 @@ class VilkårsvurderingService(
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val sanityService: SanityService,
     private val personidentService: PersonidentService,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     @Transactional
     fun opprettVilkårsvurdering(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ks.sak.api.dto.EndreVilkårResultatDto
 import no.nav.familie.ks.sak.api.dto.NyttVilkårDto
 import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -20,6 +21,7 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,6 +32,7 @@ class VilkårsvurderingService(
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val sanityService: SanityService,
     private val personidentService: PersonidentService,
+    private val unleashService: UnleashService,
 ) {
     @Transactional
     fun opprettVilkårsvurdering(
@@ -49,6 +52,7 @@ class VilkårsvurderingService(
                 behandling,
                 vilkårsvurderingFraForrigeBehandling,
                 personopplysningGrunnlag,
+                unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
             )
 
         vilkårsvurderingFraForrigeBehandling?.let {
@@ -94,8 +98,7 @@ class VilkårsvurderingService(
 
     fun finnAktivVilkårsvurdering(behandlingId: Long): Vilkårsvurdering? = vilkårsvurderingRepository.finnAktivForBehandling(behandlingId)
 
-    fun hentVilkårsbegrunnelser(): Map<BegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårResponseDto>> =
-        standardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityBegrunnelser())
+    fun hentVilkårsbegrunnelser(): Map<BegrunnelseType, List<VedtakBegrunnelseTilknyttetVilkårResponseDto>> = standardbegrunnelserTilNedtrekksmenytekster(sanityService.hentSanityBegrunnelser())
 
     @Transactional
     fun endreVilkårPåBehandling(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
 
-import lagAutomatiskGenererteVilkårForBarnetsAlder
 import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.api.dto.VilkårResultatDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
@@ -240,6 +239,7 @@ fun genererInitiellVilkårsvurdering(
     behandling: Behandling,
     forrigeVilkårsvurdering: Vilkårsvurdering?,
     personopplysningGrunnlag: PersonopplysningGrunnlag,
+    skalBrukeRegelverk2025: Boolean = false,
 ): Vilkårsvurdering =
     Vilkårsvurdering(behandling = behandling).apply {
         personResultater =
@@ -266,8 +266,9 @@ fun genererInitiellVilkårsvurdering(
                                     Vilkår.BARNETS_ALDER -> {
                                         lagAutomatiskGenererteVilkårForBarnetsAlder(
                                             personResultat = personResultat,
-                                            behandling = behandling,
+                                            behandlingId = behandling.id,
                                             fødselsdato = person.fødselsdato,
+                                            skalBrukeRegelverk2025 = skalBrukeRegelverk2025,
                                         )
                                     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -132,7 +132,7 @@ class CucumberMock(
             personopplysningGrunnlagService = personopplysningGrunnlagService,
             sanityService = mockk(),
             personidentService = personidentService,
-            unleashService = mockUnleashService(),
+            unleashService = mockUnleashNextMedContextService(),
         )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -132,6 +132,7 @@ class CucumberMock(
             personopplysningGrunnlagService = personopplysningGrunnlagService,
             sanityService = mockk(),
             personidentService = personidentService,
+            unleashService = mockUnleashService(),
         )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtilsKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtilsKtTest.kt
@@ -1,0 +1,95 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
+
+import no.nav.familie.ks.sak.data.lagPersonResultat
+import no.nav.familie.ks.sak.data.lagVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class AutomatiskSatteVilkårUtilsKtTest {
+    private val fødselsDato = LocalDate.of(2024, 1, 1)
+    private val behandlingId = 0L
+    private val personResultat =
+        lagPersonResultat(
+            vilkårsvurdering = lagVilkårsvurdering(),
+            lagVilkårResultater = { emptySet() },
+        )
+
+    @Test
+    fun `skal bruke gammelt regelverk for barn født fra og med første januar 2024 hvis toggle er skrudd av`() {
+        // Act
+        val barnetsAlderVilkår =
+            lagAutomatiskGenererteVilkårForBarnetsAlder(
+                personResultat = personResultat,
+                behandlingId = behandlingId,
+                fødselsdato = fødselsDato,
+                skalBrukeRegelverk2025 = false,
+            )
+
+        // Assert
+        assertThat(barnetsAlderVilkår).hasSize(1)
+        assertThat(barnetsAlderVilkår).anySatisfy {
+            validerFellesfelter(it)
+            assertThat(it.periodeFom).isEqualTo(fødselsDato.plusMonths(13))
+            assertThat(it.periodeTom).isEqualTo(fødselsDato.plusMonths(19))
+            assertThat(it.utdypendeVilkårsvurderinger).isEmpty()
+        }
+    }
+
+    @Test
+    fun `skal bruke nytt regelverk for barn født fra og med første januar 2024 hvis toggle er skrudd på`() {
+        // Act
+        val barnetsAlderVilkår =
+            lagAutomatiskGenererteVilkårForBarnetsAlder(
+                personResultat = personResultat,
+                behandlingId = behandlingId,
+                fødselsdato = fødselsDato,
+                erAdopsjon = false,
+                skalBrukeRegelverk2025 = true,
+            )
+
+        // Assert
+        assertThat(barnetsAlderVilkår).hasSize(1)
+        assertThat(barnetsAlderVilkår).anySatisfy {
+            validerFellesfelter(it)
+            assertThat(it.periodeFom).isEqualTo(fødselsDato.plusMonths(12))
+            assertThat(it.periodeTom).isEqualTo(fødselsDato.plusMonths(20))
+            assertThat(it.utdypendeVilkårsvurderinger).isEmpty()
+        }
+    }
+
+    @Test
+    fun `skal bruke nytt regelverk for barn adoptert fra og med første januar 2024 hvis toggle er skrudd på`() {
+        // Act
+        val barnetsAlderVilkår =
+            lagAutomatiskGenererteVilkårForBarnetsAlder(
+                personResultat = personResultat,
+                behandlingId = behandlingId,
+                fødselsdato = fødselsDato,
+                erAdopsjon = true,
+                skalBrukeRegelverk2025 = true,
+            )
+
+        // Assert
+        assertThat(barnetsAlderVilkår).hasSize(1)
+        assertThat(barnetsAlderVilkår).anySatisfy {
+            validerFellesfelter(it)
+            assertThat(it.periodeFom).isEqualTo(fødselsDato.plusMonths(12))
+            assertThat(it.periodeTom).isEqualTo(fødselsDato.plusMonths(20))
+            assertThat(it.utdypendeVilkårsvurderinger).containsExactly(UtdypendeVilkårsvurdering.ADOPSJON)
+        }
+    }
+
+    private fun validerFellesfelter(it: VilkårResultat) {
+        assertThat(it.personResultat).isEqualTo(personResultat)
+        assertThat(it.erAutomatiskVurdert).isTrue()
+        assertThat(it.resultat).isEqualTo(Resultat.OPPFYLT)
+        assertThat(it.vilkårType).isEqualTo(Vilkår.BARNETS_ALDER)
+        assertThat(it.begrunnelse).isEqualTo("Vurdert og satt automatisk")
+        assertThat(it.behandlingId).isEqualTo(behandlingId)
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtilsKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtilsKtTest.kt
@@ -84,6 +84,29 @@ class AutomatiskSatteVilkårUtilsKtTest {
         }
     }
 
+    @Test
+    fun `skal bruke gammelt regelverk for barn født før første januar 2024 hvis toggle er skrudd på`() {
+        val fødselsDatoFørJan24 = LocalDate.of(2023, 12, 31)
+
+        // Act
+        val barnetsAlderVilkår =
+            lagAutomatiskGenererteVilkårForBarnetsAlder(
+                personResultat = personResultat,
+                behandlingId = behandlingId,
+                fødselsdato = fødselsDatoFørJan24,
+                skalBrukeRegelverk2025 = true,
+            )
+
+        // Assert
+        assertThat(barnetsAlderVilkår).hasSize(1)
+        assertThat(barnetsAlderVilkår).anySatisfy {
+            validerFellesfelter(it)
+            assertThat(it.periodeFom).isEqualTo(fødselsDatoFørJan24.plusMonths(13))
+            assertThat(it.periodeTom).isEqualTo(fødselsDatoFørJan24.plusMonths(19))
+            assertThat(it.utdypendeVilkårsvurderinger).isEmpty()
+        }
+    }
+
     private fun validerFellesfelter(it: VilkårResultat) {
         assertThat(it.personResultat).isEqualTo(personResultat)
         assertThat(it.erAutomatiskVurdert).isTrue()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -26,11 +26,13 @@ import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseType
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.unleash.UnleashService
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -50,6 +52,9 @@ class VilkårsvurderingServiceTest {
     @MockK
     private lateinit var personidentService: PersonidentService
 
+    @MockK
+    private lateinit var unleashService: UnleashService
+
     @InjectMockKs
     private lateinit var vilkårsvurderingService: VilkårsvurderingService
 
@@ -58,6 +63,11 @@ class VilkårsvurderingServiceTest {
     private val fagsak = lagFagsak(søker)
 
     private val behandling = lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
+
+    @BeforeEach
+    fun setUp() {
+        every { unleashService.isEnabled(any()) } returns false
+    }
 
     @Test
     fun `opprettVilkårsvurdering - skal opprette tom vilkårsvurdering dersom det ikke finnes tidligere vedtatte behandlinger på fagsak`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
 
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
@@ -40,23 +38,19 @@ import org.hamcrest.CoreMatchers.`is` as Is
 
 @ExtendWith(MockKExtension::class)
 class VilkårsvurderingServiceTest {
-    @MockK
-    private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
-
-    @MockK
-    private lateinit var personopplysningGrunnlagService: PersonopplysningGrunnlagService
-
-    @MockK
-    private lateinit var sanityService: SanityService
-
-    @MockK
-    private lateinit var personidentService: PersonidentService
-
-    @MockK
-    private lateinit var unleashService: UnleashService
-
-    @InjectMockKs
-    private lateinit var vilkårsvurderingService: VilkårsvurderingService
+    private val vilkårsvurderingRepository: VilkårsvurderingRepository = mockk()
+    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk()
+    private val sanityService: SanityService = mockk()
+    private val personidentService: PersonidentService = mockk()
+    private val unleashService: UnleashService = mockk()
+    private val vilkårsvurderingService =
+        VilkårsvurderingService(
+            vilkårsvurderingRepository,
+            personopplysningGrunnlagService,
+            sanityService,
+            personidentService,
+            unleashService,
+        )
 
     private val søker = randomAktør()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.fnrTilFødselsdato
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
@@ -24,7 +25,6 @@ import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseType
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalEllerFellesBegrunnelse
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
-import no.nav.familie.unleash.UnleashService
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -42,7 +42,7 @@ class VilkårsvurderingServiceTest {
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk()
     private val sanityService: SanityService = mockk()
     private val personidentService: PersonidentService = mockk()
-    private val unleashService: UnleashService = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
     private val vilkårsvurderingService =
         VilkårsvurderingService(
             vilkårsvurderingRepository,
@@ -60,7 +60,7 @@ class VilkårsvurderingServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { unleashService.isEnabled(any()) } returns false
+        every { unleashService.isEnabled(any()) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtlederKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtlederKtTest.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
-import lagAutomatiskGenererteVilkårForBarnetsAlder
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagVilkårsvurdering
 import no.nav.familie.ks.sak.data.tilfeldigPerson
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårLovverkInformasjonForBarn
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.lagAutomatiskGenererteVilkårForBarnetsAlder
 import no.nav.familie.ks.sak.kjerne.beregning.lovverkFørFebruar2025.utledMaksAntallMånederMedUtbetaling
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
@@ -37,7 +37,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
                 vilkårsvurdering = vilkårsvurdering,
                 aktør = tilfeldigPerson(fødselsdato = fødselsdato).aktør,
             )
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling, fødselsdato)
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling.id, fødselsdato)
 
         // Act
         val maksAntallMånederMedUtbetaling = utledMaksAntallMånederMedUtbetaling(vilkårLovverkInformasjonForBarn, barnetsAlderVilkårResultater)
@@ -60,7 +60,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
                 vilkårsvurdering = vilkårsvurdering,
                 aktør = tilfeldigPerson(fødselsdato = fødselsdato).aktør,
             )
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling, fødselsdato)
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling.id, fødselsdato)
 
         // Act
         val maksAntallMånederMedUtbetaling = utledMaksAntallMånederMedUtbetaling(vilkårLovverkInformasjonForBarn, barnetsAlderVilkårResultater)
@@ -83,7 +83,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
                 vilkårsvurdering = vilkårsvurdering,
                 aktør = tilfeldigPerson(fødselsdato = fødselsdato).aktør,
             )
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling, fødselsdato)
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling.id, fødselsdato)
 
         // Act
         val maksAntallMånederMedUtbetaling = utledMaksAntallMånederMedUtbetaling(vilkårLovverkInformasjonForBarn, barnetsAlderVilkårResultater)
@@ -106,7 +106,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
                 vilkårsvurdering = vilkårsvurdering,
                 aktør = tilfeldigPerson(fødselsdato = fødselsdato).aktør,
             )
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling, fødselsdato)
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat, behandling.id, fødselsdato)
 
         // Act
         val maksAntallMånederMedUtbetaling = utledMaksAntallMånederMedUtbetaling(vilkårLovverkInformasjonForBarn, barnetsAlderVilkårResultater)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
-import lagAutomatiskGenererteVilkårForBarnetsAlder
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.exception.KONTAKT_TEAMET_SUFFIX
@@ -17,6 +16,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.lagAutomatiskGenererteVilkårForBarnetsAlder
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.finnAktørIderMedUgyldigEtterbetalingsperiode
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp
@@ -68,7 +68,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(setOf(andelTilkjentYtelse1, andelTilkjentYtelse2))
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.of(2022, 1, 1).minusMonths(11))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 1, 1).minusMonths(11))
 
         val exception =
             assertThrows<FunksjonellFeil> {
@@ -109,7 +109,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(setOf(andelTilkjentYtelse1, andelTilkjentYtelse2))
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtIJanuar2023.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.of(2023, 1, 1))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 1, 1))
 
         val exception =
             assertThrows<FunksjonellFeil> {
@@ -149,7 +149,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(setOf(andelTilkjentYtelse1))
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtIAugust2022.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.of(2022, 8, 1))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 8, 1))
 
         val exception =
             assertThrows<FunksjonellFeil> {
@@ -198,10 +198,10 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(setOf(andelTilkjentYtelse1, andelTilkjentYtelse2))
 
         val personResultatBarn1 = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtAugust2022.aktør)
-        val barnetsAlderVilkårResultaterBarn1 = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultatBarn1, behandling = behandling, fødselsdato = LocalDate.of(2022, 8, 1))
+        val barnetsAlderVilkårResultaterBarn1 = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultatBarn1, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 8, 1))
 
         val personResultatBarn2 = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtAugust2023.aktør)
-        val barnetsAlderVilkårResultaterBarn2 = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultatBarn2, behandling = behandling, fødselsdato = LocalDate.of(2023, 8, 1))
+        val barnetsAlderVilkårResultaterBarn2 = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultatBarn2, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 8, 1))
 
         assertDoesNotThrow {
             validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
@@ -235,7 +235,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(listOf(andelTilkjentYtelseForSøker, andelTilkjentYtelseForBarn))
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.now().minusYears(1).minusMonths(5))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.now().minusYears(1).minusMonths(5))
 
         val exception =
             assertThrows<Feil> {
@@ -265,7 +265,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.add(andelTilkjentYtelseForBarn)
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtJuli2023.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.now().minusYears(1).minusMonths(5))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.now().minusYears(1).minusMonths(5))
 
         val andeler = tilkjentYtelse.andelerTilkjentYtelse
 
@@ -520,7 +520,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andeler)
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.of(2023, 2, 1))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 2, 1))
         val barnetsAlderVilkårResultaterMedAdopsjon = barnetsAlderVilkårResultater.map { it.kopier(utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON)) }
 
         assertDoesNotThrow {
@@ -548,7 +548,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andeler)
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.of(2022, 8, 1))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 8, 1))
         val barnetsAlderVilkårResultaterMedAdopsjon = barnetsAlderVilkårResultater.map { it.kopier(utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON)) }
 
         assertDoesNotThrow {
@@ -576,7 +576,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andeler)
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.of(2023, 7, 1))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 7, 1))
         val barnetsAlderVilkårResultaterMedAdopsjon = barnetsAlderVilkårResultater.map { it.kopier(utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON)) }
 
         assertDoesNotThrow {
@@ -604,7 +604,7 @@ internal class TilkjentYtelseValidatorTest {
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andeler)
 
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
-        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandling = behandling, fødselsdato = LocalDate.of(2023, 1, 1))
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 1, 1))
         val barnetsAlderVilkårResultaterMedAdopsjon = barnetsAlderVilkårResultater.map { it.kopier(utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON)) }
 
         val feil =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24093

Legger til funksjon for å preutfylle aldersvilkår i følge regelverk 2025.
Ligger bak toggle `STØTTER_LOVENDRING_2025`

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇