### PR TITLE
Nav 24213 forskyv barnehageplass for lovvkerk 2025

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFebruar2025/barnehageplass/FomForskyver.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFebruar2025/barnehageplass/FomForskyver.kt
@@ -17,6 +17,8 @@ fun forskyvFomBasertPåGraderingsforskjell(
         -> fomDato.minusDays(1).plusMonths(1).førsteDagIInneværendeMåned()
 
         Graderingsforskjell.INGEN_UTBETALING_GRUNNET_FULL_BARNEHAGEPLASS_TIL_ØKNING,
+        -> fomDato.minusDays(1).plusMonths(2).førsteDagIInneværendeMåned()
+
         Graderingsforskjell.INGEN_UTBETALING_GRUNNET_FØRSTE_PERIODE_TIL_ØKNING,
         -> fomDato.plusMonths(1).førsteDagIInneværendeMåned()
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFebruar2025/barnehageplass/Graderingsforskjell.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lovverkFebruar2025/barnehageplass/Graderingsforskjell.kt
@@ -41,8 +41,8 @@ fun finnGraderingsforskjellMellomDenneOgForrigePeriode(
     return when {
         graderingForrigePeriode > graderingDennePerioden && graderingDennePerioden == BigDecimal.ZERO -> Graderingsforskjell.REDUKSJON_GÅR_TIL_INGEN_UTBETALING
         graderingForrigePeriode > graderingDennePerioden -> Graderingsforskjell.REDUKSJON
-        sluttetIBarnehageDennePerioden -> Graderingsforskjell.ØKNING_GRUNNET_SLUTT_I_BARNEHAGE
         graderingForrigePeriode < graderingDennePerioden && graderingForrigePeriode == BigDecimal.ZERO -> if (erFørstePeriode) Graderingsforskjell.INGEN_UTBETALING_GRUNNET_FØRSTE_PERIODE_TIL_ØKNING else Graderingsforskjell.INGEN_UTBETALING_GRUNNET_FULL_BARNEHAGEPLASS_TIL_ØKNING
+        sluttetIBarnehageDennePerioden -> Graderingsforskjell.ØKNING_GRUNNET_SLUTT_I_BARNEHAGE
         graderingForrigePeriode < graderingDennePerioden -> Graderingsforskjell.ØKNING
         else -> Graderingsforskjell.LIK
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lov2025/barnehageplass/FomForskyverTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lov2025/barnehageplass/FomForskyverTest.kt
@@ -117,7 +117,7 @@ class FomForskyverTest {
     }
 
     @Test
-    fun `skal forskyve fom dato for graderingsforskjell INGEN_UTBETALING_GRUNNET_FULL_BARNEHAGEPLASS_TIL_ØKNING til første dag i neste måneden når fom dato er siste dag i måneden`() {
+    fun `skal forskyve fom dato for graderingsforskjell INGEN_UTBETALING_GRUNNET_FULL_BARNEHAGEPLASS_TIL_ØKNING til første dag to måneder etter fom dato når fom dato er siste dag i måneden`() {
         // Arrange
         val fomDato = LocalDate.of(2025, 1, 31)
 
@@ -129,7 +129,7 @@ class FomForskyverTest {
             )
 
         // Assert
-        assertThat(forskjøvetFom).isEqualTo(LocalDate.of(2025, 2, 1))
+        assertThat(forskjøvetFom).isEqualTo(LocalDate.of(2025, 3, 1))
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lov2025/barnehageplass/ForskyvBarnehageplass2025Test.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lov2025/barnehageplass/ForskyvBarnehageplass2025Test.kt
@@ -136,7 +136,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(15),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(17),
                 ),
             )
@@ -150,8 +150,8 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().fom).isEqualTo(september.atDay(1))
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(oktober.atEndOfMonth())
 
-        assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(november.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(desember.atDay(1))
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -268,7 +268,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(14),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(8),
                 ),
             )
@@ -282,8 +282,8 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().fom).isEqualTo(september.atDay(1))
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(oktober.atEndOfMonth())
 
