### PR TITLE
legg til annen gruppering av dependabot-PRer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
         patterns:
           - "org.springframework*"
           - "no.nav.security*"
+          - "org.springdoc*"
       prod-avhengigheter:
         dependency-type: "production"
         exclude-patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,21 +15,21 @@ updates:
     registries:
       - familie-felles
     groups:
-      patch-dependencies:
+      interne-avhengigheter:
         patterns:
-          - "*"
-        update-types:
-          - "patch"
-      minor-dependencies:
+          - "no.nav.familie*"
+      spring-med-avhengigheter:
         patterns:
-          - "*"
-        update-types:
-          - "minor"
-      major-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
+          - "org.springframework*"
+          - "no.nav.security*"
+      prod-avhengigheter:
+        dependency-type: "production"
+        exclude-patterns:
+          - "no.nav.security*"
+      utvikler-avhengigheter:
+        dependency-type: "development"
+        exclude-patterns:
+          - "no.nav.security*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Grupperingen av dependabot-PRer for øyeblikket er lite hjelpsom da vi ikke grupperer oppdateringer som hører sammen (som f.eks. spring-boot). Legger derfor til med inspo fra baks-soknad-api


