### PR TITLE
NAV-24653: Legger til klagebehandlinger i data for manuell journalføring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/DataForManuellJournalføringDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/DataForManuellJournalføringDto.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.api.dto
 
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 
 data class DataForManuellJournalføringDto(
@@ -8,4 +9,5 @@ data class DataForManuellJournalføringDto(
     val person: PersonInfoDto?,
     val journalpost: Journalpost?,
     val minimalFagsak: MinimalFagsakResponsDto?,
+    val klagebehandlinger: List<KlagebehandlingDto> = emptyList(),
 )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24653](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24653)

Ønsker å sende opp klagebehandlinger når man skal journalføre dokumenter. Setter inn klagebehandlinger inn i data for manuell journalføring. Dette er nødvendig for å blant annet vise klagebehandlinger i GUI når man journalfører. 

Kjørte opp løsningen lokalt med ks-sak-frontend sin main branch og det ser ut til å fungere fint. Får følgende i responsen:

<img width="627" alt="image" src="https://github.com/user-attachments/assets/cb73a746-49b8-4fb1-8e47-9821b447c497" />

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ingen tester fra før. Burde refaktoreres før man skriver tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
