### PR TITLE
NAV-24505: Legger til behandlingstype klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/JournalføringController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/JournalføringController.kt
@@ -67,8 +67,7 @@ class JournalføringController(
     fun journalførOppgave(
         @PathVariable journalpostId: String,
         @PathVariable oppgaveId: String,
-        @RequestBody @Valid
-        request: JournalføringRequestDto,
+        @RequestBody @Valid request: JournalføringRequestDto,
     ): ResponseEntity<Ressurs<String>> {
         tilgangService.validerTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -285,7 +285,7 @@ enum class BehandlingÅrsak(
     ÅRLIG_KONTROLL("Årsak kontroll", listOf(REVURDERING)),
     DØDSFALL("Dødsfall", listOf(REVURDERING)),
     NYE_OPPLYSNINGER("Nye opplysninger", listOf(REVURDERING)),
-    KLAGE("Klage", listOf(REVURDERING)),
+    KLAGE("Klage", listOf(BehandlingType.KLAGE, REVURDERING)),
     TEKNISK_ENDRING(
         "Teknisk endring",
         listOf(BehandlingType.TEKNISK_ENDRING),
@@ -304,6 +304,7 @@ enum class BehandlingType(
     FØRSTEGANGSBEHANDLING("Førstegangsbehandling"),
     REVURDERING("Revurdering"),
     TEKNISK_ENDRING("Teknisk endring"),
+    KLAGE("Klage"),
 }
 
 enum class BehandlingKategori(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -42,7 +42,10 @@ class PersonopplysningGrunnlagService(
         val barnasAktørFraSisteVedtattBehandling =
             when (behandling.type) {
                 BehandlingType.FØRSTEGANGSBEHANDLING -> emptyList()
-                BehandlingType.REVURDERING, BehandlingType.TEKNISK_ENDRING -> {
+                BehandlingType.REVURDERING,
+                BehandlingType.TEKNISK_ENDRING,
+                BehandlingType.KLAGE,
+                -> {
                     if (sisteVedtattBehandling == null) {
                         throw Feil("Kan ikke behandle ${behandling.type} uten minst en vedtatt behandling")
                     }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro:[ NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Har pratet med Anna og hun tenker at det er fornuftig å ha en egen behandlingstype "KLAGE". Legger det derfor til som en enum-verdi.

Får følgende stacktrace:
```
com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `no.nav.familie.ba.sak.kjerne.behandling.domene.BehandlingType` from String "KLAGE": not one of the values accepted for Enum class: [TEKNISK_ENDRING, FØRSTEGANGSBEHANDLING, MIGRERING_FRA_INFOTRYGD, MIGRERING_FRA_INFOTRYGD_OPPHØRT, REVURDERING]
```

Oppstår ved journalføring av klage. Se favro-kortet for bilder.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Er det korrekt å ha "Klage" som en egen behandlingstype? Ser at kombinasjon behandlingstype=REVURDERING og behandlingsårsak=KLAGE er brukt, men antar at det er da snakk om en revurdering som har blitt opprettet på grunn av en tidligere klagebehandling. Stemmer det? Behandlingstype=KLAGE blir altså når man oppretter behandlinger av type KLAGE. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
