### PR TITLE
Ved opphørsperiode rett etter at et ikke aktuelt vilkår ender, så skal vilkåret regnet som utgjørende

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -74,11 +74,11 @@ class BegrunnelserForPeriodeContext(
         return when (this.utvidetVedtaksperiodeMedBegrunnelser.type) {
             Vedtaksperiodetype.FORTSATT_INNVILGET,
             Vedtaksperiodetype.AVSLAG,
-            -> tillateBegrunnelserForVedtakstype
+                -> tillateBegrunnelserForVedtakstype
 
             Vedtaksperiodetype.UTBETALING,
             Vedtaksperiodetype.OPPHØR,
-            -> tillateBegrunnelserForVedtakstype.filtrerErGyldigForVedtaksperiode()
+                -> tillateBegrunnelserForVedtakstype.filtrerErGyldigForVedtaksperiode()
         }
     }
 
@@ -105,7 +105,7 @@ class BegrunnelserForPeriodeContext(
 
         val personerSomMatcherBegrunnelseIPeriode =
             hentPersonerSomPasserMedBegrunnelseOgPeriode(this, sanityBegrunnelse) +
-                hentPersonerSomPasserForKompetanseIPeriode(this, sanityBegrunnelse)
+                    hentPersonerSomPasserForKompetanseIPeriode(this, sanityBegrunnelse)
 
         return when {
             sanityBegrunnelse.skalAlltidVises -> true
@@ -249,11 +249,11 @@ class BegrunnelserForPeriodeContext(
         val personerMedEndretUtbetalingsAndelerSomPasserVedtaksperioden = hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse)
 
         return (
-            personerMedVilkårResultaterSomPasserVedtaksperioden.keys +
-                personerMedOvergangsordningAndel +
-                personerMedOvergangsordningAndelerSomSlutterRettFørVedtaksperiode +
-                personerMedEndretUtbetalingsAndelerSomPasserVedtaksperioden
-        ).toSet()
+                personerMedVilkårResultaterSomPasserVedtaksperioden.keys +
+                        personerMedOvergangsordningAndel +
+                        personerMedOvergangsordningAndelerSomSlutterRettFørVedtaksperiode +
+                        personerMedEndretUtbetalingsAndelerSomPasserVedtaksperioden
+                ).toSet()
     }
 
     fun hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse: SanityBegrunnelse): Set<Person> =
@@ -263,7 +263,7 @@ class BegrunnelserForPeriodeContext(
                     endretUtbetalingAndel.periode.tom
                         .sisteDagIInneværendeMåned()
                         .erDagenFør(utvidetVedtaksperiodeMedBegrunnelser.fom) &&
-                        sanityBegrunnelse.endringsårsaker.contains(endretUtbetalingAndel.årsak)
+                            sanityBegrunnelse.endringsårsaker.contains(endretUtbetalingAndel.årsak)
 
                 val endretUtbetalingAndelStarterSamtidigSomVedtaksperiode = endretUtbetalingAndel.fom == utvidetVedtaksperiodeMedBegrunnelser.fom?.toYearMonth()
 
@@ -280,7 +280,7 @@ class BegrunnelserForPeriodeContext(
                 vilkårResultaterSomPasserMedVedtaksperiodeDato.contains(
                     vilkårResultat.id,
                 ) ||
-                    begrunnelseType == SanityBegrunnelseType.STANDARD
+                        begrunnelseType == SanityBegrunnelseType.STANDARD
             }
         }.filterValues { it.isNotEmpty() }
 
@@ -291,16 +291,16 @@ class BegrunnelserForPeriodeContext(
             BegrunnelseType.EØS_INNVILGET,
             BegrunnelseType.ENDRET_UTBETALING,
             BegrunnelseType.INNVILGET,
-            -> finnVilkårResultaterSomStarterSamtidigSomPeriode()
+                -> finnVilkårResultaterSomStarterSamtidigSomPeriode()
 
             BegrunnelseType.EØS_OPPHØR,
             BegrunnelseType.ETTER_ENDRET_UTBETALING,
             BegrunnelseType.OPPHØR,
-            -> finnVilkårResultaterSomSlutterFørPeriode()
+                -> finnVilkårResultaterSomSlutterFørPeriode()
 
             BegrunnelseType.AVSLAG,
             BegrunnelseType.EØS_AVSLAG,
-            -> finnVilkårResultaterSomStarterSamtidigSomPeriode() + finnVilkårResultaterSomSlutterFørPeriode()
+                -> finnVilkårResultaterSomStarterSamtidigSomPeriode() + finnVilkårResultaterSomSlutterFørPeriode()
 
             BegrunnelseType.FORTSATT_INNVILGET -> throw Feil("FORTSATT_INNVILGET skal være filtrert bort.")
         }
