### PR TITLE
Fjerner busybox fra docker og skrevet om ks-sak mot preprod oppstart skript til å ikke bruke printenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM busybox:1.36.1-uclibc AS busybox
-
-# Final image
 FROM gcr.io/distroless/java21:nonroot
-COPY --from=busybox /bin/printenv /bin/printenv
 COPY --chown=nonroot:nonroot ./target/familie-ks-sak.jar /app/app.jar
 WORKDIR /app
 

--- a/hentMiljøvariabler.sh
+++ b/hentMiljøvariabler.sh
@@ -1,11 +1,26 @@
-kubectl config use-context dev-gcp
-PODNAVN=$(kubectl -n teamfamilie get pods --field-selector=status.phase==Running -o name | grep familie-ks-sak | grep -v "frontend" |  sed "s/^.\{4\}//" | head -n 1);
+# Check the status of nais device
+ NAIS_STATUS=$(nais device status)
 
-PODVARIABLER="$(kubectl -n teamfamilie exec -c familie-ks-sak -it "$PODNAVN" -- printenv)"
+ if [[ "$NAIS_STATUS" != *"Connected"* ]]; then
+   echo "Naisdevice er ikke tilkoblet. Start naisdevice og velg connect. Status må være grønn."
+   exit 1
+ fi
+
+ # Check the status of gcloud auth print-identity-token
+ if ! gcloud auth print-identity-token > /dev/null 2>&1; then
+   echo "Ikke logget inn på gcloud. Kjør nais login"
+   exit 1
+ fi
+
+
+kubectl config use-context dev-gcp
+AZURE_SECRET=$(kubectl -n teamfamilie get secrets | grep azure-familie-ks-sak | grep -v "frontend" |  sed 's/^\([a-zA-Z0-9-]*\).*/\1/');
+
+PODVARIABLER="$(kubectl -n teamfamilie get secret "$AZURE_SECRET" -o json | jq '.data | map_values(@base64d)')"
 UNLEASH_VARIABLER="$(kubectl -n teamfamilie get secret familie-ks-sak-unleash-api-token -o json | jq '.data | map_values(@base64d)')"
 
-AZURE_APP_CLIENT_ID="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_ID" | tr -d '\r' )"
-AZURE_APP_CLIENT_SECRET="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_SECRET" | tr -d '\r' )";
+AZURE_APP_CLIENT_ID="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_ID" | sed 's/:/=/1' | tr -d '",'| tr -d ' "')"
+AZURE_APP_CLIENT_SECRET="$(echo "$PODVARIABLER" | grep "AZURE_APP_CLIENT_SECRET" | sed 's/:/=/1' | tr -d '",'| tr -d ' "')"
 
 UNLEASH_SERVER_API_URL="$(echo "$UNLEASH_VARIABLER" | grep "UNLEASH_SERVER_API_URL" | sed 's/:/=/1' | tr -d ' "')"
 UNLEASH_SERVER_API_TOKEN="$(echo "$UNLEASH_VARIABLER" | grep "UNLEASH_SERVER_API_TOKEN" | sed 's/:/=/1' | tr -d ' ,"')"

--- a/src/test/integrasjonstester/kotlin/DevLauncherPostgresPreprod.kt
+++ b/src/test/integrasjonstester/kotlin/DevLauncherPostgresPreprod.kt
@@ -36,11 +36,11 @@ private fun settClientIdOgSecret() {
     logger.info("Henter miljøvariabler fra Kubernetes...")
     val process = ProcessBuilder(cmd).start()
 
-    val status = process.waitFor()
-    if (status == 1) {
+    if (process.waitFor() == 1) {
+        val inputStream = BufferedReader(InputStreamReader(process.inputStream))
+        inputStream.lines().forEach { println(it) }
+        inputStream.close()
         error("Klarte ikke hente variabler fra Nais. Er du logget på Naisdevice og gcloud?")
-    } else if (status == 2) {
-        error("Feil context satt for kubectl, du må bruke dev-gcp?")
     }
 
     val inputStream = BufferedReader(InputStreamReader(process.inputStream))


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner busybox fra docker og skrevet om scriptet for å starte ks-sak mot preprod til å fungere uten printenv. Dette betyr at man ikke lenger kan bruke  kubectl exec for å hente ut secrets. Dette for å gjøre distroless-imaget tryggere.

I stedet for å kjøre printenv, så bruker scriptet
```kubectl -n teamfamilie get secrets```
For å finnne navn på secret og så
```
kubectl -n teamfamilie get secret navn-på-secret -o json | jq '.data | map_values(@base64d)' 
```
 kubectl get secret azure-familie-ks-sak-* secreten for å hente det samme.

Utvidet skriptet til å sjekke om naisdevice og gcloud er logget inn. Hvis det ikke er det så vil det komme en melding i terminalvinduet
<img width="1195" alt="Screenshot 2025-02-28 at 09 39 59" src="https://github.com/user-attachments/assets/718f39ba-d110-4242-9999-5efbc5dbc800" />

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