-        assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(november.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(desember.atDay(1))
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -587,7 +587,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = null,
                 ),
             )
@@ -606,8 +606,8 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater[1].tom).isEqualTo(september.atEndOfMonth())
         assertThat(forskjøvedeVilkårResultater[1].verdi.antallTimer).isEqualTo(BigDecimal.valueOf(33))
 
-        assertThat(forskjøvedeVilkårResultater[2].fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater[2].tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater[2].fom).isEqualTo(november.atDay(1))
+        assertThat(forskjøvedeVilkårResultater[2].tom).isNull()
         assertThat(forskjøvedeVilkårResultater[2].verdi.antallTimer).isNull()
     }
 
@@ -702,8 +702,8 @@ class ForskyvBarnehageplass2025Test {
                 ),
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
-                    periodeFom = LocalDate.of(2025, 2, 15),
-                    periodeTom = LocalDate.of(2025, 4, 14),
+                    periodeFom = LocalDate.of(2025, 2, 14),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(16),
                 ),
             )
@@ -714,7 +714,8 @@ class ForskyvBarnehageplass2025Test {
         // Assert
         assertThat(forskjøvedeVilkårResultater).hasSize(1)
 
-        assertThat(forskjøvedeVilkårResultater.single().fom).isEqualTo(LocalDate.of(2025, 3, 1))
-        assertThat(forskjøvedeVilkårResultater.single().tom).isEqualTo(LocalDate.of(2025, 3, 31))
+        assertThat(forskjøvedeVilkårResultater.single().fom).isEqualTo(LocalDate.of(2025, 2, 1))
+        assertThat(forskjøvedeVilkårResultater.single().tom).isNull()
+        assertThat(forskjøvedeVilkårResultater.single().verdi.antallTimer).isEqualTo(BigDecimal(16))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lov2025/barnehageplass/ForskyvBarnehageplass2025Test.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/lov2025/barnehageplass/ForskyvBarnehageplass2025Test.kt
@@ -36,7 +36,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(15),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(8),
                 ),
             )
@@ -51,7 +51,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(september.atEndOfMonth())
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -69,7 +69,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(15),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = null,
                 ),
             )
@@ -84,7 +84,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(oktober.atEndOfMonth())
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(november.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -102,7 +102,7 @@ class ForskyvBarnehageplass2025Test {
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNEHAGEPLASS,
                 periodeFom = oktober.atDay(1),
-                periodeTom = desember.atDay(1),
+                periodeTom = null,
                 antallTimer = BigDecimal.valueOf(17),
             )
 
@@ -118,7 +118,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(september.atEndOfMonth())
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -169,7 +169,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = null,
                 ),
             )
@@ -184,7 +184,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(september.atEndOfMonth())
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -202,7 +202,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(8),
                 ),
             )
@@ -217,7 +217,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(september.atEndOfMonth())
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -235,7 +235,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(14),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(33),
                 ),
             )
@@ -250,7 +250,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(september.atEndOfMonth())
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -307,7 +307,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = februar.atDay(24),
-                    periodeTom = mars.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(8),
                 ),
             )
@@ -316,11 +316,15 @@ class ForskyvBarnehageplass2025Test {
         val forskjøvedeVilkårResultater = forskyvBarnehageplassVilkår(vilkårResultater)
 
         // Assert
-        assertThat(forskjøvedeVilkårResultater).hasSize(1)
+        assertThat(forskjøvedeVilkårResultater).hasSize(2)
 
         assertThat(forskjøvedeVilkårResultater.first().fom).isEqualTo(februar.atDay(1))
         assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(februar.atEndOfMonth())
         assertThat(forskjøvedeVilkårResultater.first().verdi.antallTimer).isEqualTo(BigDecimal.valueOf(32))
+
+        assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(mars.atDay(1))
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
+        assertThat(forskjøvedeVilkårResultater.last().verdi.antallTimer).isEqualTo(BigDecimal.valueOf(8))
     }
 
     // Eksempel i src/test/resources/barnehageplassscenarioer
