### PR TITLE
Tar i bruk VilkårLovverk.LOVVERK_2025

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
 
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.IBehandlingSteg
@@ -30,6 +32,7 @@ class BehandlingsresultatSteg(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val overgangsordningAndelService: OvergangsordningAndelService,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.BEHANDLINGSRESULTAT
 
@@ -51,6 +54,7 @@ class BehandlingsresultatSteg(
             tilkjentYtelse = tilkjentYtelseNåværendeBehandling,
             endretUtbetalingMedAndeler = endretUtbetalingMedAndeler,
             personResultaterForBarn = personResultaterForBarn,
+            skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025),
         )
 
         if (behandling.erOvergangsordning()) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -34,11 +34,17 @@ object BehandlingsresultatValideringUtils {
         tilkjentYtelse: TilkjentYtelse,
         endretUtbetalingMedAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
         personResultaterForBarn: List<PersonResultat>,
+        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ) {
         val alleBarnetsAlderVilkårResultater = personResultaterForBarn.flatMap { it.vilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.BARNETS_ALDER } }
 
         // valider TilkjentYtelse
-        TilkjentYtelseValidator.validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(tilkjentYtelse, personopplysningGrunnlag, alleBarnetsAlderVilkårResultater)
+        TilkjentYtelseValidator.validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
+            tilkjentYtelse = tilkjentYtelse,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            alleBarnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater,
+            skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+        )
 
         // valider EndretUtbetalingAndel
         EndretUtbetalingAndelValidator.validerAtAlleOpprettedeEndringerErUtfylt(endretUtbetalingMedAndeler.map { it.endretUtbetaling })

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
@@ -1,15 +1,17 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
 
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
 import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
