### PR TITLE
Filtrere på løpende andel i stedet for løpende fagsak i barnehagelister

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BarnehagebarnRequestParams.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BarnehagebarnRequestParams.kt
@@ -3,9 +3,10 @@ package no.nav.familie.ks.sak.api.dto
 data class BarnehagebarnRequestParams(
     val ident: String?,
     val kommuneNavn: String?,
-    val kunLøpendeFagsak: Boolean,
+    val kunLøpendeFagsak: Boolean, // TODO Skal renames til kunLøpendeAndel
     val limit: Int = 50,
     val offset: Int = 0,
     val sortBy: String = "kommuneNavn",
     val sortAsc: Boolean = false,
+    val kunLøpendeAndel: Boolean = false, // TODO Skal fjernes
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BarnehagebarnRequestParams.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BarnehagebarnRequestParams.kt
@@ -3,10 +3,10 @@ package no.nav.familie.ks.sak.api.dto
 data class BarnehagebarnRequestParams(
     val ident: String?,
     val kommuneNavn: String?,
-    val kunLøpendeFagsak: Boolean, // TODO Skal renames til kunLøpendeAndel
+    val kunLøpendeFagsak: Boolean,
     val limit: Int = 50,
     val offset: Int = 0,
     val sortBy: String = "kommuneNavn",
     val sortAsc: Boolean = false,
-    val kunLøpendeAndel: Boolean = false, // TODO Skal fjernes
+    val kunLøpendeAndel: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
@@ -22,14 +22,24 @@ class BarnehagebarnService(
         val sort = barnehagebarnRequestParams.toSort()
         val pageable = PageRequest.of(barnehagebarnRequestParams.offset, barnehagebarnRequestParams.limit, sort)
         val hentForKunLøpendeFagsak = barnehagebarnRequestParams.kunLøpendeFagsak
+        val hentForKunLøpendeAndel: Boolean = barnehagebarnRequestParams.kunLøpendeAndel
         val dagensDato = LocalDate.now()
 
         return when {
+            !barnehagebarnRequestParams.ident.isNullOrEmpty() && hentForKunLøpendeAndel ->
+                hentBarnehageBarnMedIdentOgLøpendeAndel(hentForKunLøpendeAndel, barnehagebarnRequestParams.ident, dagensDato, pageable)
+
             !barnehagebarnRequestParams.ident.isNullOrEmpty() ->
                 hentBarnehageBarnMedIdent(hentForKunLøpendeFagsak, barnehagebarnRequestParams.ident, pageable)
 
+            !barnehagebarnRequestParams.kommuneNavn.isNullOrEmpty() && hentForKunLøpendeAndel ->
+                hentBarnehageBarnMedKommuneNavnOgLøpendeAndel(hentForKunLøpendeAndel, barnehagebarnRequestParams.kommuneNavn, dagensDato, pageable)
+
             !barnehagebarnRequestParams.kommuneNavn.isNullOrEmpty() ->
                 hentBarnehageBarnMedKommuneNavn(hentForKunLøpendeFagsak, barnehagebarnRequestParams.kommuneNavn, pageable)
+
+            hentForKunLøpendeAndel ->
+                hentAlleBarnehageBarnLøpendeAndel(hentForKunLøpendeAndel, dagensDato, pageable)
 
             else -> hentAlleBarnehageBarn(hentForKunLøpendeFagsak, pageable)
         }
@@ -81,12 +91,34 @@ class BarnehagebarnService(
         barnehagebarnRepository.findBarnehagebarnByKommuneNavnUavhengigAvFagsak(kommuneNavn, pageable)
     }
 
+    private fun hentBarnehageBarnMedKommuneNavnOgLøpendeAndel(
+        hentForKunLøpendeAndel: Boolean,
+        kommuneNavn: String,
+        dagensDato: LocalDate,
+        pageable: PageRequest,
+    ) = if (hentForKunLøpendeAndel) {
+        barnehagebarnRepository.findBarnehagebarnByKommuneNavnOgLøpendeAndel(kommuneNavn, dagensDato, pageable)
+    } else {
+        barnehagebarnRepository.findBarnehagebarnByKommuneNavnUavhengigAvFagsak(kommuneNavn, pageable)
+    }
+
     private fun hentBarnehageBarnMedIdent(
         hentForKunLøpendeFagsak: Boolean,
         ident: String,
         pageable: PageRequest,
     ) = if (hentForKunLøpendeFagsak) {
         barnehagebarnRepository.findBarnehagebarnByIdent(LØPENDE_FAGSAK_STATUS, ident, pageable)
+    } else {
+        barnehagebarnRepository.findBarnehagebarnByIdentUavhengigAvFagsak(ident, pageable)
+    }
+
+    private fun hentBarnehageBarnMedIdentOgLøpendeAndel(
+        hentForKunLøpendeAndel: Boolean,
+        ident: String,
+        dagensDato: LocalDate,
+        pageable: PageRequest,
+    ) = if (hentForKunLøpendeAndel) {
+        barnehagebarnRepository.findBarnehagebarnByIdentOgLøpendeAndel(ident, dagensDato, pageable)
     } else {
         barnehagebarnRepository.findBarnehagebarnByIdentUavhengigAvFagsak(ident, pageable)
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class BarnehagebarnService(
@@ -21,6 +22,7 @@ class BarnehagebarnService(
         val sort = barnehagebarnRequestParams.toSort()
         val pageable = PageRequest.of(barnehagebarnRequestParams.offset, barnehagebarnRequestParams.limit, sort)
         val hentForKunLøpendeFagsak = barnehagebarnRequestParams.kunLøpendeFagsak
+        val dagensDato = LocalDate.now()
 
         return when {
             !barnehagebarnRequestParams.ident.isNullOrEmpty() ->
@@ -55,6 +57,16 @@ class BarnehagebarnService(
         pageable: PageRequest,
     ) = if (hentForKunLøpendeFagsak) {
         barnehagebarnRepository.findBarnehagebarn(LØPENDE_FAGSAK_STATUS, pageable)
+    } else {
+        barnehagebarnRepository.findAlleBarnehagebarnUavhengigAvFagsak(pageable)
+    }
+
+    private fun hentAlleBarnehageBarnLøpendeAndel(
+        hentForKunLøpendeAndel: Boolean,
+        dagensDato: LocalDate,
+        pageable: PageRequest,
+    ) = if (hentForKunLøpendeAndel) {
+        barnehagebarnRepository.findBarnehagebarnLøpendeAndel(dagensDato, pageable)
     } else {
         barnehagebarnRepository.findAlleBarnehagebarnUavhengigAvFagsak(pageable)
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -84,6 +84,29 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
             INNER JOIN po_person pp ON p.fk_aktoer_id = pp.fk_aktoer_id
             INNER JOIN gr_personopplysninger go ON pp.fk_gr_personopplysninger_id = go.id
             INNER JOIN behandling b ON go.fk_behandling_id = b.id AND b.aktiv = true
+            INNER JOIN fagsak f ON b.fk_fagsak_id = f.id AND f.arkivert = false 
+            INNER JOIN andel_tilkjent_ytelse a on pp.fk_aktoer_id = a.fk_aktoer_id
+            WHERE (a.stonad_tom >= :dagensDato) AND bb.ident = :ident
+            GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr, f.id, f.status
+        """,
+        nativeQuery = true,
+    )
+    fun findBarnehagebarnByIdentOgLøpendeAndel(
+        ident: String,
+        dagensDato: LocalDate,
+        pageable: Pageable,
+    ): Page<BarnehagebarnDtoInterface>
+
+    @Query(
+        """
+            SELECT bb.ident as ident, bb.fom as fom, bb.tom as tom, bb.antall_timer_i_barnehage as antallTimerIBarnehage, 
+            bb.endringstype as endringstype, bb.kommune_navn as kommuneNavn, bb.kommune_nr as kommuneNr, MAX(bb.endret_tid) as endretTid,
+            f.id as fagsakId, f.status as fagsakstatus
+            FROM barnehagebarn bb
+            INNER JOIN personident p ON bb.ident = p.foedselsnummer AND p.aktiv = true
+            INNER JOIN po_person pp ON p.fk_aktoer_id = pp.fk_aktoer_id
+            INNER JOIN gr_personopplysninger go ON pp.fk_gr_personopplysninger_id = go.id
+            INNER JOIN behandling b ON go.fk_behandling_id = b.id AND b.aktiv = true
             INNER JOIN fagsak f ON b.fk_fagsak_id = f.id AND f.arkivert = false WHERE UPPER(bb.kommune_navn) = UPPER(:kommuneNavn)
             AND f.status IN (:fagsakStatuser)
             GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr, f.id, f.status""",
@@ -92,6 +115,30 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
     fun findBarnehagebarnByKommuneNavn(
         fagsakStatuser: List<String>,
         kommuneNavn: String,
+        pageable: Pageable,
+    ): Page<BarnehagebarnDtoInterface>
+
+    @Query(
+        """
+           SELECT bb.ident as ident, bb.fom as fom, bb.tom as tom, bb.antall_timer_i_barnehage as antallTimerIBarnehage, 
+            bb.endringstype as endringstype, bb.kommune_navn as kommuneNavn, bb.kommune_nr as kommuneNr, MAX(bb.endret_tid) as endretTid,
+            f.id as fagsakId, f.status as fagsakstatus
+            FROM barnehagebarn bb
+            INNER JOIN personident p ON bb.ident = p.foedselsnummer AND p.aktiv = true
+            INNER JOIN po_person pp ON p.fk_aktoer_id = pp.fk_aktoer_id
+            INNER JOIN gr_personopplysninger go ON pp.fk_gr_personopplysninger_id = go.id
+            INNER JOIN behandling b ON go.fk_behandling_id = b.id AND b.aktiv = true
+            INNER JOIN fagsak f ON b.fk_fagsak_id = f.id AND f.arkivert = false 
+            INNER JOIN andel_tilkjent_ytelse a on pp.fk_aktoer_id = a.fk_aktoer_id
+            WHERE UPPER(bb.kommune_navn) = UPPER(:kommuneNavn)
+            AND (a.stonad_tom >= :dagensDato)
+            GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr, f.id, f.status 
+        """,
+        nativeQuery = true,
+    )
+    fun findBarnehagebarnByKommuneNavnOgLøpendeAndel(
+        kommuneNavn: String,
+        dagensDato: LocalDate,
         pageable: Pageable,
     ): Page<BarnehagebarnDtoInterface>
 
@@ -127,6 +174,7 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
         nativeQuery = true,
     )
     fun findBarnehagebarnByIdentUavhengigAvFagsak(
+        // TODO Skal renames til findBarnehagebarnByIdentUavhengigAvLøpendeAndel
         ident: String,
         pageable: Pageable,
     ): Page<BarnehagebarnDtoInterface>
@@ -147,6 +195,7 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
         nativeQuery = true,
     )
     fun findBarnehagebarnByKommuneNavnUavhengigAvFagsak(
+        // TODO Skal renames til findBarnehagebarnByKommuneNavnUavhengigAvLøpendeAndel
         kommuneNavn: String,
         pageable: Pageable,
     ): Page<BarnehagebarnDtoInterface>

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
 import java.util.UUID
 
 interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , JpaSpecificationExecutor<Barnehagebarn>
@@ -26,6 +27,29 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
     )
     fun findBarnehagebarn(
         fagsakStatuser: List<String>,
+        pageable: Pageable,
+    ): Page<BarnehagebarnDtoInterface>
+
+    @Query(
+        """
+           SELECT bb.ident as ident, bb.fom as fom, bb.tom as tom, bb.antall_timer_i_barnehage as antallTimerIBarnehage, 
+            bb.endringstype as endringstype, bb.kommune_navn as kommuneNavn, bb.kommune_nr as kommuneNr, MAX(bb.endret_tid) as endretTid,
+            f.id as fagsakId, f.status as fagsakstatus
+            FROM barnehagebarn bb
+            INNER JOIN personident p ON bb.ident = p.foedselsnummer AND p.aktiv = true
+            INNER JOIN po_person pp ON p.fk_aktoer_id = pp.fk_aktoer_id
+            INNER JOIN gr_personopplysninger go ON pp.fk_gr_personopplysninger_id = go.id
+            INNER JOIN behandling b ON go.fk_behandling_id = b.id AND b.aktiv = true
+            INNER JOIN fagsak f ON b.fk_fagsak_id = f.id AND f.arkivert = false
+            INNER JOIN andel_tilkjent_ytelse a on pp.fk_aktoer_id = a.fk_aktoer_id
+            WHERE (a.stonad_tom >= :dagensDato) 
+            GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype, bb.kommune_navn, bb.kommune_nr, f.id, f.status
+
+        """,
+        nativeQuery = true,
+    )
+    fun findBarnehagebarnLøpendeAndel(
+        dagensDato: LocalDate,
         pageable: Pageable,
     ): Page<BarnehagebarnDtoInterface>
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceTest.kt
@@ -201,6 +201,81 @@ class BarnehagebarnServiceTest {
     }
 
     @Nested
+    inner class HentBarnehagebarnLøpendeAndelTest {
+        @Test
+        fun `skal hente alle barn med løpende andel dersom det sendes inn som parameter`() {
+            // Arrange
+            val dagensDato = LocalDate.now()
+            val mocketPageBarnehagebarnDtoInterface = mockk<Page<BarnehagebarnDtoInterface>>()
+            val barnehagebarnRequestParams =
+                BarnehagebarnRequestParams(
+                    ident = null,
+                    kunLøpendeFagsak = false,
+                    kommuneNavn = null,
+                    kunLøpendeAndel = true,
+                )
+            every {
+                mockBarnehagebarnRepository.findBarnehagebarnLøpendeAndel(dagensDato, any())
+            } returns mocketPageBarnehagebarnDtoInterface
+
+            // Act
+            val hentetMocketPageBarnehagebarnDtoInterface = barnehagebarnService.hentBarnehageBarn(barnehagebarnRequestParams)
+
+            // Assert
+            assertThat(hentetMocketPageBarnehagebarnDtoInterface).isEqualTo(mocketPageBarnehagebarnDtoInterface)
+            verify(exactly = 1) { mockBarnehagebarnRepository.findBarnehagebarnLøpendeAndel(dagensDato, any()) }
+        }
+
+        @Test
+        fun `skal hente barn med løpende andel fra kommunenavn dersom det sendes inn som parameter`() {
+            // Arrange
+            val dagensDato = LocalDate.now()
+            val mocketPageBarnehagebarnDtoInterface = mockk<Page<BarnehagebarnDtoInterface>>()
+            val barnehagebarnRequestParams =
+                BarnehagebarnRequestParams(
+                    ident = null,
+                    kunLøpendeFagsak = false,
+                    kommuneNavn = "kommune",
+                    kunLøpendeAndel = true,
+                )
+            every {
+                mockBarnehagebarnRepository.findBarnehagebarnByKommuneNavnOgLøpendeAndel("kommune", dagensDato, any())
+            } returns mocketPageBarnehagebarnDtoInterface
+
+            // Act
+            val hentetMocketPageBarnehagebarnDtoInterface = barnehagebarnService.hentBarnehageBarn(barnehagebarnRequestParams)
+
+            // Assert
+            assertThat(hentetMocketPageBarnehagebarnDtoInterface).isEqualTo(mocketPageBarnehagebarnDtoInterface)
+            verify(exactly = 1) { mockBarnehagebarnRepository.findBarnehagebarnByKommuneNavnOgLøpendeAndel("kommune", dagensDato, any()) }
+        }
+
+        @Test
+        fun `skal hente barn med løpende andel fra ident dersom det sendes inn som parameter`() {
+            // Arrange
+            val dagensDato = LocalDate.now()
+            val mocketPageBarnehagebarnDtoInterface = mockk<Page<BarnehagebarnDtoInterface>>()
+            val barnehagebarnRequestParams =
+                BarnehagebarnRequestParams(
+                    ident = "ident",
+                    kunLøpendeFagsak = false,
+                    kommuneNavn = null,
+                    kunLøpendeAndel = true,
+                )
+            every {
+                mockBarnehagebarnRepository.findBarnehagebarnByIdentOgLøpendeAndel("ident", dagensDato, any())
+            } returns mocketPageBarnehagebarnDtoInterface
+
+            // Act
+            val hentetMocketPageBarnehagebarnDtoInterface = barnehagebarnService.hentBarnehageBarn(barnehagebarnRequestParams)
+
+            // Assert
+            assertThat(hentetMocketPageBarnehagebarnDtoInterface).isEqualTo(mocketPageBarnehagebarnDtoInterface)
+            verify(exactly = 1) { mockBarnehagebarnRepository.findBarnehagebarnByIdentOgLøpendeAndel("ident", dagensDato, any()) }
+        }
+    }
+
+    @Nested
     inner class HentBarnehagebarnInfotrygdTest {
         @Test
         fun `skal hente barn fra infotrygd uavhengig av fagsak fra kommunenavn dersom det sendes inn som parameter`() {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24115

Ønsker å filtrere på løpende andel i stedet for løpende fagsak. Har lagt til støtte for å filtrere på begge, så endrer frontend og fjerner støtte for å filtrere på fagsak når denne er merget. 
Noen navn i barnehageRepository gir ikke helt mening pr nå, endrer fra "UavhengigAvFagsak" til "UavhengigAvLøpendeAndel" når frontend er endret. 


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
