### PR TITLE
Legg til generering av andeler for praksisendring 2024

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -15,6 +15,7 @@ enum class FeatureToggle(
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
     STØTTER_LOVENDRING_2025("familie-ks-sak.stotter-lovendring-2025"),
     STØTTER_ADOPSJON("familie-ks-sak.stotter-adopsjon"),
+    SKAL_GENERERE_ANDELER_FOR_PRAKSISENDRING_2024("familie-ks-sak.skal-generere-andel-for-praksisendring-2024"),
 
     BRUK_OMSKRIVING_AV_HJEMLER_I_BREV("familie-ks-sak.bruk_omskriving_av_hjemler_i_brev"),
     ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK("familie-ks-sak.allerede-utbetalt"),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAnde
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.utfyltePerioder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import no.nav.familie.ks.sak.kjerne.praksisendring.Praksisendring2024Service
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -18,6 +19,7 @@ import java.time.LocalDate
 class TilkjentYtelseService(
     private val beregnAndelTilkjentYtelseService: BeregnAndelTilkjentYtelseService,
     private val overgangsordningAndelRepository: OvergangsordningAndelRepository,
+    private val praksisendring2024Service: Praksisendring2024Service,
 ) {
     fun beregnTilkjentYtelse(
         vilkårsvurdering: Vilkårsvurdering,
@@ -47,7 +49,17 @@ class TilkjentYtelseService(
                 tilkjentYtelse = tilkjentYtelse,
             )
 
-        val alleAndelerTilkjentYtelse = andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel } + overgangsordningAndelerSomAndelTilkjentYtelse
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        val alleAndelerTilkjentYtelse =
+            andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel } +
+                overgangsordningAndelerSomAndelTilkjentYtelse +
+                andelerForPraksisendring2024
 
         tilkjentYtelse.andelerTilkjentYtelse.addAll(alleAndelerTilkjentYtelse)
         return tilkjentYtelse

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -147,8 +147,7 @@ data class AndelTilkjentYtelse(
             this.differanseberegnetPeriodebeløp == andel.differanseberegnetPeriodebeløp
 }
 
-fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> =
-    overgangsordningAndelerPerAktør().map { it.value.minBy { it.stønadFom } } + ordinæreAndeler().filter { it.kalkulertUtbetalingsbeløp != 0 }
+fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> = overgangsordningAndelerPerAktør().map { it.value.minBy { it.stønadFom } } + ordinæreAndeler().filter { it.kalkulertUtbetalingsbeløp != 0 }
 
 fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp(): List<AndelTilkjentYtelse> =
     this.fold(emptyList()) { acc, andelTilkjentYtelse ->
@@ -167,22 +166,22 @@ fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp():
 
 fun AndelTilkjentYtelse.totalKalkulertUtbetalingsbeløpForPeriode(): Int = kalkulertUtbetalingsbeløp * stønadsPeriode().antallMåneder()
 
-fun Iterable<AndelTilkjentYtelse>.ordinæreAndeler() =
-    this.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
+fun Iterable<AndelTilkjentYtelse>.ordinæreAndeler() = this.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
 
-fun Iterable<AndelTilkjentYtelse>.overgangsordningAndelerPerAktør() =
-    this.filter { it.type == YtelseType.OVERGANGSORDNING }.groupBy { it.aktør }
+fun Iterable<AndelTilkjentYtelse>.overgangsordningAndelerPerAktør() = this.filter { it.type == YtelseType.OVERGANGSORDNING }.groupBy { it.aktør }
 
 enum class YtelseType(
     val klassifisering: String,
 ) {
     ORDINÆR_KONTANTSTØTTE("KS"),
     OVERGANGSORDNING("OO"),
+    PRAKSISENDRING_2024("KS"),
     ;
 
     fun tilYtelseType(): YtelsetypeKS =
         when (this) {
             ORDINÆR_KONTANTSTØTTE -> YtelsetypeKS.ORDINÆR_KONTANTSTØTTE
             OVERGANGSORDNING -> YtelsetypeKS.ORDINÆR_KONTANTSTØTTE
+            PRAKSISENDRING_2024 -> YtelsetypeKS.ORDINÆR_KONTANTSTØTTE
         }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024Service.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024Service.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ks.sak.kjerne.praksisendring
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.inkluderer
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle.SKAL_GENERERE_ANDELER_FOR_PRAKSISENDRING_2024
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
@@ -21,7 +23,9 @@ import java.math.BigDecimal
 import java.time.YearMonth
 
 @Service
-class Praksisendring2024Service {
+class Praksisendring2024Service(
+    private val unleashService: UnleashNextMedContextService,
+) {
     private val gyldigeMånederForPraksisendring = (8..12).map { YearMonth.of(2024, it) }
 
     fun genererAndelerForPraksisendring2024(
@@ -29,8 +33,12 @@ class Praksisendring2024Service {
         vilkårsvurdering: Vilkårsvurdering,
         tilkjentYtelse: TilkjentYtelse,
     ): List<AndelTilkjentYtelse> =
-        personopplysningGrunnlag.barna.mapNotNull {
-            genererAndelerForPraksisendring2024(it, vilkårsvurdering, tilkjentYtelse)
+        if (unleashService.isEnabled(SKAL_GENERERE_ANDELER_FOR_PRAKSISENDRING_2024)) {
+            personopplysningGrunnlag.barna.mapNotNull {
+                genererAndelerForPraksisendring2024(it, vilkårsvurdering, tilkjentYtelse)
+            }
+        } else {
+            emptyList()
         }
 
     private fun genererAndelerForPraksisendring2024(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024Service.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024Service.kt
@@ -1,0 +1,128 @@
+package no.nav.familie.ks.sak.kjerne.praksisendring
+
+import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
+import no.nav.familie.ks.sak.common.util.inkluderer
+import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.forskyvning.lovverkFørFebruar2025.ForskyvVilkårFørFebruar2025
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.beregning.domene.hentGyldigSatsFor
+import no.nav.familie.ks.sak.kjerne.beregning.domene.prosent
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.YearMonth
+
+@Service
+class Praksisendring2024Service {
+    private val gyldigeMånederForPraksisendring = (8..12).map { YearMonth.of(2024, it) }
+
+    fun genererAndelerForPraksisendring2024(
+        personopplysningGrunnlag: PersonopplysningGrunnlag,
+        vilkårsvurdering: Vilkårsvurdering,
+        tilkjentYtelse: TilkjentYtelse,
+    ): List<AndelTilkjentYtelse> =
+        personopplysningGrunnlag.barna.mapNotNull {
+            genererAndelerForPraksisendring2024(it, vilkårsvurdering, tilkjentYtelse)
+        }
+
+    private fun genererAndelerForPraksisendring2024(
+        barn: Person,
+        vilkårsvurdering: Vilkårsvurdering,
+        tilkjentYtelse: TilkjentYtelse,
+    ): AndelTilkjentYtelse? {
+        val barnetsVilkårResultater =
+            vilkårsvurdering.personResultater.find { it.aktør == barn.aktør }?.vilkårResultater
+                ?: error("Finner ikke vilkårresultater for barn")
+
+        if (!skalHaAndel(barn, barnetsVilkårResultater, tilkjentYtelse.andelerTilkjentYtelse)) {
+            return null
+        }
+
+        val barn13Måneder = barn.fødselsdato.plusMonths(13).toYearMonth()
+        val satsperiode =
+            hentGyldigSatsFor(
+                antallTimer = BigDecimal.ZERO,
+                erDeltBosted = erDeltBostedIMåned(barn, barnetsVilkårResultater),
+                stønadFom = barn13Måneder,
+                stønadTom = barn13Måneder,
+            )
+
+        val kalkulertUtbetalingsbeløp = satsperiode.sats.prosent(satsperiode.prosent)
+
+        return AndelTilkjentYtelse(
+            behandlingId = tilkjentYtelse.behandling.id,
+            tilkjentYtelse = tilkjentYtelse,
+            aktør = barn.aktør,
+            stønadFom = barn13Måneder,
+            stønadTom = barn13Måneder,
+            kalkulertUtbetalingsbeløp = kalkulertUtbetalingsbeløp,
+            nasjonaltPeriodebeløp = kalkulertUtbetalingsbeløp,
+            type = YtelseType.PRAKSISENDRING_2024,
+            sats = satsperiode.sats,
+            prosent = satsperiode.prosent,
+        )
+    }
+
+    private fun skalHaAndel(
+        barn: Person,
+        vilkårResultater: Set<VilkårResultat>,
+        andelerTilkjentYtelse: Set<AndelTilkjentYtelse>,
+    ): Boolean {
+        val barn13Måneder = barn.fødselsdato.plusMonths(13).toYearMonth()
+        if (barn13Måneder !in gyldigeMånederForPraksisendring) {
+            return false
+        }
+
+        val harOrdinærAndelISammeMånedSom13Måneder = andelerTilkjentYtelse.any { it.aktør == barn.aktør && it.stønadsPeriode().inkluderer(barn13Måneder) }
+        if (harOrdinærAndelISammeMånedSom13Måneder) {
+            return false
+        }
+
+        val starterIBarnehageSammeMånedSom13Måneder =
+            vilkårResultater.any {
+                it.periodeFom?.toYearMonth() == barn13Måneder && it.vilkårType == Vilkår.BARNEHAGEPLASS && it.resultat == Resultat.IKKE_OPPFYLT
+            }
+
+        val vilkårResultaterUtenBarnehageplass = vilkårResultater.filter { it.vilkårType != Vilkår.BARNEHAGEPLASS }.toSet()
+        val forskøvedeVilkår = ForskyvVilkårFørFebruar2025.forskyvVilkårResultater(vilkårResultaterUtenBarnehageplass)
+
+        val andreVilkårErOppfyltSammeMånedSom13Måneder =
+            forskøvedeVilkår.all {
+                it.value.any {
+                    val fom = (it.fom ?: TIDENES_MORGEN).toYearMonth()
+                    val tom = (it.tom ?: TIDENES_MORGEN).toYearMonth()
+                    barn13Måneder in fom..tom && it.verdi.resultat == Resultat.OPPFYLT
+                }
+            }
+
+        // TODO: Sjekk at fagsak og barn ligger i uttrekk
+
+        return starterIBarnehageSammeMånedSom13Måneder && andreVilkårErOppfyltSammeMånedSom13Måneder
+    }
+
+    private fun erDeltBostedIMåned(
+        barn: Person,
+        barnetsVilkårResultater: Collection<VilkårResultat>,
+    ): Boolean =
+        barnetsVilkårResultater.any { vilkårResultat ->
+
+            val barn13Måneder = barn.fødselsdato.plusMonths(13).toYearMonth()
+
+            val fom = vilkårResultat.periodeFom?.toYearMonth() ?: error("Finner ikke fom for vilkårresultat")
+            val tom = vilkårResultat.periodeTom?.toYearMonth() ?: barn13Måneder
+            val barnEr13MånederIPeriode = barn13Måneder in fom..tom
+
+            vilkårResultat.vilkårType == Vilkår.BOR_MED_SØKER &&
+                vilkårResultat.utdypendeVilkårsvurderinger.any { it == UtdypendeVilkårsvurdering.DELT_BOSTED } &&
+                vilkårResultat.resultat == Resultat.OPPFYLT &&
+                barnEr13MånederIPeriode
+        }
+}

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -225,8 +225,7 @@ fun lagPersonopplysningGrunnlag(
     return personopplysningGrunnlag
 }
 
-fun Person.tilPersonEnkel() =
-    PersonEnkel(this.type, this.aktør, this.fødselsdato, this.dødsfall?.dødsfallDato, this.målform)
+fun Person.tilPersonEnkel() = PersonEnkel(this.type, this.aktør, this.fødselsdato, this.dødsfall?.dødsfallDato, this.målform)
 
 fun lagFagsak(
     aktør: Aktør = randomAktør(randomFnr()),
@@ -399,8 +398,7 @@ fun lagStatsborgerskap(land: String = "NOR"): Statsborgerskap =
         bekreftelsesdato = LocalDate.of(1987, 9, 1),
     )
 
-fun lagInitieltTilkjentYtelse(behandling: Behandling) =
-    TilkjentYtelse(behandling = behandling, opprettetDato = LocalDate.now(), endretDato = LocalDate.now())
+fun lagInitieltTilkjentYtelse(behandling: Behandling) = TilkjentYtelse(behandling = behandling, opprettetDato = LocalDate.now(), endretDato = LocalDate.now())
 
 fun lagAndelTilkjentYtelse(
     tilkjentYtelse: TilkjentYtelse? = null,
@@ -466,18 +464,17 @@ fun tilfeldigPerson(
     aktør: Aktør = randomAktør(),
     personId: Long = nestePersonId(),
     dødsfall: Dødsfall? = null,
-) =
-    Person(
-        id = personId,
-        aktør = aktør,
-        fødselsdato = fødselsdato,
-        type = personType,
-        personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 0),
-        navn = "",
-        kjønn = kjønn,
-        målform = Målform.NB,
-        dødsfall = dødsfall,
-    ).apply { sivilstander = mutableListOf(GrSivilstand(type = SIVILSTANDTYPE.UGIFT, person = this)) }
+) = Person(
+    id = personId,
+    aktør = aktør,
+    fødselsdato = fødselsdato,
+    type = personType,
+    personopplysningGrunnlag = PersonopplysningGrunnlag(behandlingId = 0),
+    navn = "",
+    kjønn = kjønn,
+    målform = Målform.NB,
+    dødsfall = dødsfall,
+).apply { sivilstander = mutableListOf(GrSivilstand(type = SIVILSTANDTYPE.UGIFT, person = this)) }
 
 fun lagVilkårsvurderingMedSøkersVilkår(
     søkerAktør: Aktør,
@@ -618,6 +615,14 @@ fun lagVilkårResultaterForBarn(
                             periodeTom = perioderMedAntallTimer.first.tom,
                             behandlingId = behandlingId,
                             antallTimer = perioderMedAntallTimer.second,
+                            resultat =
+                                if (perioderMedAntallTimer.second == null ||
+                                    perioderMedAntallTimer.second!! < BigDecimal(33)
+                                ) {
+                                    Resultat.OPPFYLT
+                                } else {
+                                    Resultat.IKKE_OPPFYLT
+                                },
                         )
                     },
                 )
@@ -761,8 +766,7 @@ fun lagUtvidetVedtaksperiodeMedBegrunnelser(
     type: Vedtaksperiodetype = Vedtaksperiodetype.FORTSATT_INNVILGET,
     begrunnelser: List<NasjonalEllerFellesBegrunnelseDB> = emptyList(),
     eøsBegrunnelser: List<EØSBegrunnelseDB> = emptyList(),
-): UtvidetVedtaksperiodeMedBegrunnelser =
-    UtvidetVedtaksperiodeMedBegrunnelser(id = 0, fom = fom, tom = tom, type = type, begrunnelser = begrunnelser, eøsBegrunnelser = eøsBegrunnelser, støtterFritekst = false)
+): UtvidetVedtaksperiodeMedBegrunnelser = UtvidetVedtaksperiodeMedBegrunnelser(id = 0, fom = fom, tom = tom, type = type, begrunnelser = begrunnelser, eøsBegrunnelser = eøsBegrunnelser, støtterFritekst = false)
 
 fun lagPersonResultat(
     vilkårsvurdering: Vilkårsvurdering,
@@ -844,18 +848,17 @@ fun lagPersonResultatFraVilkårResultater(
 fun lagBeregnetUtbetalingsoppdrag(
     vedtak: Vedtak,
     utbetlingsperioder: List<no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode> = emptyList(),
-) =
-    BeregnetUtbetalingsoppdragLongId(
-        no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag(
-            aktoer = "",
-            fagSystem = "KS",
-            saksnummer = "1234",
-            kodeEndring = no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.KodeEndring.NY,
-            saksbehandlerId = "123abc",
-            utbetalingsperiode = utbetlingsperioder,
-        ),
-        listOf(AndelMedPeriodeIdLongId(id = 0L, periodeId = 0L, forrigePeriodeId = null, kildeBehandlingId = vedtak.behandling.id)),
-    )
+) = BeregnetUtbetalingsoppdragLongId(
+    no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag(
+        aktoer = "",
+        fagSystem = "KS",
+        saksnummer = "1234",
+        kodeEndring = no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.KodeEndring.NY,
+        saksbehandlerId = "123abc",
+        utbetalingsperiode = utbetlingsperioder,
+    ),
+    listOf(AndelMedPeriodeIdLongId(id = 0L, periodeId = 0L, forrigePeriodeId = null, kildeBehandlingId = vedtak.behandling.id)),
+)
 
 fun lagUtbetalingsperiode(vedtak: Vedtak) =
     no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode(
@@ -1210,13 +1213,12 @@ fun lagTestPersonopplysningGrunnlag(
 fun lagVedtak(
     behandling: Behandling = lagBehandling(),
     stønadBrevPdF: ByteArray? = null,
-) =
-    Vedtak(
-        id = nesteVedtakId(),
-        behandling = behandling,
-        vedtaksdato = LocalDateTime.now(),
-        stønadBrevPdf = stønadBrevPdF,
-    )
+) = Vedtak(
+    id = nesteVedtakId(),
+    behandling = behandling,
+    vedtaksdato = LocalDateTime.now(),
+    stønadBrevPdf = stønadBrevPdF,
+)
 
 fun lagVilkårsvurdering(
     søkerAktør: Aktør,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -55,13 +55,15 @@ class CucumberMock(
     val personRepository = mockk<PersonRepository>()
     val tilbakekrevingsbehandlingHentService = mockk<TilbakekrevingsbehandlingHentService>()
     val arbeidsfordelingServiceMock = mockk<ArbeidsfordelingService>()
+    val praksisendring2024Service = mockPraksisendring2024Service()
 
     val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
             unleashService = mockUnleashNextMedContextService(),
         )
-    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, overgangsordningAndelRepositoryMock)
+
+    val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, overgangsordningAndelRepositoryMock, praksisendring2024Service)
 
     val tilpassDifferanseberegningEtterTilkjentYtelseService =
         TilpassDifferanseberegningEtterTilkjentYtelseService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPraksisendring2024Service.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockPraksisendring2024Service.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ks.sak.cucumber.mocking
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.kjerne.praksisendring.Praksisendring2024Service
+
+fun mockPraksisendring2024Service(): Praksisendring2024Service =
+    mockk<Praksisendring2024Service>().apply {
+        every { genererAndelerForPraksisendring2024(any(), any(), any()) } returns emptyList()
+    }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -35,6 +35,7 @@ import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseAktivitet
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.ks.sak.kjerne.praksisendring.Praksisendring2024Service
 import no.nav.familie.tidslinje.Periode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -580,6 +581,7 @@ internal class UtbetalingsperiodeUtilTest {
                         unleashService = mockUnleashNextMedContextService(),
                     ),
                 overgangsordningAndelRepository = mockOvergangsordningAndelRepository(),
+                praksisendring2024Service = mockPraksisendring2024Service(),
             )
 
         val tilkjentYtelse =
@@ -615,5 +617,10 @@ internal class UtbetalingsperiodeUtilTest {
     private fun mockOvergangsordningAndelRepository(): OvergangsordningAndelRepository =
         mockk<OvergangsordningAndelRepository>().apply {
             every { hentOvergangsordningAndelerForBehandling(any()) } returns emptyList()
+        }
+
+    private fun mockPraksisendring2024Service() =
+        mockk<Praksisendring2024Service>().apply {
+            every { genererAndelerForPraksisendring2024(any(), any(), any()) } returns emptyList()
         }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -31,6 +31,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.lovverkFørFebruar2025.LovverkFør
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndel
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.ks.sak.kjerne.praksisendring.Praksisendring2024Service
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -66,8 +67,9 @@ internal class TilkjentYtelseServiceTest {
         )
 
     private val overgangsordningAndelRepositoryMock: OvergangsordningAndelRepository = mockk()
+    private val praksisendring2024Service: Praksisendring2024Service = mockk()
 
-    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, overgangsordningAndelRepositoryMock)
+    private val tilkjentYtelseService = TilkjentYtelseService(beregnAndelTilkjentYtelseService, overgangsordningAndelRepositoryMock, praksisendring2024Service)
 
     @BeforeEach
     fun init() {
@@ -81,6 +83,7 @@ internal class TilkjentYtelseServiceTest {
             )
 
         every { overgangsordningAndelRepositoryMock.hentOvergangsordningAndelerForBehandling(any()) } returns emptyList()
+        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns emptyList()
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -28,6 +28,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.lovverkFørFebruar2025.LovverkFør
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import no.nav.familie.ks.sak.kjerne.praksisendring.Praksisendring2024Service
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.filtrerIkkeNull
@@ -107,6 +108,7 @@ data class VilkårsvurderingBuilder(
                         unleashService = mockUnleashNextMedContextService(),
                     ),
                 overgangsordningAndelRepository = mockOvergangsordningAndelRepository(),
+                praksisendring2024Service = mockPraksisendring2024Service(),
             )
 
         return tilkjentYtelseService.beregnTilkjentYtelse(
@@ -114,6 +116,11 @@ data class VilkårsvurderingBuilder(
             personopplysningGrunnlag = this.byggPersonopplysningGrunnlag(),
         )
     }
+
+    private fun mockPraksisendring2024Service() =
+        mockk<Praksisendring2024Service>().apply {
+            every { genererAndelerForPraksisendring2024(any(), any(), any()) } returns emptyList()
+        }
 
     private fun mockOvergangsordningAndelRepository(): OvergangsordningAndelRepository =
         mockk<OvergangsordningAndelRepository>().apply {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024ServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024ServiceTest.kt
@@ -1,0 +1,399 @@
+package no.nav.familie.ks.sak.kjerne.praksisendring
+
+import aug
+import io.mockk.every
+import io.mockk.mockk
+import jan
+import jul
+import no.nav.familie.ks.sak.common.util.NullablePeriode
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle.SKAL_GENERERE_ANDELER_FOR_PRAKSISENDRING_2024
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
+import no.nav.familie.ks.sak.data.lagInitiellTilkjentYtelse
+import no.nav.familie.ks.sak.data.lagPersonResultat
+import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.lagVilkårResultat
+import no.nav.familie.ks.sak.data.lagVilkårResultaterForBarn
+import no.nav.familie.ks.sak.data.lagVilkårsvurdering
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.data.randomFnr
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import okt
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.YearMonth
+
+class Praksisendring2024ServiceTest {
+    private val unleashService = mockk<UnleashNextMedContextService>()
+    private val praksisendring2024Service = Praksisendring2024Service(unleashService)
+
+    @BeforeEach
+    fun setUp() {
+        every { unleashService.isEnabled(SKAL_GENERERE_ANDELER_FOR_PRAKSISENDRING_2024) } returns true
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [8, 9, 10, 11, 12])
+    fun `skal generere andel for barn som blir 13 måneder i aug-des 2024`(måned: Int) {
+        // Arrange
+        val utbetalingsmåned = YearMonth.of(2024, måned)
+        val (barn, fødselsdato) = lagBarn(utbetalingsmåned)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val vilkårsvurdering = lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn to fødselsdato))
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024).hasSize(1)
+        with(andelerForPraksisendring2024.first()) {
+            assertThat(aktør).isEqualTo(barn)
+            assertThat(stønadFom).isEqualTo(utbetalingsmåned)
+            assertThat(stønadTom).isEqualTo(utbetalingsmåned)
+            assertThat(kalkulertUtbetalingsbeløp).isEqualTo(7500)
+            assertThat(nasjonaltPeriodebeløp).isEqualTo(7500)
+            assertThat(type).isEqualTo(YtelseType.PRAKSISENDRING_2024)
+            assertThat(sats).isEqualTo(7500)
+            assertThat(prosent).isEqualTo(BigDecimal(100))
+        }
+    }
+
+    @Test
+    fun `skal ikke generere andel hvis toggle er skrudd av`() {
+        // Arrange
+        every { unleashService.isEnabled(SKAL_GENERERE_ANDELER_FOR_PRAKSISENDRING_2024) } returns false
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = mockk(),
+                vilkårsvurdering = mockk(),
+                tilkjentYtelse = mockk(),
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024).hasSize(0)
+    }
+
+    @Test
+    fun `skal ikke generere andel for barn som blir 13 måneder i juli 2024`() {
+        // Arrange
+        val utbetalingsmåned = jul(2024)
+        val (barn, fødselsdato) = lagBarn(utbetalingsmåned)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val vilkårsvurdering = lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn to fødselsdato))
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024).isEmpty()
+    }
+
+    @Test
+    fun `skal ikke generere andel for barn som blir 13 måneder i januar 2025`() {
+        // Arrange
+        val utbetalingsmåned = jan(2025)
+        val (barn, fødselsdato) = lagBarn(utbetalingsmåned)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val vilkårsvurdering = lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn to fødselsdato))
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024).isEmpty()
+    }
+
+    @Test
+    fun `skal generere to andeler for barn som blir 13 måneder i forskjellige måneder`() {
+        // Arrange
+        val utbetalingsmånedBarn1 = aug(2024)
+        val (barn1, fødselsdatoBarn1) = lagBarn(utbetalingsmånedBarn1)
+
+        val utbetalingsmånedBarn2 = okt(2024)
+        val (barn2, fødselsdatoBarn2) = lagBarn(utbetalingsmånedBarn2)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn1, barn2))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val vilkårsvurdering = lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn1 to fødselsdatoBarn1, barn2 to fødselsdatoBarn2))
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024)
+            .hasSize(2)
+            .anySatisfy {
+                assertThat(it.aktør).isEqualTo(barn1)
+                assertThat(it.stønadFom).isEqualTo(utbetalingsmånedBarn1)
+                assertThat(it.stønadTom).isEqualTo(utbetalingsmånedBarn1)
+            }.anySatisfy {
+                assertThat(it.aktør).isEqualTo(barn2)
+                assertThat(it.stønadFom).isEqualTo(utbetalingsmånedBarn2)
+                assertThat(it.stønadTom).isEqualTo(utbetalingsmånedBarn2)
+            }.allSatisfy {
+                assertThat(it.kalkulertUtbetalingsbeløp).isEqualTo(7500)
+                assertThat(it.nasjonaltPeriodebeløp).isEqualTo(7500)
+                assertThat(it.type).isEqualTo(YtelseType.PRAKSISENDRING_2024)
+                assertThat(it.sats).isEqualTo(7500)
+                assertThat(it.prosent).isEqualTo(BigDecimal(100))
+            }
+    }
+
+    @Test
+    fun `skal generere en andel dersom ett av to barn blir truffet av praksisendring`() {
+        // Arrange
+        val utbetalingsmånedBarn1 = jul(2024)
+        val (barn1, fødselsdatoBarn1) = lagBarn(utbetalingsmånedBarn1)
+
+        val utbetalingsmånedBarn2 = aug(2024)
+        val (barn2, fødselsdatoBarn2) = lagBarn(utbetalingsmånedBarn2)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn1, barn2))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val vilkårsvurdering = lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn1 to fødselsdatoBarn1, barn2 to fødselsdatoBarn2))
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024)
+            .hasSize(1)
+            .anySatisfy {
+                assertThat(it.aktør).isEqualTo(barn2)
+                assertThat(it.stønadFom).isEqualTo(utbetalingsmånedBarn2)
+                assertThat(it.stønadTom).isEqualTo(utbetalingsmånedBarn2)
+                assertThat(it.kalkulertUtbetalingsbeløp).isEqualTo(7500)
+                assertThat(it.nasjonaltPeriodebeløp).isEqualTo(7500)
+                assertThat(it.type).isEqualTo(YtelseType.PRAKSISENDRING_2024)
+                assertThat(it.sats).isEqualTo(7500)
+                assertThat(it.prosent).isEqualTo(BigDecimal(100))
+            }
+    }
+
+    @Test
+    fun `skal generere en andel med 50 prosent utbetaling for barn med delt bosted`() {
+        // Arrange
+        val utbetalingsmånedBarn = aug(2024)
+        val (barn, fødselsdatoBarn) = lagBarn(utbetalingsmånedBarn)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val vilkårsvurdering =
+            lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn to fødselsdatoBarn)).apply {
+                personResultater.first().vilkårResultater.removeIf { it.vilkårType == Vilkår.BOR_MED_SØKER }
+                personResultater.first().vilkårResultater.add(
+                    lagVilkårResultat(
+                        vilkårType = Vilkår.BOR_MED_SØKER,
+                        resultat = Resultat.OPPFYLT,
+                        periodeFom = fødselsdatoBarn,
+                        periodeTom = null,
+                        utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.DELT_BOSTED),
+                    ),
+                )
+            }
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024)
+            .hasSize(1)
+            .anySatisfy {
+                assertThat(it.aktør).isEqualTo(barn)
+                assertThat(it.stønadFom).isEqualTo(utbetalingsmånedBarn)
+                assertThat(it.stønadTom).isEqualTo(utbetalingsmånedBarn)
+                assertThat(it.kalkulertUtbetalingsbeløp).isEqualTo(3750)
+                assertThat(it.nasjonaltPeriodebeløp).isEqualTo(3750)
+                assertThat(it.type).isEqualTo(YtelseType.PRAKSISENDRING_2024)
+                assertThat(it.sats).isEqualTo(7500)
+                assertThat(it.prosent).isEqualTo(BigDecimal(50))
+            }
+    }
+
+    @Test
+    fun `skal ikke generere andel dersom barn allerede har andel i måned`() {
+        // Arrange
+        val utbetalingsmåned = aug(2024)
+        val (barn, fødselsdato) = lagBarn(utbetalingsmåned)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn))
+        val tilkjentYtelse =
+            lagInitiellTilkjentYtelse().apply {
+                andelerTilkjentYtelse.add(
+                    lagAndelTilkjentYtelse(
+                        aktør = barn,
+                        stønadFom = utbetalingsmåned,
+                        stønadTom = utbetalingsmåned,
+                    ),
+                )
+            }
+        val vilkårsvurdering = lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn to fødselsdato))
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024).isEmpty()
+    }
+
+    @Test
+    fun `skal ikke generere andel dersom barn ikke starter i barnehage samme måned som det blir 13 måneder`() {
+        // Arrange
+        val utbetalingsmåned = aug(2024)
+        val (barn, fødselsdato) = lagBarn(utbetalingsmåned)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val fullBarnehageplassFraMåned15 = listOf(NullablePeriode(fødselsdato.plusMonths(15), null) to BigDecimal(33))
+        val vilkårsvurdering =
+            lagVilkårsvurdering { vilkårsvurdering ->
+                setOf(
+                    lagPersonResultat(
+                        vilkårsvurdering = vilkårsvurdering,
+                        aktør = barn,
+                        lagVilkårResultater = { personResultat ->
+                            lagVilkårResultaterForBarn(
+                                personResultat = personResultat,
+                                barnFødselsdato = fødselsdato,
+                                barnehageplassPerioder = fullBarnehageplassFraMåned15,
+                                behandlingId = 0,
+                            )
+                        },
+                    ),
+                )
+            }
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024).isEmpty()
+    }
+
+    @ParameterizedTest
+    @EnumSource(Vilkår::class, names = ["BOSATT_I_RIKET", "MEDLEMSKAP_ANNEN_FORELDER", "BOR_MED_SØKER", "BARNETS_ALDER"])
+    fun `skal ikke generere andel dersom andre vilkår enn barnehageplass ikke er oppfylt i måned`(vilkår: Vilkår) {
+        // Arrange
+        val utbetalingsmåned = aug(2024)
+        val (barn, fødselsdato) = lagBarn(utbetalingsmåned)
+
+        val personopplysningGrunnlag = lagPersonopplysningGrunnlag(barn = listOf(barn))
+        val tilkjentYtelse = lagInitiellTilkjentYtelse()
+        val vilkårsvurdering =
+            lagVilkårsvurderingMedBarnehageplassFomMåned13(setOf(barn to fødselsdato)).apply {
+                personResultater.first().vilkårResultater.removeIf { it.vilkårType == vilkår }
+                personResultater.first().vilkårResultater.add(
+                    lagVilkårResultat(
+                        vilkårType = vilkår,
+                        resultat = Resultat.IKKE_OPPFYLT,
+                        periodeFom = fødselsdato,
+                        periodeTom = null,
+                    ),
+                )
+            }
+
+        // Act
+        val andelerForPraksisendring2024 =
+            praksisendring2024Service.genererAndelerForPraksisendring2024(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                vilkårsvurdering = vilkårsvurdering,
+                tilkjentYtelse = tilkjentYtelse,
+            )
+
+        // Assert
+        assertThat(andelerForPraksisendring2024).isEmpty()
+    }
+
+    private fun lagVilkårsvurderingMedBarnehageplassFomMåned13(
+        barnMedFødselsdato: Collection<Pair<Aktør, LocalDate>>,
+    ) = lagVilkårsvurdering { vilkårsvurdering ->
+        barnMedFødselsdato
+            .map { (barn, fødselsdato) ->
+                lagPersonResultat(
+                    vilkårsvurdering = vilkårsvurdering,
+                    aktør = barn,
+                    lagVilkårResultater = { personResultat ->
+                        lagVilkårResultaterForBarn(
+                            personResultat = personResultat,
+                            barnFødselsdato = fødselsdato,
+                            barnehageplassPerioder = listOf(NullablePeriode(fødselsdato.plusMonths(13), null) to BigDecimal(33)),
+                            behandlingId = 0,
+                        )
+                    },
+                )
+            }.toSet()
+    }
+
+    private fun lagPersonopplysningGrunnlag(
+        barn: List<Aktør>,
+    ): PersonopplysningGrunnlag =
+        lagPersonopplysningGrunnlag(
+            barnasIdenter = barn.map { it.aktivFødselsnummer() },
+            barnAktør = barn,
+        )
+
+    private fun lagBarn(månedBarnBlir13Måneder: YearMonth): Pair<Aktør, LocalDate> {
+        val fødselsdato = månedBarnBlir13Måneder.atDay(1).minusMonths(13)
+        val barn = randomAktør(randomFnr(fødselsdato))
+        return barn to fødselsdato
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24111

Legger til generering av andeler med ytelsestype `PRAKSISENDRING_2024`

For at et barn skal få en slik andel i måneden det fylte 13 måneder må disse kravene være oppfylt:
- Fylte 13 måneder i aug-des 2024
- Startet i barnehage samme måned som barnet fylte 13 måneder
- Fikk utbetalt KS samme måned som barnet fylte 13 måneder
- Andre vilkår er oppfylt i måneden barnet fylte 13 måneder
- Det har ikke blitt generert en ordinær andel i måneden barnet fylte 13 måneder
- Fagsak og barn må ligge i tabellen over fagsaker praksisendringen treffer (NAV-24204)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
