### PR TITLE
Erstatt ordinær andel med praksis endring andel hvis det overlappes i samme periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
-import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -14,7 +13,6 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import no.nav.familie.ks.sak.kjerne.praksisendring.Praksisendring2024Service
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
-import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -88,25 +88,9 @@ class TilkjentYtelseService(
             val praksisendringTidslinjeForAktør = praksisendringTidslinjer[aktør] ?: return@flatMap ordinæreAndeler.filter { it.aktør == aktør }
 
             ordinæreAndelTidslinjeForAktør
-                .kombinerMed(praksisendringTidslinjeForAktør) { ordinæreAndel, praksisendringAndel ->
-                    praksisendringAndel ?: ordinæreAndel
-                }.tilPerioderIkkeNull()
-                .map { periode ->
-                    val andelIPeriode = periode.verdi
-
-                    AndelTilkjentYtelse(
-                        behandlingId = andelIPeriode.behandlingId,
-                        tilkjentYtelse = andelIPeriode.tilkjentYtelse,
-                        aktør = andelIPeriode.aktør,
-                        prosent = andelIPeriode.prosent,
-                        stønadFom = periode.fom!!.toYearMonth(),
-                        stønadTom = periode.tom!!.toYearMonth(),
-                        kalkulertUtbetalingsbeløp = andelIPeriode.kalkulertUtbetalingsbeløp,
-                        nasjonaltPeriodebeløp = andelIPeriode.nasjonaltPeriodebeløp,
-                        type = andelIPeriode.type,
-                        sats = andelIPeriode.sats,
-                    )
-                }
+                .kombinerMed(praksisendringTidslinjeForAktør) { ordinærAndel, praksisendringAndel ->
+                    praksisendringAndel ?: ordinærAndel
+                }.tilAndelerTilkjentYtelse()
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.beregning
 
+import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -12,6 +13,8 @@ import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.utfyltePerioder
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import no.nav.familie.ks.sak.kjerne.praksisendring.Praksisendring2024Service
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -56,13 +59,55 @@ class TilkjentYtelseService(
                 tilkjentYtelse = tilkjentYtelse,
             )
 
-        val alleAndelerTilkjentYtelse =
-            andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel } +
-                overgangsordningAndelerSomAndelTilkjentYtelse +
-                andelerForPraksisendring2024
+        val alleOrdinæreAndeler = andelerTilkjentYtelseBarnaMedAlleEndringer.map { it.andel }
+
+        val alleOrdinæreAndelerJustert = alleOrdinæreAndeler.taHensynTilPraksisendringAndeler(andelerForPraksisendring2024)
+
+        val alleAndelerTilkjentYtelse = alleOrdinæreAndelerJustert + overgangsordningAndelerSomAndelTilkjentYtelse
 
         tilkjentYtelse.andelerTilkjentYtelse.addAll(alleAndelerTilkjentYtelse)
         return tilkjentYtelse
