### PR TITLE
Inkluder praksisendring andeler når man henter ordinære andeler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -15,7 +15,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
+import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreOgPraksisendringAndeler
 import no.nav.familie.ks.sak.kjerne.beregning.domene.overgangsordningAndelerPerAktør
 import no.nav.familie.ks.sak.kjerne.beregning.domene.totalKalkulertUtbetalingsbeløpForPeriode
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
@@ -102,18 +102,18 @@ class UtbetalingsoppdragGenerator {
         )
 
     private fun TilkjentYtelse.tilAndelDataLongId(): List<AndelDataLongId> =
-        this.ordinæreAndelerTilAndelDataLongId() +
+        this.ordinæreOgPraksisendringAndelerTilAndelDataLongId() +
             this.overgangsordningAndelerOgOrdinærForOvergangsordningUtbetalingsmånedTilAndelDataLongId()
 
-    private fun TilkjentYtelse.ordinæreAndelerTilAndelDataLongId(): List<AndelDataLongId> =
+    private fun TilkjentYtelse.ordinæreOgPraksisendringAndelerTilAndelDataLongId(): List<AndelDataLongId> =
         this
             .andelerTilkjentYtelse
-            .ordinæreAndeler()
+            .ordinæreOgPraksisendringAndeler()
             .map { it.tilAndelDataLongId() }
 
     private fun TilkjentYtelse.overgangsordningAndelerOgOrdinærForOvergangsordningUtbetalingsmånedTilAndelDataLongId(): List<AndelDataLongId> {
         val ordinærAndelerPerBarnIOvergangsordningUtbetalingsmåned =
-            ordinæreAndelerPerBarnIOvergangsordningUtbetalingMåned()
+            ordinæreOgPraksisendringAndelerPerBarnIOvergangsordningUtbetalingMåned()
         return this
             .andelerTilkjentYtelse
             .overgangsordningAndelerPerAktør()
@@ -136,9 +136,9 @@ class UtbetalingsoppdragGenerator {
             }
     }
 
-    private fun TilkjentYtelse.ordinæreAndelerPerBarnIOvergangsordningUtbetalingMåned(): Map<Aktør, AndelTilkjentYtelse?> =
+    private fun TilkjentYtelse.ordinæreOgPraksisendringAndelerPerBarnIOvergangsordningUtbetalingMåned(): Map<Aktør, AndelTilkjentYtelse?> =
         andelerTilkjentYtelse
-            .ordinæreAndeler()
+            .ordinæreOgPraksisendringAndeler()
             .groupBy { it.aktør }
             .mapValues { (_, andeler) ->
                 andeler.find { andel ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
-import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
+import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreOgPraksisendringAndeler
 import no.nav.familie.ks.sak.kjerne.beregning.domene.tilTidslinjeMedAndeler
 import no.nav.familie.ks.sak.kjerne.beregning.lovverkFørFebruar2025.utledMaksAntallMånederMedUtbetaling
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.tilBrevTekst
@@ -51,7 +51,7 @@ object TilkjentYtelseValidator {
         val andelerPerAktør = tilkjentYtelse.andelerTilkjentYtelse.groupBy { it.aktør }
 
         andelerPerAktør.filter { it.value.isNotEmpty() }.forEach { (aktør, andeler) ->
-            val ordinæreAndeler = andeler.ordinæreAndeler()
+            val ordinæreAndeler = andeler.ordinæreOgPraksisendringAndeler()
 
             val stønadFom = ordinæreAndeler.minOf { it.stønadFom }
             val stønadTom = ordinæreAndeler.maxOf { it.stønadTom }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -147,7 +147,7 @@ data class AndelTilkjentYtelse(
             this.differanseberegnetPeriodebeløp == andel.differanseberegnetPeriodebeløp
 }
 
-fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> = overgangsordningAndelerPerAktør().map { it.value.minBy { it.stønadFom } } + ordinæreAndeler().filter { it.kalkulertUtbetalingsbeløp != 0 }
+fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> = overgangsordningAndelerPerAktør().map { it.value.minBy { it.stønadFom } } + ordinæreOgPraksisendringAndeler().filter { it.kalkulertUtbetalingsbeløp != 0 }
 
 fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp(): List<AndelTilkjentYtelse> =
     this.fold(emptyList()) { acc, andelTilkjentYtelse ->
@@ -166,7 +166,7 @@ fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp():
 
 fun AndelTilkjentYtelse.totalKalkulertUtbetalingsbeløpForPeriode(): Int = kalkulertUtbetalingsbeløp * stønadsPeriode().antallMåneder()
 
-fun Iterable<AndelTilkjentYtelse>.ordinæreAndeler() = this.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE }
+fun Iterable<AndelTilkjentYtelse>.ordinæreOgPraksisendringAndeler() = this.filter { it.type == YtelseType.ORDINÆR_KONTANTSTØTTE || it.type == YtelseType.PRAKSISENDRING_2024 }
 
 fun Iterable<AndelTilkjentYtelse>.overgangsordningAndelerPerAktør() = this.filter { it.type == YtelseType.OVERGANGSORDNING }.groupBy { it.aktør }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidator.kt
@@ -12,7 +12,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilTidslinje
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
-import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreAndeler
+import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreOgPraksisendringAndeler
 import no.nav.familie.ks.sak.kjerne.beregning.tilSeparateTidslinjerForBarna
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndel
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.UtfyltOvergangsordningAndel
@@ -48,8 +48,8 @@ object OvergangsordningAndelValidator {
         andelerForrigeBehandling: Set<AndelTilkjentYtelse>,
         barna: List<Person>,
     ) {
-        val nåværendeAndelerTidslinjer = andelerNåværendeBehandling.ordinæreAndeler().tilSeparateTidslinjerForBarna()
-        val forrigeAndelerTidslinjer = andelerForrigeBehandling.ordinæreAndeler().tilSeparateTidslinjerForBarna()
+        val nåværendeAndelerTidslinjer = andelerNåværendeBehandling.ordinæreOgPraksisendringAndeler().tilSeparateTidslinjerForBarna()
+        val forrigeAndelerTidslinjer = andelerForrigeBehandling.ordinæreOgPraksisendringAndeler().tilSeparateTidslinjerForBarna()
 
         nåværendeAndelerTidslinjer
             .outerJoin(forrigeAndelerTidslinjer) { nåværendeAndeler, forrigeAndeler ->


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24111

Når vi henter 'ordinære' andeler, så må vi også hente praksisendring andeler.
Dette fordi praksisendring andeler uansett gjøres om til ORDINÆR_KONTANTSTØTTE.