### PR TITLE
Chore: fjern toggle for 'støtter adopsjon'

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -12,7 +12,6 @@ enum class FeatureToggle(
 
     // Ikke operasjonelle
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
-    STØTTER_ADOPSJON("familie-ks-sak.stotter-adopsjon"),
 
     // NAV-24034
     BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR("familie-ks-sak.bruk-ny-saksbehandler-navn-format-i-signatur"),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonValidator.kt
@@ -2,8 +2,6 @@ package no.nav.familie.ks.sak.kjerne.adopsjon
 
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
@@ -12,16 +10,11 @@ import java.time.LocalDate
 
 @Component
 class AdopsjonValidator(
-    private val unleashService: UnleashNextMedContextService,
     private val adopsjonService: AdopsjonService,
 ) {
     fun validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(
         vilkårsvurdering: Vilkårsvurdering,
     ) {
-        if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
-            return
-        }
-
         val adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(behandlingId = vilkårsvurdering.behandling.behandlingId)
 
         vilkårsvurdering.personResultater.forEach { personResultat ->
@@ -50,9 +43,6 @@ class AdopsjonValidator(
         nyAdopsjonsdato: LocalDate?,
         barnetsFødselsdato: LocalDate,
     ) {
-        if (!unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)) {
-            return
-        }
         if (vilkår != Vilkår.BARNETS_ALDER) {
             throw Feil("Prøver å oppdatere adopsjonsdato på $vilkår-vilkåret, men adopsjonsdato kan ikke oppdateres for andre vilkår enn barnets alder")
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -7,8 +7,6 @@ import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.slåSammen
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonValidator
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
@@ -48,7 +46,6 @@ class VilkårsvurderingSteg(
     private val beregningService: BeregningService,
     private val kompetanseService: KompetanseService,
     private val barnetsVilkårValidator: BarnetsVilkårValidator,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
     private val adopsjonValidator: AdopsjonValidator,
     private val adopsjonService: AdopsjonService,
 ) : IBehandlingSteg {
@@ -63,12 +60,6 @@ class VilkårsvurderingSteg(
 
         val søknadDto = søknadGrunnlagService.finnAktiv(behandlingId = behandling.id)?.tilSøknadDto()
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id)
-
-        if (vilkårsvurdering.personResultater.any { personResultat -> personResultat.vilkårResultater.any { it.erAdopsjonOppfylt() } } &&
-            !unleashNextMedContextService.isEnabled(FeatureToggle.STØTTER_ADOPSJON)
-        ) {
-            throw FunksjonellFeil("Adopsjonssaker kan ikke behandles før nytt regelverk er støttet i løsningen")
-        }
 
         adopsjonValidator.validerAdopsjonIUtdypendeVilkårsvurderingOgAdopsjonsdato(vilkårsvurdering = vilkårsvurdering)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -131,7 +131,7 @@ class CucumberMock(
             loggService = loggServiceMock,
         )
 
-    val adopsjonValidator = AdopsjonValidator(mockUnleashNextMedContextService(), adopsjonServiceMock)
+    val adopsjonValidator = AdopsjonValidator(adopsjonServiceMock)
 
     val vilkårsvurderingService =
         VilkårsvurderingService(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -13,8 +13,6 @@ import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.NullablePeriode
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPerson
@@ -63,7 +61,6 @@ class VilkårsvurderingStegTest {
     private val søknadGrunnlagService: SøknadGrunnlagService = mockk()
     private val beregningService: BeregningService = mockk()
     private val kompetanseService: KompetanseService = mockk()
-    private val unleashService: UnleashNextMedContextService = mockk()
     private val adopsjonService: AdopsjonService = mockk()
 
     private val barnetsAlderVilkårValidator2021 = BarnetsAlderVilkårValidator2021()
@@ -82,7 +79,7 @@ class VilkårsvurderingStegTest {
             ),
             adopsjonService,
         )
-    private val adopsjonValidator = AdopsjonValidator(unleashService, adopsjonService)
+    private val adopsjonValidator = AdopsjonValidator(adopsjonService)
 
     private val vilkårsvurderingSteg: VilkårsvurderingSteg =
         VilkårsvurderingSteg(
@@ -93,7 +90,6 @@ class VilkårsvurderingStegTest {
             beregningService,
             kompetanseService,
             barnetsVilkårValidator,
-            unleashService,
             adopsjonValidator,
             adopsjonService,
         )
@@ -134,7 +130,6 @@ class VilkårsvurderingStegTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
         every { beregningService.oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(any(), any(), any()) } just runs
-        every { unleashService.isEnabled(FeatureToggle.STØTTER_ADOPSJON) } returns true
         every { adopsjonService.hentAlleAdopsjonerForBehandling(any()) } returns emptyList()
         every { adopsjonService.finnAdopsjonForAktørIBehandling(any(), any()) } returns null
     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24426

Fjerner toggle for støtte for adopsjon. Dette har vært skrudd på i prod i noen dager og tenker det derfor er trygt å fjerne. Om noe skulle vise seg å være feil er det bedre å fikse feilen enn å skru av alt igjen :)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Fjerner bare toggle

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
