### PR TITLE
Bare trekk inn ønskede begrunnelser

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -356,6 +356,10 @@ class StepDefinition {
         dataTable: DataTable,
     ) {
         val forventedeStandardBegrunnelser = mapBegrunnelser(dataTable).toSet()
+        val forventedeSanityBegrunnelser =
+            forventedeStandardBegrunnelser
+                .flatMap { it.inkluderteStandardBegrunnelser }
+                .mapNotNull { begrunnelse -> sanityBegrunnelserMock.singleOrNull { it.apiNavn == begrunnelse.sanityApiNavn } }
 
         forventedeStandardBegrunnelser.forEach { forventet ->
             val faktisk =
@@ -365,7 +369,7 @@ class StepDefinition {
                             gyldigeBegrunnelser =
                                 BegrunnelserForPeriodeContext(
                                     utvidetVedtaksperiodeMedBegrunnelser = utvidetVedtaksperiodeMedBegrunnelser,
-                                    sanityBegrunnelser = sanityBegrunnelserMock,
+                                    sanityBegrunnelser = forventedeSanityBegrunnelser,
                                     personopplysningGrunnlag = personopplysningGrunnlagMap[behandlingId]!!,
                                     personResultater = vilkårsvurdering[behandlingId]!!.personResultater.toList(),
                                     endretUtbetalingsandeler = endredeUtbetalinger[behandlingId] ?: emptyList(),


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24543

Vi har en svakhet i cucumber testene våres som forhindrer bygg av ks-sak.

Variabelen `sanityBegrunnelserMock` inneholder ALLE sanity begrunnelser vi har i ks-sak.
Per i dag ligger den på rundt 395 stykker. Denne øker for hver gang vi legger til begrunnelser, som er sikkert derfor den nå starter å tukle.

Når vi i cucumber testene våres sjekker om en begrunnelse er gyldig for en periode, så sjekkes alle disse 395 begrunnelsene siden de blir sendt inn som sanityBegrunnelserMock til BegrunnelserForPeriodeContext.

Dette fører til mye minnebruk, og det er derfor denne feilen også bare oppstår når man kjører alle testene samlet.

Se minnebruken ved kjøring av testene som koden er i dag - den kjørte aldri ferdig grunnet out of memory:
<img width="1689" alt="oom" src="https://github.com/user-attachments/assets/7bc44d50-7328-4b17-b39c-b4f81e5000a3" />
Merk også hvor lang tid opphørstestene til venstre tar, rundt 5sec per, opp til 15 sec.

Jeg har derfor endret det slik at vi bare sender inn begrunnelsene vi faktisk forventer inn til BegrunnelserForPeriodeContext.
Dette har ulempen at ved feilende tester, så vil man ikke vite hvilke andre begrunnelser som var gyldig for en periode noe som kan hjelpe under feilsøking.

Minnebruk og tidsbruk etter mine endringer, fra 5 sec til 80ms.:
<img width="1662" alt="ikke oom" src="https://github.com/user-attachments/assets/401cda6a-2383-4b85-9a7b-d5dd2526582d" />
