### PR TITLE
Stopp adopsjonssaker når toggle er av

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -14,6 +14,7 @@ enum class FeatureToggle(
     OPPRETT_SAK_PÅ_RIKTIG_ENHET_OG_SAKSBEHANDLER("familie-ba-ks-sak.opprett-sak-paa-riktig-enhet-og-saksbehandler"),
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
     STØTTER_LOVENDRING_2025("familie-ks-sak.stotter-lovendring-2025"),
+    STØTTER_ADOPSJON("familie-ks-sak.stotter-adopsjon"),
 
     BRUK_OMSKRIVING_AV_HJEMLER_I_BREV("familie-ks-sak.bruk_omskriving_av_hjemler_i_brev"),
     ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK("familie-ks-sak.allerede-utbetalt"),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -66,6 +66,12 @@ class VilkårsvurderingSteg(
         val søknadDto = søknadGrunnlagService.finnAktiv(behandlingId = behandling.id)?.tilSøknadDto()
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id)
 
+        if (vilkårsvurdering.personResultater.any { personResultat -> personResultat.vilkårResultater.any { it.erAdopsjonOppfylt() } } &&
+            !unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)
+        ) {
+            throw FunksjonellFeil("Adopsjonssaker kan ikke behandles før nytt regelverk er støttet i løsningen")
+        }
+
         validerVilkårsvurdering(vilkårsvurdering, personopplysningGrunnlag, søknadDto, behandling)
 
         settBehandlingstemaBasertPåVilkårsvurdering(behandling, vilkårsvurdering)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24187

Stopper adopsjonssaker i produksjon midlertidig frem til vi har lagt inn støtte for det på nytt regelverk. Vi har ikke lagret ned adopsjonsdatoen så vi kan per nå ikke stoppe adopsjonssaker som kun treffer det nye regelverket. Stopper også kun oppfylte adopsjonssaker da avslag fortsatt kan håndteres selv om nytt regelverk ikke er støttet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tenker det ikke er hensiktsmessig her

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
