### PR TITLE
Legger til nytt flettefelt maanedOgAarFoorVedtaksperiode og ny begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -319,7 +319,7 @@ class BrevPeriodeContext(
                         begrunnelse = begrunnelse,
                     )
 
-                val maanedOgAarBegrunnelsenGjelderFor =
+                val månedOgÅrBegrunnelsenGjelderFor =
                     this.utvidetVedtaksperiodeMedBegrunnelser.fom?.let { fom ->
                         hentMånedOgÅrForBegrunnelse(
                             vedtaksperiodeType = this.utvidetVedtaksperiodeMedBegrunnelser.type,
@@ -332,6 +332,8 @@ class BrevPeriodeContext(
                             skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
                         )
                     }
+
+                val månedOgÅrFørVedtaksperiode = utvidetVedtaksperiodeMedBegrunnelser.fom?.minusMonths(1)?.tilMånedÅr()
 
                 validerBrevbegrunnelse(
                     gjelderSøker = gjelderSøker,
@@ -349,7 +351,8 @@ class BrevPeriodeContext(
                             barnasFødselsdatoer = barnasFødselsdatoer,
                             begrunnelse = begrunnelse,
                         ),
-                    maanedOgAarBegrunnelsenGjelderFor = maanedOgAarBegrunnelsenGjelderFor,
+                    maanedOgAarBegrunnelsenGjelderFor = månedOgÅrBegrunnelsenGjelderFor,
+                    maanedOgAarFoorVedtaksperiode = månedOgÅrFørVedtaksperiode,
                     maalform = personopplysningGrunnlag.søker.målform.tilSanityFormat(),
                     apiNavn = begrunnelse.sanityApiNavn,
                     belop = formaterBeløp(hentBeløp(begrunnelse)),
@@ -584,6 +587,7 @@ class BrevPeriodeContext(
                             vedtaksperiodeFom.tilMånedÅr()
                         }
                     }
+
                     else -> "${vedtaksperiodeFom.tilMånedÅr()} til ${vedtaksperiodeTom.tilMånedÅr()}"
                 }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