@@ -344,7 +348,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = februar.atDay(24),
-                    periodeTom = april.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(16),
                 ),
             )
@@ -360,7 +364,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().verdi.antallTimer).isEqualTo(BigDecimal.valueOf(32))
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(mars.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(mars.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
         assertThat(forskjøvedeVilkårResultater.last().verdi.antallTimer).isEqualTo(BigDecimal.valueOf(16))
     }
 
@@ -378,7 +382,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(35),
                 ),
             )
@@ -394,7 +398,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultaterForBarn1.first().verdi.antallTimer).isEqualTo(BigDecimal(17))
 
         assertThat(forskjøvedeVilkårResultaterForBarn1.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultaterForBarn1.last().tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultaterForBarn1.last().tom).isNull()
         assertThat(forskjøvedeVilkårResultaterForBarn1.last().verdi.antallTimer).isEqualTo(BigDecimal(35))
     }
 
@@ -412,7 +416,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(16),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(40),
                 ),
             )
@@ -428,7 +432,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultaterForBarn2.first().verdi.antallTimer).isEqualTo(BigDecimal(24))
 
         assertThat(forskjøvedeVilkårResultaterForBarn2.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultaterForBarn2.last().tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultaterForBarn2.last().tom).isNull()
         assertThat(forskjøvedeVilkårResultaterForBarn2.last().verdi.antallTimer).isEqualTo(BigDecimal(40))
     }
 
@@ -440,7 +444,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = september.atDay(1),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(15),
                 ),
             )
@@ -451,7 +455,7 @@ class ForskyvBarnehageplass2025Test {
         // Assert
         assertThat(forskjøvedeVilkårResultater).hasSize(1)
         assertThat(forskjøvedeVilkårResultater.first().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.first().tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.first().tom).isNull()
         assertThat(forskjøvedeVilkårResultater.first().verdi.antallTimer).isEqualTo(BigDecimal(15))
     }
 
@@ -469,7 +473,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = BigDecimal(8),
                 ),
             )
@@ -485,7 +489,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().verdi.antallTimer).isNull()
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
         assertThat(forskjøvedeVilkårResultater.last().verdi.antallTimer).isEqualTo(BigDecimal(8))
     }
 
@@ -503,7 +507,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = null,
                 ),
             )
@@ -519,7 +523,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().verdi.antallTimer).isEqualTo(BigDecimal.valueOf(25))
 
         assertThat(forskjøvedeVilkårResultater.last().fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater.last().tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater.last().tom).isNull()
         assertThat(forskjøvedeVilkårResultater.last().verdi.antallTimer).isNull()
     }
 
@@ -543,7 +547,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(15),
                 ),
             )
@@ -563,7 +567,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater[1].verdi.antallTimer).isEqualTo(BigDecimal.valueOf(33))
 
         assertThat(forskjøvedeVilkårResultater[2].fom).isEqualTo(november.atDay(1))
-        assertThat(forskjøvedeVilkårResultater[2].tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater[2].tom).isNull()
         assertThat(forskjøvedeVilkårResultater[2].verdi.antallTimer).isEqualTo(BigDecimal.valueOf(15))
     }
 
@@ -631,7 +635,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = oktober.atDay(1),
-                    periodeTom = desember.atEndOfMonth(),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(15),
                 ),
             )
@@ -651,7 +655,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater[1].verdi.antallTimer).isEqualTo(BigDecimal.valueOf(8))
 
         assertThat(forskjøvedeVilkårResultater[2].fom).isEqualTo(oktober.atDay(1))
-        assertThat(forskjøvedeVilkårResultater[2].tom).isEqualTo(desember.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater[2].tom).isNull()
         assertThat(forskjøvedeVilkårResultater[2].verdi.antallTimer).isEqualTo(BigDecimal.valueOf(15))
     }
 
