### PR TITLE
Hent ut AndelTilkjentYtelse per ident for å lage utbetalingsoppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -131,7 +131,7 @@ class UtbetalingsoppdragService(
 
     private fun hentSisteAndelTilkjentYtelse(fagsak: Fagsak) =
         andelTilkjentYtelseRepository
-            .hentSisteAndelPerIdentOgType(fagsakId = fagsak.id)
+            .hentSisteAndelPerIdent(fagsakId = fagsak.id)
             .associateBy { IdentOgType(it.aktør.aktivFødselsnummer(), it.type.tilYtelseType()) }
 
     private fun utledOpphør(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelseRepository.kt
@@ -35,7 +35,7 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
         WITH andeler AS (
             SELECT
              aty.id,
-             row_number() OVER (ORDER BY aty.periode_offset DESC) rn
+             row_number() OVER (PARTITION BY aty.fk_aktoer_id ORDER BY aty.periode_offset DESC) rn
              FROM andel_tilkjent_ytelse aty
               JOIN tilkjent_ytelse ty ON ty.id = aty.tilkjent_ytelse_id
               JOIN Behandling b ON b.id = aty.fk_behandling_id
@@ -48,5 +48,5 @@ interface AndelTilkjentYtelseRepository : JpaRepository<AndelTilkjentYtelse, Lon
     """,
         nativeQuery = true,
     )
-    fun hentSisteAndelPerIdentOgType(fagsakId: Long): List<AndelTilkjentYtelse>
+    fun hentSisteAndelPerIdent(fagsakId: Long): List<AndelTilkjentYtelse>
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -789,13 +789,13 @@ internal class UtbetalingsperiodeServiceTest {
     ) {
         if (forrigeTilkjentYtelse == null) {
             every { behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns null
-            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(behandling.fagsak.id) } returns emptyList()
+            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdent(behandling.fagsak.id) } returns emptyList()
         } else {
             every { behandlingService.hentSisteBehandlingSomErIverksatt(behandling.fagsak.id) } returns forrigeTilkjentYtelse.behandling
 
             every { tilkjentYtelseRepository.finnByBehandlingAndHasUtbetalingsoppdrag(forrigeTilkjentYtelse.behandling.id) } returns forrigeTilkjentYtelse
 
-            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdentOgType(behandling.fagsak.id) } returns
+            every { andelTilkjentYtelseRepository.hentSisteAndelPerIdent(behandling.fagsak.id) } returns
                 forrigeTilkjentYtelse.andelerTilkjentYtelse
                     .filtrerAndelerSomSkalSendesTilOppdrag()
                     .groupBy { it.aktør.aktivFødselsnummer() }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24073

I [denne PR'en](https://github.com/navikt/familie-ks-sak/pull/1011) ble partisjonering over ident og type fjernet, når det egentlig bare var meningen å fjerne per type.
Reverterer endringen slik at spørringen partisjonerer over ident, men ikke type
