### PR TITLE
Bug/maned og ar begrunnelsen gjelder for

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -478,7 +478,7 @@ fun hentBrevBegrunnelseTekster(
         """
 
     Så forvent følgende brevbegrunnelser for behandling $behandlingId i periode ${vedtaksperiode.fom?.tilddMMyyyy() ?: "-"} til ${vedtaksperiode.tom?.tilddMMyyyy() ?: "-"}
-        | Begrunnelse | Type | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | Gjelder andre forelder |""" +
+        | Begrunnelse | Type | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | Måned og år før vedtaksperiode |""" +
             vedtaksperiode.begrunnelser.map { it.nasjonalEllerFellesBegrunnelse }.joinToString("") {
                 """
         | $it | STANDARD |               |                      |             |                                      |         |       |                  |                         |                               |         |"""

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -50,7 +50,7 @@ fun lagBrevTest(
 # language: no
 # encoding: UTF-8
 
-Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric(10)}
+Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.insecure().nextAlphanumeric(10)}
 
   Bakgrunn:""" +
             hentTekstForFagsak() +
@@ -58,7 +58,7 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.randomAlphanumeric
             hentTekstForPersongrunnlag(persongrunnlag, persongrunnlagForrigeBehandling) +
             """
       
-  Scenario: Plassholdertekst for scenario - ${RandomStringUtils.randomAlphanumeric(10)}
+  Scenario: Plassholdertekst for scenario - ${RandomStringUtils.insecure().nextAlphanumeric(10)}
     Og følgende dagens dato ${LocalDate.now().tilddMMyyyy()}""" +
             hentTekstForVilkårresultater(
                 personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -23,8 +23,8 @@ import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.Utenland
 import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.domene.Valutakurs
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
-import org.apache.commons.lang3.RandomStringUtils
 import java.math.BigDecimal
+import java.security.SecureRandom
 import java.time.LocalDate
 
 fun lagBrevTest(
@@ -50,7 +50,7 @@ fun lagBrevTest(
 # language: no
 # encoding: UTF-8
 
-Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.insecure().nextAlphanumeric(10)}
+Egenskap: Plassholdertekst for egenskap - ${SecureRandom().nextLong()}
 
   Bakgrunn:""" +
             hentTekstForFagsak() +
@@ -58,7 +58,7 @@ Egenskap: Plassholdertekst for egenskap - ${RandomStringUtils.insecure().nextAlp
             hentTekstForPersongrunnlag(persongrunnlag, persongrunnlagForrigeBehandling) +
             """
       
-  Scenario: Plassholdertekst for scenario - ${RandomStringUtils.insecure().nextAlphanumeric(10)}
+  Scenario: Plassholdertekst for scenario - ${SecureRandom().nextLong()}
     Og følgende dagens dato ${LocalDate.now().tilddMMyyyy()}""" +
             hentTekstForVilkårresultater(
                 personResultaterForrigeBehandling?.sorterPåFødselsdato(persongrunnlagForrigeBehandling!!),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -66,9 +66,9 @@ fun hentPerioderMedUtbetaling(
             .slåSammen()
             .filtrer { !it.isNullOrEmpty() }
             .kombinerMed(splittkriterierForVilkårResultatTidslinje, splittkriterierForKompetanseTidslinjer) {
-                andelerTilkjentYtelseIPeriode,
-                splittkriterierVilkår,
-                splittKriterierKompetanse,
+                    andelerTilkjentYtelseIPeriode,
+                    splittkriterierVilkår,
+                    splittKriterierKompetanse,
                 ->
                 andelerTilkjentYtelseIPeriode?.let {
                     SplittkriterierForVedtaksperiode(splittkriterierVilkår, splittKriterierKompetanse, andelerTilkjentYtelseIPeriode)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiodeMedBegrunnelser/UtbetalingsperiodeUtil.kt
@@ -66,9 +66,9 @@ fun hentPerioderMedUtbetaling(
             .slåSammen()
             .filtrer { !it.isNullOrEmpty() }
             .kombinerMed(splittkriterierForVilkårResultatTidslinje, splittkriterierForKompetanseTidslinjer) {
-                    andelerTilkjentYtelseIPeriode,
-                    splittkriterierVilkår,
-                    splittKriterierKompetanse,
+                andelerTilkjentYtelseIPeriode,
+                splittkriterierVilkår,
+                splittKriterierKompetanse,
                 ->
                 andelerTilkjentYtelseIPeriode?.let {
                     SplittkriterierForVedtaksperiode(splittkriterierVilkår, splittKriterierKompetanse, andelerTilkjentYtelseIPeriode)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -359,7 +359,7 @@ class BrevPeriodeContext(
                             begrunnelse = begrunnelse,
                         ),
                     maanedOgAarBegrunnelsenGjelderFor = månedOgÅrBegrunnelsenGjelderFor,
-                    maanedOgAarFoorVedtaksperiode = månedOgÅrFørVedtaksperiode,
+                    maanedOgAarFoerVedtaksperiode = månedOgÅrFørVedtaksperiode,
                     maalform = personopplysningGrunnlag.søker.målform.tilSanityFormat(),
                     apiNavn = begrunnelse.sanityApiNavn,
                     belop = formaterBeløp(hentBeløp(begrunnelse)),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -610,8 +610,8 @@ class BrevPeriodeContext(
 
                 kastFeilHvisFomErUgyldig(vedtaksperiodeFom)
                 when {
-                    alleLovverkForBarna.all { it == Lovverk.LOVENDRING_FEBRUAR_2025 } -> vedtaksperiodeFom.tilMånedÅr()
                     sanityBegrunnelse.inneholderGjelderFørstePeriodeTrigger() -> hentTidligesteFomSomIkkeErOppfyltOgOverstiger33Timer(vilkårResultaterForRelevantePersoner, vedtaksperiodeFom)
+                    alleLovverkForBarna.all { it == Lovverk.LOVENDRING_FEBRUAR_2025 } -> vedtaksperiodeFom.tilMånedÅr()
                     opphørGrunnetFulltidsBarnehageplassAugust2024 -> vedtaksperiodeFom.tilMånedÅr()
                     fomErFørLovendring2024 -> vedtaksperiodeFom.tilMånedÅr()
                     else -> månedenFørFom.tilMånedÅr()
@@ -622,7 +622,7 @@ class BrevPeriodeContext(
             Vedtaksperiodetype.FORTSATT_INNVILGET,
             -> {
                 kastFeilHvisFomErUgyldig(vedtaksperiodeFom)
-                if (sanityBegrunnelse.resultat == SanityResultat.REDUKSJON && !fomErFørLovendring2024) {
+                if (sanityBegrunnelse.resultat == SanityResultat.REDUKSJON && !fomErFørLovendring2024 && alleLovverkForBarna.none { it == Lovverk.LOVENDRING_FEBRUAR_2025 }) {
                     månedenFørFom.tilMånedÅr()
                 } else {
                     vedtaksperiodeFom.tilMånedÅr()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
@@ -58,7 +58,7 @@ data class NasjonalOgFellesBegrunnelseDataDto(
     val belop: String,
     val antallTimerBarnehageplass: String,
     val soknadstidspunkt: String,
-    val maanedOgAarFoorVedtaksperiode: String?,
+    val maanedOgAarFoerVedtaksperiode: String?,
 ) : BegrunnelseDtoMedData(
         apiNavn = apiNavn,
         type = BrevBegrunnelseType.BEGRUNNELSE,

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -1459,7 +1459,7 @@ fun lagNasjonalOgFellesBegrunnelseDataDto(
         belop = belop.toString(),
         antallTimerBarnehageplass = antallTimerBarnehageplass.toString(),
         soknadstidspunkt = soknadstidspunkt.tilKortString(),
-        maanedOgAarFoorVedtaksperiode = månedOgÅrFørVedtaksperiode.tilMånedÅrKort(),
+        maanedOgAarFoerVedtaksperiode = månedOgÅrFørVedtaksperiode.tilMånedÅrKort(),
     )
 
 fun lagBrevmottakerDto(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -75,7 +75,7 @@ fun parseNasjonalEllerFellesBegrunnelse(rad: Tabellrad): BegrunnelseDtoMedData {
                 BrevPeriodeParser.DomenebegrepBrevBegrunnelse.SØKNADSTIDSPUNKT,
                 rad,
             ) ?: "",
-        maanedOgAarFoorVedtaksperiode =
+        maanedOgAarFoerVedtaksperiode =
             parseValgfriString(
                 BrevPeriodeParser.DomenebegrepBrevBegrunnelse.MÅNED_OG_ÅR_FØR_VEDTAKSPERIODE,
                 rad,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -477,8 +477,8 @@ class StepDefinition {
     ).genererBrevPeriodeDto()
 
     /**
-     * Mulige verdier Nasjonal: | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Gjelder søker  | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for| Avtale tidspunkt delt bosted | Søkers rett til utvidet |
-     * Mulige verdier EØS: | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+     * Mulige verdier Nasjonal: | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Gjelder søker  | Målform | Beløp | Søknadstidspunkt | Måned og år begrunnelsen gjelder for| Avtale tidspunkt delt bosted | Søkers rett til utvidet | Måned og år før vedtaksperiode |
+     * Mulige verdier EØS: | Begrunnelse | Type | Barnas fødselsdatoer | Antall barn | Gjelder søker | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland | Måned og år før vedtaksperiode |
      */
     @Så("forvent følgende brevbegrunnelser for behandling {} i periode {} til {}")
     fun `forvent følgende brevbegrunnelser for behandling i periode`(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -114,7 +114,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
-                maanedOgAarFoorVedtaksperiode = "mars 2022",
+                maanedOgAarFoerVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -168,7 +168,7 @@ class BrevPeriodeContextTest {
                 belop = "3 000",
                 antallTimerBarnehageplass = "17",
                 soknadstidspunkt = "",
-                maanedOgAarFoorVedtaksperiode = "mars 2022",
+                maanedOgAarFoerVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -228,7 +228,7 @@ class BrevPeriodeContextTest {
                 belop = "3 000",
                 antallTimerBarnehageplass = "17",
                 soknadstidspunkt = "",
-                maanedOgAarFoorVedtaksperiode = "mars 2022",
+                maanedOgAarFoerVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -282,7 +282,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
-                maanedOgAarFoorVedtaksperiode = "mars 2022",
+                maanedOgAarFoerVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -343,7 +343,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
-                maanedOgAarFoorVedtaksperiode = "mars 2022",
+                maanedOgAarFoerVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )
@@ -404,7 +404,7 @@ class BrevPeriodeContextTest {
                 belop = "7 500",
                 antallTimerBarnehageplass = "0",
                 soknadstidspunkt = "",
-                maanedOgAarFoorVedtaksperiode = "mars 2022",
+                maanedOgAarFoerVedtaksperiode = "mars 2022",
             ),
             brevPeriodeDto?.begrunnelser?.single(),
         )

--- a/src/test/resources/cucumber/opphør-første-periode-måned-og-år-begrunnelsen-gjelder-for.feature
+++ b/src/test/resources/cucumber/opphør-første-periode-måned-og-år-begrunnelsen-gjelder-for.feature
@@ -1,0 +1,71 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Opphør første periode måned og år begrunnelsen gjelder for
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | NYE_OPPLYSNINGER | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 25.02.1996  |
+      | 1            | 2       | BARN       | 17.01.2024  |
+      | 2            | 1       | SØKER      | 25.02.1996  |
+      | 2            | 2       | BARN       | 17.01.2024  |
+
+  Scenario: Når det er opphør første periode og måned og år begrunnelsen gjelder for er lenge før vedtaksperioden er flettefeltet fortsatt riktig
+    Og følgende dagens dato 24.02.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 07.10.2014 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 07.10.2019 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.01.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 17.01.2024 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 17.02.2025 | 17.08.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 07.10.2014 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 07.10.2019 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 17.01.2024 | 30.11.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 17.01.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.12.2024 |            | IKKE_OPPFYLT | Nei                  |                      |                  | Nei                                   | 45           |
+      | 2       | BARNETS_ALDER                |                  | 17.01.2025 | 17.09.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Og når behandlingsresultatet er utledet for behandling 2
+
+    Så forvent at behandlingsresultatet er OPPHØRT på behandling 2
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
+      | 01.03.2025 |          | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                             | Ugyldige begrunnelser |
+      | 01.03.2025 |          | OPPHØR             |                                | OPPHØR_FULLTIDSPLASS_I_BARNEHAGEN_FØRSTE_PERIODE |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato | Standardbegrunnelser                             | Eøsbegrunnelser | Fritekster |
+      | 01.03.2025 |          | OPPHØR_FULLTIDSPLASS_I_BARNEHAGEN_FØRSTE_PERIODE |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.03.2025 til -
+      | Begrunnelse                                      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | OPPHØR_FULLTIDSPLASS_I_BARNEHAGEN_FØRSTE_PERIODE | STANDARD | false         | 17.01.24             | 1           | desember 2024                        | 0     |                  | 45                          | februar 2025                   |

--- a/src/test/resources/cucumber/reduksjon-måned-og-år-begrunnelsen-gjelder-for.feature
+++ b/src/test/resources/cucumber/reduksjon-måned-og-år-begrunnelsen-gjelder-for.feature
@@ -1,0 +1,76 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Reduksjon pga færre antall timer i barnehage etter lovendring 2025
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | NYE_OPPLYSNINGER | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 30.06.1993  |
+      | 1            | 2       | BARN       | 01.01.2024  |
+      | 2            | 1       | SØKER      | 30.06.1993  |
+      | 2            | 2       | BARN       | 01.01.2024  |
+
+  Scenario: Når det er reduksjon etter lovendring 2025 ønsker vi å flette inn måned og år begrunnelsen gjelder for riktig
+    Og følgende dagens dato 24.02.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 30.06.1993 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 30.06.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 09.05.1997 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.01.2024 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 01.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 01.01.2025 | 01.09.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 30.06.1993 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 30.06.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 09.05.1997 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 01.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 01.01.2025 | 01.09.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.01.2024 | 09.03.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 10.03.2025 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   | 30           |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.02.2025 | 28.02.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+      | 2       | 01.03.2025 | 31.08.2025 | 1500  | ORDINÆR_KONTANTSTØTTE | 20      | 7500 | 1500                   |                          |
+    Og når behandlingsresultatet er utledet for behandling 2
+    Så forvent at behandlingsresultatet er ENDRET_UTBETALING på behandling 2
+
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.03.2025 | 31.08.2025 | UTBETALING         |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser             | Ugyldige begrunnelser |
+      | 01.03.2025 | 31.08.2025 | UTBETALING         |                                | REDUKSJON_TILDELT_BARNEHAGEPLASS |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser             | Eøsbegrunnelser | Fritekster |
+      | 01.03.2025 | 31.08.2025 | REDUKSJON_TILDELT_BARNEHAGEPLASS |                 |            |
+
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.03.2025 til 31.08.2025
+      | Begrunnelse                      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Måned og år før vedtaksperiode |
+      | REDUKSJON_TILDELT_BARNEHAGEPLASS | STANDARD | false         | 01.01.24             | 1           | mars 2025                            | 1 500 |                  | 30                          | true                   | februar 2025                   |


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24368)
Har to behandlinger der vi fletter inn feil for måned og år begrunnelsen gjelder for. 
Skyldes at vi i det ene tilfelle prioriterer at det er lovendring som bestemmer over at det er opphør i første periode og i det andre at vi ikke tar høyde for lovendring 2025, men bare 2024. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er det edgecaser jeg ikke har tenkt på? Var det et bevisst valg å prioritere å se på lovendring over opphør i første periode? 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
