### PR TITLE
dependabot spring-avhengigheter i feil gruppe

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,7 +26,9 @@ updates:
       prod-avhengigheter:
         dependency-type: "production"
         exclude-patterns:
+          - "org.springframework*"
           - "no.nav.security*"
+          - "org.springdoc*"
       utvikler-avhengigheter:
         dependency-type: "development"
         exclude-patterns:


### PR DESCRIPTION
oppdater dependabot.yaml sånn at spring-avhengigheter ikke kommer i prod-gruppen

