### PR TITLE
NAV-24773: Fritekst på alle begrunnelser i revurderinger med årsak klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
@@ -62,19 +62,17 @@ data class BegrunnelseDto(
 fun NasjonalEllerFellesBegrunnelseDB.tilVedtaksbegrunnelseDto(
     sanityBegrunnelser: List<SanityBegrunnelse>,
     alleBegrunnelserSkalStøtteFritekst: Boolean,
-) =
-    BegrunnelseDto(
-        begrunnelse = nasjonalEllerFellesBegrunnelse.enumnavnTilString(),
-        begrunnelseType = nasjonalEllerFellesBegrunnelse.begrunnelseType,
-        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser),
-    )
+) = BegrunnelseDto(
+    begrunnelse = nasjonalEllerFellesBegrunnelse.enumnavnTilString(),
+    begrunnelseType = nasjonalEllerFellesBegrunnelse.begrunnelseType,
+    støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser),
+)
 
 fun EØSBegrunnelseDB.tilEøsBegrunnelseDto(
     sanityBegrunnelser: List<SanityBegrunnelse>,
     alleBegrunnelserSkalStøtteFritekst: Boolean,
-) =
-    BegrunnelseDto(
-        begrunnelse = this.begrunnelse.enumnavnTilString(),
-        begrunnelseType = this.begrunnelse.begrunnelseType,
-        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.begrunnelse.støtterFritekst(sanityBegrunnelser),
-    )
+) = BegrunnelseDto(
+    begrunnelse = this.begrunnelse.enumnavnTilString(),
+    begrunnelseType = this.begrunnelse.begrunnelseType,
+    støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.begrunnelse.støtterFritekst(sanityBegrunnelser),
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
@@ -38,17 +38,18 @@ data class UtvidetVedtaksperiodeMedBegrunnelserDto(
 fun UtvidetVedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelserDto(
     sanityBegrunnelser: List<SanityBegrunnelse>,
     adopsjonerIBehandling: List<Adopsjon>,
+    alleBegrunnelserSkalStøtteFritekst: Boolean,
 ): UtvidetVedtaksperiodeMedBegrunnelserDto =
     UtvidetVedtaksperiodeMedBegrunnelserDto(
         id = this.id,
         fom = this.fom,
         tom = this.tom,
         type = this.type,
-        begrunnelser = this.begrunnelser.map { it.tilVedtaksbegrunnelseDto(sanityBegrunnelser) },
+        begrunnelser = this.begrunnelser.map { it.tilVedtaksbegrunnelseDto(sanityBegrunnelser, alleBegrunnelserSkalStøtteFritekst) },
         fritekster = this.fritekster,
         utbetalingsperiodeDetaljer = this.utbetalingsperiodeDetaljer.map { it.tilUtbetalingsperiodeDetaljDto(adopsjonerIBehandling) },
         gyldigeBegrunnelser = this.gyldigeBegrunnelser.map { it.enumnavnTilString() },
-        eøsBegrunnelser = this.eøsBegrunnelser.map { it.tilEøsBegrunnelseDto(sanityBegrunnelser) },
+        eøsBegrunnelser = this.eøsBegrunnelser.map { it.tilEøsBegrunnelseDto(sanityBegrunnelser, alleBegrunnelserSkalStøtteFritekst) },
         støtterFritekst = this.støtterFritekst,
     )
 
@@ -58,16 +59,22 @@ data class BegrunnelseDto(
     val støtterFritekst: Boolean,
 )
 
-fun NasjonalEllerFellesBegrunnelseDB.tilVedtaksbegrunnelseDto(sanityBegrunnelser: List<SanityBegrunnelse>) =
+fun NasjonalEllerFellesBegrunnelseDB.tilVedtaksbegrunnelseDto(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    alleBegrunnelserSkalStøtteFritekst: Boolean,
+) =
     BegrunnelseDto(
         begrunnelse = nasjonalEllerFellesBegrunnelse.enumnavnTilString(),
         begrunnelseType = nasjonalEllerFellesBegrunnelse.begrunnelseType,
-        støtterFritekst = nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser),
+        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser),
     )
 
-fun EØSBegrunnelseDB.tilEøsBegrunnelseDto(sanityBegrunnelser: List<SanityBegrunnelse>) =
+fun EØSBegrunnelseDB.tilEøsBegrunnelseDto(
+    sanityBegrunnelser: List<SanityBegrunnelse>,
+    alleBegrunnelserSkalStøtteFritekst: Boolean,
+) =
     BegrunnelseDto(
         begrunnelse = this.begrunnelse.enumnavnTilString(),
         begrunnelseType = this.begrunnelse.begrunnelseType,
-        støtterFritekst = this.begrunnelse.støtterFritekst(sanityBegrunnelser),
+        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.begrunnelse.støtterFritekst(sanityBegrunnelser),
     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak.LOVENDRING_2024
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
@@ -155,6 +156,9 @@ class BehandlingService(
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
 
+        // For revurderinger med årsak klage skal fritekst legges til på alle begrunnelser
+        val alleBegrunnelserSkalStøtteFritekst = behandling.type == BehandlingType.REVURDERING && behandling.erKlage()
+
         val vedtak =
             vedtakRepository.findByBehandlingAndAktivOptional(behandlingId)?.let {
                 it.tilVedtakDto(
@@ -163,7 +167,11 @@ class BehandlingService(
                             vedtaksperiodeService
                                 .hentUtvidetVedtaksperioderMedBegrunnelser(vedtak = it)
                                 .map { utvidetVedtaksperiodeMedBegrunnelser ->
-                                    utvidetVedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelserDto(sanityBegrunnelser = sanityBegrunnelser, adopsjonerIBehandling = adopsjonerIBehandling)
+                                    utvidetVedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelserDto(
+                                        sanityBegrunnelser = sanityBegrunnelser,
+                                        adopsjonerIBehandling = adopsjonerIBehandling,
+                                        alleBegrunnelserSkalStøtteFritekst = alleBegrunnelserSkalStøtteFritekst,
+                                    )
                                 }.sortedBy { dto -> dto.fom }
                         } else {
                             emptyList()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -156,7 +156,7 @@ class BehandlingService(
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
 
-        // For revurderinger med årsak klage skal fritekst legges til på alle begrunnelser
+        // For revurderinger med årsak klage skal fritekst støttes på alle begrunnelser
         val alleBegrunnelserSkalStøtteFritekst = behandling.type == BehandlingType.REVURDERING && behandling.erKlage()
 
         val vedtak =


### PR DESCRIPTION
Favro: [NAV-24773](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24773)

### 💰 Hva skal gjøres, og hvorfor?
Sørger for at saksbehandler kan legge til fritekst på alle begrunnelser uavhengig av type for alle revurderinger med `opprettetÅrsak` = `KLAGE`.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

![image](https://github.com/user-attachments/assets/19d7937a-d0aa-44f1-9fa8-12d267fd5159)
