### PR TITLE
Fiks bug i overlapp av regelverk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.beskjærEtter
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.kombiner
 import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
@@ -65,8 +66,8 @@ object LovverkTidslinjeGenerator {
                         )
                     }.tilTidslinje()
                     .slåSammenLikePerioder()
-            }.kombiner {
-                it.toSet().single()
+            }.reduce { acc, tidslinje ->
+                acc.beskjærEtter(tidslinje)
             }
 
     private fun List<Periode<Lovverk>>.erstattFørsteFomOgSisteTomMedNull(): List<Periode<Lovverk>> =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGeneratorTest.kt
@@ -39,8 +39,12 @@ class LovverkTidslinjeGeneratorTest {
                         Vilkår
                             .hentVilkårFor(barn.type)
                             .associateWith { vilkår ->
-                                val fom = barn.fødselsdato.plusYears(1)
-                                val tom = barn.fødselsdato.plusYears(2)
+                                val (fom, tom) =
+                                    if (vilkår == Vilkår.BARNETS_ALDER) {
+                                        barn.fødselsdato.plusMonths(12) to barn.fødselsdato.plusMonths(20)
+                                    } else {
+                                        barn.fødselsdato to null
+                                    }
                                 listOf(
                                     Periode(
                                         verdi =
@@ -51,7 +55,7 @@ class LovverkTidslinjeGeneratorTest {
                                                 periodeTom = tom,
                                             ),
                                         fom = fom.førsteDagIInneværendeMåned(),
-                                        tom = tom.sisteDagIMåned(),
+                                        tom = tom?.sisteDagIMåned(),
                                     ),
                                 )
                             }
@@ -94,8 +98,12 @@ class LovverkTidslinjeGeneratorTest {
                         Vilkår
                             .hentVilkårFor(barn.type)
                             .associateWith { vilkår ->
-                                val fom = barn.fødselsdato.plusYears(1)
-                                val tom = barn.fødselsdato.plusYears(2)
+                                val (fom, tom) =
+                                    if (vilkår == Vilkår.BARNETS_ALDER) {
+                                        barn.fødselsdato.plusMonths(12) to barn.fødselsdato.plusMonths(20)
+                                    } else {
+                                        barn.fødselsdato to null
+                                    }
                                 listOf(
                                     Periode(
                                         verdi =
@@ -106,7 +114,7 @@ class LovverkTidslinjeGeneratorTest {
                                                 periodeTom = tom,
                                             ),
                                         fom = fom.førsteDagIInneværendeMåned(),
-                                        tom = tom.sisteDagIMåned(),
+                                        tom = tom?.sisteDagIMåned(),
                                     ),
                                 )
                             }
@@ -149,8 +157,12 @@ class LovverkTidslinjeGeneratorTest {
                         Vilkår
                             .hentVilkårFor(barn.type)
                             .associateWith { vilkår ->
-                                val fom = barn.fødselsdato.plusYears(1)
-                                val tom = barn.fødselsdato.plusYears(2)
+                                val (fom, tom) =
+                                    if (vilkår == Vilkår.BARNETS_ALDER) {
+                                        barn.fødselsdato.plusMonths(12) to barn.fødselsdato.plusMonths(20)
+                                    } else {
+                                        barn.fødselsdato to null
+                                    }
                                 listOf(
                                     Periode(
                                         verdi =
@@ -161,7 +173,7 @@ class LovverkTidslinjeGeneratorTest {
                                                 periodeTom = tom,
                                             ),
                                         fom = fom.førsteDagIInneværendeMåned(),
-                                        tom = tom.sisteDagIMåned(),
+                                        tom = tom?.sisteDagIMåned(),
                                     ),
                                 )
                             }
@@ -204,8 +216,12 @@ class LovverkTidslinjeGeneratorTest {
                         Vilkår
                             .hentVilkårFor(barn.type)
                             .associateWith { vilkår ->
-                                val fom = barn.fødselsdato.plusYears(1)
-                                val tom = barn.fødselsdato.plusYears(2)
+                                val (fom, tom) =
+                                    if (vilkår == Vilkår.BARNETS_ALDER) {
+                                        barn.fødselsdato.plusMonths(12) to barn.fødselsdato.plusMonths(20)
+                                    } else {
+                                        barn.fødselsdato to null
+                                    }
                                 listOf(
                                     Periode(
                                         verdi =
@@ -216,7 +232,7 @@ class LovverkTidslinjeGeneratorTest {
                                                 periodeTom = tom,
                                             ),
                                         fom = fom.førsteDagIInneværendeMåned(),
-                                        tom = tom.sisteDagIMåned(),
+                                        tom = tom?.sisteDagIMåned(),
                                     ),
                                 )
                             }
@@ -271,8 +287,12 @@ class LovverkTidslinjeGeneratorTest {
                         Vilkår
                             .hentVilkårFor(barn.type)
                             .associateWith { vilkår ->
-                                val fom = barn.fødselsdato.plusYears(1)
-                                val tom = barn.fødselsdato.plusYears(2)
+                                val (fom, tom) =
+                                    if (vilkår == Vilkår.BARNETS_ALDER) {
+                                        barn.fødselsdato.plusMonths(12) to barn.fødselsdato.plusMonths(20)
+                                    } else {
+                                        barn.fødselsdato to null
+                                    }
                                 listOf(
                                     Periode(
                                         verdi =
@@ -283,7 +303,7 @@ class LovverkTidslinjeGeneratorTest {
                                                 periodeTom = tom,
                                             ),
                                         fom = fom.førsteDagIInneværendeMåned(),
-                                        tom = tom.sisteDagIMåned(),
+                                        tom = tom?.sisteDagIMåned(),
                                     ),
                                 )
                             }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24249

I genereringen av lovverk strakk tidslinjen seg evig frem i tid, som førte til at det ble kastet en feil dersom det var forskjellige lovverk i en behandling.
Løser problemet ved å bare generere lovverktidslinje basert på barnets alder-vilkåret, ettersom dette er begrenset av fom og tom, og bare vil kaste feil dersom det er overlapp mellom barnets alder-vilkår mellom forskjellige barn

Oppdaterer testene til å bedre gjenspeile fom- og tom-dato på vilkår i prod

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
