### PR TITLE
Fiks vilkårsvurdering sjekk i endringstidspuntk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringstidspunktService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringstidspunktService.kt
@@ -78,8 +78,8 @@ class EndringstidspunktService(
         inneværendeBehandlingId: Long,
         forrigeBehandlingId: Long,
     ): YearMonth? {
-        val nåværendeVilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = inneværendeBehandlingId) ?: return null
-        val forrigeVilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = forrigeBehandlingId) ?: return null
+        val nåværendeVilkårsvurdering = vilkårsvurderingService.finnAktivVilkårsvurdering(behandlingId = inneværendeBehandlingId) ?: return null
+        val forrigeVilkårsvurdering = vilkårsvurderingService.finnAktivVilkårsvurdering(behandlingId = forrigeBehandlingId) ?: return null
 
         return EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
             nåværendePersonResultat = nåværendeVilkårsvurdering.personResultater,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -783,6 +783,10 @@ class StepDefinition {
             val behandlingId = firstArg<Long>()
             vilkårsvurdering[behandlingId]!!
         }
+        every { vilkårsvurderingService.finnAktivVilkårsvurdering(any<Long>()) } answers {
+            val behandlingId = firstArg<Long>()
+            vilkårsvurdering[behandlingId]!!
+        }
         every { vilkårsvurderingService.oppdater(any()) } answers { firstArg<Vilkårsvurdering>() }
 
         return vilkårsvurderingService


### PR DESCRIPTION
Vi må bruke finn istedenfor hent, da det ikke er sikkert at vilkårsvurdering er opprettet når man først skal sjekke endringstidspunkt.