### PR TITLE
Legger til callId når vi kaster feil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- Nav Familie-->
         <prosessering.version>2.20250219093533_62416e5</prosessering.version>
-        <felles-kontrakter.version>3.0_20250224083824_7fcdc47</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250226115003_49b0dfa</felles-kontrakter.version>
         <eksterne-kontrakter-bisys.version>2.0_20230214104704_706e9c0</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.stønadsstatistikk>2.0_20250205141909_256ecd1</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.saksstatistikk>2.0_20230214104704_706e9c0</familie.kontrakter.saksstatistikk>

--- a/src/main/kotlin/no/nav/familie/ks/sak/common/exception/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/exception/Feil.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ks.sak.common.exception
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import no.nav.familie.log.mdc.MDCConstants
+import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
 
@@ -11,7 +13,12 @@ open class Feil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-) : RuntimeException(message)
+    var callId: String? = null,
+) : RuntimeException(message) {
+    init {
+        callId = MDC.get(MDCConstants.MDC_CALL_ID)
+    }
+}
 
 open class FunksjonellFeil(
     open val melding: String,
@@ -19,7 +26,12 @@ open class FunksjonellFeil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-) : RuntimeException(melding)
+    var callId: String? = null,
+) : RuntimeException(melding) {
+    init {
+        callId = MDC.get(MDCConstants.MDC_CALL_ID)
+    }
+}
 
 class UtbetalingsikkerhetFeil(
     melding: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/common/exception/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/exception/Feil.kt
@@ -13,12 +13,8 @@ open class Feil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-    var callId: String? = null,
-) : RuntimeException(message) {
-    init {
-        callId = MDC.get(MDCConstants.MDC_CALL_ID)
-    }
-}
+    open val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID),
+) : RuntimeException(message)
 
 open class FunksjonellFeil(
     open val melding: String,
@@ -26,12 +22,8 @@ open class FunksjonellFeil(
     open val httpStatus: HttpStatus = HttpStatus.OK,
     open val throwable: Throwable? = null,
     override val cause: Throwable? = throwable,
-    var callId: String? = null,
-) : RuntimeException(melding) {
-    init {
-        callId = MDC.get(MDCConstants.MDC_CALL_ID)
-    }
-}
+    open val callId: String? = MDC.get(MDCConstants.MDC_CALL_ID),
+) : RuntimeException(melding)
 
 class UtbetalingsikkerhetFeil(
     melding: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/common/util/RessursUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/util/RessursUtils.kt
@@ -89,6 +89,7 @@ object RessursUtils {
             Ressurs.failure(
                 frontendFeilmelding = feil.frontendFeilmelding,
                 errorMessage = feil.message.toString(),
+                callId = feil.callId,
             ),
         )
     }


### PR DESCRIPTION
Favorkort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24416

Vi legger til nytt felt callId i Feil, som da propageres videre opp til frontend.