### PR TITLE
Kaster funksjonell feil ved validering av begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.brev
 
 import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.DATO_LOVENDRING_2024
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
@@ -265,7 +266,7 @@ class BrevPeriodeContext(
             nasjonalEllerFellesBegrunnelse != NasjonalEllerFellesBegrunnelse.AVSLAG_SØKT_FOR_SENT_ENDRINGSPERIODE &&
             nasjonalEllerFellesBegrunnelse != NasjonalEllerFellesBegrunnelse.AVSLAG_FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024
         ) {
-            throw IllegalStateException("Ingen personer på brevbegrunnelse $nasjonalEllerFellesBegrunnelse")
+            throw FunksjonellFeil("Begrunnelsen '${sanityBegrunnelse.apiNavn}' passer ikke vedtaksperioden. Hvis du mener dette er feil ta kontakt med team BAKS.")
         }
     }
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24608

Vi kaster funksjonell feil når det ikke finnes noen personer på en begrunnelse.
Ref slack tråd:

https://nav-it.slack.com/archives/C0205N5B9CK/p1741160801586449

```
Jeg synes alle brev feilene grunnet manglende personer på flettepersoner støyer sykt mye.
I tillegg så er det ikke noe vi heller aktivt går inn og prøver å løse mens vi har vakt, 
da det kan være at SB har valgt en begrunnelse som ikke matcher perioden.
I KS-sak f.eks så har vi dårlig filtrering på hvilke begrunnelser som kan velges, 
og velger SB feil så dukker det opp som error i loggene våres.
 
Et alternativ er jo å forbedre filtreringen av gyldige begrunnelser bedre, 
men det kan bli en ganske komplisert jobb.
```

Feilmeldingen som nå kastes er hentet fra når vi får bad request mot familie-brev, så SB er nok kjent med denne.
Tatt en sync med Fredrik og Schirin på feilmeldingen.

