### PR TITLE
Adopsjon: bedre validering ved oppdatering av adopsjonsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ks.sak.kjerne.adopsjon
 
+import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import org.springframework.stereotype.Component
+import java.time.LocalDate
 
 @Component
 class AdopsjonValidator {
@@ -33,6 +35,31 @@ class AdopsjonValidator {
                     frontendFeilmelding = "Du må fjerne adopsjonsdato for barn ${personResultat.aktør.aktivFødselsnummer()} på 'barnets alder'-vilkåret eller legge til adopsjon i utdypende vilkårsvurdering",
                 )
             }
+        }
+    }
+
+    fun validerAtAdopsjonsdatoKanEndres(
+        vilkårType: Vilkår,
+        utypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
+        nyAdopsjonsdato: LocalDate?
+    ){
+        if (vilkårType != Vilkår.BARNETS_ALDER){
+            throw Feil("Prøver å oppdatere adopsjonsdato på $vilkårType, men adopsjonsdato kan ikke oppdateres for andre vilkår enn barnets alder")
+        }
+        val adopsjonIUtdypendeVilkårsvurdering = utypendeVilkårsvurdering.contains(UtdypendeVilkårsvurdering.ADOPSJON)
+
+        if (adopsjonIUtdypendeVilkårsvurdering && nyAdopsjonsdato == null) {
+            throw FunksjonellFeil(
+                melding = "Adopsjon er valgt i utdypende vilkårsvurdering, men det mangler adopsjonsdato",
+                frontendFeilmelding = "Du må legge til adopsjonsdato eller fjerne adopsjon i utdypende vilkårsvurdering",
+            )
+        }
+
+        if (!adopsjonIUtdypendeVilkårsvurdering && nyAdopsjonsdato != null) {
+            throw FunksjonellFeil(
+                melding = "Adopsjon er ikke valgt i utdypende vilkårsvurdering, men det er lagret en adopsjonsdato",
+                frontendFeilmelding = "Du må fjerne adopsjonsdato eller legge til adopsjon i utdypende vilkårsvurdering",
+            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -48,11 +48,11 @@ class AdopsjonValidator(
         vilkårType: Vilkår,
         utypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
         nyAdopsjonsdato: LocalDate?,
-    ){
+    ) {
         if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
             return
         }
-        if (vilkårType != Vilkår.BARNETS_ALDER){
+        if (vilkårType != Vilkår.BARNETS_ALDER) {
             throw Feil("Prøver å oppdatere adopsjonsdato på $vilkårType, men adopsjonsdato kan ikke oppdateres for andre vilkår enn barnets alder")
         }
         val adopsjonIUtdypendeVilkårsvurdering = utypendeVilkårsvurdering.contains(UtdypendeVilkårsvurdering.ADOPSJON)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -46,7 +46,7 @@ class AdopsjonValidator(
 
     fun validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(
         vilkårType: Vilkår,
-        utypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
+        utdypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
         nyAdopsjonsdato: LocalDate?,
     ) {
         if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
@@ -55,7 +55,7 @@ class AdopsjonValidator(
         if (vilkårType != Vilkår.BARNETS_ALDER) {
             throw Feil("Prøver å oppdatere adopsjonsdato på $vilkårType, men adopsjonsdato kan ikke oppdateres for andre vilkår enn barnets alder")
         }
-        val adopsjonIUtdypendeVilkårsvurdering = utypendeVilkårsvurdering.contains(UtdypendeVilkårsvurdering.ADOPSJON)
+        val adopsjonIUtdypendeVilkårsvurdering = utdypendeVilkårsvurdering.contains(UtdypendeVilkårsvurdering.ADOPSJON)
 
         if (adopsjonIUtdypendeVilkårsvurdering && nyAdopsjonsdato == null) {
             throw FunksjonellFeil(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -45,15 +45,15 @@ class AdopsjonValidator(
     }
 
     fun validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(
-        vilkårType: Vilkår,
+        vilkår: Vilkår,
         utdypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
         nyAdopsjonsdato: LocalDate?,
     ) {
         if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
             return
         }
-        if (vilkårType != Vilkår.BARNETS_ALDER) {
-            throw Feil("Prøver å oppdatere adopsjonsdato på $vilkårType, men adopsjonsdato kan ikke oppdateres for andre vilkår enn barnets alder")
+        if (vilkår != Vilkår.BARNETS_ALDER) {
+            throw Feil("Prøver å oppdatere adopsjonsdato på $vilkår-vilkåret, men adopsjonsdato kan ikke oppdateres for andre vilkår enn barnets alder")
         }
         val adopsjonIUtdypendeVilkårsvurdering = utdypendeVilkårsvurdering.contains(UtdypendeVilkårsvurdering.ADOPSJON)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -41,8 +41,12 @@ class AdopsjonValidator {
     fun validerAtAdopsjonsdatoKanEndresFraVilkår(
         vilkårType: Vilkår,
         utypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
-        nyAdopsjonsdato: LocalDate?
+        nyAdopsjonsdato: LocalDate?,
+        støtterAdopsjonILøsningen: Boolean
     ){
+        if (!støtterAdopsjonILøsningen) {
+            return
+        }
         if (vilkårType != Vilkår.BARNETS_ALDER){
             throw Feil("Prøver å oppdatere adopsjonsdato på $vilkårType, men adopsjonsdato kan ikke oppdateres for andre vilkår enn barnets alder")
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -38,7 +38,7 @@ class AdopsjonValidator {
         }
     }
 
-    fun validerAtAdopsjonsdatoKanEndres(
+    fun validerAtAdopsjonsdatoKanEndresFraVilkår(
         vilkårType: Vilkår,
         utypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
         nyAdopsjonsdato: LocalDate?

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ks.sak.kjerne.adopsjon
 
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
@@ -9,13 +11,14 @@ import org.springframework.stereotype.Component
 import java.time.LocalDate
 
 @Component
-class AdopsjonValidator {
+class AdopsjonValidator(
+    private val unleashService: UnleashNextMedContextService,
+) {
     fun validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(
         vilkårsvurdering: Vilkårsvurdering,
         adopsjonerIBehandling: List<Adopsjon>,
-        støtterAdopsjonILøsningen: Boolean,
     ) {
-        if (!støtterAdopsjonILøsningen) {
+        if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
             return
         }
         vilkårsvurdering.personResultater.forEach { personResultat ->
@@ -42,9 +45,8 @@ class AdopsjonValidator {
         vilkårType: Vilkår,
         utypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
         nyAdopsjonsdato: LocalDate?,
-        støtterAdopsjonILøsningen: Boolean
     ){
-        if (!støtterAdopsjonILøsningen) {
+        if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
             return
         }
         if (vilkårType != Vilkår.BARNETS_ALDER){

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -44,7 +44,7 @@ class AdopsjonValidator(
         }
     }
 
-    fun validerAtAdopsjonsdatoKanEndresFraVilkår(
+    fun validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(
         vilkårType: Vilkår,
         utypendeVilkårsvurdering: List<UtdypendeVilkårsvurdering>,
         nyAdopsjonsdato: LocalDate?,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -13,14 +13,17 @@ import java.time.LocalDate
 @Component
 class AdopsjonValidator(
     private val unleashService: UnleashNextMedContextService,
+    private val adopsjonService: AdopsjonService,
 ) {
     fun validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(
         vilkårsvurdering: Vilkårsvurdering,
-        adopsjonerIBehandling: List<Adopsjon>,
     ) {
         if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
             return
         }
+
+        val adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(behandlingId = vilkårsvurdering.behandling.behandlingId)
+
         vilkårsvurdering.personResultater.forEach { personResultat ->
             val adopsjonForPerson = adopsjonerIBehandling.firstOrNull { it.aktør == personResultat.aktør }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagSteg.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg
 
-import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
@@ -52,13 +51,13 @@ class RegistrerPersonGrunnlagSteg(
             )
 
             eøsSkjemaerForNyBehandlingService.kopierEøsSkjemaer(
-                forrigeBehandlingSomErVedtattId = BehandlingId(sisteVedtattBehandling.id),
-                behandlingId = BehandlingId(behandling.id),
+                forrigeBehandlingSomErVedtattId = sisteVedtattBehandling.behandlingId,
+                behandlingId = behandling.behandlingId,
             )
 
             adopsjonService.kopierAdopsjonerFraForrigeBehandling(
-                behandlingId = BehandlingId(behandling.id),
-                forrigeBehandlingId = BehandlingId(sisteVedtattBehandling.id),
+                behandlingId = behandling.behandlingId,
+                forrigeBehandlingId = sisteVedtattBehandling.behandlingId,
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -119,7 +119,6 @@ class VilkårsvurderingService(
                 vilkårType = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
                 utypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
                 nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato,
-                støtterAdopsjonILøsningen = unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)
             )
             adopsjonService.oppdaterAdopsjonsdato(behandlingId = BehandlingId(behandlingId), aktør = personResultat.aktør, nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato)
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -115,7 +115,7 @@ class VilkårsvurderingService(
             hentPersonResultatForPerson(vilkårsvurdering.personResultater, endreVilkårResultatDto.personIdent)
 
         if (endreVilkårResultatDto.endretVilkårResultat.vilkårType == Vilkår.BARNETS_ALDER) {
-            adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(
+            adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(
                 vilkårType = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
                 utypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
                 nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -117,7 +117,7 @@ class VilkårsvurderingService(
         if (endreVilkårResultatDto.endretVilkårResultat.vilkårType == Vilkår.BARNETS_ALDER) {
             adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(
                 vilkårType = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
-                utypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
+                utdypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
                 nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato,
             )
             adopsjonService.oppdaterAdopsjonsdato(behandlingId = BehandlingId(behandlingId), aktør = personResultat.aktør, nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -116,7 +116,7 @@ class VilkårsvurderingService(
 
         if (endreVilkårResultatDto.endretVilkårResultat.vilkårType == Vilkår.BARNETS_ALDER) {
             adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(
-                vilkårType = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
+                vilkår = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
                 utdypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
                 nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato,
             )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
+import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonValidator
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
@@ -36,6 +37,7 @@ class VilkårsvurderingService(
     private val personidentService: PersonidentService,
     private val unleashService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
+    private val adopsjonValidator: AdopsjonValidator,
 ) {
     @Transactional
     fun opprettVilkårsvurdering(
@@ -113,6 +115,11 @@ class VilkårsvurderingService(
             hentPersonResultatForPerson(vilkårsvurdering.personResultater, endreVilkårResultatDto.personIdent)
 
         if (endreVilkårResultatDto.endretVilkårResultat.vilkårType == Vilkår.BARNETS_ALDER) {
+            adopsjonValidator.validerAtAdopsjonsdatoKanEndres(
+                vilkårType = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
+                utypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
+                nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato
+            )
             adopsjonService.oppdaterAdopsjonsdato(behandlingId = BehandlingId(behandlingId), aktør = personResultat.aktør, nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato)
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -115,7 +115,7 @@ class VilkårsvurderingService(
             hentPersonResultatForPerson(vilkårsvurdering.personResultater, endreVilkårResultatDto.personIdent)
 
         if (endreVilkårResultatDto.endretVilkårResultat.vilkårType == Vilkår.BARNETS_ALDER) {
-            adopsjonValidator.validerAtAdopsjonsdatoKanEndres(
+            adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(
                 vilkårType = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
                 utypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
                 nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -118,7 +118,8 @@ class VilkårsvurderingService(
             adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(
                 vilkårType = endreVilkårResultatDto.endretVilkårResultat.vilkårType,
                 utypendeVilkårsvurdering = endreVilkårResultatDto.endretVilkårResultat.utdypendeVilkårsvurderinger,
-                nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato
+                nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato,
+                støtterAdopsjonILøsningen = unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)
             )
             adopsjonService.oppdaterAdopsjonsdato(behandlingId = BehandlingId(behandlingId), aktør = personResultat.aktør, nyAdopsjonsdato = endreVilkårResultatDto.adopsjonsdato)
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.slåSammen
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
-import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonValidator
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -50,7 +49,6 @@ class VilkårsvurderingSteg(
     private val barnetsVilkårValidator: BarnetsVilkårValidator,
     private val unleashNextMedContextService: UnleashNextMedContextService,
     private val adopsjonValidator: AdopsjonValidator,
-    private val adopsjonService: AdopsjonService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.VILKÅRSVURDERING
 
@@ -78,10 +76,7 @@ class VilkårsvurderingSteg(
 
         validerVilkårsvurdering(vilkårsvurdering, personopplysningGrunnlag, søknadDto, behandling)
 
-        adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(
-            vilkårsvurdering = vilkårsvurdering,
-            adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(behandlingId = BehandlingId(behandling.id)),
-        )
+        adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering)
 
         settBehandlingstemaBasertPåVilkårsvurdering(behandling, vilkårsvurdering)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -81,7 +81,6 @@ class VilkårsvurderingSteg(
         adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(
             vilkårsvurdering = vilkårsvurdering,
             adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(behandlingId = BehandlingId(behandling.id)),
-            støtterAdopsjonILøsningen = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_ADOPSJON),
         )
 
         settBehandlingstemaBasertPåVilkårsvurdering(behandling, vilkårsvurdering)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -132,7 +132,7 @@ class CucumberMock(
             loggService = loggServiceMock,
         )
 
-    val adopsjonValidator = AdopsjonValidator(mockUnleashNextMedContextService())
+    val adopsjonValidator = AdopsjonValidator(mockUnleashNextMedContextService(), adopsjonServiceMock)
 
     val vilkårsvurderingService =
         VilkårsvurderingService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.cucumber.StepDefinition
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.integrasjon.pdl.PdlClient
 import no.nav.familie.ks.sak.integrasjon.pdl.PersonopplysningerService
+import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonValidator
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
@@ -139,6 +140,7 @@ class CucumberMock(
             personidentService = personidentService,
             unleashService = mockUnleashNextMedContextService(),
             adopsjonService = adopsjonServiceMock,
+            adopsjonValidator = AdopsjonValidator()
         )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -132,6 +132,8 @@ class CucumberMock(
             loggService = loggServiceMock,
         )
 
+    val adopsjonValidator = AdopsjonValidator(mockUnleashNextMedContextService())
+
     val vilkårsvurderingService =
         VilkårsvurderingService(
             vilkårsvurderingRepository = vilkårsvurderingRepositoryMock,
@@ -140,7 +142,7 @@ class CucumberMock(
             personidentService = personidentService,
             unleashService = mockUnleashNextMedContextService(),
             adopsjonService = adopsjonServiceMock,
-            adopsjonValidator = AdopsjonValidator()
+            adopsjonValidator = adopsjonValidator,
         )
 }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -129,32 +129,32 @@ class AdopsjonValidatorTest {
         every { unleashServiceMock.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns false
 
         // Act & Assert
-        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkår = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato på et annet vilkår enn barnets alder`() {
-        assertThrows<Feil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertThrows<Feil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkår = Vilkår.BARNEHAGEPLASS, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato uten adopsjon i utdypende, men med adopsjonsdato`() {
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkår = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med adopsjon i utdypende, men uten adopsjonsdato`() {
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkår = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med både adopsjon i utdypende og med adopsjonsdato`() {
-        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkår = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med verken adopsjon i utdypende eller med adopsjonsdato`() {
-        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkår = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     private fun lagVilkårResultaterForBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -104,22 +104,22 @@ class AdopsjonValidatorTest {
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato på et annet vilkår enn barnets alder`(){
-        assertThrows<Feil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndres(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertThrows<Feil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato uten adopsjon i utdypende, men med adopsjonsdato`(){
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndres(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med adopsjon i utdypende, men uten adopsjonsdato`(){
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndres(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med både adopsjon i utdypende og med adopsjonsdato`(){
-        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndres(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     private fun lagVilkårResultaterForBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -125,32 +125,32 @@ class AdopsjonValidatorTest {
         every { unleashServiceMock.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns false
 
         // Act & Assert
-        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato på et annet vilkår enn barnets alder`(){
-        assertThrows<Feil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertThrows<Feil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato uten adopsjon i utdypende, men med adopsjonsdato`(){
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med adopsjon i utdypende, men uten adopsjonsdato`(){
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med både adopsjon i utdypende og med adopsjonsdato`(){
-        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med verken adopsjon i utdypende eller med adopsjonsdato`(){
-        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     private fun lagVilkårResultaterForBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -22,7 +22,8 @@ import java.time.LocalDate
 
 class AdopsjonValidatorTest {
     private val unleashServiceMock: UnleashNextMedContextService = mockk()
-    private val adopsjonValidator = AdopsjonValidator(unleashService = unleashServiceMock)
+    private val adopsjonServiceMock: AdopsjonService = mockk()
+    private val adopsjonValidator = AdopsjonValidator(unleashService = unleashServiceMock, adopsjonService = adopsjonServiceMock)
 
     @BeforeEach
     fun setup(){
@@ -45,9 +46,10 @@ class AdopsjonValidatorTest {
             }
 
         val adopsjoner = listOf(Adopsjon(behandlingId = vilkårsvurdering.behandling.id, aktør = barn2.aktør, adopsjonsdato = barn2.fødselsdato.plusMonths(2)))
+        every { adopsjonServiceMock.hentAlleAdopsjonerForBehandling(any()) } returns adopsjoner
 
         // Act & Assert
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering, adopsjonerIBehandling = adopsjoner) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering) }
     }
 
     @Test
@@ -66,9 +68,10 @@ class AdopsjonValidatorTest {
             }
 
         val adopsjoner = listOf(Adopsjon(behandlingId = vilkårsvurdering.behandling.id, aktør = barn.aktør, adopsjonsdato = barn.fødselsdato.plusMonths(2)))
+        every { adopsjonServiceMock.hentAlleAdopsjonerForBehandling(any()) } returns adopsjoner
 
         // Act & Assert
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering, adopsjonerIBehandling = adopsjoner) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering) }
     }
 
     @Test
@@ -87,9 +90,10 @@ class AdopsjonValidatorTest {
             }
 
         val adopsjoner = listOf(Adopsjon(behandlingId = vilkårsvurdering.behandling.id, aktør = barn.aktør, adopsjonsdato = barn.fødselsdato.plusMonths(2)))
+        every { adopsjonServiceMock.hentAlleAdopsjonerForBehandling(any()) } returns adopsjoner
 
         // Act & Assert
-        assertDoesNotThrow { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering, adopsjonerIBehandling = adopsjoner) }
+        assertDoesNotThrow { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering) }
     }
 
     @Test
@@ -108,11 +112,11 @@ class AdopsjonValidatorTest {
             }
 
         val adopsjoner = listOf(Adopsjon(behandlingId = vilkårsvurdering.behandling.id, aktør = barn2.aktør, adopsjonsdato = barn2.fødselsdato.plusMonths(2)))
-
+        every { adopsjonServiceMock.hentAlleAdopsjonerForBehandling(any()) } returns adopsjoner
         every { unleashServiceMock.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns false
 
         // Act & Assert
-        assertDoesNotThrow { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering, adopsjonerIBehandling = adopsjoner) }
+        assertDoesNotThrow { adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering) }
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -11,7 +11,11 @@ import no.nav.familie.ks.sak.data.lagPersonResultat
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.lagVilkårsvurdering
 import no.nav.familie.ks.sak.data.randomAktør
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.*
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.lagAutomatiskGenererteVilkårForBarnetsAlder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.junit.jupiter.api.BeforeEach
@@ -26,7 +30,7 @@ class AdopsjonValidatorTest {
     private val adopsjonValidator = AdopsjonValidator(unleashService = unleashServiceMock, adopsjonService = adopsjonServiceMock)
 
     @BeforeEach
-    fun setup(){
+    fun setup() {
         every { unleashServiceMock.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns true
     }
 
@@ -120,7 +124,7 @@ class AdopsjonValidatorTest {
     }
 
     @Test
-    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med ugyldig tilstand, men toggle for at vi støtter adopsjon er ikke påskrudd`(){
+    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med ugyldig tilstand, men toggle for at vi støtter adopsjon er ikke påskrudd`() {
         // Arrange
         every { unleashServiceMock.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns false
 
@@ -129,27 +133,27 @@ class AdopsjonValidatorTest {
     }
 
     @Test
-    fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato på et annet vilkår enn barnets alder`(){
+    fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato på et annet vilkår enn barnets alder`() {
         assertThrows<Feil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     @Test
-    fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato uten adopsjon i utdypende, men med adopsjonsdato`(){
+    fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato uten adopsjon i utdypende, men med adopsjonsdato`() {
         assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
-    fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med adopsjon i utdypende, men uten adopsjonsdato`(){
+    fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med adopsjon i utdypende, men uten adopsjonsdato`() {
         assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
-    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med både adopsjon i utdypende og med adopsjonsdato`(){
+    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med både adopsjon i utdypende og med adopsjonsdato`() {
         assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
-    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med verken adopsjon i utdypende eller med adopsjonsdato`(){
+    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med verken adopsjon i utdypende eller med adopsjonsdato`() {
         assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -103,23 +103,33 @@ class AdopsjonValidatorTest {
     }
 
     @Test
+    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato, men toggle for at vi støtter adopsjon er ikke påskrudd`(){
+        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null, støtterAdopsjonILøsningen = false) }
+    }
+
+    @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato på et annet vilkår enn barnets alder`(){
-        assertThrows<Feil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertThrows<Feil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null, støtterAdopsjonILøsningen = true) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato uten adopsjon i utdypende, men med adopsjonsdato`(){
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1), støtterAdopsjonILøsningen = true) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med adopsjon i utdypende, men uten adopsjonsdato`(){
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null, støtterAdopsjonILøsningen = true) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med både adopsjon i utdypende og med adopsjonsdato`(){
-        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1), støtterAdopsjonILøsningen = true) }
+    }
+
+    @Test
+    fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med verken adopsjon i utdypende eller med adopsjonsdato`(){
+        assertDoesNotThrow { adopsjonValidator.validerAtAdopsjonsdatoKanEndresFraVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null, støtterAdopsjonILøsningen = true) }
     }
 
     private fun lagVilkårResultaterForBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -129,32 +129,32 @@ class AdopsjonValidatorTest {
         every { unleashServiceMock.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns false
 
         // Act & Assert
-        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato på et annet vilkår enn barnets alder`() {
-        assertThrows<Feil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertThrows<Feil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNEHAGEPLASS, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato uten adopsjon i utdypende, men med adopsjonsdato`() {
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
     fun `Skal kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med adopsjon i utdypende, men uten adopsjonsdato`() {
-        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
+        assertThrows<FunksjonellFeil> { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = null) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med både adopsjon i utdypende og med adopsjonsdato`() {
-        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = listOf(UtdypendeVilkårsvurdering.ADOPSJON), nyAdopsjonsdato = LocalDate.now().minusYears(1)) }
     }
 
     @Test
     fun `Skal ikke kaste feil hvis man validerer at man kan oppdatere adopsjonsdato med verken adopsjon i utdypende eller med adopsjonsdato`() {
-        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
+        assertDoesNotThrow { adopsjonValidator.validerGyldigAdopsjonstilstandForBarnetsAlderVilkår(vilkårType = Vilkår.BARNETS_ALDER, utdypendeVilkårsvurdering = emptyList(), nyAdopsjonsdato = null) }
     }
 
     private fun lagVilkårResultaterForBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -56,7 +56,7 @@ class VilkårsvurderingServiceTest {
             personidentService,
             unleashService,
             adopsjonService,
-            adopsjonValidator
+            adopsjonValidator,
         )
 
     private val søker = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseType
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityResultat
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
+import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonValidator
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
@@ -46,6 +47,7 @@ class VilkårsvurderingServiceTest {
     private val personidentService: PersonidentService = mockk()
     private val unleashService: UnleashNextMedContextService = mockk()
     private val adopsjonService: AdopsjonService = mockk()
+    private val adopsjonValidator: AdopsjonValidator = mockk()
     private val vilkårsvurderingService =
         VilkårsvurderingService(
             vilkårsvurderingRepository,
@@ -54,6 +56,7 @@ class VilkårsvurderingServiceTest {
             personidentService,
             unleashService,
             adopsjonService,
+            adopsjonValidator
         )
 
     private val søker = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -82,7 +82,7 @@ class VilkårsvurderingStegTest {
                 unleashService,
             ),
         )
-    private val adopsjonValidator = AdopsjonValidator()
+    private val adopsjonValidator = AdopsjonValidator(unleashService)
 
     private val vilkårsvurderingSteg: VilkårsvurderingSteg =
         VilkårsvurderingSteg(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -82,7 +82,7 @@ class VilkårsvurderingStegTest {
                 unleashService,
             ),
         )
-    private val adopsjonValidator = AdopsjonValidator(unleashService)
+    private val adopsjonValidator = AdopsjonValidator(unleashService, adopsjonService)
 
     private val vilkårsvurderingSteg: VilkårsvurderingSteg =
         VilkårsvurderingSteg(
@@ -95,7 +95,6 @@ class VilkårsvurderingStegTest {
             barnetsVilkårValidator,
             unleashService,
             adopsjonValidator,
-            adopsjonService,
         )
 
     private val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24277

Legger på mer validering for adopsjonsdato når man er på barnets alder-vilkåret. På barnets alder-vilkåret skal man alltid enten sende med: 
- BÅDE adopsjon i utdypende vilkårsvurdering OG adopsjonsdato
- Ingen av delene

Hvis man har den ene, men ikke den andre, ønsker vi å kaste en feil. Gjør det kun hvis toggle er på, men hadde vel strengt tatt ikke trengt det. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
