### PR TITLE
NAV-24038: Forskyve søkers vilkår basert på lovverk tidslinje

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -14,6 +14,8 @@ import no.nav.familie.ks.sak.common.util.storForbokstav
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
 import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -70,6 +72,7 @@ class VedtaksperiodeService(
     private val integrasjonClient: IntegrasjonClient,
     private val refusjonEøsRepository: RefusjonEøsRepository,
     private val kompetanseService: KompetanseService,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun oppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeId: Long,
@@ -407,6 +410,7 @@ class VedtaksperiodeService(
                         kompetanser = utfylteKompetanser,
                         andelerTilkjentYtelse = andeler,
                         overgangsordningAndeler = overgangsordningAndelService.hentOvergangsordningAndeler(behandling.id),
+                        skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
                     ).hentGyldigeBegrunnelserForVedtaksperiode(),
             )
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.utbetalingsperiodeMedBegrunnelser
 
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.VedtaksperiodeMedBegrunnelser
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
@@ -15,6 +17,7 @@ class UtbetalingsperiodeMedBegrunnelserService(
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val kompetanseService: KompetanseService,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun hentUtbetalingsperioder(
         vedtak: Vedtak,
@@ -29,7 +32,10 @@ class UtbetalingsperiodeMedBegrunnelserService(
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = vedtak.behandling.id)
 
         val forskjøvetVilkårResultatTidslinjeMap =
-            vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
+            vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
+            )
 
         return hentPerioderMedUtbetaling(
             andelerTilkjentYtelse = andelerTilkjentYtelse,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkår.kt
@@ -115,6 +115,7 @@ fun Collection<PersonResultat>.forskyvVilkårResultater(personopplysningGrunnlag
             personResultat.aktør to personResultat.forskyvVilkårResultater(lovverk)
         }
 
+    // Lager LovverkTidslinje basert på barnas forskjøvede vilkårResultater
     val barnasLovverkTidslinje =
         barnasForskjøvedeVilkårResultater
             .map { entry ->
@@ -127,6 +128,7 @@ fun Collection<PersonResultat>.forskyvVilkårResultater(personopplysningGrunnlag
                 lovverk.single()
             }
 
+    // Forskyver søker etter alle lovverk og kombinerer med lovverktidslinje
     val søkersForskjøvedeVilkårResultater = this.single { it.erSøkersResultater() }.forskyvVilkårResultaterEtterLovverkTidslinje(barnasLovverkTidslinje)
 
     return barnasForskjøvedeVilkårResultater.plus(Pair(this.single { it.erSøkersResultater() }.aktør, søkersForskjøvedeVilkårResultater))

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
@@ -59,7 +59,7 @@ object LovverkTidslinjeGenerator {
                             tom = periode.tom,
                             verdi =
                                 LovverkUtleder.utledLovverkForBarn(
-                                    barn.fødselsdato,
+                                    fødselsdato = barn.fødselsdato,
                                     skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
                                 ),
                         )
@@ -74,8 +74,8 @@ object LovverkTidslinjeGenerator {
         // Da er vi sikre på at tidslinja dekker søkers vilkår.
         this.mapIndexed { index, periode ->
             when (index) {
-                0 -> Periode(verdi = periode.verdi, null, tom = periode.tom)
-                this.lastIndex -> Periode(verdi = periode.verdi, periode.fom, tom = null)
+                0 -> Periode(verdi = periode.verdi, fom = null, tom = periode.tom)
+                this.lastIndex -> Periode(verdi = periode.verdi, fom = periode.fom, tom = null)
                 else -> periode
             }
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
@@ -1,0 +1,75 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning
+
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
+import no.nav.familie.ks.sak.kjerne.lovverk.LovverkUtleder
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.kombiner
+import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+
+object LovverkTidslinjeGenerator {
+    fun generer(
+        barnasForskjøvedeVilkårResultater: Map<Aktør, Map<Vilkår, List<Periode<VilkårResultat>>>>,
+        personopplysningGrunnlag: PersonopplysningGrunnlag,
+    ): Tidslinje<Lovverk> =
+        barnasForskjøvedeVilkårResultater
+            .map { entry ->
+                entry.value.tilLovverkTidslinje(personopplysningGrunnlag.barna.single { it.aktør == entry.key })
+            }.kombiner {
+                val lovverk = it.toSet()
+                if (lovverk.size > 1) {
+                    throw Feil("Støtter ikke overlappende lovverk")
+                }
+                lovverk.single()
+            }.tilPerioderIkkeNull()
+            .sortedBy { it.fom }
+            .erstattFørsteFomOgSisteTomMedNull()
+            .kombinerEtterfølgendeElementer()
+            .map { (lovverkPeriode, nesteLovverkPeriode) -> Periode(verdi = lovverkPeriode.verdi, fom = lovverkPeriode.fom, tom = nesteLovverkPeriode?.fom?.minusDays(1)) }
+            .tilTidslinje()
+
+    private fun Map<Vilkår, List<Periode<VilkårResultat>>>.tilLovverkTidslinje(barn: Person): Tidslinje<Lovverk> =
+        // Konverterer alle VilkårResultatPerioder for alle barn til Lovverk-tidslinjer og kombinerer disse til en felles tidslinje.
+        // Sørger for at vi kaster feil dersom det finnes mer enn ett lovverk i en periode.
+        this.values
+            .map { perioder ->
+                perioder
+                    .map { periode ->
+                        Periode(
+                            fom = periode.fom,
+                            tom = periode.tom,
+                            verdi =
+                                LovverkUtleder.utledLovverkForBarn(
+                                    barn.fødselsdato,
+                                    skalBestemmeLovverkBasertPåFødselsdato = false,
+                                ),
+                        )
+                    }.tilTidslinje()
+                    .slåSammenLikePerioder()
+            }.kombiner {
+                it.toSet().single()
+            }
+
+    fun List<Periode<Lovverk>>.erstattFørsteFomOgSisteTomMedNull(): List<Periode<Lovverk>> =
+        this.mapIndexed { index, periode ->
+            when (index) {
+                0 -> Periode(verdi = periode.verdi, null, tom = periode.tom)
+                this.lastIndex -> Periode(verdi = periode.verdi, periode.fom, tom = null)
+                else -> periode
+            }
+        }
+
+    fun List<Periode<Lovverk>>.kombinerEtterfølgendeElementer(): List<Pair<Periode<Lovverk>, Periode<Lovverk>?>> {
+        if (this.isEmpty()) return emptyList()
+
+        return this.zipWithNext() + Pair(this.last(), null)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
@@ -19,7 +19,7 @@ object LovverkTidslinjeGenerator {
     fun generer(
         barnasForskjøvedeVilkårResultater: Map<Aktør, Map<Vilkår, List<Periode<VilkårResultat>>>>,
         personopplysningGrunnlag: PersonopplysningGrunnlag,
-        skalBestemmeLovverkBasertPåFødselsdato: Boolean = false,
+        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ): Tidslinje<Lovverk> =
         barnasForskjøvedeVilkårResultater
             .map { (aktør, forskjøvedeVilkårResultater) ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -66,7 +66,7 @@ import java.time.LocalDate
 class BrevPeriodeContext(
     private val utvidetVedtaksperiodeMedBegrunnelser: UtvidetVedtaksperiodeMedBegrunnelser,
     private val sanityBegrunnelser: List<SanityBegrunnelse>,
-    private val persongrunnlag: PersonopplysningGrunnlag,
+    private val personopplysningGrunnlag: PersonopplysningGrunnlag,
     private val personResultater: List<PersonResultat>,
     private val andelTilkjentYtelserMedEndreteUtbetalinger: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
     private val uregistrerteBarn: List<BarnMedOpplysningerDto>,
@@ -184,7 +184,7 @@ class BrevPeriodeContext(
             (identerIBegrunnelene + identerMedUtbetaling)
                 .toSet()
                 .mapNotNull { personIdent ->
-                    persongrunnlag.personer.find { it.aktør.aktivFødselsnummer() == personIdent }
+                    personopplysningGrunnlag.personer.find { it.aktør.aktivFødselsnummer() == personIdent }
                 }.filter { it.type == PersonType.BARN }
 
         return barnIPeriode
@@ -263,7 +263,7 @@ class BrevPeriodeContext(
         BegrunnelserForPeriodeContext(
             utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
             sanityBegrunnelser = sanityBegrunnelser,
-            personopplysningGrunnlag = persongrunnlag,
+            personopplysningGrunnlag = personopplysningGrunnlag,
             overgangsordningAndeler = overgangsordningAndeler,
             personResultater = personResultater,
             endretUtbetalingsandeler = andelTilkjentYtelserMedEndreteUtbetalinger.flatMap { it.endreteUtbetalinger },
@@ -344,7 +344,7 @@ class BrevPeriodeContext(
                             begrunnelse = begrunnelse,
                         ),
                     maanedOgAarBegrunnelsenGjelderFor = maanedOgAarBegrunnelsenGjelderFor,
-                    maalform = persongrunnlag.søker.målform.tilSanityFormat(),
+                    maalform = personopplysningGrunnlag.søker.målform.tilSanityFormat(),
                     apiNavn = begrunnelse.sanityApiNavn,
                     belop = formaterBeløp(hentBeløp(begrunnelse)),
                     vedtakBegrunnelseType = begrunnelse.begrunnelseType,
@@ -396,7 +396,7 @@ class BrevPeriodeContext(
                 .filter { utvidetVedtaksperiodeMedBegrunnelser.tom == null || it.stønadTom >= utvidetVedtaksperiodeMedBegrunnelser.tom.toYearMonth() }
 
         val aktørerMedUtbetalingIVedtaksperiode = innvilgedeAndelerIPeriode.map { it.aktør }.toSet()
-        return aktørerMedUtbetalingIVedtaksperiode.map { aktør -> persongrunnlag.personer.single { it.aktør == aktør } }.toSet()
+        return aktørerMedUtbetalingIVedtaksperiode.map { aktør -> personopplysningGrunnlag.personer.single { it.aktør == aktør } }.toSet()
     }
 
     fun hentEøsBegrunnelseDataDtoer(): List<EØSBegrunnelseDto> =
@@ -474,7 +474,7 @@ class BrevPeriodeContext(
                     val barnasFødselsdagerForAvslagOgOpphør =
                         hentBarnasFødselsdagerForAvslagOgOpphør(
                             barnIBegrunnelse = barnIBegrunnelse,
-                            barnPåBehandling = persongrunnlag.barna,
+                            barnPåBehandling = personopplysningGrunnlag.barna,
                             uregistrerteBarn = uregistrerteBarn,
                             gjelderSøker = gjelderSøker,
                         )
@@ -486,7 +486,7 @@ class BrevPeriodeContext(
                             sanityBegrunnelseType = sanityBegrunnelse.type,
                             barnasFodselsdatoer = barnasFødselsdagerForAvslagOgOpphør.tilBrevTekst(),
                             antallBarn = barnIBegrunnelse.size,
-                            maalform = persongrunnlag.søker.målform.tilSanityFormat(),
+                            maalform = personopplysningGrunnlag.søker.målform.tilSanityFormat(),
                             gjelderSoker = gjelderSøker,
                             antallTimerBarnehageplass = antallTimerBarnehageplass,
                         ),
@@ -497,7 +497,7 @@ class BrevPeriodeContext(
                             kompetanse.barnAktører
                                 .mapNotNull { barnAktør ->
                                     if (gjelderSøker && begrunnelseGjelderOpphørFraForrigeBehandling) {
-                                        persongrunnlag.barna
+                                        personopplysningGrunnlag.barna
                                     } else {
                                         personerGjeldendeForBegrunnelse
                                     }.find { it.aktør == barnAktør }
@@ -515,7 +515,7 @@ class BrevPeriodeContext(
                                 sokersAktivitetsland = kompetanse.søkersAktivitetsland.tilLandNavn(landkoder).navn,
                                 barnasFodselsdatoer = barnIBegrunnelseOgIKompetanseFødselsdato.tilBrevTekst(),
                                 antallBarn = hentAntallBarnForBegrunnelse(barnasFødselsdatoer = barnIBegrunnelseOgIKompetanseFødselsdato, begrunnelse = begrunnelse),
-                                maalform = persongrunnlag.søker.målform.tilSanityFormat(),
+                                maalform = personopplysningGrunnlag.søker.målform.tilSanityFormat(),
                                 antallTimerBarnehageplass = antallTimerBarnehageplass,
                             )
                         } else {
@@ -678,9 +678,7 @@ class BrevPeriodeContext(
     }
 
     private fun hentForskjøvedeVilkårResultater(): Map<Aktør, Map<Vilkår, Tidslinje<VilkårResultat>>> =
-        personResultater.associate { personResultat ->
-            personResultat.aktør to personResultat.forskyvVilkårResultater().mapValues { it.value.tilTidslinje() }
-        }
+        personResultater.forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag).mapValues { entry -> entry.value.mapValues { it.value.tilTidslinje() } }
 
     private fun hentForskjøvedeVilkårResultaterSomErSamtidigSomVedtaksperiode(): Map<Aktør, Map<Vilkår, Tidslinje<VilkårResultat>>> {
         val vedtaksperiodeTidslinje =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -74,6 +74,7 @@ class BrevPeriodeContext(
     private val landkoder: Map<String, String>,
     private val erFørsteVedtaksperiode: Boolean,
     private val overgangsordningAndeler: List<OvergangsordningAndel>,
+    private val skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ) {
     private val personerMedUtbetaling =
         utvidetVedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.map { it.person }
@@ -270,6 +271,7 @@ class BrevPeriodeContext(
             erFørsteVedtaksperiode = erFørsteVedtaksperiode,
             kompetanser = kompetanser,
             andelerTilkjentYtelse = andelTilkjentYtelserMedEndreteUtbetalinger,
+            skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
         )
 
     fun hentNasjonalOgFellesBegrunnelseDtoer(): List<NasjonalOgFellesBegrunnelseDataDto> =
@@ -678,7 +680,11 @@ class BrevPeriodeContext(
     }
 
     private fun hentForskjøvedeVilkårResultater(): Map<Aktør, Map<Vilkår, Tidslinje<VilkårResultat>>> =
-        personResultater.forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag).mapValues { entry -> entry.value.mapValues { it.value.tilTidslinje() } }
+        personResultater
+            .forskyvVilkårResultater(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+            ).mapValues { entry -> entry.value.mapValues { it.value.tilTidslinje() } }
 
     private fun hentForskjøvedeVilkårResultaterSomErSamtidigSomVedtaksperiode(): Map<Aktør, Map<Vilkår, Tidslinje<VilkårResultat>>> {
         val vedtaksperiodeTidslinje =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
@@ -1,8 +1,11 @@
+
 package no.nav.familie.ks.sak.kjerne.brev
 
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
@@ -35,6 +38,7 @@ class BrevPeriodeService(
     val vedtaksperiodeService: VedtaksperiodeService,
     val kompetanseService: KompetanseService,
     val integrasjonClient: IntegrasjonClient,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun hentBegrunnelsesteksterForPeriode(vedtaksperiodeId: Long): List<BegrunnelseDto> {
         val behandlingId =
@@ -89,6 +93,7 @@ class BrevPeriodeService(
                     kompetanser = kompetanser.map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>(),
                     landkoder = integrasjonClient.hentLandkoderISO2(),
                     overgangsordningAndeler = overgangsordningAndelService.hentOvergangsordningAndeler(behandlingId),
+                    skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
                 ).genererBrevPeriodeDto()
             }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
@@ -79,7 +79,7 @@ class BrevPeriodeService(
                 BrevPeriodeContext(
                     utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
                     sanityBegrunnelser = sanityBegrunnelser,
-                    persongrunnlag = personopplysningGrunnlag,
+                    personopplysningGrunnlag = personopplysningGrunnlag,
                     personResultater = vilkårsvurdering.personResultater.toList(),
                     andelTilkjentYtelserMedEndreteUtbetalinger = andelTilkjentYtelserMedEndreteUtbetalinger,
                     uregistrerteBarn =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -305,23 +305,25 @@ class BegrunnelserForPeriodeContext(
             BegrunnelseType.FORTSATT_INNVILGET -> throw Feil("FORTSATT_INNVILGET skal være filtrert bort.")
         }
 
-    private fun finnVilkårResultaterSomStarterSamtidigSomPeriode() =
-        personResultater.flatMap { personResultat ->
-            personResultat
-                .forskyvVilkårResultater()
-                .flatMap { it.value }
-                .filter { it.fom == vedtaksperiode.fom }
-                .map { it.verdi.id }
-        }
+    private fun finnVilkårResultaterSomStarterSamtidigSomPeriode(): List<Long> =
+        personResultater
+            .forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag)
+            .flatMap { entry ->
+                entry.value
+                    .flatMap { it.value }
+                    .filter { periode -> periode.fom == vedtaksperiode.fom }
+                    .map { periode -> periode.verdi.id }
+            }
 
-    private fun finnVilkårResultaterSomSlutterFørPeriode() =
-        personResultater.flatMap { personResultat ->
-            personResultat
-                .forskyvVilkårResultater()
-                .flatMap { it.value }
-                .filter { it.tom?.plusDays(1) == vedtaksperiode.fom }
-                .map { it.verdi.id }
-        }
+    private fun finnVilkårResultaterSomSlutterFørPeriode(): List<Long> =
+        personResultater
+            .forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag)
+            .flatMap { entry ->
+                entry.value
+                    .flatMap { it.value }
+                    .filter { periode -> periode.tom?.plusDays(1) == vedtaksperiode.fom }
+                    .map { periode -> periode.verdi.id }
+            }
 
     private fun hentRelevanteVilkårResultaterForVedtaksperiode(
         standardBegrunnelse: IBegrunnelse,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -51,6 +51,7 @@ class BegrunnelserForPeriodeContext(
     private val endretUtbetalingsandeler: List<EndretUtbetalingAndel>,
     private val erFørsteVedtaksperiode: Boolean,
     private val andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
+    private val skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ) {
     private val aktørIderMedUtbetaling =
         utvidetVedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.map { it.person.aktør.aktørId }
@@ -307,8 +308,10 @@ class BegrunnelserForPeriodeContext(
 
     private fun finnVilkårResultaterSomStarterSamtidigSomPeriode(): List<Long> =
         personResultater
-            .forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag)
-            .flatMap { entry ->
+            .forskyvVilkårResultater(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+            ).flatMap { entry ->
                 entry.value
                     .flatMap { it.value }
                     .filter { periode -> periode.fom == vedtaksperiode.fom }
@@ -317,8 +320,10 @@ class BegrunnelserForPeriodeContext(
 
     private fun finnVilkårResultaterSomSlutterFørPeriode(): List<Long> =
         personResultater
-            .forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag)
-            .flatMap { entry ->
+            .forskyvVilkårResultater(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+            ).flatMap { entry ->
                 entry.value
                     .flatMap { it.value }
                     .filter { periode -> periode.tom?.plusDays(1) == vedtaksperiode.fom }
@@ -373,8 +378,10 @@ class BegrunnelserForPeriodeContext(
 
     private fun finnPersonerMedVilkårResultatIFørsteVedtaksperiodeSomIkkeErOppfylt(): Map<Person, List<VilkårResultat>> =
         personResultater
-            .tilForskjøvetVilkårResultatTidslinjeMap(personopplysningGrunnlag)
-            .mapKeys { (aktør, _) -> aktør.hentPerson() }
+            .tilForskjøvetVilkårResultatTidslinjeMap(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+            ).mapKeys { (aktør, _) -> aktør.hentPerson() }
             .mapNotNull { (person, vilkårResultatTidslinjeForPerson) ->
                 val perioderMedVilkårForPerson = vilkårResultatTidslinjeForPerson.tilPerioder()
                 val månedenFørVedtaksperioden = vedtaksperiode.fom.minusMonths(1)
@@ -423,8 +430,10 @@ class BegrunnelserForPeriodeContext(
 
     private fun finnPersonerMedVilkårResultaterSomGjelderIPeriode(): Map<Person, List<VilkårResultat>> =
         personResultater
-            .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
-            .mapKeys { (aktør, _) -> aktør.hentPerson() }
+            .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+            ).mapKeys { (aktør, _) -> aktør.hentPerson() }
             .mapNotNull { (person, vilkårResultatTidslinjeForPerson) ->
                 val forskøvedeVilkårResultaterMedSammeFom =
                     vilkårResultatTidslinjeForPerson
@@ -443,8 +452,10 @@ class BegrunnelserForPeriodeContext(
 
     private fun finnPersonerMedVilkårResultaterSomGjelderRettFørPeriode(): Map<Person, List<VilkårResultat>> =
         personResultater
-            .tilForskjøvetVilkårResultatTidslinjeMap(personopplysningGrunnlag)
-            .mapKeys { (aktør, _) -> aktør.hentPerson() }
+            .tilForskjøvetVilkårResultatTidslinjeMap(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+            ).mapKeys { (aktør, _) -> aktør.hentPerson() }
             .mapNotNull { (person, tidslinje) ->
                 val vilkårResultatSomSlutterFørVedtaksperiode =
                     tidslinje

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -34,7 +34,6 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
-import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.klipp
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.tilPerioder

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -567,6 +567,7 @@ fun lagVilkårResultat(
     regelverk: Regelverk = Regelverk.NASJONALE_REGLER,
     antallTimer: BigDecimal? = null,
     søkerHarMeldtFraOmBarnehageplass: Boolean? = null,
+    erEksplisittAvslagPåSøknad: Boolean? = null,
 ): VilkårResultat =
     VilkårResultat(
         id = id,
@@ -581,6 +582,7 @@ fun lagVilkårResultat(
         vurderesEtter = regelverk,
         antallTimer = antallTimer,
         søkerHarMeldtFraOmBarnehageplass = søkerHarMeldtFraOmBarnehageplass,
+        erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
     )
 
 fun lagVilkårResultaterForBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.tilddMMyyyy
 import no.nav.familie.ks.sak.cucumber.BrevBegrunnelseParser.mapBegrunnelser
 import no.nav.familie.ks.sak.cucumber.mocking.CucumberMock
+import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseDto
@@ -371,6 +372,7 @@ class StepDefinition {
                                     kompetanser = hentUtfylteKompetanserPåBehandling(behandlingId),
                                     overgangsordningAndeler = overgangsordningAndeler[behandlingId] ?: emptyList(),
                                     andelerTilkjentYtelse = hentAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId),
+                                    skalBestemmeLovverkBasertPåFødselsdato = true,
                                 ).hentGyldigeBegrunnelserForVedtaksperiode(),
                         )
                     }.find { it.fom == forventet.fom && it.tom == forventet.tom }
@@ -470,6 +472,7 @@ class StepDefinition {
         erFørsteVedtaksperiode = erFørsteVedtaksperiode,
         kompetanser = hentUtfylteKompetanserPåBehandling(behandlingId),
         landkoder = LANDKODER,
+        skalBestemmeLovverkBasertPåFødselsdato = true,
     ).genererBrevPeriodeDto()
 
     /**
@@ -690,6 +693,7 @@ class StepDefinition {
                 andelerTilkjentYtelseOgEndreteUtbetalingerService = mockAndelerTilkjentYtelseOgEndreteUtbetalingerService(),
                 personopplysningGrunnlagService = mockPersonopplysningGrunnlagService(),
                 kompetanseService = kompetanseService,
+                unleashNextMedContextService = mockUnleashNextMedContextService(),
             )
 
         return VedtaksperiodeService(
@@ -706,6 +710,7 @@ class StepDefinition {
             integrasjonClient = mockk(),
             refusjonEøsRepository = mockk(),
             kompetanseService = kompetanseService,
+            unleashNextMedContextService = mockUnleashNextMedContextService(),
         )
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -82,7 +82,7 @@ class StepDefinition {
     var fagsaker: Map<Long, Fagsak> = emptyMap()
     var behandlinger = mutableMapOf<Long, Behandling>()
     var behandlingTilForrigeBehandling = mapOf<Long, Long?>()
-    var persongrunnlag = mutableMapOf<Long, PersonopplysningGrunnlag>()
+    var personopplysningGrunnlagMap = mutableMapOf<Long, PersonopplysningGrunnlag>()
     var vilkårsvurdering = mutableMapOf<Long, Vilkårsvurdering>()
     var vedtaksperioderMedBegrunnelser = mutableMapOf<Long, List<VedtaksperiodeMedBegrunnelser>>()
     var kompetanser = mutableMapOf<Long, List<Kompetanse>>()
@@ -133,7 +133,7 @@ class StepDefinition {
     @Og("følgende persongrunnlag")
     fun `følgende persongrunnlag`(dataTable: DataTable) {
         val nyePersongrunnlag = lagPersonGrunnlag(dataTable)
-        persongrunnlag.putAll(nyePersongrunnlag)
+        personopplysningGrunnlagMap.putAll(nyePersongrunnlag)
     }
 
     /**
@@ -170,7 +170,7 @@ class StepDefinition {
     fun `følgende endrede utbetalinger`(
         dataTable: DataTable,
     ) {
-        endredeUtbetalinger = lagEndredeUtbetalinger(dataTable.asMaps(), persongrunnlag)
+        endredeUtbetalinger = lagEndredeUtbetalinger(dataTable.asMaps(), personopplysningGrunnlagMap)
     }
 
     /**
@@ -182,7 +182,7 @@ class StepDefinition {
         behandlingId: Long,
         dataTable: DataTable,
     ) {
-        kompetanser = lagKompetanser(dataTable.asMaps(), persongrunnlag, behandlingId)
+        kompetanser = lagKompetanser(dataTable.asMaps(), personopplysningGrunnlagMap, behandlingId)
     }
 
     /**
@@ -194,7 +194,7 @@ class StepDefinition {
         behandlingId: Long,
         dataTable: DataTable,
     ) {
-        valutakurs[behandlingId] = lagValutakurs(dataTable.asMaps(), persongrunnlag, behandlingId)
+        valutakurs[behandlingId] = lagValutakurs(dataTable.asMaps(), personopplysningGrunnlagMap, behandlingId)
     }
 
     /**
@@ -206,7 +206,7 @@ class StepDefinition {
         behandlingId: Long,
         dataTable: DataTable,
     ) {
-        utenlandskPeriodebeløp[behandlingId] = lagUtenlandskperiodeBeløp(dataTable.asMaps(), persongrunnlag, behandlingId)
+        utenlandskPeriodebeløp[behandlingId] = lagUtenlandskperiodeBeløp(dataTable.asMaps(), personopplysningGrunnlagMap, behandlingId)
     }
 
     @Og("andeler er beregnet for behandling {}")
@@ -218,7 +218,7 @@ class StepDefinition {
                 .tilkjentYtelseService
                 .beregnTilkjentYtelse(
                     vilkårsvurdering = vilkårsvurdering[behandlingId]!!,
-                    personopplysningGrunnlag = persongrunnlag[behandlingId]!!,
+                    personopplysningGrunnlag = personopplysningGrunnlagMap[behandlingId]!!,
                     endretUtbetalingAndeler = endredeUtbetalinger[behandlingId]?.map { EndretUtbetalingAndelMedAndelerTilkjentYtelse(it, emptyList()) } ?: emptyList(),
                 ).andelerTilkjentYtelse
                 .toList()
@@ -241,7 +241,7 @@ class StepDefinition {
         behandlingId: Long,
         dataTable: DataTable,
     ) {
-        andelerTilkjentYtelse[behandlingId] = lagAndelerTilkjentYtelse(dataTable, behandlingId, behandlinger, persongrunnlag)
+        andelerTilkjentYtelse[behandlingId] = lagAndelerTilkjentYtelse(dataTable, behandlingId, behandlinger, personopplysningGrunnlagMap)
     }
 
     /**
@@ -252,7 +252,7 @@ class StepDefinition {
         behandlingId: Long,
         dataTable: DataTable,
     ) {
-        overgangsordningAndeler[behandlingId] = lagOvergangsordningAndeler(dataTable, behandlingId, behandlinger, persongrunnlag)
+        overgangsordningAndeler[behandlingId] = lagOvergangsordningAndeler(dataTable, behandlingId, behandlinger, personopplysningGrunnlagMap)
     }
 
     /**
@@ -264,7 +264,7 @@ class StepDefinition {
         dataTable: DataTable,
     ) {
         val beregnetTilkjentYtelse = andelerTilkjentYtelse[behandlingId]!!
-        val forventedeAndeler = lagAndelerTilkjentYtelse(dataTable, behandlingId, behandlinger, persongrunnlag)
+        val forventedeAndeler = lagAndelerTilkjentYtelse(dataTable, behandlingId, behandlinger, personopplysningGrunnlagMap)
 
         assertThat(beregnetTilkjentYtelse)
             .usingRecursiveComparison()
@@ -364,7 +364,7 @@ class StepDefinition {
                                 BegrunnelserForPeriodeContext(
                                     utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
                                     sanityBegrunnelser = sanityBegrunnelserMock,
-                                    personopplysningGrunnlag = persongrunnlag[behandlingId]!!,
+                                    personopplysningGrunnlag = personopplysningGrunnlagMap[behandlingId]!!,
                                     personResultater = vilkårsvurdering[behandlingId]!!.personResultater.toList(),
                                     endretUtbetalingsandeler = endredeUtbetalinger[behandlingId] ?: emptyList(),
                                     erFørsteVedtaksperiode = index == 0,
@@ -407,7 +407,7 @@ class StepDefinition {
         val vedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser[behandlingId]!!
         return vedtaksperioderMedBegrunnelser.map {
             it.tilUtvidetVedtaksperiodeMedBegrunnelser(
-                personopplysningGrunnlag = persongrunnlag[behandlingId]!!,
+                personopplysningGrunnlag = personopplysningGrunnlagMap[behandlingId]!!,
                 andelerTilkjentYtelse = hentAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId),
                 dagensDato = dagensDato,
                 sanityBegrunnelser = emptyList(),
@@ -461,7 +461,7 @@ class StepDefinition {
     ) = BrevPeriodeContext(
         utvidetVedtaksperiodeMedBegrunnelser = this,
         sanityBegrunnelser = sanityBegrunnelserMock,
-        persongrunnlag = persongrunnlag[behandlingId]!!,
+        personopplysningGrunnlag = personopplysningGrunnlagMap[behandlingId]!!,
         personResultater = vilkårsvurdering[behandlingId]!!.personResultater.toList(),
         andelTilkjentYtelserMedEndreteUtbetalinger = hentAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId),
         overgangsordningAndeler = overgangsordningAndeler[behandlingId] ?: emptyList(),
@@ -580,7 +580,7 @@ class StepDefinition {
         val personidentService = mockk<PersonidentService>()
         every { personidentService.hentAktør(any()) } answers {
             val personId = firstArg<String>()
-            persongrunnlag.flatMap { it.value.personer }.first { it.id.toString() == personId }.aktør
+            personopplysningGrunnlagMap.flatMap { it.value.personer }.first { it.id.toString() == personId }.aktør
         }
 
         val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
@@ -710,7 +710,7 @@ class StepDefinition {
     }
 
     private fun lagRegistrertebarn(behandlingId: Long): List<BarnMedOpplysningerDto> =
-        persongrunnlag[behandlingId]
+        personopplysningGrunnlagMap[behandlingId]
             ?.personer
             ?.filter { it.type == PersonType.BARN }
             ?.map { person ->
@@ -723,14 +723,14 @@ class StepDefinition {
     private fun mockPersonopplysningGrunnlagService(): PersonopplysningGrunnlagService {
         val personopplysningGrunnlagService = mockk<PersonopplysningGrunnlagService>()
         every { personopplysningGrunnlagService.finnAktivPersonopplysningGrunnlag(any<Long>()) } answers {
-            persongrunnlag[firstArg()]
+            personopplysningGrunnlagMap[firstArg()]
         }
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any<Long>()) } answers {
-            persongrunnlag[firstArg()]!!
+            personopplysningGrunnlagMap[firstArg()]!!
         }
         every { personopplysningGrunnlagService.hentBarna(any<Long>()) } answers {
             val behandlingId = firstArg<Long>()
-            persongrunnlag[behandlingId]!!.barna
+            personopplysningGrunnlagMap[behandlingId]!!.barna
         }
         return personopplysningGrunnlagService
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -143,7 +143,7 @@ fun lagVilkårsvurdering(
                     PersonResultat(
                         vilkårsvurdering = vilkårvurdering,
                         aktør =
-                            stepDefinition.persongrunnlag[behandlingId]!!
+                            stepDefinition.personopplysningGrunnlagMap[behandlingId]!!
                                 .personer
                                 .single { it.aktør.aktørId == aktørId }
                                 .aktør,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPersonopplysningGrunnlagRepository.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPersonopplysningGrunnlagRepository.kt
@@ -10,7 +10,7 @@ fun mockPersonopplysningGrunnlagRepository(stepDefinition: StepDefinition): Pers
 
     every { personopplysningGrunnlagRepository.findByBehandlingAndAktiv(any()) } answers {
         val behandlingsId = firstArg<Long>()
-        stepDefinition.persongrunnlag[behandlingsId]
+        stepDefinition.personopplysningGrunnlagMap[behandlingsId]
             ?: error("Fant ikke personopplysninggrunnlag for behandling $behandlingsId")
     }
     return personopplysningGrunnlagRepository

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagInitieltTilkjentYtelse
@@ -106,6 +107,9 @@ internal class VedtaksperiodeServiceTest {
 
     @MockK(relaxed = true)
     private lateinit var kompetanseService: KompetanseService
+
+    @MockK
+    private lateinit var unleashNextMedContextService: UnleashNextMedContextService
 
     @InjectMockKs
     private lateinit var vedtaksperiodeService: VedtaksperiodeService

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
@@ -86,7 +86,7 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
             )
 
         val førskjøvetVilkårResultatTidslinjeMap =
-            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
+            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag, true)
 
         Assertions.assertEquals(2, førskjøvetVilkårResultatTidslinjeMap.size)
 
@@ -162,7 +162,7 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
             )
 
         assertDoesNotThrow {
-            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
+            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag, true)
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
@@ -6,14 +6,13 @@ import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.tilYearMonth
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
+import no.nav.familie.ks.sak.data.lagPersonResultatFraVilkårResultater
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
-import no.nav.familie.ks.sak.data.lagVilkårsvurderingMedSøkersVilkår
+import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning.tilForskjøvetOppfylteVilkårResultatTidslinjeMap
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
@@ -21,6 +20,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
 import java.time.YearMonth
 
 @ExtendWith(MockKExtension::class)
@@ -33,48 +33,62 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
     // Fom mars2020 til tom juni2020 gir utbetaling bare i april2020 og mai2020
     @Test
     fun `lagFørskjøvetVilkårResultatTidslinjeMap - skal kutte først og siste måned`() {
-        val søker = randomAktør()
+        val søkerPerson = lagPerson(aktør = randomAktør(), personType = PersonType.SØKER)
+        val barnPerson = lagPerson(aktør = randomAktør(), personType = PersonType.BARN, fødselsdato = LocalDate.of(2021, 10, 5))
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val personopplysningGrunnlag =
             lagPersonopplysningGrunnlag(
-                søkerAktør = søker,
-                behandlingId = behandling.id,
-                søkerPersonIdent = søker.aktivFødselsnummer(),
-            )
-        val søkerPerson = lagPerson(personopplysningGrunnlag, søker, PersonType.SØKER)
-
-        val vilkårsvurdering =
-            lagVilkårsvurderingMedSøkersVilkår(
                 søkerAktør = søkerPerson.aktør,
-                behandling = behandling,
-                resultat = Resultat.OPPFYLT,
+                behandlingId = behandling.id,
+                søkerPersonIdent = søkerPerson.aktør.aktivFødselsnummer(),
+                barnAktør = listOf(barnPerson.aktør),
+                barnasFødselsdatoer = listOf(barnPerson.fødselsdato),
             )
 
-        val personResultat =
-            PersonResultat(
-                vilkårsvurdering = vilkårsvurdering,
-                aktør = søkerPerson.aktør,
-            )
-        val vilkårResultater =
-            Vilkår.hentVilkårFor(søkerPerson.type).map {
-                VilkårResultat(
-                    personResultat = personResultat,
-                    periodeFom = mars2020.førsteDagIInneværendeMåned(),
-                    periodeTom = juni2020.sisteDagIInneværendeMåned(),
-                    vilkårType = it,
-                    resultat = Resultat.OPPFYLT,
-                    begrunnelse = "",
-                    behandlingId = vilkårsvurdering.behandling.id,
-                    utdypendeVilkårsvurderinger = emptyList(),
-                )
-            }
+        val vilkårResultaterSøker =
+            Vilkår
+                .hentVilkårFor(søkerPerson.type)
+                .map {
+                    lagVilkårResultat(
+                        periodeFom = mars2020.førsteDagIInneværendeMåned(),
+                        periodeTom = juni2020.sisteDagIInneværendeMåned(),
+                        vilkårType = it,
+                        resultat = Resultat.OPPFYLT,
+                        begrunnelse = "",
+                        utdypendeVilkårsvurderinger = emptyList(),
+                    )
+                }.toSet()
 
-        personResultat.setSortedVilkårResultater(vilkårResultater.toSet())
+        val vilkårResultaterBarn =
+            Vilkår
+                .hentVilkårFor(barnPerson.type)
+                .map {
+                    lagVilkårResultat(
+                        periodeFom = mars2020.førsteDagIInneværendeMåned(),
+                        periodeTom = juni2020.sisteDagIInneværendeMåned(),
+                        vilkårType = it,
+                        resultat = Resultat.OPPFYLT,
+                        begrunnelse = "",
+                        utdypendeVilkårsvurderinger = emptyList(),
+                    )
+                }.toSet()
+
+        val personResultater =
+            listOf(
+                lagPersonResultatFraVilkårResultater(
+                    aktør = søkerPerson.aktør,
+                    vilkårResultater = vilkårResultaterSøker,
+                ),
+                lagPersonResultatFraVilkårResultater(
+                    aktør = barnPerson.aktør,
+                    vilkårResultater = vilkårResultaterBarn,
+                ),
+            )
 
         val førskjøvetVilkårResultatTidslinjeMap =
-            setOf(personResultat).tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
+            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
 
-        Assertions.assertEquals(1, førskjøvetVilkårResultatTidslinjeMap.size)
+        Assertions.assertEquals(2, førskjøvetVilkårResultatTidslinjeMap.size)
 
         val forskjøvedeVedtaksperioder = førskjøvetVilkårResultatTidslinjeMap[søkerPerson.aktør]!!.tilPerioder()
 
@@ -84,55 +98,71 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
 
     @Test
     fun `lagFørskjøvetVilkårResultatTidslinjeMap - skal håndtere bor med søker-overlapp`() {
-        val søker = randomAktør()
+        val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+        val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2021, 10, 5))
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val personopplysningGrunnlag =
             lagPersonopplysningGrunnlag(
-                søkerAktør = søker,
+                søkerAktør = søker.aktør,
                 behandlingId = behandling.id,
-                søkerPersonIdent = søker.aktivFødselsnummer(),
-            )
-        val søkerPerson = lagPerson(personopplysningGrunnlag, søker, PersonType.SØKER)
-
-        val vilkårsvurdering =
-            lagVilkårsvurderingMedSøkersVilkår(
-                søkerAktør = søkerPerson.aktør,
-                behandling = behandling,
-                resultat = Resultat.OPPFYLT,
+                søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+                barnAktør = listOf(barn.aktør),
+                barnasFødselsdatoer = listOf(barn.fødselsdato),
             )
 
-        val personResultat =
-            PersonResultat(
-                vilkårsvurdering = vilkårsvurdering,
-                aktør = søkerPerson.aktør,
-            ).also {
-                it.setSortedVilkårResultater(
-                    setOf(
-                        VilkårResultat(
-                            personResultat = it,
-                            periodeFom = mars2020.førsteDagIInneværendeMåned(),
-                            periodeTom = null,
-                            vilkårType = Vilkår.BOR_MED_SØKER,
-                            resultat = Resultat.OPPFYLT,
-                            begrunnelse = "",
-                            behandlingId = vilkårsvurdering.behandling.id,
-                        ),
-                        VilkårResultat(
-                            personResultat = it,
-                            periodeFom = null,
-                            periodeTom = null,
-                            vilkårType = Vilkår.BOR_MED_SØKER,
-                            resultat = Resultat.IKKE_OPPFYLT,
-                            begrunnelse = "",
-                            behandlingId = vilkårsvurdering.behandling.id,
-                            erEksplisittAvslagPåSøknad = true,
-                        ),
+        val vilkårResultaterSøker =
+            Vilkår
+                .hentVilkårFor(søker.type)
+                .map {
+                    lagVilkårResultat(
+                        periodeFom = mars2020.førsteDagIInneværendeMåned(),
+                        periodeTom = juni2020.sisteDagIInneværendeMåned(),
+                        vilkårType = it,
+                        resultat = Resultat.OPPFYLT,
+                        begrunnelse = "",
+                        utdypendeVilkårsvurderinger = emptyList(),
+                    )
+                }.toSet()
+
+        val vilkårResultaterBarn =
+            Vilkår
+                .hentVilkårFor(barn.type)
+                .map {
+                    lagVilkårResultat(
+                        periodeFom = mars2020.førsteDagIInneværendeMåned(),
+                        periodeTom = juni2020.sisteDagIInneværendeMåned(),
+                        vilkårType = it,
+                        resultat = Resultat.OPPFYLT,
+                        begrunnelse = "",
+                        utdypendeVilkårsvurderinger = emptyList(),
+                    )
+                }.toSet()
+                .plus(
+                    lagVilkårResultat(
+                        periodeFom = null,
+                        periodeTom = null,
+                        vilkårType = Vilkår.BOR_MED_SØKER,
+                        resultat = Resultat.IKKE_OPPFYLT,
+                        begrunnelse = "",
+                        utdypendeVilkårsvurderinger = emptyList(),
+                        erEksplisittAvslagPåSøknad = true,
                     ),
                 )
-            }
+
+        val personResultater =
+            listOf(
+                lagPersonResultatFraVilkårResultater(
+                    aktør = søker.aktør,
+                    vilkårResultater = vilkårResultaterSøker,
+                ),
+                lagPersonResultatFraVilkårResultater(
+                    aktør = barn.aktør,
+                    vilkårResultater = vilkårResultaterBarn,
+                ),
+            )
 
         assertDoesNotThrow {
-            setOf(personResultat).tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
+            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -130,7 +130,7 @@ internal class UtbetalingsperiodeUtilTest {
             hentPerioderMedUtbetaling(
                 andelerTilkjentYtelse = listOf(andelPerson1MarsTilApril, andelPerson1MaiTilJuli, andelPerson2MarsTilJuli),
                 vedtak = vedtak,
-                forskjøvetVilkårResultatTidslinjeMap = personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag),
+                forskjøvetVilkårResultatTidslinjeMap = personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag = personopplysningGrunnlag, skalBestemmeLovverkBasertPåFødselsdato = true),
                 kompetanser = emptyList(),
             )
 
@@ -214,7 +214,11 @@ internal class UtbetalingsperiodeUtilTest {
             hentPerioderMedUtbetaling(
                 andelerTilkjentYtelse = listOf(andelPerson1MarsTilMai, andelPerson2MaiTilJuli),
                 vedtak = vedtak,
-                forskjøvetVilkårResultatTidslinjeMap = personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag),
+                forskjøvetVilkårResultatTidslinjeMap =
+                    personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                        personopplysningGrunnlag = personopplysningGrunnlag,
+                        skalBestemmeLovverkBasertPåFødselsdato = true,
+                    ),
                 kompetanser = emptyList(),
             )
 
@@ -234,7 +238,11 @@ internal class UtbetalingsperiodeUtilTest {
         @Test
         fun `Skal lage ny vedtaksperiode dersom vi får en ny kompetansene`() {
             val (vilkårsvurdering, tilkjentYtelse) = kjørBehandlingFramTilBehandlingsresultatMedAltGodkjent()
-            val forskjøvetVilkårResultatTidslinjeMap = vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
+            val forskjøvetVilkårResultatTidslinjeMap =
+                vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
+                )
 
             val vedtaksperioderUtenKompetanse =
                 hentPerioderMedUtbetaling(
@@ -273,7 +281,11 @@ internal class UtbetalingsperiodeUtilTest {
         @Test
         fun `Skal lage ny vedtaksperiode dersom det er endring i kompetansene`() {
             val (vilkårsvurdering, tilkjentYtelse) = kjørBehandlingFramTilBehandlingsresultatMedAltGodkjent()
-            val forskjøvetVilkårResultatTidslinjeMap = vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
+            val forskjøvetVilkårResultatTidslinjeMap =
+                vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
+                )
 
             val vedtaksperioderUtenKompetanse =
                 hentPerioderMedUtbetaling(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -121,6 +121,7 @@ internal class UtbetalingsperiodeUtilTest {
 
         val personResultater =
             setOf(
+                vilkårsvurdering.lagGodkjentPersonResultatForSøker(søker),
                 vilkårsvurdering.lagGodkjentPersonResultatForBarn(barn1),
                 vilkårsvurdering.lagGodkjentPersonResultatForBarn(barn2),
             )
@@ -204,6 +205,7 @@ internal class UtbetalingsperiodeUtilTest {
 
         val personResultater =
             setOf(
+                vilkårsvurdering.lagGodkjentPersonResultatForSøker(søker),
                 vilkårsvurdering.lagGodkjentPersonResultatForBarn(barn1),
                 vilkårsvurdering.lagGodkjentPersonResultatForBarn(barn2),
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
@@ -200,12 +200,10 @@ class ForskyvVilkårKtTest {
             val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
             val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2020).toLocalDate())
             val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = mai(2023).toLocalDate())
-            val barn3 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2024).toLocalDate())
-            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(søkerAktør = søker.aktør, barnAktør = listOf(barn.aktør, barn2.aktør, barn3.aktør), barnasFødselsdatoer = listOf(barn.fødselsdato, barn2.fødselsdato, barn3.fødselsdato))
+            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(søkerAktør = søker.aktør, barnAktør = listOf(barn.aktør, barn2.aktør), barnasFødselsdatoer = listOf(barn.fødselsdato, barn2.fødselsdato))
 
             val vilkårResultaterBarn = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn.fødselsdato.plusYears(1), periodeTom = barn.fødselsdato.plusYears(2)))
             val vilkårResultaterBarn2 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn2.fødselsdato.plusYears(1), periodeTom = barn2.fødselsdato.plusMonths(19)))
-            val vilkårResultaterBarn3 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn3.fødselsdato.plusMonths(13), periodeTom = barn3.fødselsdato.plusMonths(19)))
             val vilkårResultaterSøker =
                 setOf(
                     lagVilkårResultat(vilkårType = Vilkår.BOSATT_I_RIKET, periodeFom = søker.fødselsdato, periodeTom = barn.fødselsdato.plusMonths(15)),
@@ -223,20 +221,16 @@ class ForskyvVilkårKtTest {
                         barn2.aktør,
                     ),
                     lagPersonResultatFraVilkårResultater(
-                        vilkårResultaterBarn3,
-                        barn3.aktør,
-                    ),
-                    lagPersonResultatFraVilkårResultater(
                         vilkårResultaterSøker,
                         søker.aktør,
                     ),
                 )
 
             // Act
-            val forskjøvedeVilkårResultater = personResultater.forskyvVilkårResultater(personopplysningGrunnlag)
+            val forskjøvedeVilkårResultater = personResultater.forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag, skalBestemmeLovverkBasertPåFødselsdato = true)
 
             // Assert
-            assertThat(forskjøvedeVilkårResultater).hasSize(4)
+            assertThat(forskjøvedeVilkårResultater).hasSize(3)
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
@@ -201,10 +201,13 @@ class ForskyvVilkårKtTest {
             val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
             val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2020).toLocalDate())
             val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = mai(2023).toLocalDate())
-            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(søkerAktør = søker.aktør, barnAktør = listOf(barn.aktør, barn2.aktør), barnasFødselsdatoer = listOf(barn.fødselsdato, barn2.fødselsdato))
+            val barn3 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2024).toLocalDate())
+
+            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(søkerAktør = søker.aktør, barnAktør = listOf(barn.aktør, barn2.aktør, barn3.aktør), barnasFødselsdatoer = listOf(barn.fødselsdato, barn2.fødselsdato, barn3.fødselsdato))
 
             val vilkårResultaterBarn = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn.fødselsdato.plusYears(1), periodeTom = barn.fødselsdato.plusYears(2)))
             val vilkårResultaterBarn2 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn2.fødselsdato.plusYears(1), periodeTom = barn2.fødselsdato.plusMonths(19)))
+            val vilkårResultaterBarn3 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn3.fødselsdato.plusMonths(12), periodeTom = barn3.fødselsdato.plusMonths(20)))
             val vilkårResultaterSøker =
                 setOf(
                     lagVilkårResultat(vilkårType = Vilkår.BOSATT_I_RIKET, periodeFom = søker.fødselsdato, periodeTom = barn.fødselsdato.plusMonths(15)),
@@ -222,6 +225,10 @@ class ForskyvVilkårKtTest {
                         barn2.aktør,
                     ),
                     lagPersonResultatFraVilkårResultater(
+                        vilkårResultaterBarn3,
+                        barn3.aktør,
+                    ),
+                    lagPersonResultatFraVilkårResultater(
                         vilkårResultaterSøker,
                         søker.aktør,
                     ),
@@ -231,7 +238,7 @@ class ForskyvVilkårKtTest {
             val forskjøvedeVilkårResultater = personResultater.forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag, skalBestemmeLovverkBasertPåFødselsdato = true)
 
             // Assert
-            assertThat(forskjøvedeVilkårResultater).hasSize(3)
+            assertThat(forskjøvedeVilkårResultater).hasSize(4)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
@@ -2,6 +2,9 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvni
 
 import jan
 import mai
+import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
+import no.nav.familie.ks.sak.common.util.førsteDagINesteMåned
+import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonResultatFraVilkårResultater
@@ -15,6 +18,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.YearMonth
 
 class ForskyvVilkårKtTest {
@@ -194,52 +198,6 @@ class ForskyvVilkårKtTest {
             // Assert
             assertThat(forskjøvedeVilkårResultater).isEmpty()
         }
-
-        @Test
-        fun `skal forskyve barn og søker hver for seg og søker skal forskyves basert på barnas lovverk tidslinje`() {
-            // Arrange
-            val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
-            val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2020).toLocalDate())
-            val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = mai(2023).toLocalDate())
-            val barn3 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2024).toLocalDate())
-
-            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(søkerAktør = søker.aktør, barnAktør = listOf(barn.aktør, barn2.aktør, barn3.aktør), barnasFødselsdatoer = listOf(barn.fødselsdato, barn2.fødselsdato, barn3.fødselsdato))
-
-            val vilkårResultaterBarn = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn.fødselsdato.plusYears(1), periodeTom = barn.fødselsdato.plusYears(2)))
-            val vilkårResultaterBarn2 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn2.fødselsdato.plusYears(1), periodeTom = barn2.fødselsdato.plusMonths(19)))
-            val vilkårResultaterBarn3 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn3.fødselsdato.plusMonths(12), periodeTom = barn3.fødselsdato.plusMonths(20)))
-            val vilkårResultaterSøker =
-                setOf(
-                    lagVilkårResultat(vilkårType = Vilkår.BOSATT_I_RIKET, periodeFom = søker.fødselsdato, periodeTom = barn.fødselsdato.plusMonths(15)),
-                    lagVilkårResultat(vilkårType = Vilkår.BOSATT_I_RIKET, periodeFom = barn.fødselsdato.plusMonths(20), periodeTom = null),
-                )
-
-            val personResultater =
-                listOf(
-                    lagPersonResultatFraVilkårResultater(
-                        vilkårResultaterBarn,
-                        barn.aktør,
-                    ),
-                    lagPersonResultatFraVilkårResultater(
-                        vilkårResultaterBarn2,
-                        barn2.aktør,
-                    ),
-                    lagPersonResultatFraVilkårResultater(
-                        vilkårResultaterBarn3,
-                        barn3.aktør,
-                    ),
-                    lagPersonResultatFraVilkårResultater(
-                        vilkårResultaterSøker,
-                        søker.aktør,
-                    ),
-                )
-
-            // Act
-            val forskjøvedeVilkårResultater = personResultater.forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag, skalBestemmeLovverkBasertPåFødselsdato = true)
-
-            // Assert
-            assertThat(forskjøvedeVilkårResultater).hasSize(4)
-        }
     }
 
     @Nested
@@ -417,6 +375,99 @@ class ForskyvVilkårKtTest {
 
             // Assert
             assertThat(forskjøvedeVilkårResultater).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class PersonResultaterForskyvVilkårResultater {
+        @Test
+        fun `skal forskyve barn og søker hver for seg og søker skal forskyves basert på barnas lovverk tidslinje`() {
+            // Arrange
+            val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+            val barn1 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2020).toLocalDate())
+            val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = mai(2023).toLocalDate())
+            val barn3 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = jan(2024).toLocalDate())
+
+            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(søkerAktør = søker.aktør, barnAktør = listOf(barn1.aktør, barn2.aktør, barn3.aktør), barnasFødselsdatoer = listOf(barn1.fødselsdato, barn2.fødselsdato, barn3.fødselsdato))
+
+            val vilkårResultaterBarn = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn1.fødselsdato.plusYears(1), periodeTom = barn1.fødselsdato.plusYears(2)))
+            val vilkårResultaterBarn2 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn2.fødselsdato.plusYears(1), periodeTom = barn2.fødselsdato.plusMonths(19)))
+            val vilkårResultaterBarn3 = setOf(lagVilkårResultat(vilkårType = Vilkår.BARNETS_ALDER, periodeFom = barn3.fødselsdato.plusMonths(12), periodeTom = barn3.fødselsdato.plusMonths(20)))
+
+            val søkerFlyttetFraNorge = LocalDate.of(2023, 10, 5)
+            val søkerFlyttetTilbakeTilNorge = LocalDate.of(2024, 10, 3)
+            val søkerFlyttetFraNorgeIgjen = LocalDate.of(2025, 6, 4)
+            val vilkårResultaterSøker =
+                setOf(
+                    lagVilkårResultat(vilkårType = Vilkår.BOSATT_I_RIKET, periodeFom = søker.fødselsdato, periodeTom = søkerFlyttetFraNorge),
+                    lagVilkårResultat(vilkårType = Vilkår.BOSATT_I_RIKET, periodeFom = søkerFlyttetTilbakeTilNorge, periodeTom = søkerFlyttetFraNorgeIgjen),
+                )
+
+            val personResultater =
+                listOf(
+                    lagPersonResultatFraVilkårResultater(
+                        vilkårResultaterBarn,
+                        barn1.aktør,
+                    ),
+                    lagPersonResultatFraVilkårResultater(
+                        vilkårResultaterBarn2,
+                        barn2.aktør,
+                    ),
+                    lagPersonResultatFraVilkårResultater(
+                        vilkårResultaterBarn3,
+                        barn3.aktør,
+                    ),
+                    lagPersonResultatFraVilkårResultater(
+                        vilkårResultaterSøker,
+                        søker.aktør,
+                    ),
+                )
+
+            // Act
+            val forskjøvedeVilkårResultater = personResultater.forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag, skalBestemmeLovverkBasertPåFødselsdato = true)
+
+            // Assert
+            assertThat(forskjøvedeVilkårResultater).hasSize(4)
+
+            val barn1AlderVilkår = forskjøvedeVilkårResultater[barn1.aktør]!![Vilkår.BARNETS_ALDER]!!.single()
+            assertThat(barn1AlderVilkår.verdi.periodeFom).isEqualTo(barn1.fødselsdato.plusMonths(12))
+            assertThat(barn1AlderVilkår.verdi.periodeTom).isEqualTo(barn1.fødselsdato.plusMonths(24))
+            // Fom og tom forskjøvet etter Lov 2021
+            assertThat(barn1AlderVilkår.fom).isEqualTo(barn1.fødselsdato.plusMonths(13).førsteDagIInneværendeMåned())
+            assertThat(barn1AlderVilkår.tom).isEqualTo(barn1.fødselsdato.plusMonths(23).sisteDagIMåned())
+
+            val barn2AlderVilkår = forskjøvedeVilkårResultater[barn2.aktør]!![Vilkår.BARNETS_ALDER]!!.single()
+            assertThat(barn2AlderVilkår.verdi.periodeFom).isEqualTo(barn2.fødselsdato.plusMonths(12))
+            assertThat(barn2AlderVilkår.verdi.periodeTom).isEqualTo(barn2.fødselsdato.plusMonths(19))
+            // Fom forskjøvet etter Lov 2021
+            assertThat(barn2AlderVilkår.fom).isEqualTo(barn2.fødselsdato.plusMonths(13).førsteDagIInneværendeMåned())
+            // Tom forskjøvet etter Lov 2024
+            assertThat(barn2AlderVilkår.tom).isEqualTo(barn2.fødselsdato.plusMonths(19).sisteDagIMåned())
+
+            val barn3AlderVilkår = forskjøvedeVilkårResultater[barn3.aktør]!![Vilkår.BARNETS_ALDER]!!.single()
+            assertThat(barn3AlderVilkår.verdi.periodeFom).isEqualTo(barn3.fødselsdato.plusMonths(12))
+            assertThat(barn3AlderVilkår.verdi.periodeTom).isEqualTo(barn3.fødselsdato.plusMonths(20))
+            // Fom og Tom forskjøvet etter Lov 2025
+            assertThat(barn3AlderVilkår.fom).isEqualTo(barn3.fødselsdato.plusMonths(13).førsteDagIInneværendeMåned())
+            assertThat(barn3AlderVilkår.tom).isEqualTo(barn3.fødselsdato.plusMonths(19).sisteDagIMåned())
+
+            val søkerBosattIRiketVilkår = forskjøvedeVilkårResultater[søker.aktør]!![Vilkår.BOSATT_I_RIKET]!!
+            assertThat(søkerBosattIRiketVilkår).hasSize(2)
+            // Søkers første periode
+            assertThat(søkerBosattIRiketVilkår.first().verdi.periodeFom).isEqualTo(søker.fødselsdato)
+            assertThat(søkerBosattIRiketVilkår.first().verdi.periodeTom).isEqualTo(søkerFlyttetFraNorge)
+            // Fom forskjøvet etter Lov 2021
+            assertThat(søkerBosattIRiketVilkår.first().fom).isEqualTo(søker.fødselsdato.førsteDagINesteMåned())
+            // Tom forskjøvet etter Lov 2021
+            assertThat(søkerBosattIRiketVilkår.first().tom).isEqualTo(søkerFlyttetFraNorge.minusMonths(1).sisteDagIMåned())
+
+            // Søkers andre periode
+            assertThat(søkerBosattIRiketVilkår.last().verdi.periodeFom).isEqualTo(søkerFlyttetTilbakeTilNorge)
+            assertThat(søkerBosattIRiketVilkår.last().verdi.periodeTom).isEqualTo(søkerFlyttetFraNorgeIgjen)
+            // Fom forskjøvet etter Lov 2024
+            assertThat(søkerBosattIRiketVilkår.last().fom).isEqualTo(søkerFlyttetTilbakeTilNorge.førsteDagIInneværendeMåned())
+            // Tom forskjøvet etter Lov 2025
+            assertThat(søkerBosattIRiketVilkår.last().tom).isEqualTo(søkerFlyttetFraNorgeIgjen.minusMonths(1).sisteDagIMåned())
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGeneratorTest.kt
@@ -1,0 +1,303 @@
+package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning
+
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
+import no.nav.familie.ks.sak.common.util.sisteDagIMåned
+import no.nav.familie.ks.sak.data.lagPerson
+import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.lagVilkårResultat
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class LovverkTidslinjeGeneratorTest {
+    @Test
+    fun `skal generere lovverk-tidslinje for ett barn`() {
+        // Arrange
+        val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+        val barn1 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2021, 5, 10))
+
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(
+                søkerAktør = søker.aktør,
+                barnAktør = listOf(barn1.aktør),
+                barnasFødselsdatoer = listOf(barn1.fødselsdato),
+            )
+
+        val vilkårResultaterPerBarn =
+            listOf(barn1)
+                .associate { barn ->
+                    barn.aktør to
+                        Vilkår
+                            .hentVilkårFor(barn.type)
+                            .associateWith { vilkår ->
+                                val fom = barn.fødselsdato.plusYears(1)
+                                val tom = barn.fødselsdato.plusYears(2)
+                                listOf(
+                                    Periode(
+                                        verdi =
+                                            lagVilkårResultat(
+                                                vilkårType = vilkår,
+                                                resultat = Resultat.OPPFYLT,
+                                                periodeFom = fom,
+                                                periodeTom = tom,
+                                            ),
+                                        fom = fom.førsteDagIInneværendeMåned(),
+                                        tom = tom.sisteDagIMåned(),
+                                    ),
+                                )
+                            }
+                }
+
+        // Act
+        val lovverkTidslinje =
+            LovverkTidslinjeGenerator.generer(
+                barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
+            )
+
+        // Assert
+        val lovverkPerioder = lovverkTidslinje.tilPerioderIkkeNull()
+        assertThat(lovverkPerioder).hasSize(1)
+        assertThat(lovverkPerioder.single().verdi).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
+        assertThat(lovverkPerioder.single().fom).isNull()
+        assertThat(lovverkPerioder.single().tom).isNull()
+    }
+
+    @Test
+    fun `skal generere lovverk-tidslinje for barn på likt lovverk`() {
+        // Arrange
+        val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+        val barn1 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2021, 5, 10))
+        val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 1, 10))
+
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(
+                søkerAktør = søker.aktør,
+                barnAktør = listOf(barn1.aktør, barn2.aktør),
+                barnasFødselsdatoer = listOf(barn1.fødselsdato, barn2.fødselsdato),
+            )
+
+        val vilkårResultaterPerBarn =
+            listOf(barn1, barn2)
+                .associate { barn ->
+                    barn.aktør to
+                        Vilkår
+                            .hentVilkårFor(barn.type)
+                            .associateWith { vilkår ->
+                                val fom = barn.fødselsdato.plusYears(1)
+                                val tom = barn.fødselsdato.plusYears(2)
+                                listOf(
+                                    Periode(
+                                        verdi =
+                                            lagVilkårResultat(
+                                                vilkårType = vilkår,
+                                                resultat = Resultat.OPPFYLT,
+                                                periodeFom = fom,
+                                                periodeTom = tom,
+                                            ),
+                                        fom = fom.førsteDagIInneværendeMåned(),
+                                        tom = tom.sisteDagIMåned(),
+                                    ),
+                                )
+                            }
+                }
+
+        // Act
+        val lovverkTidslinje =
+            LovverkTidslinjeGenerator.generer(
+                barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
+            )
+
+        // Assert
+        val lovverkPerioder = lovverkTidslinje.tilPerioderIkkeNull()
+        assertThat(lovverkPerioder).hasSize(1)
+        assertThat(lovverkPerioder.single().verdi).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
+        assertThat(lovverkPerioder.single().fom).isNull()
+        assertThat(lovverkPerioder.single().tom).isNull()
+    }
+
+    @Test
+    fun `skal generere lovverk-tidslinje for barn på likt lovverk som overlapper`() {
+        // Arrange
+        val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+        val barn1 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2021, 5, 10))
+        val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2022, 3, 10))
+
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(
+                søkerAktør = søker.aktør,
+                barnAktør = listOf(barn1.aktør, barn2.aktør),
+                barnasFødselsdatoer = listOf(barn1.fødselsdato, barn2.fødselsdato),
+            )
+
+        val vilkårResultaterPerBarn =
+            listOf(barn1, barn2)
+                .associate { barn ->
+                    barn.aktør to
+                        Vilkår
+                            .hentVilkårFor(barn.type)
+                            .associateWith { vilkår ->
+                                val fom = barn.fødselsdato.plusYears(1)
+                                val tom = barn.fødselsdato.plusYears(2)
+                                listOf(
+                                    Periode(
+                                        verdi =
+                                            lagVilkårResultat(
+                                                vilkårType = vilkår,
+                                                resultat = Resultat.OPPFYLT,
+                                                periodeFom = fom,
+                                                periodeTom = tom,
+                                            ),
+                                        fom = fom.førsteDagIInneværendeMåned(),
+                                        tom = tom.sisteDagIMåned(),
+                                    ),
+                                )
+                            }
+                }
+
+        // Act
+        val lovverkTidslinje =
+            LovverkTidslinjeGenerator.generer(
+                barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
+            )
+
+        // Assert
+        val lovverkPerioder = lovverkTidslinje.tilPerioderIkkeNull()
+        assertThat(lovverkPerioder).hasSize(1)
+        assertThat(lovverkPerioder.single().verdi).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
+        assertThat(lovverkPerioder.single().fom).isNull()
+        assertThat(lovverkPerioder.single().tom).isNull()
+    }
+
+    @Test
+    fun `skal generere lovverk-tidslinje for barn på ulike lovverk`() {
+        // Arrange
+        val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+        val barn1 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2021, 5, 10))
+        val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2024, 1, 10))
+
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(
+                søkerAktør = søker.aktør,
+                barnAktør = listOf(barn1.aktør, barn2.aktør),
+                barnasFødselsdatoer = listOf(barn1.fødselsdato, barn2.fødselsdato),
+            )
+
+        val vilkårResultaterPerBarn =
+            listOf(barn1, barn2)
+                .associate { barn ->
+                    barn.aktør to
+                        Vilkår
+                            .hentVilkårFor(barn.type)
+                            .associateWith { vilkår ->
+                                val fom = barn.fødselsdato.plusYears(1)
+                                val tom = barn.fødselsdato.plusYears(2)
+                                listOf(
+                                    Periode(
+                                        verdi =
+                                            lagVilkårResultat(
+                                                vilkårType = vilkår,
+                                                resultat = Resultat.OPPFYLT,
+                                                periodeFom = fom,
+                                                periodeTom = tom,
+                                            ),
+                                        fom = fom.førsteDagIInneværendeMåned(),
+                                        tom = tom.sisteDagIMåned(),
+                                    ),
+                                )
+                            }
+                }
+
+        // Act
+        val lovverkTidslinje =
+            LovverkTidslinjeGenerator.generer(
+                barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
+            )
+
+        // Assert
+        val lovverkPerioder = lovverkTidslinje.tilPerioderIkkeNull()
+        assertThat(lovverkPerioder).hasSize(2)
+        assertThat(lovverkPerioder.first().verdi).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
+        assertThat(lovverkPerioder.first().fom).isNull()
+        assertThat(lovverkPerioder.first().tom).isEqualTo(
+            barn2.fødselsdato
+                .plusYears(1)
+                .førsteDagIInneværendeMåned()
+                .minusDays(1),
+        )
+        assertThat(lovverkPerioder.last().verdi).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
+        assertThat(lovverkPerioder.last().fom).isEqualTo(
+            barn2.fødselsdato
+                .plusYears(1)
+                .førsteDagIInneværendeMåned(),
+        )
+        assertThat(lovverkPerioder.last().tom).isNull()
+    }
+
+    @Test
+    fun `skal kaste feil dersom barn på ulike lovverk overlapper`() {
+        // Arrange
+        val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+        val barn1 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 5, 10))
+        val barn2 = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2024, 1, 10))
+
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(
+                søkerAktør = søker.aktør,
+                barnAktør = listOf(barn1.aktør, barn2.aktør),
+                barnasFødselsdatoer = listOf(barn1.fødselsdato, barn2.fødselsdato),
+            )
+
+        val vilkårResultaterPerBarn =
+            listOf(barn1, barn2)
+                .associate { barn ->
+                    barn.aktør to
+                        Vilkår
+                            .hentVilkårFor(barn.type)
+                            .associateWith { vilkår ->
+                                val fom = barn.fødselsdato.plusYears(1)
+                                val tom = barn.fødselsdato.plusYears(2)
+                                listOf(
+                                    Periode(
+                                        verdi =
+                                            lagVilkårResultat(
+                                                vilkårType = vilkår,
+                                                resultat = Resultat.OPPFYLT,
+                                                periodeFom = fom,
+                                                periodeTom = tom,
+                                            ),
+                                        fom = fom.førsteDagIInneværendeMåned(),
+                                        tom = tom.sisteDagIMåned(),
+                                    ),
+                                )
+                            }
+                }
+
+        // Act & Assert
+        val feil =
+            assertThrows<Feil> {
+                LovverkTidslinjeGenerator.generer(
+                    barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
+                )
+            }
+        assertThat(feil.message).isEqualTo("Støtter ikke overlappende lovverk")
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
+import no.nav.familie.ks.sak.data.lagPersonResultat
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårResultaterForBarn
 import no.nav.familie.ks.sak.data.lagVilkårsvurderingMedSøkersVilkår
@@ -107,6 +108,17 @@ internal class TilkjentYtelseServiceTest {
                 ),
             )
 
+        vilkårsvurdering.personResultater +=
+            lagPersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = barn1,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = barnPerson.fødselsdato.plusYears(1),
+                periodeTom = barnPerson.fødselsdato.plusYears(2),
+                lagFullstendigVilkårResultat = true,
+                personType = PersonType.BARN,
+            )
+
         // act
         val tilkjentYtelse =
             tilkjentYtelseService.beregnTilkjentYtelse(
@@ -115,16 +127,18 @@ internal class TilkjentYtelseServiceTest {
             )
 
         // assert
-        assertTilkjentYtelse(tilkjentYtelse, 2)
+        assertTilkjentYtelse(tilkjentYtelse, 3)
+
+        val søkersAndeler = tilkjentYtelse.andelerTilkjentYtelse.filter { it.aktør == barn1 }
         assertAndelTilkjentYtelse(
-            andelTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.first { it.stønadFom == YearMonth.of(2024, 9) },
+            andelTilkjentYtelse = søkersAndeler.first { it.stønadFom == YearMonth.of(2024, 9) },
             prosent = BigDecimal(100),
             periodeFom = YearMonth.of(2024, 9).toLocalDate(),
             periodeTom = YearMonth.of(2024, 10).toLocalDate(),
             type = YtelseType.OVERGANGSORDNING,
         )
         assertAndelTilkjentYtelse(
-            andelTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.first { it.stønadFom == YearMonth.of(2024, 12) },
+            andelTilkjentYtelse = søkersAndeler.first { it.stønadFom == YearMonth.of(2024, 12) },
             prosent = BigDecimal(50),
             periodeFom = YearMonth.of(2024, 12).toLocalDate(),
             periodeTom = YearMonth.of(2025, 1).toLocalDate(),
@@ -143,6 +157,17 @@ internal class TilkjentYtelseServiceTest {
                 ),
             )
 
+        vilkårsvurdering.personResultater +=
+            lagPersonResultat(
+                vilkårsvurdering = vilkårsvurdering,
+                aktør = barn1,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = barnPerson.fødselsdato.plusYears(1),
+                periodeTom = barnPerson.fødselsdato.plusYears(2),
+                lagFullstendigVilkårResultat = true,
+                personType = PersonType.BARN,
+            )
+
         // act
         val tilkjentYtelse =
             tilkjentYtelseService.beregnTilkjentYtelse(
@@ -151,7 +176,7 @@ internal class TilkjentYtelseServiceTest {
             )
 
         // assert
-        assertTrue(tilkjentYtelse.andelerTilkjentYtelse.isEmpty())
+        assertTrue(tilkjentYtelse.andelerTilkjentYtelse.none { it.type == YtelseType.OVERGANGSORDNING })
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -513,6 +513,7 @@ fun lagBrevPeriodeContext(
         erFørsteVedtaksperiode = false,
         kompetanser = emptyList(),
         landkoder = LANDKODER,
+        skalBestemmeLovverkBasertPåFødselsdato = true,
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -505,7 +505,7 @@ fun lagBrevPeriodeContext(
                 emptyList(),
             ),
         sanityBegrunnelser = lagSanityBegrunnelserFraDump(),
-        persongrunnlag = persongrunnlag,
+        personopplysningGrunnlag = persongrunnlag,
         personResultater = personResultater,
         andelTilkjentYtelserMedEndreteUtbetalinger = andelTilkjentYtelserMedEndreteUtbetalinger,
         uregistrerteBarn = emptyList(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -782,8 +782,10 @@ class BegrunnelserForPeriodeContextTest {
         // Må forskyve personresultatene for å finne riktig dato for vedtaksperiode.
         val vedtaksperiodeStartsTidpunkt =
             personResultater
-                .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
-                .filterKeys { it.aktørId == aktørSomTriggerVedtaksperiode.aktørId }
+                .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
+                ).filterKeys { it.aktørId == aktørSomTriggerVedtaksperiode.aktørId }
                 .values
                 .first()
                 .startsTidspunkt
@@ -813,6 +815,7 @@ class BegrunnelserForPeriodeContextTest {
             kompetanser = emptyList(),
             overgangsordningAndeler = emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse,
+            skalBestemmeLovverkBasertPåFødselsdato = true,
         )
     }
 
@@ -887,6 +890,7 @@ class BegrunnelserForPeriodeContextTest {
             erFørsteVedtaksperiode = false,
             overgangsordningAndeler = emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse,
+            skalBestemmeLovverkBasertPåFødselsdato = true,
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -4,6 +4,7 @@ import io.mockk.mockk
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagKompetanse
 import no.nav.familie.ks.sak.data.lagPerson
+import no.nav.familie.ks.sak.data.lagPersonResultatFraVilkårResultater
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagUtbetalingsperiodeDetalj
 import no.nav.familie.ks.sak.data.lagVilkårResultat
@@ -16,6 +17,7 @@ import no.nav.familie.ks.sak.integrasjon.sanity.domene.Trigger
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.Vedtaksperiodetype
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.UtvidetVedtaksperiodeMedBegrunnelser
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
@@ -48,12 +50,14 @@ class BegrunnelserForPeriodeContextTest {
 
     private fun feb(år: Int) = YearMonth.of(år, 2)
 
-    private val barnAktør = randomAktør()
-    private val søkerAktør = randomAktør()
-    private val persongrunnlag =
+    private val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2022, 3, 10))
+    private val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
+    private val barnAktør = barn.aktør
+    private val søkerAktør = søker.aktør
+    private val personopplysningGrunnlag =
         lagPersonopplysningGrunnlag(
-            barnasIdenter = listOf(barnAktør.aktivFødselsnummer()),
             barnAktør = listOf(barnAktør),
+            barnasFødselsdatoer = listOf(barn.fødselsdato),
             søkerPersonIdent = søkerAktør.aktivFødselsnummer(),
             søkerAktør = søkerAktør,
         )
@@ -778,7 +782,7 @@ class BegrunnelserForPeriodeContextTest {
         // Må forskyve personresultatene for å finne riktig dato for vedtaksperiode.
         val vedtaksperiodeStartsTidpunkt =
             personResultater
-                .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(persongrunnlag)
+                .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag)
                 .filterKeys { it.aktørId == aktørSomTriggerVedtaksperiode.aktørId }
                 .values
                 .first()
@@ -802,7 +806,7 @@ class BegrunnelserForPeriodeContextTest {
         return BegrunnelserForPeriodeContext(
             utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
             sanityBegrunnelser = sanityBegrunnelser,
-            personopplysningGrunnlag = persongrunnlag,
+            personopplysningGrunnlag = personopplysningGrunnlag,
             personResultater = personResultater,
             endretUtbetalingsandeler = emptyList(),
             erFørsteVedtaksperiode = false,
@@ -835,12 +839,50 @@ class BegrunnelserForPeriodeContextTest {
                 støtterFritekst = false,
             )
 
+        val vilkårResultaterForSøker =
+            Vilkår
+                .hentVilkårFor(søker.type)
+                .map {
+                    lagVilkårResultat(
+                        periodeFom = søker.fødselsdato,
+                        periodeTom = null,
+                        vilkårType = it,
+                        resultat = Resultat.OPPFYLT,
+                        begrunnelse = "",
+                        utdypendeVilkårsvurderinger = emptyList(),
+                    )
+                }.toSet()
+
+        val vilkårResultaterBarn =
+            Vilkår
+                .hentVilkårFor(barn.type)
+                .map {
+                    lagVilkårResultat(
+                        periodeFom = barn.fødselsdato.plusYears(1),
+                        periodeTom = barn.fødselsdato.plusYears(2),
+                        vilkårType = it,
+                        resultat = Resultat.OPPFYLT,
+                        begrunnelse = "",
+                        utdypendeVilkårsvurderinger = emptyList(),
+                    )
+                }.toSet()
+
         return BegrunnelserForPeriodeContext(
             utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
             sanityBegrunnelser = sanityBegrunnelser,
             kompetanser = kompetanser.map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>(),
-            personopplysningGrunnlag = persongrunnlag,
-            personResultater = emptyList(),
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            personResultater =
+                listOf(
+                    lagPersonResultatFraVilkårResultater(
+                        vilkårResultater = vilkårResultaterForSøker,
+                        aktør = søkerAktør,
+                    ),
+                    lagPersonResultatFraVilkårResultater(
+                        vilkårResultater = vilkårResultaterBarn,
+                        aktør = barnAktør,
+                    ),
+                ),
             endretUtbetalingsandeler = emptyList(),
             erFørsteVedtaksperiode = false,
             overgangsordningAndeler = emptyList(),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
For å kunne begynne å behandle saker med barn født i 2024, legger vi her inn støtte for å kunne behandle alle fagsaker hvor ingen barn med ulike lovverk overlapper.

To barn overlapper dersom det er mindre enn 7 måneder mellom de og et av barna treffer lovverk før februar 2025 og det andre treffer lovverk etter 2025. Dette er svært lite sannsynlig at vil kunne skje, og er muligens noe vi aldri kommer til å støtte fullt ut.

Løsningen ligner litt på hvordan eksisterende forskyvning gjøres for `LOVVERK_FØR_FEBRUAR_2025`. Vi forskyver søkers vilkår etter alle lovverk og kombinerer resultatene ved å "klippe og lime" i overgangen mellom ulike lovverk ved hjelp av en lovverk-tidslinje.

Nå er forskyvningen av søkers vilkår tett knyttet mot barnas vilkår, og det må alltid finnes `PersonResultater` for søker og minst ett barn ved forskyvning. En rekke tester er korrigert som følge av dette.


### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
