### PR TITLE
Kast FunksjonellFeil i stedet for å tryne med NoSuchElementException for VilkårsResultater.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -85,8 +85,14 @@ fun endreVilkårResultat(
         endretVilkårResultat = endretVilkårResultatDto,
     )
 
-    val endretVilkårResultat =
-        endretVilkårResultatDto.tilVilkårResultat(eksisterendeVilkårResultater.single { it.id == endretVilkårResultatDto.id })
+    val eksisterendeVilkårsResultat =
+        eksisterendeVilkårResultater.singleOrNull { it.id == endretVilkårResultatDto.id }
+            ?: throw FunksjonellFeil(
+                "Fant ikke eksisterende vilkårsresultat med id: ${endretVilkårResultatDto.id}. Mulig knyttet til problem med flere faner",
+                "Fant ikke eksisterende vilkårsresultat med id: ${endretVilkårResultatDto.id}. Kontroller at vilkårsresultatet eksisterer ved å f.eks laste inn siden på nytt.",
+            )
+
+    val endretVilkårResultat = endretVilkårResultatDto.tilVilkårResultat(eksisterendeVilkårsResultat)
 
     val (vilkårResultaterSomSkalTilpasses, vilkårResultaterSomIkkeTrengerTilpassning) =
         eksisterendeVilkårResultater.partition {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -88,8 +88,8 @@ fun endreVilkårResultat(
     val eksisterendeVilkårsResultat =
         eksisterendeVilkårResultater.singleOrNull { it.id == endretVilkårResultatDto.id }
             ?: throw FunksjonellFeil(
-                "Fant ikke eksisterende vilkårsresultat med id: ${endretVilkårResultatDto.id}. Mulig knyttet til problem med flere faner",
-                "Fant ikke eksisterende vilkårsresultat med id: ${endretVilkårResultatDto.id}. Kontroller at vilkårsresultatet eksisterer ved å f.eks laste inn siden på nytt.",
+                melding = "Fant ikke eksisterende vilkårsresultat med id: ${endretVilkårResultatDto.id}. Mulig knyttet til problem med flere faner",
+                frontendFeilmelding = "Vilkårene har endret seg siden sist gang du lastet inn siden. Vennligst forsøk å laste inn siden på nytt",
             )
 
     val endretVilkårResultat = endretVilkårResultatDto.tilVilkårResultat(eksisterendeVilkårsResultat)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Reduserer støy i feilmeldinger og gir informasjon til saksbehandlere om hva som faktisk har skjedd.

Typisk opphav til feilen er hvis behandlingen er åpen i to faner og man bruker en utdatert ID. Feilmeldingen vil derfor foreslå å laste inn siden på nytt.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Gi gjerne tilbakemelding om teksten til saksbehandler er formulert på en god måte.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Midlertidig feilmelding inntil rotårsaken av problemet er fikset.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