+import no.nav.familie.ks.sak.kjerne.lovverk.LovverkUtleder
 import java.time.LocalDate
 import java.time.YearMonth
 
 data class VilkårLovverkInformasjonForBarn(
     val fødselsdato: LocalDate,
+    val skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     val periodeFomForAdoptertBarn: YearMonth? = null,
     val periodeTomForAdoptertBarn: YearMonth? = null,
 ) {
@@ -19,7 +21,7 @@ data class VilkårLovverkInformasjonForBarn(
     val periodeTomBarnetsAlderLov2024: LocalDate
     val periodeFomBarnetsAlderLov2025: LocalDate
     val periodeTomBarnetsAlderLov2025: LocalDate
-    val lovverk: VilkårLovverk
+    val vilkårLovverk: VilkårLovverk
 
     init {
         this.periodeFomBarnetsAlderLov2021 = fødselsdato.plusYears(1)
@@ -29,17 +31,22 @@ data class VilkårLovverkInformasjonForBarn(
         this.periodeFomBarnetsAlderLov2025 = fødselsdato.plusMonths(12)
         this.periodeTomBarnetsAlderLov2025 = fødselsdato.plusMonths(20)
 
+        val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato, skalBestemmeLovverkBasertPåFødselsdato)
+
+        this.vilkårLovverk =
+            when (lovverk) {
+                Lovverk.LOVENDRING_FEBRUAR_2025 -> VilkårLovverk.LOVVERK_2025
+                Lovverk.FØR_LOVENDRING_2025 -> utledVilkårLovverkFørLovendring2025()
+            }
+    }
+
+    private fun utledVilkårLovverkFørLovendring2025(): VilkårLovverk {
         val erTruffetAvLovverk2021 = periodeFomForAdoptertBarn?.isBefore(DATO_LOVENDRING_2024.toYearMonth()) ?: periodeFomBarnetsAlderLov2021.isBefore(DATO_LOVENDRING_2024)
         val erTruffetAvLovverk2024 = periodeTomForAdoptertBarn?.toLocalDate()?.erSammeEllerEtter(DATO_LOVENDRING_2024) ?: periodeTomBarnetsAlderLov2024.erSammeEllerEtter(DATO_LOVENDRING_2024)
-        // TODO : Ta denne i bruk for å sette lovverk variabelen
-        // val erTruffetAvLovverk2025 = fødselsdato.erSammeEllerEtter(LocalDate.of(2024, 1, 1))
-
-        this.lovverk =
-            when {
-                erTruffetAvLovverk2021 && erTruffetAvLovverk2024 -> VilkårLovverk.LOVVERK_2021_OG_2024
-                erTruffetAvLovverk2021 -> VilkårLovverk.LOVVERK_2021
-                erTruffetAvLovverk2024 -> VilkårLovverk.LOVVERK_2024
-                else -> throw Feil("Forventer at barnet blir truffet at minst et lovverk: $this")
-            }
+        return when {
+            erTruffetAvLovverk2021 && erTruffetAvLovverk2024 -> VilkårLovverk.LOVVERK_2021_OG_2024
+            erTruffetAvLovverk2021 -> VilkårLovverk.LOVVERK_2021
+            else -> VilkårLovverk.LOVVERK_2024
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.validering
 
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårLovverk
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårLovverkInformasjonForBarn
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
@@ -14,23 +16,26 @@ class BarnetsAlderVilkårValidator(
     val barnetsAlderVilkårValidator2024: BarnetsAlderVilkårValidator2024,
     val barnetsAlderVilkårValidator2021og2024: BarnetsAlderVilkårValidator2021og2024,
     val barnetsAlderVilkårValidator2025: BarnetsAlderVilkårValidator2025,
+    val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun validerVilkårBarnetsAlder(
         perioder: List<IkkeNullbarPeriode<VilkårResultat>>,
         barn: Person,
     ): List<String> {
+        val skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025)
         val vilkårLovverkInformasjonForBarn =
             if (perioder.any { it.verdi.erAdopsjonOppfylt() }) {
                 VilkårLovverkInformasjonForBarn(
                     fødselsdato = barn.fødselsdato,
                     periodeFomForAdoptertBarn = perioder.minOf { it.fom }.toYearMonth(),
                     periodeTomForAdoptertBarn = perioder.maxOf { it.tom }.toYearMonth(),
+                    skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
                 )
             } else {
-                VilkårLovverkInformasjonForBarn(barn.fødselsdato)
+                VilkårLovverkInformasjonForBarn(fødselsdato = barn.fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
             }
 
-        return when (vilkårLovverkInformasjonForBarn.lovverk) {
+        return when (vilkårLovverkInformasjonForBarn.vilkårLovverk) {
             VilkårLovverk.LOVVERK_2021_OG_2024 ->
                 barnetsAlderVilkårValidator2021og2024.validerBarnetsAlderVilkår(
                     perioder = perioder,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -37,6 +37,7 @@ object TilkjentYtelseValidator {
         tilkjentYtelse: TilkjentYtelse,
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         alleBarnetsAlderVilkårResultater: List<VilkårResultat>,
+        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ) {
         val søker = personopplysningGrunnlag.søker
         val barna = personopplysningGrunnlag.barna
@@ -59,9 +60,14 @@ object TilkjentYtelseValidator {
 
             val vilkårLovverkInformasjonForBarn =
                 if (alleBarnetsAlderVilkårResultater.any { it.erAdopsjonOppfylt() }) {
-                    VilkårLovverkInformasjonForBarn(relevantBarn.fødselsdato, stønadFom, stønadTom)
+                    VilkårLovverkInformasjonForBarn(
+                        fødselsdato = relevantBarn.fødselsdato,
+                        skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+                        periodeFomForAdoptertBarn = stønadFom,
+                        periodeTomForAdoptertBarn = stønadTom,
+                    )
                 } else {
-                    VilkårLovverkInformasjonForBarn(relevantBarn.fødselsdato)
+                    VilkårLovverkInformasjonForBarn(fødselsdato = relevantBarn.fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
                 }
 
             val barnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater.filter { it.personResultat?.aktør == aktør }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/lovverkFørFebruar2025/MaksAntallMånederMedUtbetalingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/lovverkFørFebruar2025/MaksAntallMånederMedUtbetalingUtleder.kt
@@ -11,8 +11,8 @@ fun utledMaksAntallMånederMedUtbetaling(
     vilkårLovverkInformasjonForBarn: VilkårLovverkInformasjonForBarn,
     barnetsAlderVilkårResultater: List<VilkårResultat>,
 ): Long =
-    when (vilkårLovverkInformasjonForBarn.lovverk) {
-        VilkårLovverk.LOVVERK_2025 -> TODO("Lovverk 2025 er ikke støttet")
+    when (vilkårLovverkInformasjonForBarn.vilkårLovverk) {
+        VilkårLovverk.LOVVERK_2025,
         VilkårLovverk.LOVVERK_2024,
         VilkårLovverk.LOVVERK_2021_OG_2024,
         -> 7L

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarnTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarnTest.kt
@@ -1,12 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
 
-import io.mockk.every
-import io.mockk.mockk
-import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.common.util.erSammeEllerEtter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 
 class VilkårLovverkInformasjonForBarnTest {
@@ -16,10 +11,10 @@ class VilkårLovverkInformasjonForBarnTest {
         val fødselsdato: LocalDate = LocalDate.of(2022, 12, 31)
 
         // Act
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato)
+        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true)
 
         // Assert
-        assertThat(vilkårLovverkInformasjonForBarn.lovverk).isEqualTo(VilkårLovverk.LOVVERK_2021)
+        assertThat(vilkårLovverkInformasjonForBarn.vilkårLovverk).isEqualTo(VilkårLovverk.LOVVERK_2021)
 
         assertThat(vilkårLovverkInformasjonForBarn.periodeFomBarnetsAlderLov2021).isEqualTo(fødselsdato.plusYears(1))
         assertThat(vilkårLovverkInformasjonForBarn.periodeTomBarnetsAlderLov2021).isEqualTo(fødselsdato.plusYears(2))
@@ -34,10 +29,10 @@ class VilkårLovverkInformasjonForBarnTest {
         val fødselsdato: LocalDate = LocalDate.of(2023, 8, 1)
 
         // Act
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato)
+        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true)
 
         // Assert
-        assertThat(vilkårLovverkInformasjonForBarn.lovverk).isEqualTo(VilkårLovverk.LOVVERK_2024)
+        assertThat(vilkårLovverkInformasjonForBarn.vilkårLovverk).isEqualTo(VilkårLovverk.LOVVERK_2024)
 
         assertThat(vilkårLovverkInformasjonForBarn.periodeFomBarnetsAlderLov2021).isEqualTo(fødselsdato.plusYears(1))
         assertThat(vilkårLovverkInformasjonForBarn.periodeTomBarnetsAlderLov2021).isEqualTo(fødselsdato.plusYears(2))
@@ -52,36 +47,15 @@ class VilkårLovverkInformasjonForBarnTest {
         val fødselsdato: LocalDate = LocalDate.of(2023, 7, 31)
 
         // Act
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato)
+        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true)
 
         // Assert
-        assertThat(vilkårLovverkInformasjonForBarn.lovverk).isEqualTo(VilkårLovverk.LOVVERK_2021_OG_2024)
+        assertThat(vilkårLovverkInformasjonForBarn.vilkårLovverk).isEqualTo(VilkårLovverk.LOVVERK_2021_OG_2024)
 
         assertThat(vilkårLovverkInformasjonForBarn.periodeFomBarnetsAlderLov2021).isEqualTo(fødselsdato.plusYears(1))
         assertThat(vilkårLovverkInformasjonForBarn.periodeTomBarnetsAlderLov2021).isEqualTo(fødselsdato.plusYears(2))
 
         assertThat(vilkårLovverkInformasjonForBarn.periodeFomBarnetsAlderLov2024).isEqualTo(fødselsdato.plusMonths(13))
         assertThat(vilkårLovverkInformasjonForBarn.periodeTomBarnetsAlderLov2024).isEqualTo(fødselsdato.plusMonths(19))
-    }
-
-    @Test
-    fun `skal kaste feil om barnet ikke er truffet av noen lovverk`() {
-        // Arrange
-        val mockDato: LocalDate = mockk()
-
-        every { mockDato.plusYears(any()) } returns mockDato
-        every { mockDato.plusMonths(any()) } returns mockDato
-        every { mockDato.isBefore(any()) } returns false
-        every { mockDato.isAfter(any()) } returns false
-        every { mockDato.erSammeEllerEtter(any()) } returns false
-
-        // Act & assert
-        val exception =
-            assertThrows<Feil> {
-                VilkårLovverkInformasjonForBarn(mockDato)
-            }
-        assertThat(exception.message).contains(
-            "Forventer at barnet blir truffet at minst et lovverk",
-        )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -76,6 +76,7 @@ class VilkårsvurderingStegTest {
                     barnetsAlderVilkårValidator2024,
                 ),
                 barnetsAlderVilkårValidator2025,
+                unleashService,
             ),
         )
     private val vilkårsvurderingSteg: VilkårsvurderingSteg =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2021og2024Test.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2021og2024Test.kt
@@ -30,7 +30,7 @@ class BarnetsAlderVilkårValidator2021og2024Test {
             barnetsAlderVilkårValidator2021og2024.validerBarnetsAlderVilkår(
                 perioder = listOf(),
                 barn = person,
-                vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(person.fødselsdato),
+                vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = person.fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true),
             )
 
         // Assert

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidatorTest.kt
@@ -4,6 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.randomAktør
@@ -13,6 +15,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.tidslinje.IkkeNullbarPeriode
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -21,13 +24,20 @@ class BarnetsAlderVilkårValidatorTest {
     val barnetsAlderVilkårValidator2024: BarnetsAlderVilkårValidator2024 = mockk()
     val barnetsAlderVilkårValidator2021og2024: BarnetsAlderVilkårValidator2021og2024 = mockk()
     val barnetsAlderVilkårValidator2025: BarnetsAlderVilkårValidator2025 = mockk()
+    val unleashNextMedContextService: UnleashNextMedContextService = mockk()
     val barnetsAlderVilkårValidator =
         BarnetsAlderVilkårValidator(
             barnetsAlderVilkårValidator2021,
             barnetsAlderVilkårValidator2024,
             barnetsAlderVilkårValidator2021og2024,
             barnetsAlderVilkårValidator2025,
+            unleashNextMedContextService,
         )
+
+    @BeforeEach
+    fun beforeEach() {
+        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
+    }
 
     @Test
     fun `skal returnere ingen feil når validering for 2021 og 2024 returnerer ingen feil`() {
@@ -207,14 +217,14 @@ class BarnetsAlderVilkårValidatorTest {
         val person =
             lagPerson(
                 aktør = randomAktør(),
-                fødselsdato = DATO_LOVENDRING_2024,
+                fødselsdato = LocalDate.of(2023, 8, 1),
             )
 
         val vilkårResultatPeriode =
             IkkeNullbarPeriode(
                 lagVilkårResultat(),
-                DATO_LOVENDRING_2024,
-                DATO_LOVENDRING_2024.plusYears(1),
+                person.fødselsdato.plusMonths(13),
+                person.fødselsdato.plusMonths(19),
             )
 
         val vilkårResultatPerioder = listOf(vilkårResultatPeriode)
@@ -248,14 +258,14 @@ class BarnetsAlderVilkårValidatorTest {
         val person =
             lagPerson(
                 aktør = randomAktør(),
-                fødselsdato = DATO_LOVENDRING_2024,
+                fødselsdato = LocalDate.of(2023, 8, 1),
             )
 
         val vilkårResultatPeriode =
             IkkeNullbarPeriode(
                 lagVilkårResultat(),
-                DATO_LOVENDRING_2024,
-                DATO_LOVENDRING_2024.plusYears(1),
+                person.fødselsdato.plusMonths(13),
+                person.fødselsdato.plusMonths(19),
             )
 
         val vilkårResultatPerioder = listOf(vilkårResultatPeriode)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
@@ -1,9 +1,13 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.validering
 
+import io.mockk.every
+import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -17,6 +21,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.dødsfall.Dødsfall
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.LocalDate
@@ -40,6 +45,7 @@ class BarnetsVilkårValidatorTest {
     private val barnetsAlderVilkårValidator2021 = BarnetsAlderVilkårValidator2021()
     private val barnetsAlderVilkårValidator2024 = BarnetsAlderVilkårValidator2024()
     private val barnetsAlderVilkårValidator2025 = BarnetsAlderVilkårValidator2025()
+    private val unleashNextMedContextService: UnleashNextMedContextService = mockk()
 
     private val barnetsVilkårValidator: BarnetsVilkårValidator =
         BarnetsVilkårValidator(
@@ -51,8 +57,14 @@ class BarnetsVilkårValidatorTest {
                     barnetsAlderVilkårValidator2024,
                 ),
                 barnetsAlderVilkårValidator2025,
+                unleashNextMedContextService,
             ),
         )
+
+    @BeforeEach
+    fun beforeEach() {
+        every { unleashNextMedContextService.isEnabled(FeatureToggleConfig.STØTTER_LOVENDRING_2025) } returns true
+    }
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når vilkår resulat er oppfylt men mangler fom`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtlederKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtlederKtTest.kt
@@ -31,7 +31,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2022, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato)
+        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true)
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -54,7 +54,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2022, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato)
+        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true)
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -77,7 +77,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2023, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato)
+        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true)
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -100,7 +100,7 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2024, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato)
+        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, skalBestemmeLovverkBasertPåFødselsdato = true)
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -76,6 +76,7 @@ internal class TilkjentYtelseValidatorTest {
                     tilkjentYtelse = tilkjentYtelse,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
             }
         val feilmelding =
@@ -124,6 +125,7 @@ internal class TilkjentYtelseValidatorTest {
                             barnAktør = listOf(barnFødtIJanuar2023.aktør),
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
             }
         val feilmelding =
@@ -164,6 +166,7 @@ internal class TilkjentYtelseValidatorTest {
                             barnAktør = listOf(barnFødtIAugust2022.aktør),
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
             }
         val feilmelding =
@@ -214,6 +217,7 @@ internal class TilkjentYtelseValidatorTest {
                     barnAktør = listOf(barnFødtAugust2023.aktør, barnFødtAugust2022.aktør),
                 ),
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterBarn1 + barnetsAlderVilkårResultaterBarn2,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
             )
         }
     }
@@ -243,6 +247,7 @@ internal class TilkjentYtelseValidatorTest {
                     tilkjentYtelse = tilkjentYtelse,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
             }
 
@@ -282,6 +287,7 @@ internal class TilkjentYtelseValidatorTest {
                             barnAktør = listOf(barnFødtJuli2023.aktør),
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
             }
 
@@ -528,6 +534,7 @@ internal class TilkjentYtelseValidatorTest {
                 tilkjentYtelse = tilkjentYtelse,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterMedAdopsjon,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
             )
         }
     }
@@ -556,6 +563,7 @@ internal class TilkjentYtelseValidatorTest {
                 tilkjentYtelse = tilkjentYtelse,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterMedAdopsjon,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
             )
         }
     }
@@ -584,6 +592,7 @@ internal class TilkjentYtelseValidatorTest {
                 tilkjentYtelse = tilkjentYtelse,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterMedAdopsjon,
+                skalBestemmeLovverkBasertPåFødselsdato = true,
             )
         }
     }
@@ -613,6 +622,7 @@ internal class TilkjentYtelseValidatorTest {
                     tilkjentYtelse = tilkjentYtelse,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterMedAdopsjon,
+                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
             }
         assertEquals(


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Liten omstrukturering av `VilkårLovverkInformasjonForBarn` og utledning av `VilkårLovverk`. Utleder nå først `Lovverk` ved hjelp av `LovverkUtleder` og bruker eksisterende logikk for utledning av `VilkårLoverk` dersom `Lovverk` = `Lovverk.FØR_LOVENDRING_2025`.

Tar også i bruk `VilkårLovverk.LOVVERK_2025` i `MaksAntallMånederMedUtbetalingUtleder`.

Fordi `LovverkUtleder` er avhengig av toggelen `skalBestemmeLovverkBasertPåFødselsdato` (aka `STØTTER_LOVENDRING_2025`) sender vi nå med toggelen alle steder det kreves.

Korrigert tester som har blitt påvirket av endringen.