### PR TITLE
Nav 24658 legg til relatert behandling id og relatert behandling fagsystem

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -183,6 +183,8 @@ data class Behandling(
 
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 
+    fun erRevurderingKlage() = type == REVURDERING && opprettetÅrsak == BehandlingÅrsak.KLAGE
+
     fun erLovendring() = opprettetÅrsak == BehandlingÅrsak.LOVENDRING_2024
 
     fun erOvergangsordning() = opprettetÅrsak == BehandlingÅrsak.OVERGANGSORDNING_2024

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -183,7 +183,7 @@ data class Behandling(
 
     fun erTekniskEndring() = opprettetÅrsak == BehandlingÅrsak.TEKNISK_ENDRING
 
-    fun erRevurderingKlage() = type == REVURDERING && opprettetÅrsak == BehandlingÅrsak.KLAGE
+    fun erRevurderingKlage() = type == REVURDERING && opprettetÅrsak in setOf(BehandlingÅrsak.KLAGE, BehandlingÅrsak.IVERKSETTE_KA_VEDTAK)
 
     fun erLovendring() = opprettetÅrsak == BehandlingÅrsak.LOVENDRING_2024
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageService.kt
@@ -7,7 +7,6 @@ import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
 import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
 import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
@@ -28,6 +27,7 @@ class KlageService(
     private val behandlingService: BehandlingService,
     private val vedtakService: VedtakService,
     private val tilbakekrevingKlient: TilbakekrevingKlient,
+    private val klagebehandlingHenter: KlagebehandlingHenter,
 ) {
     fun opprettKlage(
         fagsakId: Long,
@@ -62,15 +62,9 @@ class KlageService(
         )
     }
 
-    fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> {
-        val klagebehandligerPerFagsak = klageClient.hentKlagebehandlinger(setOf(fagsakId))
+    fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> = klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
 
-        val klagerPåFagsak =
-            klagebehandligerPerFagsak[fagsakId]
-                ?: throw Feil("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
-
-        return klagerPåFagsak.map { it.brukVedtaksdatoFraKlageinstansHvisOversendt() }
-    }
+    fun hentSisteVedtatteKlagebehandling(fagsakId: Long): KlagebehandlingDto? = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
 
     fun hentFagsystemVedtak(fagsakId: Long): List<FagsystemVedtak> {
         val fagsak = fagsakService.hentFagsak(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenter.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenter.kt
@@ -1,0 +1,71 @@
+package no.nav.familie.ks.sak.kjerne.klage
+
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
+import no.nav.familie.ks.sak.common.exception.Feil
+import org.springframework.stereotype.Component
+
+@Component
+class KlagebehandlingHenter(
+    private val klageClient: KlageClient,
+) {
+    fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> {
+        val klagebehandligerPerFagsak = klageClient.hentKlagebehandlinger(setOf(fagsakId))
+        val klagerPåFagsak = klagebehandligerPerFagsak[fagsakId]
+        if (klagerPåFagsak == null) {
+            throw Feil("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
+        }
+        return klagerPåFagsak.map { it.brukVedtaksdatoFraKlageinstansHvisOversendt() }
+    }
+
+    fun hentSisteVedtatteKlagebehandling(fagsakId: Long): KlagebehandlingDto? =
+        hentKlagebehandlingerPåFagsak(fagsakId)
+            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektStatus(it.status) }
+            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektHenlagtÅrsak(it.henlagtÅrsak) }
+            .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektBehandlingResultat(it.resultat) }
+            .filter { it.vedtaksdato != null }
+            .maxByOrNull { it.vedtaksdato!! }
+
+    private object SisteVedtatteKlagebehandlingSjekker {
+        fun harKlagebehandlingKorrektStatus(behandlingStatus: BehandlingStatus) =
+            when (behandlingStatus) {
+                BehandlingStatus.FERDIGSTILT,
+                -> true
+
+                BehandlingStatus.OPPRETTET,
+                BehandlingStatus.UTREDES,
+                BehandlingStatus.VENTER,
+                BehandlingStatus.SATT_PÅ_VENT,
+                -> false
+            }
+
+        fun harKlagebehandlingKorrektHenlagtÅrsak(henlagtÅrsak: HenlagtÅrsak?): Boolean {
+            if (henlagtÅrsak == null) {
+                return true
+            }
+            return when (henlagtÅrsak) {
+                HenlagtÅrsak.TRUKKET_TILBAKE,
+                HenlagtÅrsak.FEILREGISTRERT,
+                -> false
+            }
+        }
+
+        fun harKlagebehandlingKorrektBehandlingResultat(behandlingResultat: BehandlingResultat?): Boolean {
+            if (behandlingResultat == null) {
+                return false
+            }
+            return when (behandlingResultat) {
+                BehandlingResultat.MEDHOLD,
+                BehandlingResultat.IKKE_MEDHOLD,
+                BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
+                -> true
+
+                BehandlingResultat.IKKE_SATT,
+                BehandlingResultat.HENLAGT,
+                -> false
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenter.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenter.kt
@@ -22,6 +22,7 @@ class KlagebehandlingHenter(
 
     fun hentSisteVedtatteKlagebehandling(fagsakId: Long): KlagebehandlingDto? =
         hentKlagebehandlingerPåFagsak(fagsakId)
+            .asSequence()
             .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektStatus(it.status) }
             .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektHenlagtÅrsak(it.henlagtÅrsak) }
             .filter { SisteVedtatteKlagebehandlingSjekker.harKlagebehandlingKorrektBehandlingResultat(it.resultat) }

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/BehandlingStatistikkV2Dto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/BehandlingStatistikkV2Dto.kt
@@ -28,6 +28,8 @@ data class BehandlingStatistikkV2Dto(
     val ansvarligBeslutter: String?,
     val behandlingOpprettetÅrsak: BehandlingÅrsak?,
     val automatiskBehandlet: Boolean,
+    val relatertBehandlingId: String? = null,
+    val relatertBehandlingFagsystem: String? = null,
 )
 
 data class SattPåVent(

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ks.sak.statistikk.saksstatistikk
+
+import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import java.time.LocalDateTime
+
+data class RelatertBehandling(
+    val id: String,
+    val vedtattTidspunkt: LocalDateTime,
+    val fagsystem: Fagsystem,
+) {
+    enum class Fagsystem {
+        KONT,
+        KLAGE,
+    }
+
+    companion object Fabrikk {
+        fun fraKontantstøttebehandling(kontantstøttebehandling: Behandling) =
+            RelatertBehandling(
+                id = kontantstøttebehandling.id.toString(),
+                vedtattTidspunkt = kontantstøttebehandling.aktivertTidspunkt,
+                fagsystem = Fagsystem.KONT,
+            )
+
+        fun fraKlagebehandling(klagebehandling: KlagebehandlingDto): RelatertBehandling {
+            val vedtaksdato = klagebehandling.vedtaksdato
+            if (vedtaksdato == null) {
+                throw Feil("Forventer vedtaksdato for klagebehandling ${klagebehandling.id}")
+            }
+            return RelatertBehandling(
+                id = klagebehandling.id.toString(),
+                vedtattTidspunkt = vedtaksdato,
+                fagsystem = Fagsystem.KLAGE,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
@@ -11,7 +11,7 @@ data class RelatertBehandling(
     val fagsystem: Fagsystem,
 ) {
     enum class Fagsystem {
-        KONT,
+        KS,
         KLAGE,
     }
 
@@ -20,7 +20,7 @@ data class RelatertBehandling(
             RelatertBehandling(
                 id = kontantstøttebehandling.id.toString(),
                 vedtattTidspunkt = kontantstøttebehandling.aktivertTidspunkt,
-                fagsystem = Fagsystem.KONT,
+                fagsystem = Fagsystem.KS,
             )
 
         fun fraKlagebehandling(klagebehandling: KlagebehandlingDto): RelatertBehandling {

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
@@ -15,7 +15,7 @@ data class RelatertBehandling(
         KLAGE,
     }
 
-    companion object Fabrikk {
+    companion object Factory {
         fun fraKontantstøttebehandling(kontantstøttebehandling: Behandling) =
             RelatertBehandling(
                 id = kontantstøttebehandling.id.toString(),

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -6,13 +6,14 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
-import no.nav.familie.ks.sak.kjerne.klage.KlagebehandlingHenter
+import no.nav.familie.ks.sak.kjerne.klage.KlageService
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Component
 
 @Component
 class RelatertBehandlingUtleder(
     private val behandlingRepository: BehandlingRepository,
-    private val klagebehandlingHenter: KlagebehandlingHenter,
+    @Lazy private val klageService: KlageService,
     private val unleashService: UnleashNextMedContextService,
 ) {
     fun utledRelatertBehandling(fagsakId: Long): RelatertBehandling? {
@@ -29,7 +30,7 @@ class RelatertBehandlingUtleder(
                 ?.let { RelatertBehandling.fraKontantstøttebehandling(it) }
 
         val forrigeKlagebehandling =
-            klagebehandlingHenter
+            klageService
                 .hentSisteVedtatteKlagebehandling(fagsakId)
                 ?.let { RelatertBehandling.fraKlagebehandling(it) }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -20,18 +20,18 @@ class RelatertBehandlingUtleder(
             return null
         }
 
-        val forrigeKontantstøttebehandling =
+        val sisteVedtatteKontantstøttebehandling =
             behandlingService
                 .hentSisteBehandlingSomErVedtatt(fagsakId)
                 ?.takeIf { harKontantstøttebehandlingKorrektBehandlingType(it) }
                 ?.let { RelatertBehandling.fraKontantstøttebehandling(it) }
 
-        val forrigeKlagebehandling =
+        val sisteVedtatteKlagebehandling =
             klageService
                 .hentSisteVedtatteKlagebehandling(fagsakId)
                 ?.let { RelatertBehandling.fraKlagebehandling(it) }
 
-        return listOfNotNull(forrigeKontantstøttebehandling, forrigeKlagebehandling).maxByOrNull { it.vedtattTidspunkt }
+        return listOfNotNull(sisteVedtatteKontantstøttebehandling, sisteVedtatteKlagebehandling).maxByOrNull { it.vedtattTidspunkt }
     }
 
     private fun harKontantstøttebehandlingKorrektBehandlingType(kontantstøttebehandling: Behandling) =

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -1,0 +1,48 @@
+package no.nav.familie.ks.sak.statistikk.saksstatistikk
+
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ks.sak.kjerne.klage.KlagebehandlingHenter
+import org.springframework.stereotype.Component
+
+@Component
+class RelatertBehandlingUtleder(
+    private val behandlingRepository: BehandlingRepository,
+    private val klagebehandlingHenter: KlagebehandlingHenter,
+    private val unleashService: UnleashNextMedContextService,
+) {
+    fun utledRelatertBehandling(fagsakId: Long): RelatertBehandling? {
+        if (!unleashService.isEnabled(FeatureToggle.KAN_BEHANDLE_KLAGE, false)) {
+            return null
+        }
+
+        val forrigeKontantstøttebehandling =
+            behandlingRepository
+                .finnBehandlinger(fagsakId)
+                .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
+                .maxByOrNull { it.aktivertTidspunkt }
+                ?.takeIf { harKontantstøttebehandlingKorrektBehandlingType(it) }
+                ?.let { RelatertBehandling.fraKontantstøttebehandling(it) }
+
+        val forrigeKlagebehandling =
+            klagebehandlingHenter
+                .hentSisteVedtatteKlagebehandling(fagsakId)
+                ?.let { RelatertBehandling.fraKlagebehandling(it) }
+
+        return listOfNotNull(forrigeKontantstøttebehandling, forrigeKlagebehandling).maxByOrNull { it.vedtattTidspunkt }
+    }
+
+    private fun harKontantstøttebehandlingKorrektBehandlingType(kontantstøttebehandling: Behandling) =
+        when (kontantstøttebehandling.type) {
+            BehandlingType.FØRSTEGANGSBEHANDLING,
+            -> false
+
+            BehandlingType.REVURDERING,
+            BehandlingType.TEKNISK_ENDRING,
+            -> true
+        }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -2,9 +2,8 @@ package no.nav.familie.ks.sak.statistikk.saksstatistikk
 
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.klage.KlageService
 import org.springframework.context.annotation.Lazy
@@ -12,7 +11,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class RelatertBehandlingUtleder(
-    private val behandlingRepository: BehandlingRepository,
+    @Lazy private val behandlingService: BehandlingService,
     @Lazy private val klageService: KlageService,
     private val unleashService: UnleashNextMedContextService,
 ) {
@@ -22,10 +21,8 @@ class RelatertBehandlingUtleder(
         }
 
         val forrigeKontantstøttebehandling =
-            behandlingRepository
-                .finnBehandlinger(fagsakId)
-                .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
-                .maxByOrNull { it.aktivertTidspunkt }
+            behandlingService
+                .hentSisteBehandlingSomErVedtatt(fagsakId)
                 ?.takeIf { harKontantstøttebehandlingKorrektBehandlingType(it) }
                 ?.let { RelatertBehandling.fraKontantstøttebehandling(it) }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkService.kt
@@ -34,6 +34,7 @@ class SakStatistikkService(
     private val fagsakService: FagsakService,
     private val personopplysningService: PersonopplysningerService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
+    private val relatertBehandlingUtleder: RelatertBehandlingUtleder,
 ) {
     fun opprettSendingAvBehandlingensTilstand(
         behandlingId: Long,
@@ -92,6 +93,8 @@ class SakStatistikkService(
 
         val mottattTid = behandling.søknadMottattDato ?: behandling.opprettetTidspunkt
 
+        val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(behandling.fagsak.id)
+
         return BehandlingStatistikkV2Dto(
             saksnummer = behandling.fagsak.id,
             behandlingID = behandling.id,
@@ -121,6 +124,8 @@ class SakStatistikkService(
                     )
                 },
             behandlingOpprettetÅrsak = behandling.opprettetÅrsak,
+            relatertBehandlingId = relatertBehandling?.id,
+            relatertBehandlingFagsystem = relatertBehandling?.fagsystem?.name,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkService.kt
@@ -93,7 +93,7 @@ class SakStatistikkService(
 
         val mottattTid = behandling.søknadMottattDato ?: behandling.opprettetTidspunkt
 
-        val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(behandling.fagsak.id)
+        val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(behandling)
 
         return BehandlingStatistikkV2Dto(
             saksnummer = behandling.fagsak.id,

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -1609,7 +1609,7 @@ fun lagKlageinstansResultatDto(
 fun lagRelatertBehandling(
     id: String = "1",
     vedtattTidspunkt: LocalDateTime = LocalDateTime.now(),
-    fagsystem: RelatertBehandling.Fagsystem = RelatertBehandling.Fagsystem.KONT,
+    fagsystem: RelatertBehandling.Fagsystem = RelatertBehandling.Fagsystem.KS,
 ): RelatertBehandling =
     RelatertBehandling(
         id = id,

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -5,6 +5,12 @@ import no.nav.commons.foedselsnummer.testutils.FoedselsnummerGenerator
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeIdLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
 import no.nav.familie.kontrakter.felles.enhet.Enhet
+import no.nav.familie.kontrakter.felles.klage.BehandlingEventType
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
+import no.nav.familie.kontrakter.felles.klage.KlageinstansResultatDto
+import no.nav.familie.kontrakter.felles.klage.KlageinstansUtfall
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.Opphør
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
@@ -109,6 +115,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.sivilstand.G
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.statsborgerskap.GrStatsborgerskap
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
 import no.nav.familie.ks.sak.korrigertvedtak.KorrigertVedtak
+import no.nav.familie.ks.sak.statistikk.saksstatistikk.RelatertBehandling
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -281,6 +288,7 @@ fun lagBehandling(
     aktiv: Boolean = true,
     status: BehandlingStatus = BehandlingStatus.UTREDES,
     id: Long = 0L,
+    aktivertTidspunkt: LocalDateTime = LocalDateTime.now(),
     endretTidspunkt: LocalDateTime = LocalDateTime.now(),
     lagBehandlingStegTilstander: (behandling: Behandling) -> Set<BehandlingStegTilstand> = {
         setOf(
@@ -301,6 +309,7 @@ fun lagBehandling(
             resultat = resultat,
             aktiv = aktiv,
             status = status,
+            aktivertTidspunkt = aktivertTidspunkt,
         )
     behandling.behandlingStegTilstand.addAll(lagBehandlingStegTilstander(behandling))
     behandling.endretTidspunkt = endretTidspunkt
@@ -1556,4 +1565,54 @@ fun lagRefusjonEøs(
         land = land,
         refusjonAvklart = refusjonAvklart,
         id = id,
+    )
+
+fun lagKlagebehandlingDto(
+    id: UUID = UUID.randomUUID(),
+    fagsakId: UUID = UUID.randomUUID(),
+    status: no.nav.familie.kontrakter.felles.klage.BehandlingStatus = no.nav.familie.kontrakter.felles.klage.BehandlingStatus.FERDIGSTILT,
+    opprettet: LocalDateTime = LocalDateTime.now(),
+    mottattDato: LocalDate = LocalDate.now(),
+    resultat: BehandlingResultat? = BehandlingResultat.MEDHOLD,
+    årsak: no.nav.familie.kontrakter.felles.klage.Årsak? = null,
+    vedtaksdato: LocalDateTime? = LocalDateTime.now(),
+    klageinstansResultat: List<KlageinstansResultatDto> = emptyList(),
+    henlagtÅrsak: HenlagtÅrsak? = null,
+) = KlagebehandlingDto(
+    id = id,
+    fagsakId = fagsakId,
+    status = status,
+    opprettet = opprettet,
+    mottattDato = mottattDato,
+    resultat = resultat,
+    årsak = årsak,
+    vedtaksdato = vedtaksdato,
+    klageinstansResultat = klageinstansResultat,
+    henlagtÅrsak = henlagtÅrsak,
+)
+
+fun lagKlageinstansResultatDto(
+    type: BehandlingEventType = BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET,
+    utfall: KlageinstansUtfall? = KlageinstansUtfall.MEDHOLD,
+    mottattEllerAvsluttetTidspunkt: LocalDateTime = LocalDateTime.now(),
+    journalpostReferanser: List<String> = emptyList(),
+    årsakFeilregistrert: String? = null,
+): KlageinstansResultatDto =
+    KlageinstansResultatDto(
+        type = type,
+        utfall = utfall,
+        mottattEllerAvsluttetTidspunkt = mottattEllerAvsluttetTidspunkt,
+        journalpostReferanser = journalpostReferanser,
+        årsakFeilregistrert = årsakFeilregistrert,
+    )
+
+fun lagRelatertBehandling(
+    id: String = "1",
+    vedtattTidspunkt: LocalDateTime = LocalDateTime.now(),
+    fagsystem: RelatertBehandling.Fagsystem = RelatertBehandling.Fagsystem.KONT,
+): RelatertBehandling =
+    RelatertBehandling(
+        id = id,
+        vedtattTidspunkt = vedtattTidspunkt,
+        fagsystem = fagsystem,
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageServiceTest.kt
@@ -1,0 +1,86 @@
+package no.nav.familie.ks.sak.kjerne.klage
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import no.nav.familie.ks.sak.data.lagKlagebehandlingDto
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
+import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class KlageServiceTest {
+    private val fagsakService = mockk<FagsakService>()
+    private val klageClient = mockk<KlageClient>()
+    private val integrasjonClient = mockk<IntegrasjonClient>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val vedtakService = mockk<VedtakService>()
+    private val tilbakekrevingKlient = mockk<TilbakekrevingKlient>()
+    private val klagebehandlingHenter = mockk<KlagebehandlingHenter>()
+
+    private val klageService =
+        KlageService(
+            fagsakService = fagsakService,
+            klageClient = klageClient,
+            integrasjonClient = integrasjonClient,
+            behandlingService = behandlingService,
+            vedtakService = vedtakService,
+            tilbakekrevingKlient = tilbakekrevingKlient,
+            klagebehandlingHenter = klagebehandlingHenter,
+        )
+
+    @Nested
+    inner class HentKlagebehandlingerPåFagsak {
+        @Test
+        fun `skal hente alle klagebehandlinger på fagsak`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlinger =
+                listOf(
+                    lagKlagebehandlingDto(),
+                    lagKlagebehandlingDto(),
+                    lagKlagebehandlingDto(),
+                )
+
+            every { klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId) } returns klagebehandlinger
+
+            // Act
+            val resultat = klageService.hentKlagebehandlingerPåFagsak(fagsakId)
+
+            // Assert
+            assertThat(resultat).isEqualTo(klagebehandlinger)
+        }
+    }
+
+    @Nested
+    inner class HentSisteVedtatteKlagebehandling {
+        @Test
+        fun `skal hente siste vedtatte klagebehandling`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.MEDHOLD,
+                )
+
+            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandlingDto
+
+            // Act
+            val sisteVedtatteKlagebehandling = klageService.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isEqualTo(klagebehandlingDto)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenterTest.kt
@@ -1,0 +1,261 @@
+package no.nav.familie.ks.sak.kjerne.klage
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.data.lagKlagebehandlingDto
+import no.nav.familie.ks.sak.data.lagKlageinstansResultatDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDateTime
+
+class KlagebehandlingHenterTest {
+    private val klageClient = mockk<KlageClient>()
+    private val klagebehandlingHenter =
+        KlagebehandlingHenter(
+            klageClient = klageClient,
+        )
+
+    @Nested
+    inner class HentKlagebehandlingerPåFagsak {
+        @Test
+        fun `skal kaste exception om fagsaken ikke finnes i resultatet fra kallet til klageklienten`() {
+            // Arrange
+            val fagsakId = 4L
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    1L to listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto()),
+                    2L to listOf(lagKlagebehandlingDto()),
+                    3L to listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto()),
+                )
+
+            // Act & Assert
+            val exception =
+                assertThrows<Feil> {
+                    klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
+                }
+            assertThat(exception.message).isEqualTo("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
+        }
+
+        @Test
+        fun `skal hente klagebehandlinger på fagsak`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingerForFagsak1 = listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto())
+            val klagebehandlingerForFagsak2 = listOf(lagKlagebehandlingDto())
+            val klagebehandlingerForFagsak3 = listOf(lagKlagebehandlingDto(), lagKlagebehandlingDto())
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to klagebehandlingerForFagsak1,
+                    2L to klagebehandlingerForFagsak2,
+                    3L to klagebehandlingerForFagsak3,
+                )
+
+            // Act
+            val resultat = klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
+
+            // Assert
+            assertThat(resultat).isEqualTo(klagebehandlingerForFagsak1)
+        }
+    }
+
+    @Nested
+    inner class HentSisteVedtatteKlagebehandling {
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["FERDIGSTILT"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal filtrer bort klagebehandlinger som ikke er ferdigstilt`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = behandlingStatus,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = HenlagtÅrsak::class)
+        fun `skal filtrer bort klagebehandlinger med henlagt årsak`(
+            henlagtÅrsak: HenlagtÅrsak,
+        ) {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = henlagtÅrsak,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingResultat::class,
+            names = ["MEDHOLD", "IKKE_MEDHOLD", "IKKE_MEDHOLD_FORMKRAV_AVVIST"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal filtrer bort klagebehandlinger med behandlingsresultat som ikke er korrekt`(
+            behandlingResultat: BehandlingResultat,
+        ) {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = behandlingResultat,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @Test
+        fun `skal filtrer bort klagebehandlinger med behandlingsresultat som er null`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = LocalDateTime.now(),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = null,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @Test
+        fun `skal filtrer bort klagebehandlinger med vedtaksdato som er null`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val klagebehandlingDto =
+                lagKlagebehandlingDto(
+                    vedtaksdato = null,
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.MEDHOLD,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isNull()
+        }
+
+        @Test
+        fun `skal hente siste vedtatte klagebehandling med korrekt behandlingsresultat`() {
+            // Arrange
+            val fagsakId = 1L
+            val nåtidspunkt = LocalDateTime.now()
+
+            val klagebehandlingDto1 =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.MEDHOLD,
+                )
+
+            val klagebehandlingDto2 =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt,
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.IKKE_MEDHOLD,
+                    klageinstansResultat =
+                        listOf(
+                            lagKlageinstansResultatDto(
+                                mottattEllerAvsluttetTidspunkt = nåtidspunkt,
+                            ),
+                        ),
+                )
+
+            val klagebehandlingDto3 =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt.minusSeconds(2),
+                    status = BehandlingStatus.FERDIGSTILT,
+                    henlagtÅrsak = null,
+                    resultat = BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
+                )
+
+            every { klageClient.hentKlagebehandlinger(setOf(fagsakId)) } returns
+                mapOf(
+                    fagsakId to listOf(klagebehandlingDto1, klagebehandlingDto2, klagebehandlingDto3),
+                )
+
+            // Act
+            val sisteVedtatteKlagebehandling = klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId)
+
+            // Assert
+            assertThat(sisteVedtatteKlagebehandling).isEqualTo(klagebehandlingDto2)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingTest.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ks.sak.statistikk.saksstatistikk
+
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagKlagebehandlingDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+import java.util.UUID
+
+class RelatertBehandlingTest {
+    @Nested
+    inner class FraKontantstøttebehandling {
+        @Test
+        fun `skal lage relatert behandling fra kontatstøttebehandling`() {
+            // Arrange
+            val kontantstøttebehandling =
+                lagBehandling(
+                    id = 1L,
+                    aktivertTidspunkt = LocalDateTime.now(),
+                )
+
+            // Act
+            val relatertBehandling = RelatertBehandling.fraKontantstøttebehandling(kontantstøttebehandling)
+
+            // Assert
+            assertThat(relatertBehandling.id).isEqualTo(kontantstøttebehandling.id.toString())
+            assertThat(relatertBehandling.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KONT)
+            assertThat(relatertBehandling.vedtattTidspunkt).isEqualTo(kontantstøttebehandling.aktivertTidspunkt)
+        }
+    }
+
+    @Nested
+    inner class FraKlagebehandling {
+        @Test
+        fun `skal lage relatert behandling fra klagebehandling`() {
+            // Arrange
+            val klagebehandling =
+                lagKlagebehandlingDto(
+                    id = UUID.randomUUID(),
+                    vedtaksdato = LocalDateTime.now(),
+                )
+
+            // Act
+            val relatertBehandling = RelatertBehandling.fraKlagebehandling(klagebehandling)
+
+            // Assert
+            assertThat(relatertBehandling.id).isEqualTo(klagebehandling.id.toString())
+            assertThat(relatertBehandling.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KLAGE)
+            assertThat(relatertBehandling.vedtattTidspunkt).isEqualTo(klagebehandling.vedtaksdato)
+        }
+
+        @Test
+        fun `skal kaste exception om klagebehandling mangler vedtaksdato`() {
+            // Arrange
+            val klagebehandling =
+                lagKlagebehandlingDto(
+                    id = UUID.randomUUID(),
+                    vedtaksdato = null,
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    RelatertBehandling.fraKlagebehandling(klagebehandling)
+                }
+            assertThat(exception.message).isEqualTo("Forventer vedtaksdato for klagebehandling ${klagebehandling.id}")
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingTest.kt
@@ -27,7 +27,7 @@ class RelatertBehandlingTest {
 
             // Assert
             assertThat(relatertBehandling.id).isEqualTo(kontantstøttebehandling.id.toString())
-            assertThat(relatertBehandling.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KONT)
+            assertThat(relatertBehandling.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KS)
             assertThat(relatertBehandling.vedtattTidspunkt).isEqualTo(kontantstøttebehandling.aktivertTidspunkt)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -1,0 +1,208 @@
+package no.nav.familie.ks.sak.statistikk.saksstatistikk
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagKlagebehandlingDto
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ks.sak.kjerne.klage.KlagebehandlingHenter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDateTime
+
+class RelatertBehandlingUtlederTest {
+    private val behandlingRepository = mockk<BehandlingRepository>()
+    private val klagebehandlingHenter = mockk<KlagebehandlingHenter>()
+    private val unleashService = mockk<UnleashNextMedContextService>()
+    private val relatertBehandlingUtleder =
+        RelatertBehandlingUtleder(
+            behandlingRepository = behandlingRepository,
+            klagebehandlingHenter = klagebehandlingHenter,
+            unleashService = unleashService,
+        )
+
+    @BeforeEach
+    fun oppsett() {
+        every { unleashService.isEnabled(FeatureToggle.KAN_BEHANDLE_KLAGE, false) } returns true
+    }
+
+    @Nested
+    inner class UtledRelatertBehandling {
+        @Test
+        fun `skal returnere null når toggle for å behandle klage er skrudd av`() {
+            // Arrange
+            val fagsakId = 1L
+
+            every { unleashService.isEnabled(FeatureToggle.KAN_BEHANDLE_KLAGE, false) } returns false
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
+
+            // Assert
+            assertThat(relatertBehandling).isNull()
+        }
+
+        @Test
+        fun `skal utlede relatert behandling når klagebehandlingen er siste vedtatte behandling`() {
+            // Arrange
+            val fagsakId = 1L
+            val nåtidspunkt = LocalDateTime.now()
+
+            val kontantstøttebehandling =
+                lagBehandling(
+                    type = BehandlingType.REVURDERING,
+                    aktivertTidspunkt = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            val klagebehandling =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt,
+                )
+
+            every { behandlingRepository.finnBehandlinger(fagsakId) } returns listOf(kontantstøttebehandling)
+            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandling
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
+
+            // Assert
+            assertThat(relatertBehandling?.id).isEqualTo(klagebehandling.id.toString())
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KLAGE)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(klagebehandling.vedtaksdato)
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingType::class,
+            names = ["FØRSTEGANGSBEHANDLING"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal utlede relatert behandling når kontantstøttebehandlingen er siste vedtatte behandling`(
+            behandlingType: BehandlingType,
+        ) {
+            // Arrange
+            val fagsakId = 1L
+            val nåtidspunkt = LocalDateTime.now()
+
+            val kontantstøttebehandling =
+                lagBehandling(
+                    type = behandlingType,
+                    aktivertTidspunkt = nåtidspunkt,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            val klagebehandling =
+                lagKlagebehandlingDto(
+                    vedtaksdato = nåtidspunkt.minusSeconds(1),
+                )
+
+            every { behandlingRepository.finnBehandlinger(fagsakId) } returns listOf(kontantstøttebehandling)
+            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandling
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
+
+            // Assert
+            assertThat(relatertBehandling?.id).isEqualTo(kontantstøttebehandling.id.toString())
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KONT)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(kontantstøttebehandling.aktivertTidspunkt)
+        }
+
+        @Test
+        fun `skal utlede relatert behandling når flere kontantstøttebehandlingen er vedtatt`() {
+            // Arrange
+            val fagsakId = 1L
+            val nåtidspunkt = LocalDateTime.now()
+
+            val kontantstøttebehandling1 =
+                lagBehandling(
+                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    aktivertTidspunkt = nåtidspunkt.minusSeconds(2),
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            val kontantstøttebehandling2 =
+                lagBehandling(
+                    type = BehandlingType.REVURDERING,
+                    aktivertTidspunkt = nåtidspunkt.minusSeconds(1),
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET,
+                )
+
+            val kontantstøttebehandling3 =
+                lagBehandling(
+                    type = BehandlingType.REVURDERING,
+                    aktivertTidspunkt = nåtidspunkt,
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            every { behandlingRepository.finnBehandlinger(fagsakId) } returns
+                listOf(
+                    kontantstøttebehandling1,
+                    kontantstøttebehandling2,
+                    kontantstøttebehandling3,
+                )
+            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
+
+            // Assert
+            assertThat(relatertBehandling?.id).isEqualTo(kontantstøttebehandling3.id.toString())
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KONT)
+            assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(kontantstøttebehandling3.aktivertTidspunkt)
+        }
+
+        @Test
+        fun `skal ikke utlede relatert behandling når ingen behandlinger er vedtatt`() {
+            // Arrange
+            val fagsakId = 1L
+
+            every { behandlingRepository.finnBehandlinger(fagsakId) } returns emptyList()
+            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
+
+            // Assert
+            assertThat(relatertBehandling).isNull()
+        }
+
+        @Test
+        fun `skal ikke utlede relatert behandling når kun førstegangsbehandling for kontantstøtte er vedtatt`() {
+            // Arrange
+            val fagsakId = 1L
+
+            val kontantstøttebehandling =
+                lagBehandling(
+                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    aktivertTidspunkt = LocalDateTime.now(),
+                    status = BehandlingStatus.AVSLUTTET,
+                    resultat = Behandlingsresultat.INNVILGET,
+                )
+
+            every { behandlingRepository.finnBehandlinger(fagsakId) } returns listOf(kontantstøttebehandling)
+            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
+
+            // Act
+            val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
+
+            // Assert
+            assertThat(relatertBehandling).isNull()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -116,7 +116,7 @@ class RelatertBehandlingUtlederTest {
 
             // Assert
             assertThat(relatertBehandling?.id).isEqualTo(kontantstøttebehandling.id.toString())
-            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KONT)
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KS)
             assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(kontantstøttebehandling.aktivertTidspunkt)
         }
 
@@ -163,7 +163,7 @@ class RelatertBehandlingUtlederTest {
 
             // Assert
             assertThat(relatertBehandling?.id).isEqualTo(kontantstøttebehandling3.id.toString())
-            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KONT)
+            assertThat(relatertBehandling?.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KS)
             assertThat(relatertBehandling?.vedtattTidspunkt).isEqualTo(kontantstøttebehandling3.aktivertTidspunkt)
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
-import no.nav.familie.ks.sak.kjerne.klage.KlagebehandlingHenter
+import no.nav.familie.ks.sak.kjerne.klage.KlageService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -21,12 +21,12 @@ import java.time.LocalDateTime
 
 class RelatertBehandlingUtlederTest {
     private val behandlingRepository = mockk<BehandlingRepository>()
-    private val klagebehandlingHenter = mockk<KlagebehandlingHenter>()
+    private val klageService = mockk<KlageService>()
     private val unleashService = mockk<UnleashNextMedContextService>()
     private val relatertBehandlingUtleder =
         RelatertBehandlingUtleder(
             behandlingRepository = behandlingRepository,
-            klagebehandlingHenter = klagebehandlingHenter,
+            klageService = klageService,
             unleashService = unleashService,
         )
 
@@ -71,7 +71,7 @@ class RelatertBehandlingUtlederTest {
                 )
 
             every { behandlingRepository.finnBehandlinger(fagsakId) } returns listOf(kontantstøttebehandling)
-            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandling
+            every { klageService.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
@@ -109,7 +109,7 @@ class RelatertBehandlingUtlederTest {
                 )
 
             every { behandlingRepository.finnBehandlinger(fagsakId) } returns listOf(kontantstøttebehandling)
-            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandling
+            every { klageService.hentSisteVedtatteKlagebehandling(fagsakId) } returns klagebehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
@@ -156,7 +156,7 @@ class RelatertBehandlingUtlederTest {
                     kontantstøttebehandling2,
                     kontantstøttebehandling3,
                 )
-            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
+            every { klageService.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
@@ -173,7 +173,7 @@ class RelatertBehandlingUtlederTest {
             val fagsakId = 1L
 
             every { behandlingRepository.finnBehandlinger(fagsakId) } returns emptyList()
-            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
+            every { klageService.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)
@@ -196,7 +196,7 @@ class RelatertBehandlingUtlederTest {
                 )
 
             every { behandlingRepository.finnBehandlinger(fagsakId) } returns listOf(kontantstøttebehandling)
-            every { klagebehandlingHenter.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
+            every { klageService.hentSisteVedtatteKlagebehandling(fagsakId) } returns null
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(fagsakId)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkServiceTest.kt
@@ -57,7 +57,7 @@ class SakStatistikkServiceTest {
             every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
             every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId) } returns arbeidsfordelingPåBehandling
             every { totrinnskontrollService.finnAktivForBehandling(behandlingId) } returns totrinnskontroll
-            every { relatertBehandlingUtleder.utledRelatertBehandling(behandling.fagsak.id) } returns relatertBehandling
+            every { relatertBehandlingUtleder.utledRelatertBehandling(behandling) } returns relatertBehandling
 
             // Act
             val behandlingStatistikkV2Dto =
@@ -99,7 +99,7 @@ class SakStatistikkServiceTest {
             every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
             every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId) } returns arbeidsfordelingPåBehandling
             every { totrinnskontrollService.finnAktivForBehandling(behandlingId) } returns totrinnskontroll
-            every { relatertBehandlingUtleder.utledRelatertBehandling(behandling.fagsak.id) } returns null
+            every { relatertBehandlingUtleder.utledRelatertBehandling(behandling) } returns null
 
             // Act
             val behandlingStatistikkV2Dto =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkServiceTest.kt
@@ -1,0 +1,132 @@
+package no.nav.familie.ks.sak.statistikk.saksstatistikk
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagRelatertBehandling
+import no.nav.familie.ks.sak.data.lagToTrinnskontroll
+import no.nav.familie.ks.sak.integrasjon.pdl.PersonopplysningerService
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
+import no.nav.familie.ks.sak.statistikk.saksstatistikk.SakStatistikkService.Companion.TIMEZONE
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SakStatistikkServiceTest {
+    private val behandlingRepository = mockk<BehandlingRepository>()
+    private val fagsakRepository = mockk<FagsakRepository>()
+    private val taskService = mockk<TaskService>()
+    private val totrinnskontrollService = mockk<TotrinnskontrollService>()
+    private val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val personopplysningGrunnlagService = mockk<PersonopplysningGrunnlagService>()
+    private val personopplysningService = mockk<PersonopplysningerService>()
+    private val relatertBehandlingUtleder = mockk<RelatertBehandlingUtleder>()
+    private val sakStatistikkService =
+        SakStatistikkService(
+            behandlingRepository = behandlingRepository,
+            fagsakRepository = fagsakRepository,
+            taskService = taskService,
+            totrinnskontrollService = totrinnskontrollService,
+            arbeidsfordelingService = arbeidsfordelingService,
+            fagsakService = fagsakService,
+            personopplysningGrunnlagService = personopplysningGrunnlagService,
+            personopplysningService = personopplysningService,
+            relatertBehandlingUtleder = relatertBehandlingUtleder,
+        )
+
+    @Nested
+    inner class HentBehandlingensTilstandV2 {
+        @Test
+        fun `skal hente statistikk for behandling med relatert behandling`() {
+            // Arrange
+            val behandlingId = 1L
+
+            val behandling = lagBehandling(id = behandlingId)
+            val arbeidsfordelingPåBehandling = lagArbeidsfordelingPåBehandling(behandlingId = behandlingId)
+            val totrinnskontroll = lagToTrinnskontroll(behandling = behandling)
+            val relatertBehandling = lagRelatertBehandling()
+
+            every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
+            every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId) } returns arbeidsfordelingPåBehandling
+            every { totrinnskontrollService.finnAktivForBehandling(behandlingId) } returns totrinnskontroll
+            every { relatertBehandlingUtleder.utledRelatertBehandling(behandling.fagsak.id) } returns relatertBehandling
+
+            // Act
+            val behandlingStatistikkV2Dto =
+                sakStatistikkService.hentBehandlingensTilstandV2(
+                    behandlingId = behandlingId,
+                    brukEndretTidspunktSomFunksjonellTidspunkt = true,
+                )
+
+            // Assert
+            assertThat(behandlingStatistikkV2Dto.saksnummer).isEqualTo(behandling.fagsak.id)
+            assertThat(behandlingStatistikkV2Dto.behandlingID).isEqualTo(behandling.id)
+            assertThat(behandlingStatistikkV2Dto.mottattTid).isEqualTo(behandling.opprettetTidspunkt.atZone(TIMEZONE))
+            assertThat(behandlingStatistikkV2Dto.registrertTid).isEqualTo(behandling.opprettetTidspunkt.atZone(TIMEZONE))
+            assertThat(behandlingStatistikkV2Dto.behandlingType).isEqualTo(behandling.type)
+            assertThat(behandlingStatistikkV2Dto.utenlandstilsnitt).isEqualTo(behandling.kategori.name)
+            assertThat(behandlingStatistikkV2Dto.behandlingStatus).isEqualTo(behandling.status)
+            assertThat(behandlingStatistikkV2Dto.behandlingsResultat).isEqualTo(behandling.resultat)
+            assertThat(behandlingStatistikkV2Dto.ansvarligEnhet).isEqualTo(arbeidsfordelingPåBehandling.behandlendeEnhetId)
+            assertThat(behandlingStatistikkV2Dto.ansvarligBeslutter).isEqualTo(totrinnskontroll.beslutterId)
+            assertThat(behandlingStatistikkV2Dto.ansvarligSaksbehandler).isEqualTo(totrinnskontroll.saksbehandlerId)
+            assertThat(behandlingStatistikkV2Dto.behandlingErManueltOpprettet).isTrue()
+            assertThat(behandlingStatistikkV2Dto.funksjoneltTidspunkt).isEqualTo(behandling.endretTidspunkt.atZone(TIMEZONE))
+            assertThat(behandlingStatistikkV2Dto.automatiskBehandlet).isFalse()
+            assertThat(behandlingStatistikkV2Dto.sattPaaVent).isNull()
+            assertThat(behandlingStatistikkV2Dto.behandlingOpprettetÅrsak).isEqualTo(behandling.opprettetÅrsak)
+            assertThat(behandlingStatistikkV2Dto.relatertBehandlingId).isEqualTo(relatertBehandling.id)
+            assertThat(behandlingStatistikkV2Dto.relatertBehandlingFagsystem).isEqualTo(relatertBehandling.fagsystem.name)
+        }
+
+        @Test
+        fun `skal hente statistikk for behandling uten relatert behandling`() {
+            // Arrange
+            val behandlingId = 1L
+
+            val behandling = lagBehandling(id = behandlingId)
+            val arbeidsfordelingPåBehandling = lagArbeidsfordelingPåBehandling(behandlingId = behandlingId)
+            val totrinnskontroll = lagToTrinnskontroll(behandling = behandling)
+
+            every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
+            every { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId) } returns arbeidsfordelingPåBehandling
+            every { totrinnskontrollService.finnAktivForBehandling(behandlingId) } returns totrinnskontroll
+            every { relatertBehandlingUtleder.utledRelatertBehandling(behandling.fagsak.id) } returns null
+
+            // Act
+            val behandlingStatistikkV2Dto =
+                sakStatistikkService.hentBehandlingensTilstandV2(
+                    behandlingId = behandlingId,
+                    brukEndretTidspunktSomFunksjonellTidspunkt = true,
+                )
+
+            // Assert
+            assertThat(behandlingStatistikkV2Dto.saksnummer).isEqualTo(behandling.fagsak.id)
+            assertThat(behandlingStatistikkV2Dto.behandlingID).isEqualTo(behandling.id)
+            assertThat(behandlingStatistikkV2Dto.mottattTid).isEqualTo(behandling.opprettetTidspunkt.atZone(TIMEZONE))
+            assertThat(behandlingStatistikkV2Dto.registrertTid).isEqualTo(behandling.opprettetTidspunkt.atZone(TIMEZONE))
+            assertThat(behandlingStatistikkV2Dto.behandlingType).isEqualTo(behandling.type)
+            assertThat(behandlingStatistikkV2Dto.utenlandstilsnitt).isEqualTo(behandling.kategori.name)
+            assertThat(behandlingStatistikkV2Dto.behandlingStatus).isEqualTo(behandling.status)
+            assertThat(behandlingStatistikkV2Dto.behandlingsResultat).isEqualTo(behandling.resultat)
+            assertThat(behandlingStatistikkV2Dto.ansvarligEnhet).isEqualTo(arbeidsfordelingPåBehandling.behandlendeEnhetId)
+            assertThat(behandlingStatistikkV2Dto.ansvarligBeslutter).isEqualTo(totrinnskontroll.beslutterId)
+            assertThat(behandlingStatistikkV2Dto.ansvarligSaksbehandler).isEqualTo(totrinnskontroll.saksbehandlerId)
+            assertThat(behandlingStatistikkV2Dto.behandlingErManueltOpprettet).isTrue()
+            assertThat(behandlingStatistikkV2Dto.funksjoneltTidspunkt).isEqualTo(behandling.endretTidspunkt.atZone(TIMEZONE))
+            assertThat(behandlingStatistikkV2Dto.automatiskBehandlet).isFalse()
+            assertThat(behandlingStatistikkV2Dto.sattPaaVent).isNull()
+            assertThat(behandlingStatistikkV2Dto.behandlingOpprettetÅrsak).isEqualTo(behandling.opprettetÅrsak)
+            assertThat(behandlingStatistikkV2Dto.relatertBehandlingId).isNull()
+            assertThat(behandlingStatistikkV2Dto.relatertBehandlingFagsystem).isNull()
+        }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -56,6 +56,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Res
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakStatus
+import no.nav.familie.ks.sak.kjerne.klage.KlageClient
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.Tilbakekreving
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.TilbakekrevingRepository
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
@@ -96,6 +97,9 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @MockkBean(relaxed = true)
     private lateinit var avsluttBehandlingSteg: AvsluttBehandlingSteg
 
+    @MockkBean(relaxed = true)
+    private lateinit var klageClient: KlageClient
+
     @MockkBean
     private lateinit var taskService: TaskService
 
@@ -116,6 +120,11 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun setup() {
+        val fagsakIderSlot = slot<Set<Long>>()
+        every { klageClient.hentKlagebehandlinger(capture(fagsakIderSlot)) } answers {
+            fagsakIderSlot.captured.associateWith { emptyList() }
+        }
+
         opprettSøkerFagsakOgBehandling(fagsakStatus = FagsakStatus.LØPENDE)
         lagreArbeidsfordeling(lagArbeidsfordelingPåBehandling(behandlingId = behandling.id))
         opprettPersonopplysningGrunnlagOgPersonForBehandling(behandlingId = behandling.id, lagBarn = true)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/SakStatistikkServiceTest.kt
@@ -14,12 +14,14 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.RegistrerPersonGrunnlagSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakStatus
 import no.nav.familie.ks.sak.statistikk.saksstatistikk.BehandlingStatistikkV2Dto
+import no.nav.familie.ks.sak.statistikk.saksstatistikk.RelatertBehandlingUtleder
 import no.nav.familie.ks.sak.statistikk.saksstatistikk.SakStatistikkService
 import no.nav.familie.ks.sak.statistikk.saksstatistikk.SendBehandlinghendelseTilDvhV2Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDateTime
@@ -41,6 +43,14 @@ class SakStatistikkServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var sakStatistikkService: SakStatistikkService
+
+    @MockkBean
+    private lateinit var relatertBehandlingUtleder: RelatertBehandlingUtleder
+
+    @BeforeEach
+    fun setup() {
+        every { relatertBehandlingUtleder.utledRelatertBehandling(any()) } returns null
+    }
 
     @Test
     fun `opprettSendingAvBehandlingensTilstand skal generere melding om ny tilstand til DVH`() {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

Ønsker å sende over `relatertBehandlingId` og `relatertBehandlingFagsystem` til DVH for statistikk. `relatertBehandlingId` må kunne peke på både kontantstøttebehandlinger og klagebehandlinger. Hvis man har en behandling av type `REVURDERING` med årsak `KLAGE` eller `IVERKSETTE_VA_VEDTAK` skal man bruke den siste vedtatte klagebehandlingen. I andre tilfeller skal man bruke, om det finnes, den siste vedtatte kontantstøttebehandlingen. Den siste vedtatte kontantstøttebehandlingen må være av type `REVURDERING` eller `TEKNISK_ENDRING` for å bli tatt med som en relatert behandling. Om man har en behandling av type `REVURDERING` med årsak `KLAGE` eller `IVERKSETTE_VA_VEDTAK` og det ikke finnes en vedtatt klagebehandling skal man kaste feil. 

Loggiken her er basert på en allerede eksisterende logikk i ba-sak, se [her](https://github.com/navikt/familie-ba-sak/blob/main/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt#L53-L57). 

Relatert PR for BA: https://github.com/navikt/familie-ba-sak/pull/5190

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Se kommentarer i koden.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta om noen ønsker
