### PR TITLE
Legger til nye endepunkter som tar imot ident i requestbody istedenfor

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/PersonController.kt
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
@@ -36,6 +37,7 @@ class PersonController(
     val behandlingService: BehandlingService,
 ) {
     @GetMapping
+    @Deprecated("Slettes når vi går over til POST endepunktene i frontend")
     fun hentPerson(
         @RequestHeader personIdent: String,
         @RequestBody personIdentBody: PersonIdent?,
@@ -49,11 +51,42 @@ class PersonController(
         return ResponseEntity.ok(Ressurs.success(personinfo))
     }
 
+    @PostMapping
+    fun hentPerson(
+        @RequestBody personIdentDto: PersonIdent,
+    ): ResponseEntity<Ressurs<PersonInfoDto>> {
+        val personIdent = personIdentDto.ident
+
+        val aktør = personidentService.hentAktør(personIdent)
+        val personinfo =
+            integrasjonService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
+                ?: personOpplysningerService
+                    .hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+                    .tilPersonInfoDto(personIdent)
+        return ResponseEntity.ok(Ressurs.success(personinfo))
+    }
+
     @GetMapping(path = ["/enkel"])
+    @Deprecated("Slettes når vi går over til POST endepunktene i frontend")
     fun hentPersonEnkel(
         @RequestHeader personIdent: String,
         @RequestBody personIdentBody: PersonIdent?,
     ): ResponseEntity<Ressurs<PersonInfoDto>> {
+        val aktør = personidentService.hentAktør(personIdent)
+        val personinfo =
+            integrasjonService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
+                ?: personOpplysningerService
+                    .hentPersoninfoEnkel(aktør)
+                    .tilPersonInfoDto(personIdent)
+        return ResponseEntity.ok(Ressurs.success(personinfo))
+    }
+
+    @PostMapping(path = ["/enkel"])
+    fun hentPersonEnkel(
+        @RequestBody personIdentDto: PersonIdent,
+    ): ResponseEntity<Ressurs<PersonInfoDto>> {
+        val personIdent = personIdentDto.ident
+
         val aktør = personidentService.hentAktør(personIdent)
         val personinfo =
             integrasjonService.hentMaskertPersonInfoVedManglendeTilgang(aktør)


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24650

Bytter til POST fra GET ved henting av personer.
Da unngår vi å måtte legge personident i header, men heller i body mtp sensitiv info i headers.

PR i frontend: https://github.com/navikt/familie-ks-sak-frontend/pull/1101