+    }
+
+    private fun List<AndelTilkjentYtelse>.taHensynTilPraksisendringAndeler(praksisendringAndeler: List<AndelTilkjentYtelse>): List<AndelTilkjentYtelse> {
+        val ordinæreAndeler = this
+
+        if (praksisendringAndeler.isEmpty()) return ordinæreAndeler
+        if (ordinæreAndeler.isEmpty()) return praksisendringAndeler
+
+        val aktørerMedPraksisendringAndeler = praksisendringAndeler.map { it.aktør }
+        val aktørerMedOrdinæreAndeler = ordinæreAndeler.map { it.aktør }
+
+        val alleAktører = (aktørerMedPraksisendringAndeler + aktørerMedOrdinæreAndeler).distinct()
+
+        val ordinæreAndelTidslinjer = ordinæreAndeler.tilSeparateTidslinjerForBarna()
+        val praksisendringTidslinjer = praksisendringAndeler.tilSeparateTidslinjerForBarna()
+
+        return alleAktører.flatMap { aktør ->
+            val ordinæreAndelTidslinjeForAktør = ordinæreAndelTidslinjer[aktør] ?: return@flatMap praksisendringAndeler.filter { it.aktør == aktør }
+            val praksisendringTidslinjeForAktør = praksisendringTidslinjer[aktør] ?: return@flatMap ordinæreAndeler.filter { it.aktør == aktør }
+
+            ordinæreAndelTidslinjeForAktør
+                .kombinerMed(praksisendringTidslinjeForAktør) { ordinæreAndel, praksisendringAndel ->
+                    praksisendringAndel ?: ordinæreAndel
+                }.tilPerioderIkkeNull()
+                .map { periode ->
+                    val andelIPeriode = periode.verdi
+
+                    AndelTilkjentYtelse(
+                        behandlingId = andelIPeriode.behandlingId,
+                        tilkjentYtelse = andelIPeriode.tilkjentYtelse,
+                        aktør = andelIPeriode.aktør,
+                        prosent = andelIPeriode.prosent,
+                        stønadFom = periode.fom!!.toYearMonth(),
+                        stønadTom = periode.tom!!.toYearMonth(),
+                        kalkulertUtbetalingsbeløp = andelIPeriode.kalkulertUtbetalingsbeløp,
+                        nasjonaltPeriodebeløp = andelIPeriode.nasjonaltPeriodebeløp,
+                        type = andelIPeriode.type,
+                        sats = andelIPeriode.sats,
+                    )
+                }
+        }
     }
 
     private fun genererAndelerTilkjentYtelseFraOvergangsordningAndeler(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024Service.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/praksisendring/Praksisendring2024Service.kt
@@ -86,8 +86,12 @@ class Praksisendring2024Service(
             return false
         }
 
-        val harOrdinærAndelISammeMånedSom13Måneder = andelerTilkjentYtelse.any { it.aktør == barn.aktør && it.stønadsPeriode().inkluderer(barn13Måneder) }
-        if (harOrdinærAndelISammeMånedSom13Måneder) {
+        val harOrdinærAndelISammeMånedSom13MånederSomIkkeErRedusert =
+            andelerTilkjentYtelse.any {
+                it.aktør == barn.aktør && it.stønadsPeriode().inkluderer(barn13Måneder) && it.prosent == BigDecimal.valueOf(100)
+            }
+
+        if (harOrdinærAndelISammeMånedSom13MånederSomIkkeErRedusert) {
             return false
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -155,7 +155,7 @@ internal class TilkjentYtelseServiceTest {
 
     @Test
     fun `beregnTilkjentYtelse skal legge til praksisendringsandeler som blir generert`() {
-        // Arrage
+        // Arrange
         every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns
             listOf(
                 lagAndelTilkjentYtelse(aktør = barn1, fom = YearMonth.of(2024, 9), tom = YearMonth.of(2024, 9), ytelseType = YtelseType.PRAKSISENDRING_2024),
@@ -283,7 +283,7 @@ internal class TilkjentYtelseServiceTest {
     }
 
     @Test
-    fun `beregnTilkjentYtelse skal erstatte ordinære andeler maed praksisendring andeler og lage riktig splitt hvis ordinær andel spaserer flere måned og overlapper med praksisendring `() {
+    fun `beregnTilkjentYtelse skal erstatte ordinære andeler med praksisendring andeler og lage riktig splitt hvis ordinær andel strekker seg over flere måneder og overlapper med praksisendring `() {
         // arrange
         every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns
             listOf(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseServiceTest.kt
@@ -64,10 +64,10 @@ internal class TilkjentYtelseServiceTest {
 
     private val beregnAndelTilkjentYtelseService: BeregnAndelTilkjentYtelseService =
         spyk(
-        BeregnAndelTilkjentYtelseService(
-            andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
-            adopsjonService = mockAdopsjonService(),
-        )
+            BeregnAndelTilkjentYtelseService(
+                andelGeneratorLookup = AndelGenerator.Lookup(listOf(LovverkFebruar2025AndelGenerator(), LovverkFørFebruar2025AndelGenerator())),
+                adopsjonService = mockAdopsjonService(),
+            ),
         )
 
     private val overgangsordningAndelRepositoryMock: OvergangsordningAndelRepository = mockk()
@@ -156,9 +156,10 @@ internal class TilkjentYtelseServiceTest {
     @Test
     fun `beregnTilkjentYtelse skal legge til praksisendringsandeler som blir generert`() {
         // Arrage
-        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns listOf(
-            lagAndelTilkjentYtelse(aktør = barn1, fom = YearMonth.of(2024, 9), tom = YearMonth.of(2024, 9), ytelseType = YtelseType.PRAKSISENDRING_2024),
-        )
+        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(aktør = barn1, fom = YearMonth.of(2024, 9), tom = YearMonth.of(2024, 9), ytelseType = YtelseType.PRAKSISENDRING_2024),
+            )
 
         vilkårsvurdering.personResultater +=
             lagPersonResultat(
@@ -195,13 +196,15 @@ internal class TilkjentYtelseServiceTest {
     @Test
     fun `beregnTilkjentYtelse skal legge sammen praksisendringsandeler og ordinære andeler som ikke overlapper`() {
         // Arrange
-        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns listOf(
-            lagAndelTilkjentYtelse(aktør = barn1, fom = YearMonth.of(2024, 9), tom = YearMonth.of(2024, 9), ytelseType = YtelseType.PRAKSISENDRING_2024),
-        )
+        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(aktør = barn1, fom = YearMonth.of(2024, 9), tom = YearMonth.of(2024, 9), ytelseType = YtelseType.PRAKSISENDRING_2024),
+            )
 
-        every { beregnAndelTilkjentYtelseService.beregnAndelerTilkjentYtelse(any(), any(), any()) } returns listOf(
-            lagAndelTilkjentYtelse(aktør = barn1, fom = YearMonth.of(2024, 6), tom = YearMonth.of(2024, 8), ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE),
-        )
+        every { beregnAndelTilkjentYtelseService.beregnAndelerTilkjentYtelse(any(), any(), any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(aktør = barn1, fom = YearMonth.of(2024, 6), tom = YearMonth.of(2024, 8), ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE),
+            )
 
         // Act
         val tilkjentYtelse =
@@ -235,26 +238,28 @@ internal class TilkjentYtelseServiceTest {
     @Test
     fun `beregnTilkjentYtelse skal erstatte ordinære andeler med praksisendring andeler hvis det finnes begge i samme periode`() {
         // Arrange
-        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns listOf(
-            lagAndelTilkjentYtelse(
-                aktør = barn1,
-                fom = YearMonth.of(2024, 9),
-                tom = YearMonth.of(2024, 9),
-                ytelseType = YtelseType.PRAKSISENDRING_2024,
-                prosent = BigDecimal(100)
-            ),
-        )
+        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(
+                    aktør = barn1,
+                    fom = YearMonth.of(2024, 9),
+                    tom = YearMonth.of(2024, 9),
+                    ytelseType = YtelseType.PRAKSISENDRING_2024,
+                    prosent = BigDecimal(100),
+                ),
+            )
 
-        every { beregnAndelTilkjentYtelseService.beregnAndelerTilkjentYtelse(any(), any(), any()) } returns listOf(
-            lagAndelTilkjentYtelse(
-                aktør = barn1,
-                fom = YearMonth.of(2024, 9),
-                tom = YearMonth.of(2024, 9),
-                ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
-                prosent = BigDecimal(50),
-                beløp = 3750
-            ),
-        )
+        every { beregnAndelTilkjentYtelseService.beregnAndelerTilkjentYtelse(any(), any(), any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(
+                    aktør = barn1,
+                    fom = YearMonth.of(2024, 9),
+                    tom = YearMonth.of(2024, 9),
+                    ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
+                    prosent = BigDecimal(50),
+                    beløp = 3750,
+                ),
+            )
 
         // Act
         val tilkjentYtelse =
@@ -280,26 +285,28 @@ internal class TilkjentYtelseServiceTest {
     @Test
     fun `beregnTilkjentYtelse skal erstatte ordinære andeler maed praksisendring andeler og lage riktig splitt hvis ordinær andel spaserer flere måned og overlapper med praksisendring `() {
         // arrange
-        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns listOf(
-            lagAndelTilkjentYtelse(
-                aktør = barn1,
-                fom = YearMonth.of(2024, 9),
-                tom = YearMonth.of(2024, 9),
-                ytelseType = YtelseType.PRAKSISENDRING_2024,
-                prosent = BigDecimal(100)
-            ),
-        )
+        every { praksisendring2024Service.genererAndelerForPraksisendring2024(any(), any(), any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(
+                    aktør = barn1,
+                    fom = YearMonth.of(2024, 9),
+                    tom = YearMonth.of(2024, 9),
+                    ytelseType = YtelseType.PRAKSISENDRING_2024,
+                    prosent = BigDecimal(100),
+                ),
+            )
 
-        every { beregnAndelTilkjentYtelseService.beregnAndelerTilkjentYtelse(any(), any(), any()) } returns listOf(
-            lagAndelTilkjentYtelse(
-                aktør = barn1,
-                fom = YearMonth.of(2024, 9),
-                tom = YearMonth.of(2024, 12),
-                ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
-                prosent = BigDecimal(50),
-                beløp = 3750
-            ),
-        )
+        every { beregnAndelTilkjentYtelseService.beregnAndelerTilkjentYtelse(any(), any(), any()) } returns
+            listOf(
+                lagAndelTilkjentYtelse(
+                    aktør = barn1,
+                    fom = YearMonth.of(2024, 9),
+                    tom = YearMonth.of(2024, 12),
+                    ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
+                    prosent = BigDecimal(50),
+                    beløp = 3750,
+                ),
+            )
 
         // act
         val tilkjentYtelse =
@@ -329,7 +336,6 @@ internal class TilkjentYtelseServiceTest {
             type = YtelseType.ORDINÆR_KONTANTSTØTTE,
         )
     }
-
 
     @Test
     fun `beregnTilkjentYtelse tar ikke med tom overgangsordningandel`() {
@@ -658,7 +664,7 @@ internal class TilkjentYtelseServiceTest {
         vilkårsvurdering.personResultater += personResultatForBarn
 
         val tilkjentYtelse =
-            tilkjentYtelseService. beregnTilkjentYtelse(
+            tilkjentYtelseService.beregnTilkjentYtelse(
                 vilkårsvurdering = vilkårsvurdering,
                 personopplysningGrunnlag = personopplysningGrunnlag,
             )


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24404

Per i dag så er koden satt opp slik at dersom barn får ordinær andel for en måned, så har de IKKE krav på praksisendring andel for samme måned.

Det er feil.
Gitt at et barn ble 13 mnd i august 2024, startet i deltidsbarnehage i august 2024 så ville barnet fått disse andelene:
- Før november 2024 ville barnet fått en andel på 7500 kroner
- Fra og med november 2024 ville barnet fått en andel på 1500 kroner.

Siden vi ikke skal kreve tilbake de 6000 kronene, så må derfor barnet få full andel som tidligere.
Jeg har derfor:

- Endret krav på å få praksisendring andel fra å ikke ha ordinær andel i samme måned til å ikke ha ordinær FULL sats andel i samme måned som barnehagestart
- Hvis det eksisterer ordinær andel samme måned som praksisendring andelen, vil man alltid velge praksisendring andelen
- Skape riktige splitter i ATY dersom den ordinære andelen varte flere mnd.