@@ -669,7 +673,7 @@ class ForskyvBarnehageplass2025Test {
                 lagVilkårResultat(
                     vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = november.atDay(1),
-                    periodeTom = desember.atDay(1),
+                    periodeTom = null,
                     antallTimer = BigDecimal.valueOf(33),
                 ),
             )
@@ -685,7 +689,7 @@ class ForskyvBarnehageplass2025Test {
         assertThat(forskjøvedeVilkårResultater.first().verdi.antallTimer).isEqualTo(BigDecimal.valueOf(8))
 
         assertThat(forskjøvedeVilkårResultater[1].fom).isEqualTo(november.atDay(1))
-        assertThat(forskjøvedeVilkårResultater[1].tom).isEqualTo(november.atEndOfMonth())
+        assertThat(forskjøvedeVilkårResultater[1].tom).isNull()
         assertThat(forskjøvedeVilkårResultater[1].verdi.antallTimer).isEqualTo(BigDecimal.valueOf(33))
     }
 

--- a/src/test/resources/cucumber/vilkår/barnehageplass/overgang_fra_barnehageplass_2025.feature
+++ b/src/test/resources/cucumber/vilkår/barnehageplass/overgang_fra_barnehageplass_2025.feature
@@ -1,0 +1,139 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Overgang fra barnehageplass
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            |
+
+
+  Scenario: Kontantstøtte skal innvilges i desember dersom barnet slutter i fulltids barnehageplass 31 oktober.
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 05.08.2024  |
+
+
+    Og følgende dagens dato 11.06.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 1       | LOVLIG_OPPHOLD                                         |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 05.01.2024 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 14.08.2025 | 30.10.2025 | IKKE_OPPFYLT | Nei                  |                      |                | 33           |
+      | 2       | BARNEHAGEPLASS                                         |                  | 31.10.2025 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNETS_ALDER                                          |                  | 05.09.2025 | 05.03.2026 | OPPFYLT      | Nei                  |                      |                |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
+      | 2       | 01.12.2025 | 31.02.2026 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 |
+
+  Scenario: Kontantstøtte skal innvilges i desember dersom barnet slutter i fulltids barnehageplass 1 november.
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 05.08.2024  |
+
+
+    Og følgende dagens dato 11.06.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 1       | LOVLIG_OPPHOLD                                         |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 05.01.2024 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 14.08.2025 | 31.10.2025 | IKKE_OPPFYLT | Nei                  |                      |                | 33           |
+      | 2       | BARNEHAGEPLASS                                         |                  | 01.11.2025 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNETS_ALDER                                          |                  | 05.09.2025 | 05.03.2026 | OPPFYLT      | Nei                  |                      |                |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
+      | 2       | 01.12.2025 | 31.02.2026 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 |
+
+  Scenario: Kontantstøtte skal innvilges i januar dersom barnet slutter i fulltids barnehageplass 2 november.
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 05.08.2024  |
+
+
+    Og følgende dagens dato 11.06.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 1       | LOVLIG_OPPHOLD                                         |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 05.01.2024 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 14.08.2025 | 01.11.2025 | IKKE_OPPFYLT | Nei                  |                      |                | 33           |
+      | 2       | BARNEHAGEPLASS                                         |                  | 02.11.2025 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNETS_ALDER                                          |                  | 05.09.2025 | 05.03.2026 | OPPFYLT      | Nei                  |                      |                |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
+      | 2       | 01.01.2026 | 31.02.2026 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 |
+
+  Scenario: Kontantstøtte skal innvilges i desember dersom barnet slutter i fulltids barnehageplass 15 oktober.
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 05.08.2024  |
+
+
+    Og følgende dagens dato 11.06.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 1       | LOVLIG_OPPHOLD                                         |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 05.01.2024 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 14.08.2025 | 14.10.2025 | IKKE_OPPFYLT | Nei                  |                      |                | 33           |
+      | 2       | BARNEHAGEPLASS                                         |                  | 15.10.2025 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNETS_ALDER                                          |                  | 05.09.2025 | 05.03.2026 | OPPFYLT      | Nei                  |                      |                |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
+      | 2       | 01.12.2025 | 31.02.2026 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 |
+
+  Scenario: Kontantstøtte skal innvilges i desember dersom barnet går fra fulltid til deltid barnehageplass 31 oktober.
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 19.06.1988  |
+      | 1            | 2       | BARN       | 05.08.2024  |
+
+
+    Og følgende dagens dato 11.06.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                                                 | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter | Antall timer |
+      | 1       | BOSATT_I_RIKET,MEDLEMSKAP                              |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 1       | LOVLIG_OPPHOLD                                         |                  | 19.06.1988 |            | OPPFYLT      | Nei                  |                      |                |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER,BOSATT_I_RIKET |                  | 05.01.2024 |            | OPPFYLT      | Nei                  |                      |                |              |
+      | 2       | BARNEHAGEPLASS                                         |                  | 14.08.2025 | 30.10.2025 | IKKE_OPPFYLT | Nei                  |                      |                | 33           |
+      | 2       | BARNEHAGEPLASS                                         |                  | 31.10.2025 |            | OPPFYLT      | Nei                  |                      |                | 15           |
+      | 2       | BARNETS_ALDER                                          |                  | 05.09.2025 | 05.03.2026 | OPPFYLT      | Nei                  |                      |                |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats |
+      | 2       | 01.12.2025 | 31.02.2026 | 4500  | ORDINÆR_KONTANTSTØTTE | 60     | 7500 |

