### PR TITLE
Filtrer bort overgangsordningandel med kalkulert utbetalingsbeløp lik 0

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -175,7 +175,8 @@ class UtbetalingsoppdragService(
         val andelerSomSkalSendesTilOppdrag = tilkjentYtelse.andelerTilkjentYtelse.filtrerAndelerSomSkalSendesTilOppdrag()
 
         if (andelerMedPeriodeId.size != andelerSomSkalSendesTilOppdrag.size) {
-            secureLogger.warn("andelerMedPeriodeId: $andelerMedPeriodeId, andelerSomSkalSendesTilOppdrag: $andelerSomSkalSendesTilOppdrag")
+            logger.warn("Uventet antall andeler fra utbetalingsgenerator. Se secureLogger for informasjon.")
+            secureLogger.warn("Uventet antall andeler fra utbetalingsgenerator. Andeler fra utbetalingsgenerator: $andelerMedPeriodeId, forventede andeler: $andelerSomSkalSendesTilOppdrag")
             error("Antallet andeler med oppdatert periodeOffset, forrigePeriodeOffset og kildeBehandlingId fra ny generator skal være likt antallet ordinære andeler med kalkulertUtbetalingsbeløp != 0 + antall barn med overgangsordning. Generator gir ${andelerMedPeriodeId.size} andeler men det er ${andelerSomSkalSendesTilOppdrag.size} andeler med kalkulertUtbetalingsbeløp != 0")
         }
         andelerSomSkalSendesTilOppdrag.forEach { andel ->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/AndelTilkjentYtelse.kt
@@ -147,7 +147,7 @@ data class AndelTilkjentYtelse(
             this.differanseberegnetPeriodebeløp == andel.differanseberegnetPeriodebeløp
 }
 
-fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> = overgangsordningAndelerPerAktør().map { it.value.minBy { it.stønadFom } } + ordinæreOgPraksisendringAndeler().filter { it.kalkulertUtbetalingsbeløp != 0 }
+fun Iterable<AndelTilkjentYtelse>.filtrerAndelerSomSkalSendesTilOppdrag(): List<AndelTilkjentYtelse> = (overgangsordningAndelerPerAktør().map { it.value.minBy { it.stønadFom } } + ordinæreOgPraksisendringAndeler()).filter { it.kalkulertUtbetalingsbeløp != 0 }
 
 fun List<AndelTilkjentYtelse>.slåSammenBack2BackAndelsperioderMedSammeBeløp(): List<AndelTilkjentYtelse> =
     this.fold(emptyList()) { acc, andelTilkjentYtelse ->


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-24437

I behandlinger der overgangsordning endres til å ikke gi en utbetaling, kastes det en feil, fordi forventede andeler er ulikt andeler som genereres av utbetalingsgeneratoren. Dette skyldes at overgangsordningandeler med kalkulert utbetalingsbeløp lik 0 tas med. Løser problemet ved å filtrere bort disse

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
