### PR TITLE
Vi henter saksbehandler navn fra integrasjoner når vi skal opprette signatur til vedtaksbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -14,5 +14,8 @@ enum class FeatureToggle(
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
     STØTTER_ADOPSJON("familie-ks-sak.stotter-adopsjon"),
 
+    // NAV-24034
+    BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR("familie-ks-sak.bruk-ny-saksbehandler-navn-format-i-signatur"),
+
     ALLEREDE_UTBETALT_SOM_ENDRINGSÅRSAK("familie-ks-sak.allerede-utbetalt"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
@@ -28,6 +28,7 @@ import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
+import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.familie.ks.sak.api.dto.ManuellAdresseInfo
 import no.nav.familie.ks.sak.api.dto.OppdaterJournalpostRequestDto
@@ -152,6 +153,29 @@ class IntegrasjonClient(
             tjeneste = "oppgave",
             uri = uri,
             formål = "Finn oppgave med id $oppgaveId",
+        ) {
+            getForEntity(uri)
+        }
+    }
+
+    @Retryable(
+        value = [Exception::class],
+        maxAttempts = 3,
+        backoff = Backoff(delayExpression = RETRY_BACKOFF_5000MS),
+    )
+    @Cacheable("saksbehandler", cacheManager = "shortCache")
+    fun hentSaksbehandler(id: String): Saksbehandler {
+        val uri =
+            UriComponentsBuilder
+                .fromUri(integrasjonUri)
+                .pathSegment("saksbehandler", id)
+                .build()
+                .toUri()
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "saksbehandler",
+            uri = uri,
+            formål = "Hent saksbehandler",
         ) {
             getForEntity(uri)
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/SaksbehandlerContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/sikkerhet/SaksbehandlerContext.kt
@@ -1,20 +1,40 @@
 package no.nav.familie.ks.sak.sikkerhet
 
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
 class SaksbehandlerContext(
-    @Value("\${rolle.kode6}")
-    private val kode6GruppeId: String,
+    @Value("\${rolle.kode6}") private val kode6GruppeId: String,
+    private val integrasjonClient: IntegrasjonClient,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
+    private val logger = LoggerFactory.getLogger(SaksbehandlerContext::class.java)
+
     fun hentSaksbehandlerSignaturTilBrev(): String {
         val grupper = SikkerhetContext.hentGrupper()
 
         return if (grupper.contains(kode6GruppeId)) {
             ""
         } else {
-            SikkerhetContext.hentSaksbehandlerNavn()
+            val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
+
+            if (!unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR)) {
+                return SikkerhetContext.hentSaksbehandlerNavn()
+            }
+
+            return try {
+                val saksbehandler = integrasjonClient.hentSaksbehandler(saksbehandlerIdent)
+
+                "${saksbehandler.fornavn} ${saksbehandler.etternavn}".trim()
+            } catch (exception: Exception) {
+                logger.warn("Oppstod feil ved forsøk på å hente saksbehandler signatur til brev ($saksbehandlerIdent), bruker navn fra token.")
+                SikkerhetContext.hentSaksbehandlerNavn()
+            }
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/SaksbehandlerContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/SaksbehandlerContextTest.kt
@@ -1,0 +1,109 @@
+package no.nav.familie.ks.sak.sikkerhet
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class SaksbehandlerContextTest {
+    private val mockIntegrasjonClient = mockk<IntegrasjonClient>()
+    private val kode6GruppeId = "kode6GruppeId"
+    private val mockUnleashNextMedContextService = mockk<UnleashNextMedContextService>()
+
+    private val saksbehandlerContext = SaksbehandlerContext(kode6GruppeId, mockIntegrasjonClient, mockUnleashNextMedContextService)
+
+    @BeforeEach
+    fun beforeEach() {
+        mockkObject(SikkerhetContext)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class HentSaksbehandlerSignaturTilBrevTest {
+        @Test
+        fun `skal returnere tom streng dersom SB har kode6 gruppen`() {
+            // Arrange
+            every { SikkerhetContext.hentGrupper() } returns listOf(kode6GruppeId)
+            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns true
+
+            // Act
+            val saksbehandlerSignatur = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+
+            // Assert
+            assertThat(saksbehandlerSignatur).isEqualTo("")
+        }
+
+        @Test
+        fun `skal returnere navn fra token dersom kall mot integrasjoner feiler`() {
+            // Arrange
+            every { SikkerhetContext.hentGrupper() } returns emptyList()
+            every { mockIntegrasjonClient.hentSaksbehandler(any()) } throws Exception()
+            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns true
+            every { SikkerhetContext.hentSaksbehandlerNavn() } returns "Etternavn, Fornavn"
+
+            // Act
+            val saksbehandlerSignatur = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+
+            // Assert
+            assertThat(saksbehandlerSignatur).isEqualTo("Etternavn, Fornavn")
+
+            verify(exactly = 1) { SikkerhetContext.hentSaksbehandlerNavn() }
+        }
+
+        @Test
+        fun `skal returnere navn fra token dersom feature toggle er skrudd av`() {
+            // Arrange
+            every { SikkerhetContext.hentGrupper() } returns emptyList()
+            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns false
+            every { SikkerhetContext.hentSaksbehandlerNavn() } returns "Etternavn, Fornavn"
+
+            // Act
+            val saksbehandlerSignatur = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+
+            // Assert
+            assertThat(saksbehandlerSignatur).isEqualTo("Etternavn, Fornavn")
+
+            verify(exactly = 1) { SikkerhetContext.hentSaksbehandlerNavn() }
+        }
+
+        @Test
+        fun `skal returnere navn fra integrasjoner`() {
+            // Arrange
+            val saksbehandler =
+                Saksbehandler(
+                    azureId = UUID.randomUUID(),
+                    navIdent = "navIdent",
+                    fornavn = "fornavn",
+                    etternavn = "etternavn",
+                    enhet = "enhet",
+                )
+
+            every { SikkerhetContext.hentGrupper() } returns emptyList()
+            every { mockIntegrasjonClient.hentSaksbehandler(any()) } returns saksbehandler
+            every { mockUnleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR) } returns true
+
+            // Act
+            val saksbehandlerSignatur = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+
+            // Assert
+            assertThat(saksbehandlerSignatur).isEqualTo("fornavn etternavn")
+
+            verify(exactly = 1) { mockIntegrasjonClient.hentSaksbehandler(any()) }
+        }
+    }
+}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24034

Dette er testet OK for BA, og legges nå i KS.
Kopierer begrunnelse fra BA prn på hvorfor ting er gjort som de er gjort:

Det er ønskelig at navn i vedtaksbrev på saksbehandler og beslutter kommer på formatet "Fornavn Mellomnavn Etternavn".
Per nå henter vi ut navn fra tokenet, og vi får dette: "Etternavn, Fornavn Mellomnavn".

Jeg har derfor undersøkt 3 forskjellige måter å få dette ordnet på:

- Vi splitter navn fra token på "," og restrukturerer det vi får fra tokenet
Jeg hadde egentlig ikke lyst til å gå for denne retningen, da det føles feil ut å tukle med navnet vi får fra tokenet.
Dessuten så er det ikke gitt at navn vil alltid komme med denne strukturen i evig tid, og dersom det en dag endres og kommaen forsvinner, så vil ting feile.
- Legge på ekstra claims i tokenet og hente fra `family_name` og `given_name`
Det er mulig å hente dette i AD tokenet, men family name og given name er optional claims som vanligvis ikke følges med i tokenet. Se https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference. Jeg sjekket med Trong fra Nais teamet, og dersom vi ønsker dette i tokenet så må det endres i flere systemer, og han kunne ikke si noe konkret på når dette kunne bli gjort. Det ble derfor anbefalt å bruke Graph APIet til Microsoft for å hente det ut.
- Gjøre kall mot familie-integrasjoner 
Dette er løsningen jeg gikk for.
I familie integrasjoner har vi et endepunkt for å hente ut saksbehandler objekt. Det bruker Graph APIeet. Dette objektet inkluderer navna, som jeg nå henter og slår sammen. Hvis dette feiler fallbacker vi til vanlig prosedyre og henter ut navn fra token.
