### PR TITLE
Fjerner kode rundt feature toggle regelverk 2025

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -12,7 +12,6 @@ enum class FeatureToggle(
 
     // Ikke operasjonelle
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
-    STØTTER_LOVENDRING_2025("familie-ks-sak.stotter-lovendring-2025"),
     STØTTER_ADOPSJON("familie-ks-sak.stotter-adopsjon"),
 
     ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK("familie-ks-sak.allerede-utbetalt"),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
 
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
@@ -57,7 +56,6 @@ class BehandlingsresultatSteg(
             tilkjentYtelse = tilkjentYtelseNåværendeBehandling,
             endretUtbetalingMedAndeler = endretUtbetalingMedAndeler,
             personResultaterForBarn = personResultaterForBarn,
-            skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
             adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(BehandlingId(behandlingId)),
         )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
 
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
@@ -33,7 +32,6 @@ class BehandlingsresultatSteg(
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val overgangsordningAndelService: OvergangsordningAndelService,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.BEHANDLINGSRESULTAT

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -35,7 +35,6 @@ object BehandlingsresultatValideringUtils {
         tilkjentYtelse: TilkjentYtelse,
         endretUtbetalingMedAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
         personResultaterForBarn: List<PersonResultat>,
-        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
         adopsjonerIBehandling: List<Adopsjon>,
     ) {
         val alleBarnetsAlderVilkårResultater = personResultaterForBarn.flatMap { it.vilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.BARNETS_ALDER } }
@@ -45,7 +44,6 @@ object BehandlingsresultatValideringUtils {
             tilkjentYtelse = tilkjentYtelse,
             personopplysningGrunnlag = personopplysningGrunnlag,
             alleBarnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater,
-            skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             adopsjonerIBehandling = adopsjonerIBehandling,
         )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Opphørsperiode.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/Opphørsperiode.kt
@@ -46,7 +46,6 @@ fun mapTilOpphørsperioder(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
     vilkårsvurdering: Vilkårsvurdering,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     adopsjonerIBehandling: List<Adopsjon>,
 ): List<Opphørsperiode> {
     val forrigeUtbetalingsperioder =
@@ -75,7 +74,7 @@ fun mapTilOpphørsperioder(
             } else {
                 listOf(
                     finnOpphørsperioderMellomUtbetalingsperioder(utbetalingsperioder),
-                    finnOpphørsperiodeEtterSisteUtbetalingsperiode(utbetalingsperioder, vilkårsvurdering, personopplysningGrunnlag, skalBestemmeLovverkBasertPåFødselsdato, adopsjonerIBehandling),
+                    finnOpphørsperiodeEtterSisteUtbetalingsperiode(utbetalingsperioder, vilkårsvurdering, personopplysningGrunnlag, adopsjonerIBehandling),
                 ).flatten()
             }.sortedBy { it.periodeFom }
         }
@@ -124,7 +123,6 @@ private fun finnOpphørsperiodeEtterSisteUtbetalingsperiode(
     utbetalingsperioder: List<Utbetalingsperiode>,
     vilkårsvurdering: Vilkårsvurdering,
     personopplysningGrunnlag: PersonopplysningGrunnlag,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     adopsjonerIBehandling: List<Adopsjon>,
 ): List<Opphørsperiode> {
     val sisteUtbetalingsperiodeTom =
@@ -151,7 +149,7 @@ private fun finnOpphørsperiodeEtterSisteUtbetalingsperiode(
                     val adopsjonForBarnet = adopsjonerIBehandling.firstOrNull { it.aktør == personResultat.aktør }
 
                     val forskjøvetTomForSisteUtbetalingsperiodePgaFremtidigOpphør =
-                        forskyvTomBasertPåLovverkForSisteUtbetalingsperiodePgaFremtidigOpphør(barnet = barnet, adopsjon = adopsjonForBarnet, periodeTom = barnehageplassVilkårResultat.periodeTom!!, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+                        forskyvTomBasertPåLovverkForSisteUtbetalingsperiodePgaFremtidigOpphør(barnet = barnet, adopsjon = adopsjonForBarnet, periodeTom = barnehageplassVilkårResultat.periodeTom!!)
 
                     barnehageplassVilkårResultat.søkerHarMeldtFraOmBarnehageplass == true &&
                         forskjøvetTomForSisteUtbetalingsperiodePgaFremtidigOpphør == sisteUtbetalingsperiodeTom
@@ -176,9 +174,8 @@ private fun forskyvTomBasertPåLovverkForSisteUtbetalingsperiodePgaFremtidigOpph
     barnet: Person,
     adopsjon: Adopsjon?,
     periodeTom: LocalDate,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ): YearMonth? {
-    val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = barnet.fødselsdato, adopsjonsdato = adopsjon?.adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+    val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = barnet.fødselsdato, adopsjonsdato = adopsjon?.adopsjonsdato)
 
     val periodeTomForskjøvetTomMånedForSisteUtbetalingsperiodePgaFremtidigOpphør =
         when (lovverk) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -15,8 +15,6 @@ import no.nav.familie.ks.sak.common.util.storForbokstav
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
 import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
@@ -74,7 +72,6 @@ class VedtaksperiodeService(
     private val integrasjonClient: IntegrasjonClient,
     private val refusjonEøsRepository: RefusjonEøsRepository,
     private val kompetanseService: KompetanseService,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
 ) {
     fun oppdaterVedtaksperiodeMedFritekster(
@@ -406,15 +403,14 @@ class VedtaksperiodeService(
                     BegrunnelserForPeriodeContext(
                         utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
                         sanityBegrunnelser = sanityBegrunnelser,
+                        kompetanser = utfylteKompetanser,
                         personopplysningGrunnlag = persongrunnlag,
+                        adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(BehandlingId(behandling.id)),
+                        overgangsordningAndeler = overgangsordningAndelService.hentOvergangsordningAndeler(behandling.id),
                         personResultater = vilkårsvurdering.personResultater.toList(),
                         endretUtbetalingsandeler = endreteUtbetalinger,
                         erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
-                        kompetanser = utfylteKompetanser,
                         andelerTilkjentYtelse = andeler,
-                        overgangsordningAndeler = overgangsordningAndelService.hentOvergangsordningAndeler(behandling.id),
-                        adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(BehandlingId(behandling.id)),
-                        skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
                     ).hentGyldigeBegrunnelserForVedtaksperiode(),
             )
         }
@@ -457,7 +453,6 @@ class VedtaksperiodeService(
             personopplysningGrunnlag = personopplysningGrunnlag,
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             vilkårsvurdering = vilkårsvurdering,
-            skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
             adopsjonerIBehandling = adopsjonerIBehandling,
         )
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.utbetalingsperiodeMedBegrunnelser
 
 import no.nav.familie.ks.sak.common.BehandlingId
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
@@ -40,7 +39,6 @@ class UtbetalingsperiodeMedBegrunnelserService(
             vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 adopsjonerIBehandling = adopsjonerIBehandling,
-                skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
             )
 
         return hentPerioderMedUtbetaling(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.utbetalingsperiodeMedBegrunnelser
 
 import no.nav.familie.ks.sak.common.BehandlingId
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.VedtaksperiodeMedBegrunnelser
@@ -18,7 +17,6 @@ class UtbetalingsperiodeMedBegrunnelserService(
     private val andelerTilkjentYtelseOgEndreteUtbetalingerService: AndelerTilkjentYtelseOgEndreteUtbetalingerService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val kompetanseService: KompetanseService,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
 ) {
     fun hentUtbetalingsperioder(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtils.kt
@@ -16,9 +16,8 @@ fun lagAutomatiskGenererteVilkårForBarnetsAlder(
     behandlingId: Long,
     fødselsdato: LocalDate,
     adopsjonsdato: LocalDate?,
-    skalBrukeRegelverk2025: Boolean = false,
 ): List<VilkårResultat> {
-    val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBrukeRegelverk2025)
+    val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato)
     val erAdopsjon = adopsjonsdato != null
     return when (lovverk) {
         Lovverk.FØR_LOVENDRING_2025 -> lagAutomatiskGenererteVilkårForBarnetsAlder2021og2024(personResultat, behandlingId, fødselsdato, erAdopsjon)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarn.kt
@@ -12,7 +12,6 @@ import java.time.YearMonth
 data class VilkårLovverkInformasjonForBarn(
     val fødselsdato: LocalDate,
     val adopsjonsdato: LocalDate?,
-    val skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     val periodeFomForAdoptertBarn: YearMonth? = null,
     val periodeTomForAdoptertBarn: YearMonth? = null,
 ) {
@@ -32,7 +31,7 @@ data class VilkårLovverkInformasjonForBarn(
         this.periodeFomBarnetsAlderLov2025 = fødselsdato.plusMonths(12)
         this.periodeTomBarnetsAlderLov2025 = fødselsdato.plusMonths(20)
 
-        val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+        val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato)
 
         this.vilkårLovverk =
             when (lovverk) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -5,8 +5,6 @@ import no.nav.familie.ks.sak.api.dto.NyttVilkårDto
 import no.nav.familie.ks.sak.api.dto.VedtakBegrunnelseTilknyttetVilkårResponseDto
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
@@ -35,7 +33,6 @@ class VilkårsvurderingService(
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val sanityService: SanityService,
     private val personidentService: PersonidentService,
-    private val unleashService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
     private val adopsjonValidator: AdopsjonValidator,
 ) {
@@ -60,7 +57,6 @@ class VilkårsvurderingService(
                 vilkårsvurderingFraForrigeBehandling,
                 personopplysningGrunnlag,
                 adopsjonerIBehandling,
-                unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
             )
 
         vilkårsvurderingFraForrigeBehandling?.let {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -61,12 +61,6 @@ class VilkårsvurderingSteg(
         val personopplysningGrunnlag =
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId)
 
-        if (personopplysningGrunnlag.barna.any { it.fødselsdato.isAfter(LocalDate.of(2023, 12, 31)) } &&
-            !unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025)
-        ) {
-            throw FunksjonellFeil("Barn født 1.1.24 eller senere kan ikke behandles før nytt regelverk er støttet i løsningen")
-        }
-
         val søknadDto = søknadGrunnlagService.finnAktiv(behandlingId = behandling.id)?.tilSøknadDto()
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id)
 
@@ -295,7 +289,6 @@ class VilkårsvurderingSteg(
                 vilkårsvurdering = vilkårsvurdering,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(behandlingId = vilkårsvurdering.behandling.behandlingId),
-                skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
             )
         if (vilkårsvurderingTidslinjer.harBlandetRegelverk()) {
             throw FunksjonellFeil(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -246,7 +246,6 @@ fun genererInitiellVilkårsvurdering(
     forrigeVilkårsvurdering: Vilkårsvurdering?,
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     adopsjonerIBehandling: List<Adopsjon>,
-    skalBrukeRegelverk2025: Boolean = false,
 ): Vilkårsvurdering =
     Vilkårsvurdering(behandling = behandling).apply {
         personResultater =
@@ -275,7 +274,6 @@ fun genererInitiellVilkårsvurdering(
                                             personResultat = personResultat,
                                             behandlingId = behandling.id,
                                             fødselsdato = person.fødselsdato,
-                                            skalBrukeRegelverk2025 = skalBrukeRegelverk2025,
                                             adopsjonsdato = adopsjonerIBehandling.firstOrNull { it.aktør == personResultat.aktør }?.adopsjonsdato,
                                         )
                                     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkår.kt
@@ -26,13 +26,11 @@ import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 fun Collection<PersonResultat>.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     adopsjonerIBehandling: List<Adopsjon>,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ): Map<Aktør, Tidslinje<List<VilkårResultat>>> =
     this
         .forskyvVilkårResultater(
             personopplysningGrunnlag = personopplysningGrunnlag,
             adopsjonerIBehandling = adopsjonerIBehandling,
-            skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
         ).mapValues { entry ->
             val person = personopplysningGrunnlag.personer.single { it.aktør == entry.key }
             entry.value.tilOppfylteVilkårTidslinje(person.type)
@@ -41,13 +39,11 @@ fun Collection<PersonResultat>.tilForskjøvetOppfylteVilkårResultatTidslinjeMap
 fun Collection<PersonResultat>.tilForskjøvetVilkårResultatTidslinjeMap(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     adopsjonerIBehandling: List<Adopsjon>,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ): Map<Aktør, Tidslinje<List<VilkårResultat>>> =
     this
         .forskyvVilkårResultater(
             personopplysningGrunnlag = personopplysningGrunnlag,
             adopsjonerIBehandling = adopsjonerIBehandling,
-            skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
         ).mapValues {
             it.value.tilVilkårResultaterTidslinje()
         }
@@ -78,10 +74,9 @@ private fun Map<Vilkår, List<Periode<VilkårResultat>>>.tilVilkårResultaterTid
 fun Collection<PersonResultat>.forskyvVilkårResultater(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     adopsjonerIBehandling: List<Adopsjon>,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ): Map<Aktør, Map<Vilkår, List<Periode<VilkårResultat>>>> {
     // Forskyver barnas vilkår basert på barnets lovverk
-    val barnasForskjøvedeVilkårResultater = this.forskyvBarnasVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag, adopsjonerIBehandling = adopsjonerIBehandling, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+    val barnasForskjøvedeVilkårResultater = this.forskyvBarnasVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag, adopsjonerIBehandling = adopsjonerIBehandling)
 
     // Lager lovverk-tidslinje basert på barnas forskjøvede VilkårResultater
     val lovverkTidslinje =
@@ -89,7 +84,6 @@ fun Collection<PersonResultat>.forskyvVilkårResultater(
             barnasForskjøvedeVilkårResultater = barnasForskjøvedeVilkårResultater,
             personopplysningGrunnlag = personopplysningGrunnlag,
             adopsjonerIBehandling = adopsjonerIBehandling,
-            skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
         )
 
     // Forskyver søker etter alle lovverk og kombinerer med lovverk-tidslinje
@@ -109,14 +103,12 @@ fun PersonResultat.forskyvVilkårResultater(
 private fun Collection<PersonResultat>.forskyvBarnasVilkårResultater(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     adopsjonerIBehandling: List<Adopsjon>,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ): Map<Aktør, Map<Vilkår, List<Periode<VilkårResultat>>>> =
     this.filter { !it.erSøkersResultater() }.associate { personResultat ->
         val lovverk =
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = personopplysningGrunnlag.barna.single { it.aktør == personResultat.aktør }.fødselsdato,
                 adopsjonsdato = adopsjonerIBehandling.firstOrNull { it.aktør == personResultat.aktør }?.adopsjonsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             )
         personResultat.aktør to personResultat.forskyvVilkårResultater(lovverk)
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGenerator.kt
@@ -22,7 +22,6 @@ object LovverkTidslinjeGenerator {
         barnasForskjøvedeVilkårResultater: Map<Aktør, Map<Vilkår, List<Periode<VilkårResultat>>>>,
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         adopsjonerIBehandling: List<Adopsjon>,
-        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ): Tidslinje<Lovverk> =
         barnasForskjøvedeVilkårResultater
             .map { (aktør, forskjøvedeVilkårResultater) ->
@@ -30,7 +29,6 @@ object LovverkTidslinjeGenerator {
                 forskjøvedeVilkårResultater.tilLovverkTidslinje(
                     barn = personopplysningGrunnlag.barna.single { it.aktør == aktør },
                     adopsjonsdato = adopsjonerIBehandling.firstOrNull { it.aktør == aktør }?.adopsjonsdato,
-                    skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
                 )
             }
             // Kombinerer alle Lovverk-tidslinjer til en felles Lovverk-tidslinje.
@@ -52,13 +50,11 @@ object LovverkTidslinjeGenerator {
     private fun Map<Vilkår, List<Periode<VilkårResultat>>>.tilLovverkTidslinje(
         barn: Person,
         adopsjonsdato: LocalDate?,
-        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ): Tidslinje<Lovverk> {
         val lovverkForBarn =
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = barn.fødselsdato,
                 adopsjonsdato = adopsjonsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             )
         return this
             .getOrElse(Vilkår.BARNETS_ALDER) { throw Feil("Finner ikke vilkår for barnets alder") }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.validering
 
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårLovverk
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårLovverkInformasjonForBarn
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
@@ -17,14 +15,12 @@ class BarnetsAlderVilkårValidator(
     val barnetsAlderVilkårValidator2024: BarnetsAlderVilkårValidator2024,
     val barnetsAlderVilkårValidator2021og2024: BarnetsAlderVilkårValidator2021og2024,
     val barnetsAlderVilkårValidator2025: BarnetsAlderVilkårValidator2025,
-    val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun validerVilkårBarnetsAlder(
         perioder: List<IkkeNullbarPeriode<VilkårResultat>>,
         barn: Person,
         adopsjonsdato: LocalDate?,
     ): List<String> {
-        val skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025)
         val vilkårLovverkInformasjonForBarn =
             if (perioder.any { it.verdi.erAdopsjonOppfylt() }) {
                 VilkårLovverkInformasjonForBarn(
@@ -32,10 +28,9 @@ class BarnetsAlderVilkårValidator(
                     adopsjonsdato = adopsjonsdato,
                     periodeFomForAdoptertBarn = perioder.minOf { it.fom }.toYearMonth(),
                     periodeTomForAdoptertBarn = perioder.maxOf { it.tom }.toYearMonth(),
-                    skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
                 )
             } else {
-                VilkårLovverkInformasjonForBarn(fødselsdato = barn.fødselsdato, adopsjonsdato = adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+                VilkårLovverkInformasjonForBarn(fødselsdato = barn.fødselsdato, adopsjonsdato = adopsjonsdato)
             }
 
         return when (vilkårLovverkInformasjonForBarn.vilkårLovverk) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseService.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
@@ -14,7 +12,6 @@ import org.springframework.stereotype.Service
 @Service
 class BeregnAndelTilkjentYtelseService(
     private val andelGeneratorLookup: AndelGenerator.Lookup,
-    private val unleashService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
 ) {
     fun beregnAndelerTilkjentYtelse(
@@ -41,7 +38,6 @@ class BeregnAndelTilkjentYtelseService(
             LovverkUtleder.utledLovverkForBarn(
                 fødselsdato = barn.fødselsdato,
                 adopsjonsdato = adopsjonService.finnAdopsjonForAktørIBehandling(aktør = barn.aktør, behandlingId = vilkårsvurdering.behandling.behandlingId)?.adopsjonsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
             )
         val andelGenerator = andelGeneratorLookup.hentGeneratorForLovverk(regelverk)
         val andeler = andelGenerator.beregnAndelerForBarn(søker = søker, barn = barn, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -39,7 +39,6 @@ object TilkjentYtelseValidator {
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         alleBarnetsAlderVilkårResultater: List<VilkårResultat>,
         adopsjonerIBehandling: List<Adopsjon>,
-        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ) {
         val søker = personopplysningGrunnlag.søker
         val barna = personopplysningGrunnlag.barna
@@ -66,12 +65,11 @@ object TilkjentYtelseValidator {
                     VilkårLovverkInformasjonForBarn(
                         fødselsdato = relevantBarn.fødselsdato,
                         adopsjonsdato = adopsjonsdatoForBarn,
-                        skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
                         periodeFomForAdoptertBarn = stønadFom,
                         periodeTomForAdoptertBarn = stønadTom,
                     )
                 } else {
-                    VilkårLovverkInformasjonForBarn(fødselsdato = relevantBarn.fødselsdato, adopsjonsdato = adopsjonsdatoForBarn, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+                    VilkårLovverkInformasjonForBarn(fødselsdato = relevantBarn.fødselsdato, adopsjonsdato = adopsjonsdatoForBarn)
                 }
 
             val barnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater.filter { it.personResultat?.aktør == aktør }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
@@ -4,7 +4,6 @@ package no.nav.familie.ks.sak.kjerne.brev
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
@@ -91,12 +90,11 @@ class BrevPeriodeService(
                     uregistrerteBarn =
                         søknadGrunnlagService.finnAktiv(behandlingId)?.hentUregistrerteBarn()
                             ?: emptyList(),
-                    erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
                     kompetanser = kompetanser.map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>(),
                     landkoder = integrasjonClient.hentLandkoderISO2(),
+                    erFørsteVedtaksperiode = erFørsteVedtaksperiodePåFagsak,
                     overgangsordningAndeler = overgangsordningAndelService.hentOvergangsordningAndeler(behandlingId),
                     adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(BehandlingId(behandlingId)),
-                    skalBestemmeLovverkBasertPåFødselsdato = unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025),
                 ).genererBrevPeriodeDto()
             }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeService.kt
@@ -4,7 +4,6 @@ package no.nav.familie.ks.sak.kjerne.brev
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
@@ -38,7 +37,6 @@ class BrevPeriodeService(
     val vedtaksperiodeService: VedtaksperiodeService,
     val kompetanseService: KompetanseService,
     val integrasjonClient: IntegrasjonClient,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
 ) {
     fun hentBegrunnelsesteksterForPeriode(vedtaksperiodeId: Long): List<BegrunnelseDto> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -52,7 +52,6 @@ class BegrunnelserForPeriodeContext(
     private val endretUtbetalingsandeler: List<EndretUtbetalingAndel>,
     private val erFørsteVedtaksperiode: Boolean,
     private val andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
-    private val skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ) {
     private val aktørIderMedUtbetaling =
         utvidetVedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.map { it.person.aktør.aktørId }
@@ -312,7 +311,6 @@ class BegrunnelserForPeriodeContext(
             .forskyvVilkårResultater(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 adopsjonerIBehandling = adopsjonerIBehandling,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             ).flatMap { entry ->
                 entry.value
                     .flatMap { it.value }
@@ -325,7 +323,6 @@ class BegrunnelserForPeriodeContext(
             .forskyvVilkårResultater(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 adopsjonerIBehandling = adopsjonerIBehandling,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             ).flatMap { entry ->
                 entry.value
                     .flatMap { it.value }
@@ -384,7 +381,6 @@ class BegrunnelserForPeriodeContext(
             .tilForskjøvetVilkårResultatTidslinjeMap(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 adopsjonerIBehandling = adopsjonerIBehandling,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             ).mapKeys { (aktør, _) -> aktør.hentPerson() }
             .mapNotNull { (person, vilkårResultatTidslinjeForPerson) ->
                 val perioderMedVilkårForPerson = vilkårResultatTidslinjeForPerson.tilPerioder()
@@ -437,7 +433,6 @@ class BegrunnelserForPeriodeContext(
             .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 adopsjonerIBehandling = adopsjonerIBehandling,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             ).mapKeys { (aktør, _) -> aktør.hentPerson() }
             .mapNotNull { (person, vilkårResultatTidslinjeForPerson) ->
                 val forskøvedeVilkårResultaterMedSammeFom =
@@ -460,7 +455,6 @@ class BegrunnelserForPeriodeContext(
             .tilForskjøvetVilkårResultatTidslinjeMap(
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 adopsjonerIBehandling = adopsjonerIBehandling,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
             ).mapKeys { (aktør, _) -> aktør.hentPerson() }
             .mapNotNull { (person, tidslinje) ->
                 val vilkårResultatSomSlutterFørVedtaksperiode =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeService.kt
@@ -3,8 +3,6 @@ package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
@@ -21,7 +19,6 @@ import org.springframework.stereotype.Service
 class VilkårsvurderingTidslinjeService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
-    private val unleashService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
 ) {
     fun lagVilkårsvurderingTidslinjer(behandlingId: Long): VilkårsvurderingTidslinjer {
@@ -29,7 +26,7 @@ class VilkårsvurderingTidslinjeService(
         val personopplysningGrunnlag = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId)
         val adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(BehandlingId(behandlingId))
 
-        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, adopsjonerIBehandling, unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025))
+        return VilkårsvurderingTidslinjer(vilkårsvurdering, personopplysningGrunnlag, adopsjonerIBehandling)
     }
 
     fun hentAnnenForelderOmfattetAvNorskLovgivningTidslinje(behandlingId: Long): Tidslinje<Boolean> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjer.kt
@@ -18,15 +18,13 @@ class VilkårsvurderingTidslinjer(
     vilkårsvurdering: Vilkårsvurdering,
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     adopsjonerIBehandling: List<Adopsjon>,
-    skalBestemmeLovverkBasertPåFødselsdato: Boolean,
 ) {
     private val barnasTidslinjer: Map<Person, BarnetsTidslinjer> =
         personopplysningGrunnlag.barna.associateWith { barn ->
             BarnetsTidslinjer(
                 barn = barn,
-                personResultater = vilkårsvurdering.personResultater,
                 adopsjonsdato = adopsjonerIBehandling.firstOrNull { it.aktør == barn.aktør }?.adopsjonsdato,
-                skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato,
+                personResultater = vilkårsvurdering.personResultater,
             )
         }
 
@@ -36,9 +34,12 @@ class VilkårsvurderingTidslinjer(
         barn: Person,
         adopsjonsdato: LocalDate?,
         personResultater: Set<PersonResultat>,
-        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ) {
-        private val lovverk = LovverkUtleder.utledLovverkForBarn(fødselsdato = barn.fødselsdato, adopsjonsdato = adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = skalBestemmeLovverkBasertPåFødselsdato)
+        private val lovverk =
+            LovverkUtleder.utledLovverkForBarn(
+                fødselsdato = barn.fødselsdato,
+                adopsjonsdato = adopsjonsdato,
+            )
         private val søkersTidslinje = personResultater.single { it.erSøkersResultater() }.tilVilkårRegelverkResultatTidslinje(lovverk = lovverk)
         private val barnetsTidslinje = personResultater.single { it.aktør == barn.aktør }.tilVilkårRegelverkResultatTidslinje(lovverk = lovverk)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/lovverk/LovverkUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/lovverk/LovverkUtleder.kt
@@ -8,11 +8,7 @@ object LovverkUtleder {
     fun utledLovverkForBarn(
         fødselsdato: LocalDate,
         adopsjonsdato: LocalDate?,
-        skalBestemmeLovverkBasertPåFødselsdato: Boolean,
     ): Lovverk {
-        if (!skalBestemmeLovverkBasertPåFødselsdato) {
-            return Lovverk.FØR_LOVENDRING_2025
-        }
         val fødselsdatoEllerAdopsjonsdato = adopsjonsdato ?: fødselsdato
 
         return when {

--- a/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -32,7 +31,6 @@ import org.hamcrest.CoreMatchers.`is` as Is
 internal class VilkårsvurderingTidslinjeServiceTest {
     val personopplysningGrunnlagRepository = mockk<PersonopplysningGrunnlagRepository>()
     val vilkårsvurderingService = mockk<VilkårsvurderingService>()
-    val unleashService = mockk<UnleashNextMedContextService>()
     val adopsjonService = mockk<AdopsjonService>()
 
     private lateinit var vilkårsvurderingTidslinjeService: VilkårsvurderingTidslinjeService
@@ -43,7 +41,6 @@ internal class VilkårsvurderingTidslinjeServiceTest {
             VilkårsvurderingTidslinjeService(
                 personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
                 vilkårsvurderingService = vilkårsvurderingService,
-                unleashService = unleashService,
                 adopsjonService = adopsjonService,
             )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -374,7 +374,6 @@ class StepDefinition {
                                     overgangsordningAndeler = overgangsordningAndeler[behandlingId] ?: emptyList(),
                                     andelerTilkjentYtelse = hentAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId),
                                     adopsjonerIBehandling = emptyList(), // TODO: Legg inn støtte for cucumber-tester
-                                    skalBestemmeLovverkBasertPåFødselsdato = true,
                                 ).hentGyldigeBegrunnelserForVedtaksperiode(),
                         )
                     }.find { it.fom == forventet.fom && it.tom == forventet.tom }
@@ -474,7 +473,6 @@ class StepDefinition {
         erFørsteVedtaksperiode = erFørsteVedtaksperiode,
         kompetanser = hentUtfylteKompetanserPåBehandling(behandlingId),
         landkoder = LANDKODER,
-        skalBestemmeLovverkBasertPåFødselsdato = true,
         adopsjonerIBehandling = emptyList(), // TODO: Fiks før merge
     ).genererBrevPeriodeDto()
 
@@ -714,7 +712,6 @@ class StepDefinition {
             integrasjonClient = mockk(),
             refusjonEøsRepository = mockk(),
             kompetanseService = kompetanseService,
-            unleashNextMedContextService = mockUnleashNextMedContextService(),
             adopsjonService = mockAdopsjonService(),
         )
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -25,7 +25,6 @@ import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.tilddMMyyyy
 import no.nav.familie.ks.sak.cucumber.BrevBegrunnelseParser.mapBegrunnelser
 import no.nav.familie.ks.sak.cucumber.mocking.CucumberMock
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseDto

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -694,7 +694,6 @@ class StepDefinition {
                 andelerTilkjentYtelseOgEndreteUtbetalingerService = mockAndelerTilkjentYtelseOgEndreteUtbetalingerService(),
                 personopplysningGrunnlagService = mockPersonopplysningGrunnlagService(),
                 kompetanseService = kompetanseService,
-                unleashNextMedContextService = mockUnleashNextMedContextService(),
                 adopsjonService = mockAdopsjonService(),
             )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -63,7 +63,6 @@ class CucumberMock(
     val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-            unleashService = mockUnleashNextMedContextService(),
             adopsjonService = adopsjonServiceMock,
         )
 
@@ -141,7 +140,6 @@ class CucumberMock(
             personopplysningGrunnlagService = personopplysningGrunnlagService,
             sanityService = mockk(),
             personidentService = personidentService,
-            unleashService = mockUnleashNextMedContextService(),
             adopsjonService = adopsjonServiceMock,
             adopsjonValidator = adopsjonValidator,
         )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidatorTest.kt
@@ -171,7 +171,12 @@ class AdopsjonValidatorTest {
             .hentVilkårFor(PersonType.BARN)
             .flatMap { vilkår ->
                 if (vilkår == Vilkår.BARNETS_ALDER) {
-                    lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = personResultat.vilkårsvurdering.behandling.id, fødselsdato = fødselsdato, adopsjonsdato = if (erAdopsjon) fødselsdato.plusMonths(2) else null)
+                    lagAutomatiskGenererteVilkårForBarnetsAlder(
+                        personResultat = personResultat,
+                        behandlingId = personResultat.vilkårsvurdering.behandling.id,
+                        fødselsdato = fødselsdato,
+                        adopsjonsdato = if (erAdopsjon) fødselsdato.plusMonths(2) else null,
+                    )
                 } else {
                     listOf(
                         lagVilkårResultat(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/OpphørsperiodeTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/OpphørsperiodeTest.kt
@@ -96,7 +96,6 @@ class OpphørsperiodeTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     andelerTilkjentYtelse = listOf(andelTilBarn1),
                     vilkårsvurdering = vilkårsvurdering,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
 
@@ -150,7 +149,6 @@ class OpphørsperiodeTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     andelerTilkjentYtelse = listOf(andelTilBarn),
                     vilkårsvurdering = vilkårsvurdering,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
 
@@ -233,7 +231,6 @@ class OpphørsperiodeTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     andelerTilkjentYtelse = listOf(andelTilBarn1, andelTilBarn2),
                     vilkårsvurdering = vilkårsvurdering,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
 
@@ -292,7 +289,6 @@ class OpphørsperiodeTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     andelerTilkjentYtelse = listOf(andelBarn1, andel2Barn1, andel3Barn1),
                     vilkårsvurdering = vilkårsvurdering,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
 
@@ -323,7 +319,6 @@ class OpphørsperiodeTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     andelerTilkjentYtelse = listOf(andelBarn1),
                     vilkårsvurdering = vilkårsvurdering,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
 
@@ -352,7 +347,6 @@ class OpphørsperiodeTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     andelerTilkjentYtelse = listOf(andelBarn1),
                     vilkårsvurdering = vilkårsvurdering,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -13,8 +13,6 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.MånedPeriode
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagInitieltTilkjentYtelse
@@ -111,9 +109,6 @@ internal class VedtaksperiodeServiceTest {
     private lateinit var kompetanseService: KompetanseService
 
     @MockK
-    private lateinit var unleashNextMedContextService: UnleashNextMedContextService
-
-    @MockK
     private lateinit var adopsjonService: AdopsjonService
 
     @InjectMockKs
@@ -124,9 +119,6 @@ internal class VedtaksperiodeServiceTest {
     @BeforeEach
     fun setup() {
         behandling = lagBehandling()
-        every {
-            unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025)
-        } returns true
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
@@ -86,7 +86,10 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
             )
 
         val førskjøvetVilkårResultatTidslinjeMap =
-            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag = personopplysningGrunnlag, adopsjonerIBehandling = emptyList(), skalBestemmeLovverkBasertPåFødselsdato = true)
+            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                adopsjonerIBehandling = emptyList(),
+            )
 
         Assertions.assertEquals(2, førskjøvetVilkårResultatTidslinjeMap.size)
 
@@ -162,7 +165,10 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
             )
 
         assertDoesNotThrow {
-            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag = personopplysningGrunnlag, adopsjonerIBehandling = emptyList(), skalBestemmeLovverkBasertPåFødselsdato = true)
+            personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                adopsjonerIBehandling = emptyList(),
+            )
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtilTest.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagKompetanse
@@ -132,7 +131,11 @@ internal class UtbetalingsperiodeUtilTest {
             hentPerioderMedUtbetaling(
                 andelerTilkjentYtelse = listOf(andelPerson1MarsTilApril, andelPerson1MaiTilJuli, andelPerson2MarsTilJuli),
                 vedtak = vedtak,
-                forskjøvetVilkårResultatTidslinjeMap = personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(personopplysningGrunnlag = personopplysningGrunnlag, adopsjonerIBehandling = emptyList(), skalBestemmeLovverkBasertPåFødselsdato = true),
+                forskjøvetVilkårResultatTidslinjeMap =
+                    personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
+                        personopplysningGrunnlag = personopplysningGrunnlag,
+                        adopsjonerIBehandling = emptyList(),
+                    ),
                 kompetanser = emptyList(),
             )
 
@@ -220,7 +223,6 @@ internal class UtbetalingsperiodeUtilTest {
                     personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
                         personopplysningGrunnlag = personopplysningGrunnlag,
                         adopsjonerIBehandling = emptyList(),
-                        skalBestemmeLovverkBasertPåFødselsdato = true,
                     ),
                 kompetanser = emptyList(),
             )
@@ -245,7 +247,6 @@ internal class UtbetalingsperiodeUtilTest {
                 vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     adopsjonerIBehandling = emptyList(),
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
 
             val vedtaksperioderUtenKompetanse =
@@ -289,7 +290,6 @@ internal class UtbetalingsperiodeUtilTest {
                 vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     adopsjonerIBehandling = emptyList(),
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 )
 
             val vedtaksperioderUtenKompetanse =
@@ -582,7 +582,6 @@ internal class UtbetalingsperiodeUtilTest {
                 beregnAndelTilkjentYtelseService =
                     BeregnAndelTilkjentYtelseService(
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-                        unleashService = mockUnleashNextMedContextService(),
                         adopsjonService = mockAdopsjonService(),
                     ),
                 overgangsordningAndelRepository = mockOvergangsordningAndelRepository(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtilsKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AutomatiskSatteVilkårUtilsKtTest.kt
@@ -20,28 +20,6 @@ class AutomatiskSatteVilkårUtilsKtTest {
         )
 
     @Test
-    fun `skal bruke gammelt regelverk for barn født fra og med første januar 2024 hvis toggle er skrudd av`() {
-        // Act
-        val barnetsAlderVilkår =
-            lagAutomatiskGenererteVilkårForBarnetsAlder(
-                personResultat = personResultat,
-                behandlingId = behandlingId,
-                fødselsdato = fødselsDato,
-                adopsjonsdato = null,
-                skalBrukeRegelverk2025 = false,
-            )
-
-        // Assert
-        assertThat(barnetsAlderVilkår).hasSize(1)
-        assertThat(barnetsAlderVilkår).anySatisfy {
-            validerFellesfelter(it)
-            assertThat(it.periodeFom).isEqualTo(fødselsDato.plusMonths(13))
-            assertThat(it.periodeTom).isEqualTo(fødselsDato.plusMonths(19))
-            assertThat(it.utdypendeVilkårsvurderinger).isEmpty()
-        }
-    }
-
-    @Test
     fun `skal bruke nytt regelverk for barn født fra og med første januar 2024 hvis toggle er skrudd på`() {
         // Act
         val barnetsAlderVilkår =
@@ -50,7 +28,6 @@ class AutomatiskSatteVilkårUtilsKtTest {
                 behandlingId = behandlingId,
                 fødselsdato = fødselsDato,
                 adopsjonsdato = null,
-                skalBrukeRegelverk2025 = true,
             )
 
         // Assert
@@ -72,7 +49,6 @@ class AutomatiskSatteVilkårUtilsKtTest {
                 behandlingId = behandlingId,
                 fødselsdato = fødselsDato,
                 adopsjonsdato = fødselsDato.plusMonths(10),
-                skalBrukeRegelverk2025 = true,
             )
 
         // Assert
@@ -96,7 +72,6 @@ class AutomatiskSatteVilkårUtilsKtTest {
                 behandlingId = behandlingId,
                 fødselsdato = fødselsDatoFørJan24,
                 adopsjonsdato = null,
-                skalBrukeRegelverk2025 = true,
             )
 
         // Assert

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarnTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårLovverkInformasjonForBarnTest.kt
@@ -11,7 +11,11 @@ class VilkårLovverkInformasjonForBarnTest {
         val fødselsdato: LocalDate = LocalDate.of(2022, 12, 31)
 
         // Act
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)
+        val vilkårLovverkInformasjonForBarn =
+            VilkårLovverkInformasjonForBarn(
+                fødselsdato = fødselsdato,
+                adopsjonsdato = null,
+            )
 
         // Assert
         assertThat(vilkårLovverkInformasjonForBarn.vilkårLovverk).isEqualTo(VilkårLovverk.LOVVERK_2021)
@@ -29,7 +33,11 @@ class VilkårLovverkInformasjonForBarnTest {
         val fødselsdato: LocalDate = LocalDate.of(2023, 8, 1)
 
         // Act
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)
+        val vilkårLovverkInformasjonForBarn =
+            VilkårLovverkInformasjonForBarn(
+                fødselsdato = fødselsdato,
+                adopsjonsdato = null,
+            )
 
         // Assert
         assertThat(vilkårLovverkInformasjonForBarn.vilkårLovverk).isEqualTo(VilkårLovverk.LOVVERK_2024)
@@ -47,7 +55,11 @@ class VilkårLovverkInformasjonForBarnTest {
         val fødselsdato: LocalDate = LocalDate.of(2023, 7, 31)
 
         // Act
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)
+        val vilkårLovverkInformasjonForBarn =
+            VilkårLovverkInformasjonForBarn(
+                fødselsdato = fødselsdato,
+                adopsjonsdato = null,
+            )
 
         // Assert
         assertThat(vilkårLovverkInformasjonForBarn.vilkårLovverk).isEqualTo(VilkårLovverk.LOVVERK_2021_OG_2024)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.fnrTilFødselsdato
 import no.nav.familie.ks.sak.data.lagBehandling
@@ -54,7 +53,6 @@ class VilkårsvurderingServiceTest {
             personopplysningGrunnlagService,
             sanityService,
             personidentService,
-            unleashService,
             adopsjonService,
             adopsjonValidator,
         )
@@ -67,7 +65,6 @@ class VilkårsvurderingServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
         every { adopsjonService.hentAlleAdopsjonerForBehandling(any()) } returns emptyList()
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -79,7 +79,6 @@ class VilkårsvurderingStegTest {
                     barnetsAlderVilkårValidator2024,
                 ),
                 barnetsAlderVilkårValidator2025,
-                unleashService,
             ),
             adopsjonService,
         )
@@ -135,7 +134,6 @@ class VilkårsvurderingStegTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(any(), any(), any()) } just runs
-        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
         every { unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns true
         every { adopsjonService.hentAlleAdopsjonerForBehandling(any()) } returns emptyList()
         every { adopsjonService.finnAdopsjonForAktørIBehandling(any(), any()) } returns null

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/ForskyvVilkårKtTest.kt
@@ -424,7 +424,11 @@ class ForskyvVilkårKtTest {
                 )
 
             // Act
-            val forskjøvedeVilkårResultater = personResultater.forskyvVilkårResultater(personopplysningGrunnlag = personopplysningGrunnlag, adopsjonerIBehandling = emptyList(), skalBestemmeLovverkBasertPåFødselsdato = true)
+            val forskjøvedeVilkårResultater =
+                personResultater.forskyvVilkårResultater(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    adopsjonerIBehandling = emptyList(),
+                )
 
             // Assert
             assertThat(forskjøvedeVilkårResultater).hasSize(4)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/forskyvning/LovverkTidslinjeGeneratorTest.kt
@@ -66,7 +66,6 @@ class LovverkTidslinjeGeneratorTest {
             LovverkTidslinjeGenerator.generer(
                 barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
 
@@ -126,7 +125,6 @@ class LovverkTidslinjeGeneratorTest {
             LovverkTidslinjeGenerator.generer(
                 barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
 
@@ -186,7 +184,6 @@ class LovverkTidslinjeGeneratorTest {
             LovverkTidslinjeGenerator.generer(
                 barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
 
@@ -246,7 +243,6 @@ class LovverkTidslinjeGeneratorTest {
             LovverkTidslinjeGenerator.generer(
                 barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
                 personopplysningGrunnlag = personopplysningGrunnlag,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
 
@@ -319,7 +315,6 @@ class LovverkTidslinjeGeneratorTest {
                 LovverkTidslinjeGenerator.generer(
                     barnasForskjøvedeVilkårResultater = vilkårResultaterPerBarn,
                     personopplysningGrunnlag = personopplysningGrunnlag,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2021og2024Test.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidator2021og2024Test.kt
@@ -30,7 +30,11 @@ class BarnetsAlderVilkårValidator2021og2024Test {
             barnetsAlderVilkårValidator2021og2024.validerBarnetsAlderVilkår(
                 perioder = listOf(),
                 barn = person,
-                vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = person.fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true),
+                vilkårLovverkInformasjonForBarn =
+                    VilkårLovverkInformasjonForBarn(
+                        fødselsdato = person.fødselsdato,
+                        adopsjonsdato = null,
+                    ),
             )
 
         // Assert

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsAlderVilkårValidatorTest.kt
@@ -4,8 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.randomAktør
@@ -16,7 +14,6 @@ import no.nav.familie.ks.sak.kjerne.lovverk.LovverkUtleder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.tidslinje.IkkeNullbarPeriode
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -25,20 +22,13 @@ class BarnetsAlderVilkårValidatorTest {
     val barnetsAlderVilkårValidator2024: BarnetsAlderVilkårValidator2024 = mockk()
     val barnetsAlderVilkårValidator2021og2024: BarnetsAlderVilkårValidator2021og2024 = mockk()
     val barnetsAlderVilkårValidator2025: BarnetsAlderVilkårValidator2025 = mockk()
-    val unleashNextMedContextService: UnleashNextMedContextService = mockk()
     val barnetsAlderVilkårValidator =
         BarnetsAlderVilkårValidator(
             barnetsAlderVilkårValidator2021,
             barnetsAlderVilkårValidator2024,
             barnetsAlderVilkårValidator2021og2024,
             barnetsAlderVilkårValidator2025,
-            unleashNextMedContextService,
         )
-
-    @BeforeEach
-    fun beforeEach() {
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
-    }
 
     @Test
     fun `skal returnere ingen feil når validering for 2021 og 2024 returnerer ingen feil`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
@@ -1,13 +1,9 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.validering
 
-import io.mockk.every
-import io.mockk.mockk
 import mockAdopsjonService
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -22,7 +18,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vil
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.dødsfall.Dødsfall
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.LocalDate
@@ -46,7 +41,6 @@ class BarnetsVilkårValidatorTest {
     private val barnetsAlderVilkårValidator2021 = BarnetsAlderVilkårValidator2021()
     private val barnetsAlderVilkårValidator2024 = BarnetsAlderVilkårValidator2024()
     private val barnetsAlderVilkårValidator2025 = BarnetsAlderVilkårValidator2025()
-    private val unleashNextMedContextService: UnleashNextMedContextService = mockk()
 
     private val barnetsVilkårValidator: BarnetsVilkårValidator =
         BarnetsVilkårValidator(
@@ -58,15 +52,9 @@ class BarnetsVilkårValidatorTest {
                     barnetsAlderVilkårValidator2024,
                 ),
                 barnetsAlderVilkårValidator2025,
-                unleashNextMedContextService,
             ),
             mockAdopsjonService(),
         )
-
-    @BeforeEach
-    fun beforeEach() {
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
-    }
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når vilkår resulat er oppfylt men mangler fom`() {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregnAndelTilkjentYtelseServiceTest.kt
@@ -4,8 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ks.sak.common.BehandlingId
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
@@ -17,13 +15,11 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class BeregnAndelTilkjentYtelseServiceTest {
-    private val unleashService: UnleashNextMedContextService = mockk()
     private val andelGeneratorLookup: AndelGenerator.Lookup = mockk()
     private val adopsjonService: AdopsjonService = mockk()
     private val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = andelGeneratorLookup,
-            unleashService = unleashService,
             adopsjonService = adopsjonService,
         )
 
@@ -42,7 +38,6 @@ class BeregnAndelTilkjentYtelseServiceTest {
         every { personopplysningGrunnlag.søker } returns lagPerson(aktør = randomAktør())
         every { personopplysningGrunnlag.barna } returns listOf(lagPerson(aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 12, 31)))
 
-        every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
         every { andelGeneratorLookup.hentGeneratorForLovverk(any()) } returns andelGenerator
         every { andelGenerator.beregnAndelerForBarn(any(), any(), any(), any()) } returns emptyList()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtlederKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/MaksAntallMånederMedUtbetalingUtlederKtTest.kt
@@ -31,7 +31,11 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2022, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)
+        val vilkårLovverkInformasjonForBarn =
+            VilkårLovverkInformasjonForBarn(
+                fødselsdato = fødselsdato,
+                adopsjonsdato = null,
+            )
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -54,7 +58,11 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2022, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)
+        val vilkårLovverkInformasjonForBarn =
+            VilkårLovverkInformasjonForBarn(
+                fødselsdato = fødselsdato,
+                adopsjonsdato = null,
+            )
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -77,7 +85,11 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2023, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)
+        val vilkårLovverkInformasjonForBarn =
+            VilkårLovverkInformasjonForBarn(
+                fødselsdato = fødselsdato,
+                adopsjonsdato = null,
+            )
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,
@@ -100,7 +112,11 @@ class MaksAntallMånederMedUtbetalingUtlederKtTest {
     ) {
         // Arrange
         val fødselsdato = LocalDate.of(2024, måned, 1)
-        val vilkårLovverkInformasjonForBarn = VilkårLovverkInformasjonForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)
+        val vilkårLovverkInformasjonForBarn =
+            VilkårLovverkInformasjonForBarn(
+                fødselsdato = fødselsdato,
+                adopsjonsdato = null,
+            )
         val personResultat =
             PersonResultat(
                 vilkårsvurdering = vilkårsvurdering,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.toLocalDate
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonResultat
@@ -64,7 +63,6 @@ internal class TilkjentYtelseServiceTest {
     private val beregnAndelTilkjentYtelseService: BeregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-            unleashService = mockUnleashNextMedContextService(),
             adopsjonService = mockAdopsjonService(),
         )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -75,7 +75,6 @@ internal class TilkjentYtelseValidatorTest {
                     tilkjentYtelse = tilkjentYtelse,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
             }
@@ -125,7 +124,6 @@ internal class TilkjentYtelseValidatorTest {
                             barnAktør = listOf(barnFødtIJanuar2023.aktør),
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
             }
@@ -167,7 +165,6 @@ internal class TilkjentYtelseValidatorTest {
                             barnAktør = listOf(barnFødtIAugust2022.aktør),
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
             }
@@ -219,7 +216,6 @@ internal class TilkjentYtelseValidatorTest {
                     barnAktør = listOf(barnFødtAugust2023.aktør, barnFødtAugust2022.aktør),
                 ),
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterBarn1 + barnetsAlderVilkårResultaterBarn2,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
         }
@@ -250,7 +246,6 @@ internal class TilkjentYtelseValidatorTest {
                     tilkjentYtelse = tilkjentYtelse,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
             }
@@ -291,7 +286,6 @@ internal class TilkjentYtelseValidatorTest {
                             barnAktør = listOf(barnFødtJuli2023.aktør),
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
             }
@@ -538,7 +532,6 @@ internal class TilkjentYtelseValidatorTest {
                 tilkjentYtelse = tilkjentYtelse,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
         }
@@ -567,7 +560,6 @@ internal class TilkjentYtelseValidatorTest {
                 tilkjentYtelse = tilkjentYtelse,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
         }
@@ -596,7 +588,6 @@ internal class TilkjentYtelseValidatorTest {
                 tilkjentYtelse = tilkjentYtelse,
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                skalBestemmeLovverkBasertPåFødselsdato = true,
                 adopsjonerIBehandling = emptyList(),
             )
         }
@@ -626,7 +617,6 @@ internal class TilkjentYtelseValidatorTest {
                     tilkjentYtelse = tilkjentYtelse,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                     adopsjonerIBehandling = emptyList(),
                 )
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVedtaksbegrunnelse
 import no.nav.familie.ks.sak.data.lagVedtaksperiodeMedBegrunnelser
@@ -470,7 +469,6 @@ fun lagBrevPeriodeContext(
     val andelerTilkjentYtelse =
         BeregnAndelTilkjentYtelseService(
             andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFørFebruar2025AndelGenerator(), LovverkFebruar2025AndelGenerator())),
-            unleashService = mockUnleashNextMedContextService(),
             adopsjonService = mockAdopsjonService(),
         ).beregnAndelerTilkjentYtelse(personopplysningGrunnlag = persongrunnlag, vilkårsvurdering = vilkårsvurdering, tilkjentYtelse = tilkjentYtelse)
 
@@ -517,11 +515,10 @@ fun lagBrevPeriodeContext(
         personResultater = personResultater,
         andelTilkjentYtelserMedEndreteUtbetalinger = andelTilkjentYtelserMedEndreteUtbetalinger,
         uregistrerteBarn = emptyList(),
-        overgangsordningAndeler = emptyList(),
-        erFørsteVedtaksperiode = false,
         kompetanser = emptyList(),
         landkoder = LANDKODER,
-        skalBestemmeLovverkBasertPåFødselsdato = true,
+        erFørsteVedtaksperiode = false,
+        overgangsordningAndeler = emptyList(),
         adopsjonerIBehandling = emptyList(),
     )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -785,7 +785,6 @@ class BegrunnelserForPeriodeContextTest {
                 .tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     adopsjonerIBehandling = emptyList(),
-                    skalBestemmeLovverkBasertPåFødselsdato = true,
                 ).filterKeys { it.aktørId == aktørSomTriggerVedtaksperiode.aktørId }
                 .values
                 .first()
@@ -809,15 +808,14 @@ class BegrunnelserForPeriodeContextTest {
         return BegrunnelserForPeriodeContext(
             utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
             sanityBegrunnelser = sanityBegrunnelser,
+            kompetanser = emptyList(),
             personopplysningGrunnlag = personopplysningGrunnlag,
+            adopsjonerIBehandling = emptyList(),
+            overgangsordningAndeler = emptyList(),
             personResultater = personResultater,
             endretUtbetalingsandeler = emptyList(),
             erFørsteVedtaksperiode = false,
-            kompetanser = emptyList(),
-            overgangsordningAndeler = emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse,
-            adopsjonerIBehandling = emptyList(),
-            skalBestemmeLovverkBasertPåFødselsdato = true,
         )
     }
 
@@ -877,6 +875,8 @@ class BegrunnelserForPeriodeContextTest {
             sanityBegrunnelser = sanityBegrunnelser,
             kompetanser = kompetanser.map { it.tilIKompetanse() }.filterIsInstance<UtfyltKompetanse>(),
             personopplysningGrunnlag = personopplysningGrunnlag,
+            adopsjonerIBehandling = emptyList(),
+            overgangsordningAndeler = emptyList(),
             personResultater =
                 listOf(
                     lagPersonResultatFraVilkårResultater(
@@ -890,10 +890,7 @@ class BegrunnelserForPeriodeContextTest {
                 ),
             endretUtbetalingsandeler = emptyList(),
             erFørsteVedtaksperiode = false,
-            overgangsordningAndeler = emptyList(),
             andelerTilkjentYtelse = andelerTilkjentYtelse,
-            adopsjonerIBehandling = emptyList(),
-            skalBestemmeLovverkBasertPåFødselsdato = true,
         )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -10,8 +10,6 @@ import no.nav.familie.ks.sak.common.util.Periode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.toYearMonth
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagKompetanse
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -58,14 +56,12 @@ internal class KompetanseServiceTest {
     private val overgangsordningAndelRepository: OvergangsordningAndelRepository = mockk()
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository = mockk()
     private val vilkårsvurderingService: VilkårsvurderingService = mockk()
-    private val unleashService: UnleashNextMedContextService = mockk()
     private val adopsjonService: AdopsjonService = mockk()
 
     private val vilkårsvurderingTidslinjeService =
         VilkårsvurderingTidslinjeService(
             vilkårsvurderingService = vilkårsvurderingService,
             personopplysningGrunnlagRepository = personopplysningGrunnlagRepository,
-            unleashService = unleashService,
             adopsjonService = adopsjonService,
         )
     private val tilpassKompetanserService =
@@ -480,7 +476,6 @@ internal class KompetanseServiceTest {
                     barnasIdenter = listOf(barn1, barn2).map { it.aktivFødselsnummer() },
                     barnAktør = listOf(barn1, barn2),
                 )
-            every { unleashService.isEnabled(FeatureToggle.STØTTER_LOVENDRING_2025) } returns true
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/VilkårVurderingBuilder.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ks.sak.kjerne.eøs.util
 import io.mockk.every
 import io.mockk.mockk
 import mockAdopsjonService
-import no.nav.familie.ks.sak.cucumber.mocking.mockUnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.tilfeldigPerson
@@ -106,7 +105,6 @@ data class VilkårsvurderingBuilder(
                 beregnAndelTilkjentYtelseService =
                     BeregnAndelTilkjentYtelseService(
                         andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-                        unleashService = mockUnleashNextMedContextService(),
                         adopsjonService = mockAdopsjonService(),
                     ),
                 overgangsordningAndelRepository = mockOvergangsordningAndelRepository(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/lovverk/LovverkUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/lovverk/LovverkUtlederTest.kt
@@ -5,21 +5,12 @@ import org.junit.jupiter.api.Test
 
 class LovverkUtlederTest {
     @Test
-    fun `skal returnere lovverk FØR_LOVENDRING_2025 dersom toggle er av, selv om fødselsdato er senere enn FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025`() {
-        // Arrange
-        val fødselsdato = LovverkUtleder.FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025.plusDays(1)
-
-        // Act & Assert
-        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = false)).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
-    }
-
-    @Test
     fun `skal returnere lovverk FØR_LOVENDRING_2025 dersom fødselsdato er før FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025`() {
         // Arrange
         val fødselsdato = LovverkUtleder.FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025.minusDays(1)
 
         // Act & Assert
-        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
+        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = null)).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
     }
 
     @Test
@@ -28,7 +19,7 @@ class LovverkUtlederTest {
         val fødselsdato = LovverkUtleder.FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025.plusDays(1)
 
         // Act & Assert
-        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
+        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = null)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
     }
 
     @Test
@@ -37,7 +28,7 @@ class LovverkUtlederTest {
         val fødselsdato = LovverkUtleder.FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025
 
         // Act & Assert
-        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = null, skalBestemmeLovverkBasertPåFødselsdato = true)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
+        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = null)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
     }
 
     @Test
@@ -47,7 +38,7 @@ class LovverkUtlederTest {
         val adopsjonsdato = LovverkUtleder.FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025
 
         // Act & Assert
-        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = true)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
+        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
     }
 
     @Test
@@ -57,7 +48,7 @@ class LovverkUtlederTest {
         val adopsjonsdato = LovverkUtleder.FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025.plusDays(1)
 
         // Act & Assert
-        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = true)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
+        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato)).isEqualTo(Lovverk.LOVENDRING_FEBRUAR_2025)
     }
 
     @Test
@@ -67,6 +58,6 @@ class LovverkUtlederTest {
         val adopsjonsdato = LovverkUtleder.FØDSELSDATO_GRENSE_LOVENDRING_FEBRUAR_2025.minusDays(1)
 
         // Act & Assert
-        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato, skalBestemmeLovverkBasertPåFødselsdato = true)).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
+        assertThat(LovverkUtleder.utledLovverkForBarn(fødselsdato = fødselsdato, adopsjonsdato = adopsjonsdato)).isEqualTo(Lovverk.FØR_LOVENDRING_2025)
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24343

Sletter toggle for regelverk 2025 da vi har gått live.

Ny versjon av dette da jeg tnekte det var lettere å fjerne koden på nytt istedenfor å fikse alle trillion conflicts
https://github.com/navikt/familie-ks-sak/pull/1097