--- a/src/test/resources/cucumber/vilkår/barnehageplass/overgang_fra_barnehageplass_2025.feature
+++ b/src/test/resources/cucumber/vilkår/barnehageplass/overgang_fra_barnehageplass_2025.feature
@@ -12,13 +12,11 @@ Egenskap: Overgang fra barnehageplass
       | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori |
       | 1            | 1        |                     | SØKNAD           | NASJONAL            |
 
-
   Scenario: Kontantstøtte skal innvilges i desember dersom barnet slutter i fulltids barnehageplass 31 oktober.
     Og følgende persongrunnlag
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1       | SØKER      | 19.06.1988  |
       | 1            | 2       | BARN       | 05.08.2024  |
-
 
     Og følgende dagens dato 11.06.2025
 
@@ -44,7 +42,6 @@ Egenskap: Overgang fra barnehageplass
       | 1            | 1       | SØKER      | 19.06.1988  |
       | 1            | 2       | BARN       | 05.08.2024  |
 
-
     Og følgende dagens dato 11.06.2025
 
     Og følgende vilkårresultater for behandling 1
@@ -68,7 +65,6 @@ Egenskap: Overgang fra barnehageplass
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1       | SØKER      | 19.06.1988  |
       | 1            | 2       | BARN       | 05.08.2024  |
-
 
     Og følgende dagens dato 11.06.2025
 
@@ -94,7 +90,6 @@ Egenskap: Overgang fra barnehageplass
       | 1            | 1       | SØKER      | 19.06.1988  |
       | 1            | 2       | BARN       | 05.08.2024  |
 
-
     Og følgende dagens dato 11.06.2025
 
     Og følgende vilkårresultater for behandling 1
@@ -118,7 +113,6 @@ Egenskap: Overgang fra barnehageplass
       | BehandlingId | AktørId | Persontype | Fødselsdato |
       | 1            | 1       | SØKER      | 19.06.1988  |
       | 1            | 2       | BARN       | 05.08.2024  |
-
 
     Og følgende dagens dato 11.06.2025
 


### PR DESCRIPTION
Favro(s):
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24213
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24214

### 💰 Hva skal gjøres, og hvorfor?
Pga. endringer for lovverk 2025 vil man i noen tilfeller få en "karantenemåned" hvor vi må forskyve f.o.m. datoen to måneder fram i tid. Dette gjelder når barnet slutter i fulltid barnhageplass og går over til enten full eller gradert KS.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