@@ -58,6 +58,7 @@ data class NasjonalOgFellesBegrunnelseDataDto(
     val belop: String,
     val antallTimerBarnehageplass: String,
     val soknadstidspunkt: String,
+    val maanedOgAarFoorVedtaksperiode: String?,
 ) : BegrunnelseDtoMedData(
         apiNavn = apiNavn,
         type = BrevBegrunnelseType.BEGRUNNELSE,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
@@ -713,6 +713,10 @@ enum class NasjonalEllerFellesBegrunnelse : IBegrunnelse {
         override val begrunnelseType = BegrunnelseType.INNVILGET
     },
 
+    INNVILGET_MÅNEDEN_ETTER_SLUTTET_I_FULLTIDSPLASS_0125 {
+        override val sanityApiNavn = "innvilgetMaanedenEtterSluttetIFulltidsplass0125"
+        override val begrunnelseType = BegrunnelseType.INNVILGET
+    },
     INNVILGET_TREDJELANDSBORGER_MED_LOVLIG_OPPHOLD_SAMTIDIG_SOM_BOSATT_I_NORGE_0824 {
         override val sanityApiNavn = "innvilgetTredjelandsborgerMedLovligOppholdSamtidigSomBosattINorge0824"
         override val begrunnelseType = BegrunnelseType.INNVILGET

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -32,6 +32,7 @@ import no.nav.familie.ks.sak.common.util.NullablePeriode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.tilKortString
+import no.nav.familie.ks.sak.common.util.tilMånedÅrKort
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
@@ -1443,6 +1444,7 @@ fun lagNasjonalOgFellesBegrunnelseDataDto(
     belop: Int = 7500,
     antallTimerBarnehageplass: Int = 0,
     soknadstidspunkt: LocalDate = LocalDate.now(),
+    månedOgÅrFørVedtaksperiode: YearMonth = YearMonth.now().minusMonths(1),
 ): NasjonalOgFellesBegrunnelseDataDto =
     NasjonalOgFellesBegrunnelseDataDto(
         vedtakBegrunnelseType = vedtakBegrunnelseType,
@@ -1457,6 +1459,7 @@ fun lagNasjonalOgFellesBegrunnelseDataDto(
         belop = belop.toString(),
         antallTimerBarnehageplass = antallTimerBarnehageplass.toString(),
         soknadstidspunkt = soknadstidspunkt.tilKortString(),
+        maanedOgAarFoorVedtaksperiode = månedOgÅrFørVedtaksperiode.tilMånedÅrKort(),
     )
 
 fun lagBrevmottakerDto(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BrevPeriodeParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/BrevPeriodeParser.kt
@@ -10,6 +10,7 @@ object BrevPeriodeParser {
         ANTALL_BARN("Antall barn"),
         ANTALL_TIMER_BARNEHAGEPLASS("Antall timer barnehageplass"),
         MÅNED_OG_ÅR_BEGRUNNELSEN_GJELDER_FOR("Måned og år begrunnelsen gjelder for"),
+        MÅNED_OG_ÅR_FØR_VEDTAKSPERIODE("Måned og år før vedtaksperiode"),
         MÅLFORM("Målform"),
         BELØP("Beløp"),
         SØKNADSTIDSPUNKT("Søknadstidspunkt"),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -51,7 +51,9 @@ fun parseNasjonalEllerFellesBegrunnelse(rad: Tabellrad): BegrunnelseDtoMedData {
     return NasjonalOgFellesBegrunnelseDataDto(
         vedtakBegrunnelseType = begrunnelse.begrunnelseType,
         apiNavn = begrunnelse.sanityApiNavn,
+        sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
         gjelderSoker = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_SØKER, rad) ?: false,
+        gjelderAndreForelder = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_ANDRE_FORELDER, rad) ?: false,
         barnasFodselsdatoer =
             parseValgfriString(
                 BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BARNAS_FØDSELSDATOER,
@@ -67,14 +69,17 @@ fun parseNasjonalEllerFellesBegrunnelse(rad: Tabellrad): BegrunnelseDtoMedData {
             (parseValgfriEnum<Målform>(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅLFORM, rad) ?: Målform.NB)
                 .tilSanityFormat(),
         belop = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BELØP, rad)?.replace(' ', ' ') ?: "",
+        antallTimerBarnehageplass = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_TIMER_BARNEHAGEPLASS, rad) ?: "",
         soknadstidspunkt =
             parseValgfriString(
                 BrevPeriodeParser.DomenebegrepBrevBegrunnelse.SØKNADSTIDSPUNKT,
                 rad,
             ) ?: "",
-        antallTimerBarnehageplass = parseValgfriString(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.ANTALL_TIMER_BARNEHAGEPLASS, rad) ?: "",
-        sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
-        gjelderAndreForelder = parseValgfriBoolean(BrevPeriodeParser.DomenebegrepBrevBegrunnelse.GJELDER_ANDRE_FORELDER, rad) ?: false,
+        maanedOgAarFoorVedtaksperiode =
+            parseValgfriString(
+                BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅNED_OG_ÅR_FØR_VEDTAKSPERIODE,
+                rad,
+            ),
     )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -114,6 +114,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
+                maanedOgAarFoorVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -167,6 +168,7 @@ class BrevPeriodeContextTest {
                 belop = "3 000",
                 antallTimerBarnehageplass = "17",
                 soknadstidspunkt = "",
+                maanedOgAarFoorVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -226,6 +228,7 @@ class BrevPeriodeContextTest {
                 belop = "3 000",
                 antallTimerBarnehageplass = "17",
                 soknadstidspunkt = "",
+                maanedOgAarFoorVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -279,6 +282,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
+                maanedOgAarFoorVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -339,6 +343,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
+                maanedOgAarFoorVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -399,6 +404,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
+                maanedOgAarFoorVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )

--- a/src/test/resources/cucumber/fremtidig-opphør.feature
+++ b/src/test/resources/cucumber/fremtidig-opphør.feature
@@ -45,8 +45,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 01.05.2024 |            | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.05.2024 til -
-      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
-      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.06.22             | 1           |         | 0     | mai 2024                             | true                   | 0                           |
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.06.22             | 1           |         | 0     | mai 2024                             | true                   | 0                           | april 2024                     |
 
   Scenario: Barnehageplass fra midten av en måned
     Og følgende dagens dato 06.02.2024
@@ -76,8 +76,8 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | 01.07.2024 |            | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.07.2024 til -
-      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
-      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.06.22             | 1           |         | 0     | juli 2024                            | true                   | 0                           |
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 11.06.22             | 1           |         | 0     | juli 2024                            | true                   | 0                           | juni 2024                      |
 
 
   Scenario: Revurdering. Eneste endring er framtidig opphør framtidig opphør på barnehageplass. Skal gi behandlingsresultat opphør.

--- a/src/test/resources/cucumber/opphør-første-periode.feature
+++ b/src/test/resources/cucumber/opphør-første-periode.feature
@@ -60,11 +60,11 @@ Egenskap: Opphør første periode
 
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2023 til -
-      | Begrunnelse                          | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
-      | OPPHØR_VURDERING_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
-      | OPPHØR_IKKE_BOSATT_I_NORGE           | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
-      | OPPHØR_FLYTTET_FRA_NORGE             | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
-      | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           |
+      | Begrunnelse                          | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | OPPHØR_VURDERING_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           | august 2023                    |
+      | OPPHØR_IKKE_BOSATT_I_NORGE           | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           | august 2023                    |
+      | OPPHØR_FLYTTET_FRA_NORGE             | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           | august 2023                    |
+      | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | 1           | 25.08.22             | ja            | 0     | september 2023                       | true                   | 0                           | august 2023                    |
 
 
   Scenario: Når det er opphør første periode men ikke på barn ønsker vi at barnet ikke flettes inn
@@ -112,8 +112,8 @@ Egenskap: Opphør første periode
       | 01.12.2023 |          | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.12.2023 til -
-      | Begrunnelse                          | Type     | Gjelder søker | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Gjelder andre forelder | Antall timer barnehageplass |
-      | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | Ja            | 0           | desember 2023                        | 0     | false                  |                             |
+      | Begrunnelse                          | Type     | Gjelder søker | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | OPPHØR_FRA_START_IKKE_BOSATT_I_NORGE | STANDARD | Ja            | 0           | desember 2023                        | 0     | false                  |                             | november 2023                  |
 
   Scenario: Når det er ikke oppfylt fra første periode på revurdering ønsker vi å få opp riktige begrunnelser
     Og følgende dagens dato 14.02.2024
@@ -154,11 +154,11 @@ Egenskap: Opphør første periode
 
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2023 til -
-      | Begrunnelse                                                   | Type     | Antall barn | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder |
-      | OPPHØR_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR                      | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |
-      | OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR            | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |
-      | OPPHØR_IKKE_MEDLEM_FOLKETRYGDEN_ELLER_EOS_I_5_ÅR              | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |
-      | OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_ELLER_EØS_I_5_AAR | STANDARD | 0           | ja            | 0     | september 2023                       | false                  |
+      | Begrunnelse                                                   | Type     | Antall barn | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Måned og år før vedtaksperiode |
+      | OPPHØR_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR                      | STANDARD | 0           | ja            | 0     | september 2023                       | false                  | august 2023 |
+      | OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR            | STANDARD | 0           | ja            | 0     | september 2023                       | false                  | august 2023 |
+      | OPPHØR_IKKE_MEDLEM_FOLKETRYGDEN_ELLER_EOS_I_5_ÅR              | STANDARD | 0           | ja            | 0     | september 2023                       | false                  | august 2023 |
+      | OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_ELLER_EØS_I_5_AAR | STANDARD | 0           | ja            | 0     | september 2023                       | false                  | august 2023 |
 
   Scenario: Når et vilkår ikke er oppfylt måneden før vedtaksperioden ønsker vi å få begrunnelser knyttet til vilkåret
     Og følgende persongrunnlag

--- a/src/test/resources/cucumber/overgangsordning.feature
+++ b/src/test/resources/cucumber/overgangsordning.feature
@@ -79,5 +79,5 @@ Egenskap: Overgangsordning
       | 01.09.2024 | 31.10.2024 | INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2024 til 31.10.2024
-      | Begrunnelse                                   | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Målform | Gjelder andre forelder |
-      | INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING | STANDARD | Nei           | 01.01.23             | 1           | september 2024                       | 1 500 |                  | 27                          |         | Ja                     |
+      | Begrunnelse                                   | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Målform | Gjelder andre forelder | Måned og år før vedtaksperiode |
+      | INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING | STANDARD | Nei           | 01.01.23             | 1           | september 2024                       | 1 500 |                  | 27                          |         | Ja                     | august 2024                    |

--- a/src/test/resources/cucumber/vedtaksperioder/avslag.feature
+++ b/src/test/resources/cucumber/vedtaksperioder/avslag.feature
@@ -72,8 +72,8 @@ Egenskap: Avslag perioder
       | 01.09.2024 |          | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.09.2024 til -
-      | Begrunnelse                      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Måned og år begrunnelsen gjelder for |
-      | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE | STANDARD | Nei           | 08.06.23             | 1           | NB      | 0     |                  | 40                          | Nei                    | august 2024                          |
+      | Begrunnelse                      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Måned og år begrunnelsen gjelder for | Måned og år før vedtaksperiode |
+      | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE | STANDARD | Nei           | 08.06.23             | 1           | NB      | 0     |                  | 40                          | Nei                    | august 2024                          | august 2024                    |
 
   Scenario: Avslagperioder som ikke starter samtidig som en andel slutter skal ha samme fom som vilkåret
     Gitt følgende fagsaker
@@ -148,5 +148,5 @@ Egenskap: Avslag perioder
       | 01.07.2024 |            | AVSLAG_FLYTTET_FRA_NORGE |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.07.2024 til -
-      | Begrunnelse              | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder |
-      | AVSLAG_FLYTTET_FRA_NORGE | STANDARD | Nei           | 15.05.23             | 1           | juli 2024                            | 0     |                  | 0                           |                        |
+      | Begrunnelse              | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Måned og år før vedtaksperiode |
+      | AVSLAG_FLYTTET_FRA_NORGE | STANDARD | Nei           | 15.05.23             | 1           | juli 2024                            | 0     |                  | 0                           |                        | juni 2024                      |

--- a/src/test/resources/cucumber/vedtaksperioder/opphør.feature
+++ b/src/test/resources/cucumber/vedtaksperioder/opphør.feature
@@ -61,8 +61,8 @@ Egenskap: Opphørsperiode
       | 01.08.2024 |            | OPPHØR_TILLEGSTEKST_FOR_REGLER_FØR_01_08_2024 |                 |            |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.08.2024 til -
-      | Begrunnelse                                   | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass |
-      | OPPHØR_TILLEGSTEKST_FOR_REGLER_FØR_01_08_2024 | STANDARD | 1           | 20.03.23             | Nei           | 0     | august 2024                          | true                   | 0                           |
+      | Begrunnelse                                   | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | OPPHØR_TILLEGSTEKST_FOR_REGLER_FØR_01_08_2024 | STANDARD | 1           | 20.03.23             | Nei           | 0     | august 2024                          | true                   | 0                           | juli 2024                    |
 
 
   Scenario: Opphørsperioder som oppstår i mellom perioder skal ha tom dato, opphørsperioder som oppstår


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24216

I regelverk 2025 for KS, så skal man ha en liten karensperiode dersom man går fra fulltidbarnehageplass til deltid eller ingen.
Dette vil si at slutter du i midten av mars 2025,  så vil du ikke få innvilget før mai 2025.

Vi legger inn derfor et nytt flettefelt maanedOgAarFoorVedtaksperiode, og begrunnelse slik at man kan referere til 'karens' måneden man ikke fikk KS selvom barnet ikke gikk i barnehage hele april.