### PR TITLE
Sjekk på ytelsetypeKS ved søknadsresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -75,14 +75,15 @@ object BehandlingsresultatSøknadUtils {
         personerFremstiltKravFor: List<Aktør>,
         endretUtbetalingAndeler: List<EndretUtbetalingAndel>,
     ): List<Søknadsresultat> {
+
         val alleSøknadsresultater =
             personerFremstiltKravFor.flatMap { aktør ->
-                val ytelseTyper = (forrigeAndeler.map { it.type } + nåværendeAndeler.map { it.type }).distinct()
+                val ytelseTyper = (forrigeAndeler + nåværendeAndeler).map { it.type.tilYtelseType() }.distinct()
 
                 ytelseTyper.flatMap { ytelseType ->
                     utledSøknadResultatFraAndelerTilkjentYtelsePerPersonOgType(
-                        forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
-                        nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør && it.type == ytelseType },
+                        forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør && it.type.tilYtelseType() == ytelseType },
+                        nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør && it.type.tilYtelseType() == ytelseType },
                         endretUtbetalingAndelerForPerson = endretUtbetalingAndeler.filter { it.person?.aktør == aktør },
                     )
                 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -75,7 +75,6 @@ object BehandlingsresultatSøknadUtils {
         personerFremstiltKravFor: List<Aktør>,
         endretUtbetalingAndeler: List<EndretUtbetalingAndel>,
     ): List<Søknadsresultat> {
-
         val alleSøknadsresultater =
             personerFremstiltKravFor.flatMap { aktør ->
                 val ytelseTyper = (forrigeAndeler + nåværendeAndeler).map { it.type.tilYtelseType() }.distinct()

--- a/src/test/resources/cucumber/praksisendring-2024.feature
+++ b/src/test/resources/cucumber/praksisendring-2024.feature
@@ -57,7 +57,7 @@ Egenskap:Praksisendring 2024
 
     Og når behandlingsresultatet er utledet for behandling 2
 
-    Så forvent at behandlingsresultatet er DELVIS_INNVILGET på behandling 2
+    Så forvent at behandlingsresultatet er AVSLÅTT på behandling 2
 
     Og vedtaksperioder er laget for behandling 2
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24111

Vi ønsker ikke at endring av andeltype fra ordinær til praksisendring skal trigge behandlingsresultatet innvilget.
Vi ønsker bare dette dersom det mot økonomi faktisk endrer på seg og man faktisk får innvilget mer KS., sjekker derfor på ytelsetype istedenfor.

Samme som https://github.com/navikt/familie-ks-sak/pull/1087, men bare ved sjekk av innvilgelse.