@@ -338,7 +338,7 @@ class BegrunnelserForPeriodeContext(
         BegrunnelseType.EØS_INNVILGET,
         BegrunnelseType.ENDRET_UTBETALING,
         BegrunnelseType.INNVILGET,
-        -> finnPersonerMedVilkårResultaterSomGjelderIPeriode()
+            -> finnPersonerMedVilkårResultaterSomGjelderIPeriode()
 
         BegrunnelseType.AVSLAG, BegrunnelseType.EØS_AVSLAG ->
             finnPersonerMedIkkeOppfylteVilkårResultaterSomStarterSamtidigSomEllerRettFørPeriodeOgHarGjeldendeAvslagsbegrunnelse(standardBegrunnelse)
@@ -346,7 +346,7 @@ class BegrunnelserForPeriodeContext(
         BegrunnelseType.EØS_OPPHØR,
         BegrunnelseType.ETTER_ENDRET_UTBETALING,
         BegrunnelseType.OPPHØR,
-        -> {
+            -> {
             if (erFørsteVedtaksperiodeOgBegrunnelseInneholderGjelderFørstePeriodeTrigger) finnPersonerMedVilkårResultatIFørsteVedtaksperiodeSomIkkeErOppfylt() else finnPersonerMedVilkårResultaterSomGjelderRettFørPeriode()
         }
 
@@ -462,7 +462,7 @@ class BegrunnelserForPeriodeContext(
                         .singleOrNull {
                             it.tom?.plusDays(1) == vedtaksperiode.fom
                         }?.verdi
-                        ?.filter { it.erOppfylt() }
+                        ?.filter { it.erOppfylt() || it.erIkkeAktuelt() }
 
                 if (vilkårResultatSomSlutterFørVedtaksperiode != null) {
                     Pair(person, vilkårResultatSomSlutterFørVedtaksperiode)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -74,11 +74,11 @@ class BegrunnelserForPeriodeContext(
         return when (this.utvidetVedtaksperiodeMedBegrunnelser.type) {
             Vedtaksperiodetype.FORTSATT_INNVILGET,
             Vedtaksperiodetype.AVSLAG,
-                -> tillateBegrunnelserForVedtakstype
+            -> tillateBegrunnelserForVedtakstype
 
             Vedtaksperiodetype.UTBETALING,
             Vedtaksperiodetype.OPPHØR,
-                -> tillateBegrunnelserForVedtakstype.filtrerErGyldigForVedtaksperiode()
+            -> tillateBegrunnelserForVedtakstype.filtrerErGyldigForVedtaksperiode()
         }
     }
 
@@ -105,7 +105,7 @@ class BegrunnelserForPeriodeContext(
 
         val personerSomMatcherBegrunnelseIPeriode =
             hentPersonerSomPasserMedBegrunnelseOgPeriode(this, sanityBegrunnelse) +
-                    hentPersonerSomPasserForKompetanseIPeriode(this, sanityBegrunnelse)
+                hentPersonerSomPasserForKompetanseIPeriode(this, sanityBegrunnelse)
 
         return when {
             sanityBegrunnelse.skalAlltidVises -> true
@@ -249,11 +249,11 @@ class BegrunnelserForPeriodeContext(
         val personerMedEndretUtbetalingsAndelerSomPasserVedtaksperioden = hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse)
 
         return (
-                personerMedVilkårResultaterSomPasserVedtaksperioden.keys +
-                        personerMedOvergangsordningAndel +
-                        personerMedOvergangsordningAndelerSomSlutterRettFørVedtaksperiode +
-                        personerMedEndretUtbetalingsAndelerSomPasserVedtaksperioden
-                ).toSet()
+            personerMedVilkårResultaterSomPasserVedtaksperioden.keys +
+                personerMedOvergangsordningAndel +
+                personerMedOvergangsordningAndelerSomSlutterRettFørVedtaksperiode +
+                personerMedEndretUtbetalingsAndelerSomPasserVedtaksperioden
+        ).toSet()
     }
 
     fun hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse: SanityBegrunnelse): Set<Person> =
@@ -263,7 +263,7 @@ class BegrunnelserForPeriodeContext(
                     endretUtbetalingAndel.periode.tom
                         .sisteDagIInneværendeMåned()
                         .erDagenFør(utvidetVedtaksperiodeMedBegrunnelser.fom) &&
-                            sanityBegrunnelse.endringsårsaker.contains(endretUtbetalingAndel.årsak)
+                        sanityBegrunnelse.endringsårsaker.contains(endretUtbetalingAndel.årsak)
 
                 val endretUtbetalingAndelStarterSamtidigSomVedtaksperiode = endretUtbetalingAndel.fom == utvidetVedtaksperiodeMedBegrunnelser.fom?.toYearMonth()
 
@@ -280,7 +280,7 @@ class BegrunnelserForPeriodeContext(
                 vilkårResultaterSomPasserMedVedtaksperiodeDato.contains(
                     vilkårResultat.id,
                 ) ||
-                        begrunnelseType == SanityBegrunnelseType.STANDARD
+                    begrunnelseType == SanityBegrunnelseType.STANDARD
             }
         }.filterValues { it.isNotEmpty() }
 
@@ -291,16 +291,16 @@ class BegrunnelserForPeriodeContext(
             BegrunnelseType.EØS_INNVILGET,
             BegrunnelseType.ENDRET_UTBETALING,
             BegrunnelseType.INNVILGET,
-                -> finnVilkårResultaterSomStarterSamtidigSomPeriode()
+            -> finnVilkårResultaterSomStarterSamtidigSomPeriode()
 
             BegrunnelseType.EØS_OPPHØR,
             BegrunnelseType.ETTER_ENDRET_UTBETALING,
             BegrunnelseType.OPPHØR,
-                -> finnVilkårResultaterSomSlutterFørPeriode()
+            -> finnVilkårResultaterSomSlutterFørPeriode()
 
             BegrunnelseType.AVSLAG,
             BegrunnelseType.EØS_AVSLAG,
-                -> finnVilkårResultaterSomStarterSamtidigSomPeriode() + finnVilkårResultaterSomSlutterFørPeriode()
+            -> finnVilkårResultaterSomStarterSamtidigSomPeriode() + finnVilkårResultaterSomSlutterFørPeriode()
 
             BegrunnelseType.FORTSATT_INNVILGET -> throw Feil("FORTSATT_INNVILGET skal være filtrert bort.")
         }
@@ -338,7 +338,7 @@ class BegrunnelserForPeriodeContext(
         BegrunnelseType.EØS_INNVILGET,
         BegrunnelseType.ENDRET_UTBETALING,
         BegrunnelseType.INNVILGET,
-            -> finnPersonerMedVilkårResultaterSomGjelderIPeriode()
+        -> finnPersonerMedVilkårResultaterSomGjelderIPeriode()
 
         BegrunnelseType.AVSLAG, BegrunnelseType.EØS_AVSLAG ->
             finnPersonerMedIkkeOppfylteVilkårResultaterSomStarterSamtidigSomEllerRettFørPeriodeOgHarGjeldendeAvslagsbegrunnelse(standardBegrunnelse)
@@ -346,7 +346,7 @@ class BegrunnelserForPeriodeContext(
         BegrunnelseType.EØS_OPPHØR,
         BegrunnelseType.ETTER_ENDRET_UTBETALING,
         BegrunnelseType.OPPHØR,
-            -> {
+        -> {
             if (erFørsteVedtaksperiodeOgBegrunnelseInneholderGjelderFørstePeriodeTrigger) finnPersonerMedVilkårResultatIFørsteVedtaksperiodeSomIkkeErOppfylt() else finnPersonerMedVilkårResultaterSomGjelderRettFørPeriode()
         }
 

--- a/src/test/resources/cucumber/vedtaksperioder/opphør.feature
+++ b/src/test/resources/cucumber/vedtaksperioder/opphør.feature
@@ -62,7 +62,7 @@ Egenskap: Opphørsperiode
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.08.2024 til -
       | Begrunnelse                                   | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
-      | OPPHØR_TILLEGSTEKST_FOR_REGLER_FØR_01_08_2024 | STANDARD | 1           | 20.03.23             | Nei           | 0     | august 2024                          | true                   | 0                           | juli 2024                    |
+      | OPPHØR_TILLEGSTEKST_FOR_REGLER_FØR_01_08_2024 | STANDARD | 1           | 20.03.23             | Nei           | 0     | august 2024                          | true                   | 0                           | juli 2024                      |
 
 
   Scenario: Opphørsperioder som oppstår i mellom perioder skal ha tom dato, opphørsperioder som oppstår
@@ -180,3 +180,79 @@ Egenskap: Opphørsperiode
       | Fra dato   | Til dato | Standardbegrunnelser                         | Eøsbegrunnelser | Fritekster |
       | 01.08.2024 |          |                                              |                 |            |
       | 01.08.2024 |          | AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024 |                 |            |
+
+
+  Scenario: Ikke aktuelt vilkår som ender rett før en opphørsperiode skal være regnes som utgjørende vilkår
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | NYE_OPPLYSNINGER | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 04.08.1983  |
+      | 1            | 2       | BARN       | 01.05.2022  |
+      | 1            | 3       | BARN       | 29.11.2023  |
+      | 2            | 1       | SØKER      | 04.08.1983  |
+      | 2            | 2       | BARN       | 01.05.2022  |
+
+    Og følgende dagens dato 13.02.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser                             | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 27.01.2000 |            | OPPFYLT      | Nei                  |                                                  | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 27.01.2005 |            | OPPFYLT      | Nei                  |                                                  | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                                                  | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.05.2022 |            | OPPFYLT      | Nei                  |                                                  |                  | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 01.05.2022 |            | OPPFYLT      | Nei                  |                                                  | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 01.05.2023 | 01.05.2024 | OPPFYLT      | Nei                  |                                                  |                  | Nei                                   |              |
+
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_OPPFYLT | Ja                   | AVSLAG_DEN_ANDRE_FORELDEREN_IKKE_MEDLEM_I_FEM_ÅR | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 29.11.2023 |            | OPPFYLT      | Nei                  |                                                  | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               |                  | 29.11.2023 |            | OPPFYLT      | Nei                  |                                                  |                  | Nei                                   |              |
+      | 3       | BARNETS_ALDER                |                  | 29.12.2024 | 29.06.2025 | OPPFYLT      | Nei                  |                                                  |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 27.01.2000 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 27.01.2005 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | BARNEHAGEPLASS               |                  | 01.05.2022 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 01.05.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 01.05.2022 | 16.11.2023 | IKKE_AKTUELT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 01.05.2023 | 01.05.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 17.11.2023 |            | IKKE_OPPFYLT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.06.2023 | 31.10.2023 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+    Og når behandlingsresultatet er utledet for behandling 2
+    Så forvent at behandlingsresultatet er OPPHØRT på behandling 2
+
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
+      | 01.11.2023 |          | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                                    | Ugyldige begrunnelser |
+      | 01.11.2023 |          | OPPHØR             |                                | OPPHØR_ANNEN_FORELDER_IKKE_MEDLEM_FOLKETRYGDEN_I_FEM_ÅR |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato | Standardbegrunnelser                                    | Eøsbegrunnelser | Fritekster |
+      | 01.11.2023 |          | OPPHØR_ANNEN_FORELDER_IKKE_MEDLEM_FOLKETRYGDEN_I_FEM_ÅR |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.11.2023 til -
+      | Begrunnelse                                             | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Målform | Gjelder andre forelder | Måned og år før vedtaksperiode |
+      | OPPHØR_ANNEN_FORELDER_IKKE_MEDLEM_FOLKETRYGDEN_I_FEM_ÅR | STANDARD |               | 01.05.22             | 1           | november 2023                        | 0     |                  | 0                           |         |                        | oktober 2023                   |


### PR DESCRIPTION
Favrokort:  https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24092

Dersom et ikke aktuelt vilkår ender rett før en opphørsperiode, så må det også regnes ut som den utgjørende vilkår, på samme måte som oppfylte vilkår.