### PR TITLE
Lovverk 2025: ikke send med lovverk til frontend

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VilkårsvurderingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VilkårsvurderingDto.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.IBegrunnelse
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.IBegrunnelseDeserializer
-import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -19,7 +18,6 @@ data class PersonResultatResponsDto(
     val personIdent: String,
     val vilkårResultater: List<VilkårResultatDto>,
     val andreVurderinger: List<AnnenVurderingDto>,
-    val lovverk: Lovverk?,
 )
 
 data class EndreVilkårResultatDto(

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
@@ -93,10 +93,7 @@ object BehandlingMapper {
         personer = personer,
         personResultater =
             personResultater?.map { personResultat ->
-                VilkårsvurderingMapper.lagPersonResultatRespons(
-                    personResultat,
-                    personer.find { it.personIdent == personResultat.aktør.aktivFødselsnummer() }!!,
-                )
+                VilkårsvurderingMapper.lagPersonResultatRespons(personResultat)
             }
                 ?: emptyList(),
         behandlingPåVent =

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/VilkårsvurderingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/VilkårsvurderingMapper.kt
@@ -1,25 +1,21 @@
 package no.nav.familie.ks.sak.api.mapper
 
 import no.nav.familie.ks.sak.api.dto.AnnenVurderingDto
-import no.nav.familie.ks.sak.api.dto.PersonResponsDto
 import no.nav.familie.ks.sak.api.dto.PersonResultatResponsDto
 import no.nav.familie.ks.sak.api.dto.VilkårResultatDto
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.AnnenVurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
-import no.nav.familie.ks.sak.kjerne.lovverk.LovverkUtleder
 
 object VilkårsvurderingMapper {
     fun lagPersonResultatRespons(
         personResultat: PersonResultat,
-        person: PersonResponsDto,
     ) =
         PersonResultatResponsDto(
             personIdent = personResultat.aktør.aktivFødselsnummer(),
             vilkårResultater = personResultat.vilkårResultater.map { lagVilkårResultatRespons(it) },
             andreVurderinger = personResultat.andreVurderinger.map { lagAnnenVurderingRespons(it) },
-            lovverk = if (personResultat.erSøkersResultater()) null else LovverkUtleder.utledLovverkForBarn(fødselsdato = person.fødselsdato!!, adopsjonsdato = person.adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = true),
         )
 
     private fun lagVilkårResultatRespons(vilkårResultat: VilkårResultat) =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -17,10 +17,7 @@ import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
-import no.nav.familie.ks.sak.data.lagPersonResultat
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
-import no.nav.familie.ks.sak.data.lagVilkårResultat
-import no.nav.familie.ks.sak.data.lagVilkårsvurdering
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.oppgave.OppgaveService
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
@@ -39,7 +36,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.feilutbetaltvaluta.Fe
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.refusjonEøs.RefusjonEøsService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.VedtaksperiodeService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
-import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbetalingerService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.brev.mottaker.BrevmottakerService
@@ -48,7 +44,6 @@ import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPerio
 import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.ValutakursRepository
 import no.nav.familie.ks.sak.kjerne.korrigertetterbetaling.KorrigertEtterbetalingRepository
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
-import no.nav.familie.ks.sak.kjerne.lovverk.Lovverk
 import no.nav.familie.ks.sak.kjerne.overgangsordning.OvergangsordningAndelService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.StatsborgerskapService
@@ -64,7 +59,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
-import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
 class BehandlingServiceTest {
@@ -220,45 +214,6 @@ class BehandlingServiceTest {
         assertNotNull(behandlingResponsDto.søknadsgrunnlag)
         assertTrue { behandlingResponsDto.personerMedAndelerTilkjentYtelse.isNotEmpty() }
         assertNull(behandlingResponsDto.endringstidspunkt)
-    }
-
-    @Test
-    fun `lagBehandlingRespons - skal inkludere lovverk i personResultater for barn`() {
-        val barn = randomAktør()
-        val barnsIdent = barn.personidenter.first { personIdent -> personIdent.aktiv }.fødselsnummer
-
-        every { mockPersonopplysningGrunnlagService.finnAktivPersonopplysningGrunnlag(any()) } returns
-            lagPersonopplysningGrunnlag(
-                behandlingId = behandling.id,
-                søkerPersonIdent = søkersIdent,
-                barnasIdenter = listOf(barnsIdent),
-                barnasFødselsdatoer = listOf(LocalDate.of(2020, 1, 1)),
-            )
-        every { mockVilkårsvurderingService.finnAktivVilkårsvurdering(any()) } returns
-            lagVilkårsvurdering(
-                behandling = behandling,
-                lagPersonResultat = { vilkårsvurdering ->
-                    setOf(
-                        lagPersonResultat(
-                            vilkårsvurdering = vilkårsvurdering,
-                            aktør = barn,
-                            lagVilkårResultater = { personResultat ->
-                                setOf(
-                                    lagVilkårResultat(
-                                        personResultat = personResultat,
-                                        vilkårType = Vilkår.BARNETS_ALDER,
-                                    ),
-                                )
-                            },
-                        ),
-                    )
-                },
-            )
-        val behandlingResponsDto = behandlingService.lagBehandlingRespons(behandling.id)
-
-        assertTrue { behandlingResponsDto.personer.isNotEmpty() }
-        assertEquals(2, behandlingResponsDto.personer.size)
-        assertEquals(behandlingResponsDto.personResultater[0].lovverk, Lovverk.FØR_LOVENDRING_2025)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
I [denne PRen](https://github.com/navikt/familie-ks-sak-frontend/pull/1052) fjernet jeg at frontend bruker lovverk-verdien som sendes fra backend, men heller utleder den selv (se begrunnelse i PRen jeg lenket til). Derfor trenger vi heller ikke sende med denne verdien fra backend lenger.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
