### PR TITLE
Legg til enum for FeatureToggle

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/KSBarnehagelisterConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/KSBarnehagelisterConsumer.kt
@@ -44,7 +44,7 @@ class KSBarnehagelisterConsumer(
             ack.acknowledge()
             return
         }
-        if (unleashService.isEnabled(FeatureToggleConfig.LAGRE_BARNEHAGEBARN_I_KS)) {
+        if (unleashService.isEnabled(FeatureToggleConfig.LAGRE_BARNEHAGEBARN_I_KS.navn)) {
             barnehageBarnService.lagreBarnehageBarn(barnehagebarn)
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/KSBarnehagelisterConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/KSBarnehagelisterConsumer.kt
@@ -4,7 +4,7 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.ks.sak.barnehagelister.domene.Barnehagebarn
 import no.nav.familie.ks.sak.barnehagelister.domene.KSBarnehagebarnDTO
 import no.nav.familie.ks.sak.config.KafkaConfig
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.unleash.UnleashService
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
@@ -44,7 +44,7 @@ class KSBarnehagelisterConsumer(
             ack.acknowledge()
             return
         }
-        if (unleashService.isEnabled(FeatureToggleConfig.LAGRE_BARNEHAGEBARN_I_KS.navn)) {
+        if (unleashService.isEnabled(FeatureToggle.LAGRE_BARNEHAGEBARN_I_KS.navn)) {
             barnehageBarnService.lagreBarnehageBarn(barnehagebarn)
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/KSBarnehagelisterConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/KSBarnehagelisterConsumer.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ks.sak.barnehagelister.domene.Barnehagebarn
 import no.nav.familie.ks.sak.barnehagelister.domene.KSBarnehagebarnDTO
 import no.nav.familie.ks.sak.config.KafkaConfig
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.unleash.UnleashService
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service
 @Profile("!integrasjonstest & !dev-postgres-preprod & !postgres")
 class KSBarnehagelisterConsumer(
     val barnehageBarnService: BarnehagebarnService,
-    val unleashService: UnleashService,
+    val unleashService: UnleashNextMedContextService,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -44,7 +44,7 @@ class KSBarnehagelisterConsumer(
             ack.acknowledge()
             return
         }
-        if (unleashService.isEnabled(FeatureToggle.LAGRE_BARNEHAGEBARN_I_KS.navn)) {
+        if (unleashService.isEnabled(FeatureToggle.LAGRE_BARNEHAGEBARN_I_KS)) {
             barnehageBarnService.lagreBarnehageBarn(barnehagebarn)
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ks.sak.config.featureToggle
 
-enum class FeatureToggleConfig(
+enum class FeatureToggle(
     val navn: String,
 ) {
     // Operasjonelle

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggleConfig.kt
@@ -1,20 +1,20 @@
 package no.nav.familie.ks.sak.config.featureToggle
 
-class FeatureToggleConfig {
-    companion object {
-        // Operasjonelle
-        const val TEKNISK_VEDLIKEHOLD_HENLEGGELSE = "familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"
-        const val TEKNISK_ENDRING = "familie-ks-sak.behandling.teknisk-endring"
-        const val KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV = "familie-ks-sak.behandling.korreksjon-vedtaksbrev"
-        const val KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER = "familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"
-        const val LAGRE_BARNEHAGEBARN_I_KS = "familie-ks-sak.lagre-barnehagebarn-i-ks"
+enum class FeatureToggleConfig(
+    val navn: String,
+) {
+    // Operasjonelle
+    TEKNISK_VEDLIKEHOLD_HENLEGGELSE("familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"),
+    TEKNISK_ENDRING("familie-ks-sak.behandling.teknisk-endring"),
+    KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV("familie-ks-sak.behandling.korreksjon-vedtaksbrev"),
+    KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER("familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"),
+    LAGRE_BARNEHAGEBARN_I_KS("familie-ks-sak.lagre-barnehagebarn-i-ks"),
 
-        // Ikke operasjonelle
-        const val OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER = "familie-ba-ks-sak.opprett-sak-paa-riktig-enhet-og-saksbehandler"
-        const val KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK = "familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"
-        const val STØTTER_LOVENDRING_2025 = "familie-ks-sak.stotter-lovendring-2025"
+    // Ikke operasjonelle
+    OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER("familie-ba-ks-sak.opprett-sak-paa-riktig-enhet-og-saksbehandler"),
+    KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
+    STØTTER_LOVENDRING_2025("familie-ks-sak.stotter-lovendring-2025"),
 
-        const val BRUK_OMSKRIVING_AV_HJEMLER_I_BREV = "familie-ks-sak.bruk_omskriving_av_hjemler_i_brev"
-        const val ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK = "familie-ks-sak.allerede-utbetalt"
-    }
+    BRUK_OMSKRIVING_AV_HJEMLER_I_BREV("familie-ks-sak.bruk_omskriving_av_hjemler_i_brev"),
+    ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK("familie-ks-sak.allerede-utbetalt"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
@@ -58,4 +58,6 @@ class UnleashNextMedContextService(
         toggle: FeatureToggle,
         defaultValue: Boolean,
     ): Boolean = unleashService.isEnabled(toggle.navn, defaultValue)
+
+    fun isEnabled(toggleId: String) = unleashService.isEnabled(toggleId)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ks.sak.config.featureToggle
 
-import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.unleash.UnleashContextFields
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 class UnleashNextMedContextService(
     private val unleashService: UnleashService,
     private val behandlingRepository: BehandlingRepository,
-    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val arbeidsfordelingPåBehandlingRepository: ArbeidsfordelingPåBehandlingRepository,
 ) {
     fun isEnabled(
         toggle: FeatureToggle,
@@ -25,7 +25,11 @@ class UnleashNextMedContextService(
                 mapOf(
                     UnleashContextFields.FAGSAK_ID to behandling.fagsak.id.toString(),
                     UnleashContextFields.BEHANDLING_ID to behandling.id.toString(),
-                    UnleashContextFields.ENHET_ID to arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandling.id).behandlendeEnhetId,
+                    UnleashContextFields.ENHET_ID to
+                        (
+                            arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandlingId)
+                                ?: error("Finner ikke tilknyttet arbeidsfordeling på behandling med id $behandlingId")
+                        ).behandlendeEnhetId,
                     UnleashContextFields.NAV_IDENT to SikkerhetContext.hentSaksbehandler(),
                     UnleashContextFields.EPOST to SikkerhetContext.hentSaksbehandlerEpost(),
                 ),

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/UnleashNextMedContextService.kt
@@ -14,13 +14,13 @@ class UnleashNextMedContextService(
     private val arbeidsfordelingService: ArbeidsfordelingService,
 ) {
     fun isEnabled(
-        toggleId: String,
+        toggle: FeatureToggle,
         behandlingId: Long,
     ): Boolean {
         val behandling = behandlingRepository.hentBehandling(behandlingId)
 
         return unleashService.isEnabled(
-            toggleId,
+            toggle.navn,
             properties =
                 mapOf(
                     UnleashContextFields.FAGSAK_ID to behandling.fagsak.id.toString(),
@@ -34,23 +34,28 @@ class UnleashNextMedContextService(
 
     fun isEnabledForFagsak(
         fagsakId: Long,
-        toggleId: String,
+        toggle: FeatureToggle,
     ): Boolean =
         unleashService.isEnabled(
-            toggleId,
+            toggle.navn,
             properties =
                 mapOf(
                     UnleashContextFields.FAGSAK_ID to fagsakId.toString(),
                 ),
         )
 
-    fun isEnabled(toggleId: String): Boolean =
+    fun isEnabled(toggle: FeatureToggle): Boolean =
         unleashService.isEnabled(
-            toggleId,
+            toggle.navn,
             properties =
                 mapOf(
                     UnleashContextFields.NAV_IDENT to SikkerhetContext.hentSaksbehandler(),
                     UnleashContextFields.EPOST to SikkerhetContext.hentSaksbehandlerEpost(),
                 ),
         )
+
+    fun isEnabled(
+        toggle: FeatureToggle,
+        defaultValue: Boolean,
+    ): Boolean = unleashService.isEnabled(toggle.navn, defaultValue)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -66,7 +66,7 @@ class OppgaveService(
                 .hentArbeidsfordelingPåBehandling(behandlingId)
                 .tilArbeidsfordelingsenhet()
 
-        val opprettSakPåRiktigEnhetOgSaksbehandlerToggleErPå = unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false)
+        val opprettSakPåRiktigEnhetOgSaksbehandlerToggleErPå = unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
 
         val navIdent = tilordnetNavIdent?.let { NavIdent(it) }
         val tilordnetRessurs =
@@ -147,8 +147,7 @@ class OppgaveService(
 
     fun hentOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto = integrasjonClient.hentOppgaver(finnOppgaveRequest)
 
-    fun hentOppgaverSomIkkeErFerdigstilt(behandling: Behandling): List<DbOppgave> =
-        oppgaveRepository.findByBehandlingAndIkkeFerdigstilt(behandling)
+    fun hentOppgaverSomIkkeErFerdigstilt(behandling: Behandling): List<DbOppgave> = oppgaveRepository.findByBehandlingAndIkkeFerdigstilt(behandling)
 
     fun ferdigstillOppgave(oppgave: Oppgave) {
         val oppgaveId = oppgave.id
@@ -220,11 +219,10 @@ class OppgaveService(
 
     fun oppdaterBehandlingstypePåOppgaverFraBehandling(
         behandling: Behandling,
-    ) =
-        hentOppgaverSomIkkeErFerdigstilt(behandling).forEach { dbOppgave ->
-            val oppgave = hentOppgave(dbOppgave.gsakId.toLong())
-            integrasjonClient.oppdaterOppgave(oppgave.copy(behandlingstype = behandling.kategori.tilOppgavebehandlingType().value))
-        }
+    ) = hentOppgaverSomIkkeErFerdigstilt(behandling).forEach { dbOppgave ->
+        val oppgave = hentOppgave(dbOppgave.gsakId.toLong())
+        integrasjonClient.oppdaterOppgave(oppgave.copy(behandlingstype = behandling.kategori.tilOppgavebehandlingType().value))
+    }
 
     private fun lagOppgaveTekst(
         fagsakId: Long,

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -11,7 +11,7 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.oppgave.domene.DbOppgave
 import no.nav.familie.ks.sak.integrasjon.oppgave.domene.OppgaveRepository
@@ -66,7 +66,7 @@ class OppgaveService(
                 .hentArbeidsfordelingPåBehandling(behandlingId)
                 .tilArbeidsfordelingsenhet()
 
-        val opprettSakPåRiktigEnhetOgSaksbehandlerToggleErPå = unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
+        val opprettSakPåRiktigEnhetOgSaksbehandlerToggleErPå = unleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
 
         val navIdent = tilordnetNavIdent?.let { NavIdent(it) }
         val tilordnetRessurs =

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveService.kt
@@ -12,6 +12,7 @@ import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.oppgave.domene.DbOppgave
 import no.nav.familie.ks.sak.integrasjon.oppgave.domene.OppgaveRepository
@@ -21,7 +22,6 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.hentArbeidsfordeling
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.tilArbeidsfordelingsenhet
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -35,7 +35,7 @@ class OppgaveService(
     private val behandlingRepository: BehandlingRepository,
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
     private val arbeidsfordelingPåBehandlingRepository: ArbeidsfordelingPåBehandlingRepository,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     fun opprettOppgave(
         behandlingId: Long,
@@ -66,7 +66,7 @@ class OppgaveService(
                 .hentArbeidsfordelingPåBehandling(behandlingId)
                 .tilArbeidsfordelingsenhet()
 
-        val opprettSakPåRiktigEnhetOgSaksbehandlerToggleErPå = unleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
+        val opprettSakPåRiktigEnhetOgSaksbehandlerToggleErPå = unleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false)
 
         val navIdent = tilordnetNavIdent?.let { NavIdent(it) }
         val tilordnetRessurs =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -34,8 +34,7 @@ class ArbeidsfordelingService(
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
     private val unleashService: UnleashService,
 ) {
-    fun hentAlleBehandlingerPåEnhet(enhetId: String) =
-        arbeidsfordelingPåBehandlingRepository.hentAlleArbeidsfordelingPåBehandlingMedEnhet(enhetId)
+    fun hentAlleBehandlingerPåEnhet(enhetId: String) = arbeidsfordelingPåBehandlingRepository.hentAlleArbeidsfordelingPåBehandlingMedEnhet(enhetId)
 
     fun hentArbeidsfordelingPåBehandling(behandlingId: Long) =
         arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandlingId)
@@ -58,7 +57,7 @@ class ArbeidsfordelingService(
                 )
             } else {
                 val arbeidsfordelingsenhet =
-                    if (unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false)) {
+                    if (unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)) {
                         val arbeidsfordelingsenhet = hentArbeidsfordelingsenhet(behandling)
                         tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, NavIdent(SikkerhetContext.hentSaksbehandler()))
                     } else {
@@ -209,8 +208,7 @@ class ArbeidsfordelingService(
         }
     }
 
-    private fun identMedAdressebeskyttelse(aktør: Aktør) =
-        aktør.aktivFødselsnummer() to personopplysningerService.hentPersoninfoEnkel(aktør).adressebeskyttelseGradering
+    private fun identMedAdressebeskyttelse(aktør: Aktør) = aktør.aktivFødselsnummer() to personopplysningerService.hentPersoninfoEnkel(aktør).adressebeskyttelseGradering
 
     private fun identMedAdressebeskyttelse(ident: String) =
         IdentMedAdressebeskyttelse(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -4,7 +4,8 @@ import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ks.sak.integrasjon.oppgave.OppgaveService
@@ -18,7 +19,6 @@ import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
-import no.nav.familie.unleash.UnleashService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -32,7 +32,7 @@ class ArbeidsfordelingService(
     private val loggService: LoggService,
     private val personidentService: PersonidentService,
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     fun hentAlleBehandlingerPåEnhet(enhetId: String) = arbeidsfordelingPåBehandlingRepository.hentAlleArbeidsfordelingPåBehandlingMedEnhet(enhetId)
 
@@ -57,7 +57,7 @@ class ArbeidsfordelingService(
                 )
             } else {
                 val arbeidsfordelingsenhet =
-                    if (unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)) {
+                    if (unleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false)) {
                         val arbeidsfordelingsenhet = hentArbeidsfordelingsenhet(behandling)
                         tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, NavIdent(SikkerhetContext.hentSaksbehandler()))
                     } else {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingService.kt
@@ -104,7 +104,7 @@ class HenleggBehandlingService(
         val behandlingId = behandling.id
         when {
             HenleggÅrsak.TEKNISK_VEDLIKEHOLD == henleggÅrsak &&
-                !unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) -> {
+                !unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE) -> {
                 throw Feil(
                     "Teknisk vedlikehold henleggele er ikke påslått for " +
                         "${SikkerhetContext.hentSaksbehandlerNavn()}. Kan ikke henlegge behandling $behandlingId.",
@@ -121,7 +121,7 @@ class HenleggBehandlingService(
                 )
             }
 
-            behandling.erTekniskEndring() && !unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn) -> {
+            behandling.erTekniskEndring() && !unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING) -> {
                 throw FunksjonellFeil(
                     "Du har ikke tilgang til å henlegge en behandling " +
                         "som er opprettet med årsak=${behandling.opprettetÅrsak.visningsnavn}. " +

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingService.kt
@@ -104,7 +104,7 @@ class HenleggBehandlingService(
         val behandlingId = behandling.id
         when {
             HenleggÅrsak.TEKNISK_VEDLIKEHOLD == henleggÅrsak &&
-                !unleashService.isEnabled(FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE) -> {
+                !unleashService.isEnabled(FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) -> {
                 throw Feil(
                     "Teknisk vedlikehold henleggele er ikke påslått for " +
                         "${SikkerhetContext.hentSaksbehandlerNavn()}. Kan ikke henlegge behandling $behandlingId.",
@@ -121,7 +121,7 @@ class HenleggBehandlingService(
                 )
             }
 
-            behandling.erTekniskEndring() && !unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING) -> {
+            behandling.erTekniskEndring() && !unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn) -> {
                 throw FunksjonellFeil(
                     "Du har ikke tilgang til å henlegge en behandling " +
                         "som er opprettet med årsak=${behandling.opprettetÅrsak.visningsnavn}. " +

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingService.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ks.sak.api.dto.HenleggÅrsak
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.oppgave.OppgaveService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -104,7 +104,7 @@ class HenleggBehandlingService(
         val behandlingId = behandling.id
         when {
             HenleggÅrsak.TEKNISK_VEDLIKEHOLD == henleggÅrsak &&
-                !unleashService.isEnabled(FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) -> {
+                !unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) -> {
                 throw Feil(
                     "Teknisk vedlikehold henleggele er ikke påslått for " +
                         "${SikkerhetContext.hentSaksbehandlerNavn()}. Kan ikke henlegge behandling $behandlingId.",
@@ -121,7 +121,7 @@ class HenleggBehandlingService(
                 )
             }
 
-            behandling.erTekniskEndring() && !unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn) -> {
+            behandling.erTekniskEndring() && !unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn) -> {
                 throw FunksjonellFeil(
                     "Du har ikke tilgang til å henlegge en behandling " +
                         "som er opprettet med årsak=${behandling.opprettetÅrsak.visningsnavn}. " +

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
@@ -9,7 +9,7 @@ import no.nav.familie.kontrakter.felles.klage.Opprettet
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.oppgave.OpprettOppgaveTask
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
@@ -51,7 +51,7 @@ class OpprettBehandlingService(
     @Transactional
     fun opprettBehandling(opprettBehandlingRequest: OpprettBehandlingDto): Behandling {
         if (opprettBehandlingRequest.behandlingÅrsak == BehandlingÅrsak.IVERKSETTE_KA_VEDTAK &&
-            !unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK.navn)
+            !unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK.navn)
         ) {
             throw FunksjonellFeil(
                 melding = "Kan ikke opprette behandling med årsak Iverksette KA-vedtak.",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
@@ -51,7 +51,7 @@ class OpprettBehandlingService(
     @Transactional
     fun opprettBehandling(opprettBehandlingRequest: OpprettBehandlingDto): Behandling {
         if (opprettBehandlingRequest.behandlingÅrsak == BehandlingÅrsak.IVERKSETTE_KA_VEDTAK &&
-            !unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK.navn)
+            !unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK)
         ) {
             throw FunksjonellFeil(
                 melding = "Kan ikke opprette behandling med årsak Iverksette KA-vedtak.",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
@@ -51,7 +51,7 @@ class OpprettBehandlingService(
     @Transactional
     fun opprettBehandling(opprettBehandlingRequest: OpprettBehandlingDto): Behandling {
         if (opprettBehandlingRequest.behandlingÅrsak == BehandlingÅrsak.IVERKSETTE_KA_VEDTAK &&
-            !unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK)
+            !unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK.navn)
         ) {
             throw FunksjonellFeil(
                 melding = "Kan ikke opprette behandling med årsak Iverksette KA-vedtak.",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ks.sak.api.dto.BehandlingStegDto
 import no.nav.familie.ks.sak.api.dto.BesluttVedtakDto
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.oppgave.FerdigstillOppgaverTask
 import no.nav.familie.ks.sak.integrasjon.oppgave.OpprettOppgaveTask
@@ -52,7 +52,7 @@ class BeslutteVedtakSteg(
 
         if (behandling.erTekniskEndring() &&
             !unleashService.isEnabled(
-                FeatureToggleConfig.TEKNISK_ENDRING.navn,
+                FeatureToggle.TEKNISK_ENDRING.navn,
                 behandling.id,
             )
         ) {
@@ -121,11 +121,11 @@ class BeslutteVedtakSteg(
                 throw FunksjonellFeil("Behandlingen er allerede avsluttet")
 
             behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-                !unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) ->
+                !unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) ->
                 throw FunksjonellFeil(
                     melding =
                         "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og " +
-                            "toggle ${FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn} false",
+                            "toggle ${FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn} false",
                     frontendFeilmelding =
                         "Du har ikke tilgang til å beslutte for denne behandlingen. " +
                             "Ta kontakt med teamet dersom dette ikke stemmer.",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
@@ -52,7 +52,7 @@ class BeslutteVedtakSteg(
 
         if (behandling.erTekniskEndring() &&
             !unleashService.isEnabled(
-                FeatureToggleConfig.TEKNISK_ENDRING,
+                FeatureToggleConfig.TEKNISK_ENDRING.navn,
                 behandling.id,
             )
         ) {
@@ -121,11 +121,11 @@ class BeslutteVedtakSteg(
                 throw FunksjonellFeil("Behandlingen er allerede avsluttet")
 
             behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-                !unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV) ->
+                !unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) ->
                 throw FunksjonellFeil(
                     melding =
                         "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og " +
-                            "toggle ${FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV} false",
+                            "toggle ${FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn} false",
                     frontendFeilmelding =
                         "Du har ikke tilgang til å beslutte for denne behandlingen. " +
                             "Ta kontakt med teamet dersom dette ikke stemmer.",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakSteg.kt
@@ -52,7 +52,7 @@ class BeslutteVedtakSteg(
 
         if (behandling.erTekniskEndring() &&
             !unleashService.isEnabled(
-                FeatureToggle.TEKNISK_ENDRING.navn,
+                FeatureToggle.TEKNISK_ENDRING,
                 behandling.id,
             )
         ) {
@@ -121,7 +121,7 @@ class BeslutteVedtakSteg(
                 throw FunksjonellFeil("Behandlingen er allerede avsluttet")
 
             behandling.opprettetÅrsak == BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-                !unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) ->
+                !unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV) ->
                 throw FunksjonellFeil(
                     melding =
                         "Årsak ${BehandlingÅrsak.KORREKSJON_VEDTAKSBREV.visningsnavn} og " +

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
 
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
@@ -54,7 +54,7 @@ class BehandlingsresultatSteg(
             tilkjentYtelse = tilkjentYtelseNåværendeBehandling,
             endretUtbetalingMedAndeler = endretUtbetalingMedAndeler,
             personResultaterForBarn = personResultaterForBarn,
-            skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
+            skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
         )
 
         if (behandling.erOvergangsordning()) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.sammensattkontrollsa
 
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
@@ -17,7 +17,7 @@ class SammensattKontrollsakValidator(
     private val behandlingService: BehandlingService,
 ) {
     fun validerHentSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å hente sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -31,7 +31,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerOpprettSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å opprette sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -45,7 +45,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerOppdaterSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å oppdatere sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -59,7 +59,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerSlettSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å slette sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
@@ -17,7 +17,7 @@ class SammensattKontrollsakValidator(
     private val behandlingService: BehandlingService,
 ) {
     fun validerHentSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å hente sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -31,7 +31,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerOpprettSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å opprette sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -45,7 +45,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerOppdaterSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å oppdatere sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -59,7 +59,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerSlettSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
+        if (!unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å slette sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidator.kt
@@ -17,7 +17,7 @@ class SammensattKontrollsakValidator(
     private val behandlingService: BehandlingService,
 ) {
     fun validerHentSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å hente sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -31,7 +31,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerOpprettSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å opprette sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -45,7 +45,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerOppdaterSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å oppdatere sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,
@@ -59,7 +59,7 @@ class SammensattKontrollsakValidator(
     }
 
     fun validerSlettSammensattKontrollsakTilgang() {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)) {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)) {
             throw FunksjonellFeil(
                 melding = "Mangler tilgang for å slette sammensatt kontrollsak.",
                 httpStatus = HttpStatus.FORBIDDEN,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -451,7 +451,7 @@ class VedtaksperiodeService(
             personopplysningGrunnlag = personopplysningGrunnlag,
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             vilkårsvurdering = vilkårsvurdering,
-            skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
+            skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.slåSammen
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -58,7 +58,7 @@ class VilkårsvurderingSteg(
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId)
 
         if (personopplysningGrunnlag.barna.any { it.fødselsdato.isAfter(LocalDate.of(2023, 12, 31)) } &&
-            !unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn)
+            !unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn)
         ) {
             throw FunksjonellFeil("Barn født 1.1.24 eller senere kan ikke behandles før nytt regelverk er støttet i løsningen")
         }
@@ -278,7 +278,7 @@ class VilkårsvurderingSteg(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         vilkårsvurdering: Vilkårsvurdering,
     ) {
-        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn))
+        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn))
         if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
             throw FunksjonellFeil(
                 melding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -58,7 +58,7 @@ class VilkårsvurderingSteg(
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId)
 
         if (personopplysningGrunnlag.barna.any { it.fødselsdato.isAfter(LocalDate.of(2023, 12, 31)) } &&
-            !unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025)
+            !unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn)
         ) {
             throw FunksjonellFeil("Barn født 1.1.24 eller senere kan ikke behandles før nytt regelverk er støttet i løsningen")
         }
@@ -278,7 +278,7 @@ class VilkårsvurderingSteg(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         vilkårsvurdering: Vilkårsvurdering,
     ) {
-        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025))
+        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn))
         if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
             throw FunksjonellFeil(
                 melding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -58,7 +58,7 @@ class VilkårsvurderingSteg(
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId)
 
         if (personopplysningGrunnlag.barna.any { it.fødselsdato.isAfter(LocalDate.of(2023, 12, 31)) } &&
-            !unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn)
+            !unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025)
         ) {
             throw FunksjonellFeil("Barn født 1.1.24 eller senere kan ikke behandles før nytt regelverk er støttet i løsningen")
         }
@@ -278,7 +278,7 @@ class VilkårsvurderingSteg(
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         vilkårsvurdering: Vilkårsvurdering,
     ) {
-        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn))
+        val vilkårsvurderingTidslinjer = VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025))
         if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
             throw FunksjonellFeil(
                 melding = "Det er forskjellig regelverk for en eller flere perioder for søker eller barna",

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.validering
 
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårLovverk
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårLovverkInformasjonForBarn
@@ -22,7 +22,7 @@ class BarnetsAlderVilkårValidator(
         perioder: List<IkkeNullbarPeriode<VilkårResultat>>,
         barn: Person,
     ): List<String> {
-        val skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025)
+        val skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025)
         val vilkårLovverkInformasjonForBarn =
             if (perioder.any { it.verdi.erAdopsjonOppfylt() }) {
                 VilkårLovverkInformasjonForBarn(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårsvurderingRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -15,7 +16,6 @@ import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.slåSammen
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -26,7 +26,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     @Transactional
     fun finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId: Long): List<AndelTilkjentYtelseMedEndreteUtbetalinger> = lagKombinator(behandlingId).lagAndelerMedEndringer()
@@ -45,7 +45,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
                         årsak = endretUtbetalingAndelMedAndelTilkjentYtelse.årsak,
                         endretUtbetalingAndel = endretUtbetalingAndelMedAndelTilkjentYtelse.endretUtbetaling,
                         vilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandlingId),
-                        kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggle.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
+                        kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggle.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
                     )
                 }
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårsvurderingRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
@@ -45,7 +45,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
                         årsak = endretUtbetalingAndelMedAndelTilkjentYtelse.årsak,
                         endretUtbetalingAndel = endretUtbetalingAndelMedAndelTilkjentYtelse.endretUtbetaling,
                         vilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandlingId),
-                        kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
+                        kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggle.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
                     )
                 }
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -29,8 +29,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
     private val unleashService: UnleashService,
 ) {
     @Transactional
-    fun finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId: Long): List<AndelTilkjentYtelseMedEndreteUtbetalinger> =
-        lagKombinator(behandlingId).lagAndelerMedEndringer()
+    fun finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId: Long): List<AndelTilkjentYtelseMedEndreteUtbetalinger> = lagKombinator(behandlingId).lagAndelerMedEndringer()
 
     @Transactional
     fun finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandlingId: Long): List<EndretUtbetalingAndelMedAndelerTilkjentYtelse> =
@@ -46,7 +45,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
                         årsak = endretUtbetalingAndelMedAndelTilkjentYtelse.årsak,
                         endretUtbetalingAndel = endretUtbetalingAndelMedAndelTilkjentYtelse.endretUtbetaling,
                         vilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandlingId),
-                        kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
+                        kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
                     )
                 }
         }
@@ -73,11 +72,9 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
         }
 }
 
-fun Collection<AndelTilkjentYtelse>.tilAndelerTilkjentYtelseMedEndreteUtbetalinger(endretUtbetalingAndeler: Collection<EndretUtbetalingAndel>) =
-    AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(this, endretUtbetalingAndeler).lagAndelerMedEndringer()
+fun Collection<AndelTilkjentYtelse>.tilAndelerTilkjentYtelseMedEndreteUtbetalinger(endretUtbetalingAndeler: Collection<EndretUtbetalingAndel>) = AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(this, endretUtbetalingAndeler).lagAndelerMedEndringer()
 
-fun Collection<EndretUtbetalingAndel>.tilEndretUtbetalingAndelMedAndelerTilkjentYtelse(andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>) =
-    AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(andelerTilkjentYtelse, this).lagEndreteUtbetalingMedAndeler()
+fun Collection<EndretUtbetalingAndel>.tilEndretUtbetalingAndelMedAndelerTilkjentYtelse(andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>) = AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(andelerTilkjentYtelse, this).lagEndreteUtbetalingMedAndeler()
 
 private class AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(
     private val andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
@@ -119,8 +116,7 @@ data class AndelTilkjentYtelseMedEndreteUtbetalinger(
     val kalkulertUtbetalingsbeløp get() = andelTilkjentYtelse.kalkulertUtbetalingsbeløp
     val aktør get() = andelTilkjentYtelse.aktør
 
-    fun medTom(tom: YearMonth): AndelTilkjentYtelseMedEndreteUtbetalinger =
-        AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse.copy(stønadTom = tom), endreteUtbetalinger)
+    fun medTom(tom: YearMonth): AndelTilkjentYtelseMedEndreteUtbetalinger = AndelTilkjentYtelseMedEndreteUtbetalinger(andelTilkjentYtelse.copy(stønadTom = tom), endreteUtbetalinger)
 
     val stønadFom get() = andelTilkjentYtelse.stønadFom
     val stønadTom get() = andelTilkjentYtelse.stønadTom
@@ -179,8 +175,7 @@ fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilTidslinjer(): List<Tidsli
         ).tilTidslinje()
     }
 
-fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.lagVertikalePerioder(): Tidslinje<Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>> =
-    this.tilTidslinjer().slåSammen()
+fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.lagVertikalePerioder(): Tidslinje<Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>> = this.tilTidslinjer().slåSammen()
 
 fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilKombinertTidslinjePerAktør(): Tidslinje<Collection<AndelTilkjentYtelseMedEndreteUtbetalinger>> {
     val andelTilkjentYtelsePerPerson = groupBy { it.aktør }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -38,7 +38,7 @@ class BeregnAndelTilkjentYtelseService(
         val regelverk =
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = barn.fødselsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn),
+                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn),
             )
         val andelGenerator = andelGeneratorLookup.hentGeneratorForLovverk(regelverk)
         val andeler = andelGenerator.beregnAndelerForBarn(søker = søker, barn = barn, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
@@ -38,7 +38,7 @@ class BeregnAndelTilkjentYtelseService(
         val regelverk =
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = barn.fødselsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
+                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn),
             )
         val andelGenerator = andelGeneratorLookup.hentGeneratorForLovverk(regelverk)
         val andeler = andelGenerator.beregnAndelerForBarn(søker = søker, barn = barn, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
@@ -38,7 +38,7 @@ class BeregnAndelTilkjentYtelseService(
         val regelverk =
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = barn.fødselsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn),
+                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
             )
         val andelGenerator = andelGeneratorLookup.hentGeneratorForLovverk(regelverk)
         val andeler = andelGenerator.beregnAndelerForBarn(søker = søker, barn = barn, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ks.sak.common.util.storForbokstavIAlleNavn
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -56,7 +57,6 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGru
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import no.nav.familie.ks.sak.korrigertvedtak.KorrigertVedtakService
 import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
-import no.nav.familie.unleash.UnleashService
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 
@@ -81,7 +81,7 @@ class GenererBrevService(
     private val brevmalService: BrevmalService,
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val hjemmeltekstUtleder: HjemmeltekstUtleder,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     fun genererManueltBrev(
         manueltBrevRequest: ManueltBrevDto,
@@ -265,7 +265,7 @@ class GenererBrevService(
         val korrigertVedtak = korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(vedtak.behandling.id)
 
         val hjemler =
-            if (unleashService.isEnabled(FeatureToggle.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV.navn, false)) {
+            if (unleashService.isEnabled(FeatureToggle.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV, false)) {
                 hjemmeltekstUtleder.utledHjemmeltekst(
                     behandlingId = vedtak.behandling.id,
                     vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -265,7 +265,7 @@ class GenererBrevService(
         val korrigertVedtak = korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(vedtak.behandling.id)
 
         val hjemler =
-            if (unleashService.isEnabled(FeatureToggleConfig.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV, false)) {
+            if (unleashService.isEnabled(FeatureToggleConfig.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV.navn, false)) {
                 hjemmeltekstUtleder.utledHjemmeltekst(
                     behandlingId = vedtak.behandling.id,
                     vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,
@@ -390,40 +390,39 @@ class GenererBrevService(
 
     fun hentDødsfallbrevData(
         vedtak: Vedtak,
-    ) =
-        opprettGrunnlagOgSignaturDataService.opprett(vedtak).let { data ->
-            Dødsfall(
-                data =
-                    DødsfallData(
-                        delmalData =
-                            DødsfallData.DelmalData(
-                                signaturVedtak =
-                                    SignaturVedtak(
-                                        enhet = data.enhet,
-                                        saksbehandler = data.saksbehandler,
-                                        beslutter = data.beslutter,
-                                    ),
-                            ),
-                        flettefelter =
-                            DødsfallData.Flettefelter(
-                                navn = data.grunnlag.søker.navn,
-                                fodselsnummer =
-                                    data.grunnlag.søker.aktør
-                                        .aktivFødselsnummer(),
-                                // Selv om det er feil å anta at alle navn er på dette formatet er det ønskelig å skrive
-                                // det slik, da uppercase kan oppleves som skrikende i et brev som skal være skånsomt
-                                navnAvdode =
-                                    data.grunnlag.søker.navn
-                                        .storForbokstavIAlleNavn(),
-                                virkningstidspunkt =
-                                    hentVirkningstidspunkt(
-                                        opphørsperioder = vedtaksperiodeService.hentOpphørsperioder(vedtak.behandling),
-                                        behandlingId = vedtak.behandling.id,
-                                    ),
-                            ),
-                    ),
-            )
-        }
+    ) = opprettGrunnlagOgSignaturDataService.opprett(vedtak).let { data ->
+        Dødsfall(
+            data =
+                DødsfallData(
+                    delmalData =
+                        DødsfallData.DelmalData(
+                            signaturVedtak =
+                                SignaturVedtak(
+                                    enhet = data.enhet,
+                                    saksbehandler = data.saksbehandler,
+                                    beslutter = data.beslutter,
+                                ),
+                        ),
+                    flettefelter =
+                        DødsfallData.Flettefelter(
+                            navn = data.grunnlag.søker.navn,
+                            fodselsnummer =
+                                data.grunnlag.søker.aktør
+                                    .aktivFødselsnummer(),
+                            // Selv om det er feil å anta at alle navn er på dette formatet er det ønskelig å skrive
+                            // det slik, da uppercase kan oppleves som skrikende i et brev som skal være skånsomt
+                            navnAvdode =
+                                data.grunnlag.søker.navn
+                                    .storForbokstavIAlleNavn(),
+                            virkningstidspunkt =
+                                hentVirkningstidspunkt(
+                                    opphørsperioder = vedtaksperiodeService.hentOpphørsperioder(vedtak.behandling),
+                                    behandlingId = vedtak.behandling.id,
+                                ),
+                        ),
+                ),
+        )
+    }
 
     private fun hentVirkningstidspunkt(
         opphørsperioder: List<Opphørsperiode>,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ks.sak.common.util.formaterBeløp
 import no.nav.familie.ks.sak.common.util.storForbokstavIAlleNavn
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -265,7 +265,7 @@ class GenererBrevService(
         val korrigertVedtak = korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(vedtak.behandling.id)
 
         val hjemler =
-            if (unleashService.isEnabled(FeatureToggleConfig.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV.navn, false)) {
+            if (unleashService.isEnabled(FeatureToggle.BRUK_OMSKRIVING_AV_HJEMLER_I_BREV.navn, false)) {
                 hjemmeltekstUtleder.utledHjemmeltekst(
                     behandlingId = vedtak.behandling.id,
                     vedtakKorrigertHjemmelSkalMedIBrev = korrigertVedtak != null,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.api.dto.SanityBegrunnelseMedEndringsårsakResponseDto
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -68,7 +68,7 @@ class EndretUtbetalingAndelService(
             årsak = endretUtbetalingAndel.årsak,
             endretUtbetalingAndel = endretUtbetalingAndel,
             vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id),
-            kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
+            kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggle.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
         )
 
         validerIngenOverlappendeEndring(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ks.sak.api.dto.SanityBegrunnelseMedEndringsårsakResponseD
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -24,7 +25,6 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAnde
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.fraEndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -37,7 +37,7 @@ class EndretUtbetalingAndelService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val endretUtbetalingAndelOppdatertAbonnementer: List<EndretUtbetalingAndelerOppdatertAbonnent> = emptyList(),
     private val sanityService: SanityService,
-    private val unleashService: UnleashService,
+    private val unleashService: UnleashNextMedContextService,
 ) {
     fun hentEndredeUtbetalingAndeler(behandlingId: Long) = endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(behandlingId)
 
@@ -68,7 +68,7 @@ class EndretUtbetalingAndelService(
             årsak = endretUtbetalingAndel.årsak,
             endretUtbetalingAndel = endretUtbetalingAndel,
             vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id),
-            kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggle.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
+            kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggle.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
         )
 
         validerIngenOverlappendeEndring(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -68,7 +68,7 @@ class EndretUtbetalingAndelService(
             årsak = endretUtbetalingAndel.årsak,
             endretUtbetalingAndel = endretUtbetalingAndel,
             vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id),
-            kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK),
+            kanBrukeÅrsakAlleredeUtbetalt = unleashService.isEnabled(FeatureToggleConfig.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK.navn),
         )
 
         validerIngenOverlappendeEndring(
@@ -120,8 +120,7 @@ class EndretUtbetalingAndelService(
     }
 
     @Transactional
-    fun opprettTomEndretUtbetalingAndel(behandling: Behandling) =
-        endretUtbetalingAndelRepository.save(EndretUtbetalingAndel(behandlingId = behandling.id))
+    fun opprettTomEndretUtbetalingAndel(behandling: Behandling) = endretUtbetalingAndelRepository.save(EndretUtbetalingAndel(behandlingId = behandling.id))
 
     @Transactional
     fun kopierEndretUtbetalingAndelFraForrigeBehandling(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -26,7 +26,7 @@ class VilkårsvurderingTidslinjeService(
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId)
 
-        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn))
+        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025))
     }
 
     fun hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId: Long): Tidslinje<Boolean> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
@@ -26,7 +26,7 @@ class VilkårsvurderingTidslinjeService(
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId)
 
-        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn))
+        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn))
     }
 
     fun hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId: Long): Tidslinje<Boolean> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -26,7 +26,7 @@ class VilkårsvurderingTidslinjeService(
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandlingId)
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId)
 
-        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025))
+        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn))
     }
 
     fun hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId: Long): Tidslinje<Boolean> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -75,7 +75,7 @@ class CucumberMock(
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
             endretUtbetalingAndelRepository = endretUtbetalingAndelRepositoryMock,
             vilkårsvurderingRepository = vilkårsvurderingRepositoryMock,
-            unleashService = mockUnleashService(isEnabledDefault = false),
+            unleashService = mockUnleashNextMedContextService(isEnabledDefault = false),
         )
 
     val personidentService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUnleashService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUnleashService.kt
@@ -4,18 +4,10 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
-import no.nav.familie.unleash.UnleashService
 
 fun mockUnleashNextMedContextService(isEnabledDefault: Boolean = true): UnleashNextMedContextService {
     val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
     every { unleashNextMedContextService.isEnabled(any<String>()) } returns isEnabledDefault
     every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns isEnabledDefault
     return unleashNextMedContextService
-}
-
-fun mockUnleashService(isEnabledDefault: Boolean = true): UnleashService {
-    val unleashService = mockk<UnleashService>()
-    every { unleashService.isEnabled(any()) } returns isEnabledDefault
-    every { unleashService.isEnabled(any(), defaultValue = any()) } returns isEnabledDefault
-    return unleashService
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUnleashService.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockUnleashService.kt
@@ -2,12 +2,14 @@ package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.unleash.UnleashService
 
-fun mockUnleashNextMedContextService(): UnleashNextMedContextService {
+fun mockUnleashNextMedContextService(isEnabledDefault: Boolean = true): UnleashNextMedContextService {
     val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
-    every { unleashNextMedContextService.isEnabled(any()) } returns true
+    every { unleashNextMedContextService.isEnabled(any<String>()) } returns isEnabledDefault
+    every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns isEnabledDefault
     return unleashNextMedContextService
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
@@ -27,7 +28,6 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.hentArbeidsfordeling
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.tilArbeidsfordelingsenhet
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -40,7 +40,7 @@ class OppgaveServiceTest {
     private val mockedBehandlingRepository: BehandlingRepository = mockk()
     private val mockedTilpassArbeidsfordelingService: TilpassArbeidsfordelingService = mockk()
     private val mockedArbeidsfordelingPåBehandlingRepository: ArbeidsfordelingPåBehandlingRepository = mockk()
-    private val mockedUnleashService: UnleashService = mockk()
+    private val mockedUnleashService: UnleashNextMedContextService = mockk()
     private val oppgaveService: OppgaveService =
         OppgaveService(
             integrasjonClient = mockedIntegrasjonClient,
@@ -53,7 +53,7 @@ class OppgaveServiceTest {
 
     @BeforeEach
     fun setup() {
-        every { mockedUnleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false) } returns true
+        every { mockedUnleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false) } returns true
     }
 
     @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveServiceTest.kt
@@ -53,7 +53,7 @@ class OppgaveServiceTest {
 
     @BeforeEach
     fun setup() {
-        every { mockedUnleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false) } returns true
+        every { mockedUnleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false) } returns true
     }
 
     @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/OppgaveServiceTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
@@ -53,7 +53,7 @@ class OppgaveServiceTest {
 
     @BeforeEach
     fun setup() {
-        every { mockedUnleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false) } returns true
+        every { mockedUnleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false) } returns true
     }
 
     @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -27,7 +27,6 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
-import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -52,9 +51,6 @@ internal class UtbetalingsperiodeServiceTest {
 
     @MockK
     private lateinit var andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository
-
-    @MockK
-    private lateinit var unleashService: UnleashService
 
     @InjectMockKs
     private lateinit var utbetalingsoppdragGenerator: UtbetalingsoppdragGenerator
@@ -809,7 +805,5 @@ internal class UtbetalingsperiodeServiceTest {
         every { behandlingService.hentBehandlingerPåFagsak(behandling.fagsak.id) } returns listOf(behandling)
 
         every { tilkjentYtelseRepository.save(capture(tilkjentYtelseSlot)) } returns mockk()
-
-        every { unleashService.isEnabled(any()) } returns true
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -7,7 +7,7 @@ import io.mockk.verify
 import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -152,7 +152,7 @@ internal class ArbeidsfordelingServiceTest {
             } returns null
 
             every {
-                unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
+                unleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
             } returns true
 
             every { personopplysningerService.hentPersoninfoEnkel(any()).adressebeskyttelseGradering } returns null

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -22,7 +23,6 @@ import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
-import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -43,7 +43,7 @@ internal class ArbeidsfordelingServiceTest {
 
     private val personidentService: PersonidentService = mockk()
 
-    private val unleashService: UnleashService = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
 
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService = mockk()
 
@@ -152,7 +152,7 @@ internal class ArbeidsfordelingServiceTest {
             } returns null
 
             every {
-                unleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
+                unleashService.isEnabled(FeatureToggle.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false)
             } returns true
 
             every { personopplysningerService.hentPersoninfoEnkel(any()).adressebeskyttelseGradering } returns null

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -152,7 +152,7 @@ internal class ArbeidsfordelingServiceTest {
             } returns null
 
             every {
-                unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER, false)
+                unleashService.isEnabled(FeatureToggleConfig.OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER.navn, false)
             } returns true
 
             every { personopplysningerService.hentPersoninfoEnkel(any()).adressebeskyttelseGradering } returns null

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
@@ -107,7 +107,7 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal ikke henlegge behandling for årsak TEKNISK_VEDLIKEHOLD når toggelen er ikke på`() {
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE) } returns false
+        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) } returns false
 
         val exception =
             assertThrows<Feil> {
@@ -130,7 +130,7 @@ internal class HenleggBehandlingServiceTest {
         val tekniskEndringBehandling = behandling.copy(opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING)
 
         every { behandlingRepository.hentBehandling(behandlingId) } returns tekniskEndringBehandling
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING) } returns false
+        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn) } returns false
 
         val exception =
             assertThrows<FunksjonellFeil> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
@@ -12,7 +12,7 @@ import io.mockk.verify
 import no.nav.familie.ks.sak.api.dto.HenleggÅrsak
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.integrasjon.oppgave.OppgaveService
@@ -107,7 +107,7 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal ikke henlegge behandling for årsak TEKNISK_VEDLIKEHOLD når toggelen er ikke på`() {
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) } returns false
 
         val exception =
             assertThrows<Feil> {
@@ -130,7 +130,7 @@ internal class HenleggBehandlingServiceTest {
         val tekniskEndringBehandling = behandling.copy(opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING)
 
         every { behandlingRepository.hentBehandling(behandlingId) } returns tekniskEndringBehandling
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn) } returns false
 
         val exception =
             assertThrows<FunksjonellFeil> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
@@ -74,8 +74,7 @@ internal class HenleggBehandlingServiceTest {
     @BeforeEach
     fun init() {
         every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
-        every { unleashService.isEnabled(any<String>()) } returns true
-        every { unleashService.isEnabled(any<FeatureToggle>()) } returns true
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE) } returns true
         every { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling) } returns emptyList()
         every { loggService.opprettHenleggBehandlingLogg(any(), any(), any()) } just runs
         every { behandlingRepository.finnBehandlinger(behandling.fagsak.id) } returns listOf(behandling)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
@@ -74,7 +74,8 @@ internal class HenleggBehandlingServiceTest {
     @BeforeEach
     fun init() {
         every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
-        every { unleashService.isEnabled(any()) } returns true
+        every { unleashService.isEnabled(any<String>()) } returns true
+        every { unleashService.isEnabled(any<FeatureToggle>()) } returns true
         every { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling) } returns emptyList()
         every { loggService.opprettHenleggBehandlingLogg(any(), any(), any()) } just runs
         every { behandlingRepository.finnBehandlinger(behandling.fagsak.id) } returns listOf(behandling)
@@ -107,7 +108,7 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal ikke henlegge behandling for årsak TEKNISK_VEDLIKEHOLD når toggelen er ikke på`() {
-        every { unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE) } returns false
 
         val exception =
             assertThrows<Feil> {
@@ -130,7 +131,7 @@ internal class HenleggBehandlingServiceTest {
         val tekniskEndringBehandling = behandling.copy(opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING)
 
         every { behandlingRepository.hentBehandling(behandlingId) } returns tekniskEndringBehandling
-        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING) } returns false
 
         val exception =
             assertThrows<FunksjonellFeil> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
@@ -108,7 +109,8 @@ class OpprettBehandlingServiceTest {
             )
         every { stegService.utførSteg(any(), any()) } returns Unit
         every { behandlingMetrikker.tellNøkkelTallVedOpprettelseAvBehandling(behandling) } just runs
-        every { unleashNextMedContextService.isEnabled(any()) } returns true
+        every { unleashNextMedContextService.isEnabled(any<String>()) } returns true
+        every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns true
     }
 
     @Test
@@ -337,7 +339,8 @@ class OpprettBehandlingServiceTest {
 
     @Test
     fun `opprettBehandling - skal kaste feil dersom behandlingsårsak er IVERKSETTE_KA_VEDTAK og toggle ikke er skrudd på`() {
-        every { unleashNextMedContextService.isEnabled(any()) } returns false
+        every { unleashNextMedContextService.isEnabled(any<String>()) } returns false
+        every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns false
 
         val funksjonellFeil =
             assertThrows<FunksjonellFeil> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
@@ -109,8 +109,6 @@ class OpprettBehandlingServiceTest {
             )
         every { stegService.utførSteg(any(), any()) } returns Unit
         every { behandlingMetrikker.tellNøkkelTallVedOpprettelseAvBehandling(behandling) } just runs
-        every { unleashNextMedContextService.isEnabled(any<String>()) } returns true
-        every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns true
     }
 
     @Test
@@ -339,8 +337,7 @@ class OpprettBehandlingServiceTest {
 
     @Test
     fun `opprettBehandling - skal kaste feil dersom behandlingsårsak er IVERKSETTE_KA_VEDTAK og toggle ikke er skrudd på`() {
-        every { unleashNextMedContextService.isEnabled(any<String>()) } returns false
-        every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns false
+        every { unleashNextMedContextService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK) } returns false
 
         val funksjonellFeil =
             assertThrows<FunksjonellFeil> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
@@ -10,7 +10,7 @@ import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.ks.sak.api.dto.BesluttVedtakDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagBrevmottakerDto
@@ -74,7 +74,7 @@ class BeslutteVedtakStegTest {
     @BeforeEach
     fun init() {
         every { behandlingService.hentBehandling(200) } returns lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
-        every { unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
         every { loggService.opprettBeslutningOmVedtakLogg(any(), any(), any()) } returns mockk()
         every { taskService.save(any()) } returns mockk()
         every { genererBrevService.genererBrevForBehandling(any()) } returns ByteArray(200)
@@ -107,7 +107,7 @@ class BeslutteVedtakStegTest {
     @Test
     fun `utførSteg skal kaste FunksjonellFeil dersom behandling årsaken er satt til KORREKSJON_VEDTAKSBREV og SB ikke har feature togglet på `() {
         every { behandlingService.hentBehandling(200) } returns lagBehandling(opprettetÅrsak = BehandlingÅrsak.KORREKSJON_VEDTAKSBREV)
-        every { unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
 
         val funksjonellFeil = assertThrows<FunksjonellFeil> { beslutteVedtakSteg.utførSteg(200, godkjentVedtakDto) }
 
@@ -190,7 +190,7 @@ class BeslutteVedtakStegTest {
 
     @Test
     fun `Skal kaste feil dersom saksbehandler uten tilgang til teknisk endring prøve å godkjenne en behandling med årsak=teknisk endring`() {
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn, any()) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, any()) } returns false
 
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
@@ -74,7 +74,7 @@ class BeslutteVedtakStegTest {
     @BeforeEach
     fun init() {
         every { behandlingService.hentBehandling(200) } returns lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
-        every { unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV) } returns false
         every { loggService.opprettBeslutningOmVedtakLogg(any(), any(), any()) } returns mockk()
         every { taskService.save(any()) } returns mockk()
         every { genererBrevService.genererBrevForBehandling(any()) } returns ByteArray(200)
@@ -107,7 +107,7 @@ class BeslutteVedtakStegTest {
     @Test
     fun `utførSteg skal kaste FunksjonellFeil dersom behandling årsaken er satt til KORREKSJON_VEDTAKSBREV og SB ikke har feature togglet på `() {
         every { behandlingService.hentBehandling(200) } returns lagBehandling(opprettetÅrsak = BehandlingÅrsak.KORREKSJON_VEDTAKSBREV)
-        every { unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
+        every { unleashService.isEnabled(FeatureToggle.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV) } returns false
 
         val funksjonellFeil = assertThrows<FunksjonellFeil> { beslutteVedtakSteg.utførSteg(200, godkjentVedtakDto) }
 
@@ -190,7 +190,7 @@ class BeslutteVedtakStegTest {
 
     @Test
     fun `Skal kaste feil dersom saksbehandler uten tilgang til teknisk endring prøve å godkjenne en behandling med årsak=teknisk endring`() {
-        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING.navn, any()) } returns false
+        every { unleashService.isEnabled(FeatureToggle.TEKNISK_ENDRING, any<Long>()) } returns false
 
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/BeslutteVedtakStegTest.kt
@@ -74,7 +74,7 @@ class BeslutteVedtakStegTest {
     @BeforeEach
     fun init() {
         every { behandlingService.hentBehandling(200) } returns lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
-        every { unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV) } returns false
+        every { unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
         every { loggService.opprettBeslutningOmVedtakLogg(any(), any(), any()) } returns mockk()
         every { taskService.save(any()) } returns mockk()
         every { genererBrevService.genererBrevForBehandling(any()) } returns ByteArray(200)
@@ -107,7 +107,7 @@ class BeslutteVedtakStegTest {
     @Test
     fun `utførSteg skal kaste FunksjonellFeil dersom behandling årsaken er satt til KORREKSJON_VEDTAKSBREV og SB ikke har feature togglet på `() {
         every { behandlingService.hentBehandling(200) } returns lagBehandling(opprettetÅrsak = BehandlingÅrsak.KORREKSJON_VEDTAKSBREV)
-        every { unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV) } returns false
+        every { unleashService.isEnabled(FeatureToggleConfig.KAN_MANUELT_KORRIGERE_MED_VEDTAKSBREV.navn) } returns false
 
         val funksjonellFeil = assertThrows<FunksjonellFeil> { beslutteVedtakSteg.utførSteg(200, godkjentVedtakDto) }
 
@@ -190,7 +190,7 @@ class BeslutteVedtakStegTest {
 
     @Test
     fun `Skal kaste feil dersom saksbehandler uten tilgang til teknisk endring prøve å godkjenne en behandling med årsak=teknisk endring`() {
-        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING, any()) } returns false
+        every { unleashService.isEnabled(FeatureToggleConfig.TEKNISK_ENDRING.navn, any()) } returns false
 
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
@@ -42,7 +42,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -58,7 +58,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -81,7 +81,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -104,7 +104,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -120,7 +120,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -143,7 +143,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -166,7 +166,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -182,7 +182,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -205,7 +205,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -228,7 +228,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -244,7 +244,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -267,7 +267,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
+                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
@@ -42,7 +42,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns false
 
             // Act & assert
@@ -58,7 +58,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {
@@ -81,7 +81,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {
@@ -104,7 +104,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns false
 
             // Act & assert
@@ -120,7 +120,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {
@@ -143,7 +143,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {
@@ -166,7 +166,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns false
 
             // Act & assert
@@ -182,7 +182,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {
@@ -205,7 +205,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {
@@ -228,7 +228,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns false
 
             // Act & assert
@@ -244,7 +244,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {
@@ -267,7 +267,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER)
             } returns true
 
             every {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/sammensattkontrollsak/SammensattKontrollsakValidatorTest.kt
@@ -7,7 +7,7 @@ import io.mockk.runs
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.exception.RolleTilgangskontrollFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
@@ -42,7 +42,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -58,7 +58,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -81,7 +81,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -104,7 +104,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -120,7 +120,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -143,7 +143,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -166,7 +166,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -182,7 +182,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -205,7 +205,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -228,7 +228,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om toggel ikke er skrudd på`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns false
 
             // Act & assert
@@ -244,7 +244,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal kaste exception om man mangler egnet rolle`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {
@@ -267,7 +267,7 @@ class SammensattKontrollsakValidatorTest {
         fun `skal ikke kaste feil om valideringen er godkjent`() {
             // Arrange
             every {
-                unleashService.isEnabled(FeatureToggleConfig.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
+                unleashService.isEnabled(FeatureToggle.KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER.navn)
             } returns true
 
             every {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
@@ -121,7 +121,7 @@ internal class VedtaksperiodeServiceTest {
     fun setup() {
         behandling = lagBehandling()
         every {
-            unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025)
+            unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025)
         } returns true
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.fnrTilFødselsdato
 import no.nav.familie.ks.sak.data.lagBehandling
@@ -60,7 +61,8 @@ class VilkårsvurderingServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { unleashService.isEnabled(any()) } returns true
+        every { unleashService.isEnabled(any<String>()) } returns true
+        every { unleashService.isEnabled(any<FeatureToggle>()) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -61,8 +61,7 @@ class VilkårsvurderingServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { unleashService.isEnabled(any<String>()) } returns true
-        every { unleashService.isEnabled(any<FeatureToggle>()) } returns true
+        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -126,7 +126,7 @@ class VilkårsvurderingStegTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(any(), any(), any()) } just runs
-        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -126,7 +126,7 @@ class VilkårsvurderingStegTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(any(), any(), any()) } just runs
-        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn) } returns true
+        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.NullablePeriode
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
@@ -126,7 +126,7 @@ class VilkårsvurderingStegTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(any(), any(), any()) } just runs
-        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn) } returns true
+        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidatorTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagVilkårResultat
@@ -36,7 +36,7 @@ class BarnetsAlderVilkårValidatorTest {
 
     @BeforeEach
     fun beforeEach() {
-        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
@@ -6,7 +6,7 @@ import junit.framework.TestCase.assertEquals
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
@@ -63,7 +63,7 @@ class BarnetsVilkårValidatorTest {
 
     @BeforeEach
     fun beforeEach() {
-        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
+        every { unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -6,6 +6,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagEndretUtbetalingAndel
@@ -22,7 +24,6 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
-import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -44,14 +45,15 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
     private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
 
     @MockK
-    private lateinit var unleashService: UnleashService
+    private lateinit var unleashService: UnleashNextMedContextService
 
     @InjectMockKs
     private lateinit var andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService
 
     @BeforeEach
     fun setup() {
-        every { unleashService.isEnabled(any()) } returns true
+        every { unleashService.isEnabled(any<String>()) } returns true
+        every { unleashService.isEnabled(any<FeatureToggle>()) } returns true
     }
 
     val søker = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -52,8 +52,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
 
     @BeforeEach
     fun setup() {
-        every { unleashService.isEnabled(any<String>()) } returns true
-        every { unleashService.isEnabled(any<FeatureToggle>()) } returns true
+        every { unleashService.isEnabled(FeatureToggle.ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK) } returns true
     }
 
     val søker = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
@@ -31,7 +31,7 @@ class BeregnAndelTilkjentYtelseServiceTest {
         every { personopplysningGrunnlag.søker } returns lagPerson(aktør = randomAktør())
         every { personopplysningGrunnlag.barna } returns listOf(lagPerson(aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 12, 31)))
 
-        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
+        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn) } returns true
         every { andelGeneratorLookup.hentGeneratorForLovverk(any()) } returns andelGenerator
         every { andelGenerator.beregnAndelerForBarn(any(), any(), any(), any()) } returns emptyList()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
@@ -31,7 +31,7 @@ class BeregnAndelTilkjentYtelseServiceTest {
         every { personopplysningGrunnlag.søker } returns lagPerson(aktør = randomAktør())
         every { personopplysningGrunnlag.barna } returns listOf(lagPerson(aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 12, 31)))
 
-        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn) } returns true
+        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
         every { andelGeneratorLookup.hentGeneratorForLovverk(any()) } returns andelGenerator
         every { andelGenerator.beregnAndelerForBarn(any(), any(), any(), any()) } returns emptyList()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ks.sak.kjerne.beregning
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.randomAktør
@@ -31,7 +31,7 @@ class BeregnAndelTilkjentYtelseServiceTest {
         every { personopplysningGrunnlag.søker } returns lagPerson(aktør = randomAktør())
         every { personopplysningGrunnlag.barna } returns listOf(lagPerson(aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 12, 31)))
 
-        every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn) } returns true
+        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn) } returns true
         every { andelGeneratorLookup.hentGeneratorForLovverk(any()) } returns andelGenerator
         every { andelGenerator.beregnAndelerForBarn(any(), any(), any(), any()) } returns emptyList()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPerson
@@ -28,7 +29,6 @@ import no.nav.familie.ks.sak.kjerne.brev.sammensattkontrollsak.SammensattKontrol
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.korrigertvedtak.KorrigertVedtakService
 import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
-import no.nav.familie.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -42,7 +42,7 @@ class GenererBrevServiceTest {
     val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk()
     val saksbehandlerContext: SaksbehandlerContext = mockk()
     val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
-    val unleashService = mockk<UnleashService>()
+    val unleashService = mockk<UnleashNextMedContextService>()
 
     val genererBrevService =
         GenererBrevService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagEndretUtbetalingAndel
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
@@ -25,7 +26,6 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAnde
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
-import no.nav.familie.unleash.UnleashService
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
@@ -56,7 +56,7 @@ class EndretUtbetalingAndelServiceTest {
     private lateinit var sanityService: SanityService
 
     @MockK
-    private lateinit var unleashService: UnleashService
+    private lateinit var unleashService: UnleashNextMedContextService
 
     @Test
     fun `kopierEndretUtbetalingAndelFraForrigeBehandling - skal kopiere over endrete utbetaling i forrige behandling og lagre disse på ny`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -476,7 +476,7 @@ internal class KompetanseServiceTest {
                     barnasIdenter = listOf(barn1, barn2).map { it.aktivFødselsnummer() },
                     barnAktør = listOf(barn1, barn2),
                 )
-            every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn) } returns true
+            every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -476,7 +476,7 @@ internal class KompetanseServiceTest {
                     barnasIdenter = listOf(barn1, barn2).map { it.aktivFødselsnummer() },
                     barnAktør = listOf(barn1, barn2),
                 )
-            every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
+            every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn) } returns true
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ks.sak.common.util.Periode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagKompetanse
@@ -476,7 +476,7 @@ internal class KompetanseServiceTest {
                     barnasIdenter = listOf(barn1, barn2).map { it.aktivFødselsnummer() },
                     barnAktør = listOf(barn1, barn2),
                 )
-            every { unleashService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025.navn) } returns true
+            every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025.navn) } returns true
         }
 
         @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Samme som ba-sak: https://github.com/navikt/familie-ba-sak/pull/5040

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23170

Refaktorerer FeatureToggleConfig fra klasse med companion object til enum for bedre typesikring. Fremover kan enums parses direkte i Cucumber-tester, slik at testene kan bruke enum-navnene på samme måte som i koden ellers.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Finnes eksisterende tester

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
