### PR TITLE
NAV-24658: Skal kun utlede relatert behandling med kontantstøttebehandling som siste vedtatte behandling om det er en revurdering eller teknisk endring, og gitt at det ikke er en revurdering klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -106,6 +106,17 @@ class BehandlingService(
             .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
             .maxByOrNull { it.aktivertTidspunkt }
 
+    /**
+     * Henter siste behandling som er vedtatt FØR en gitt behandling
+     */
+    fun hentForrigeBehandlingSomErVedtatt(behandling: Behandling): Behandling? =
+        behandlingRepository
+            .finnBehandlinger(behandling.fagsak.id)
+            .filter { it.steg == BehandlingSteg.AVSLUTT_BEHANDLING }
+            .filter { !it.erHenlagt() }
+            .filter { it.aktivertTidspunkt.isBefore(behandling.aktivertTidspunkt) }
+            .maxByOrNull { it.aktivertTidspunkt }
+
     fun oppdaterBehandling(behandling: Behandling): Behandling {
         logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} oppdaterer behandling $behandling")
         return behandlingRepository.save(behandling)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/Behandling.kt
@@ -185,6 +185,8 @@ data class Behandling(
 
     fun erRevurderingKlage() = type == REVURDERING && opprettetÅrsak in setOf(BehandlingÅrsak.KLAGE, BehandlingÅrsak.IVERKSETTE_KA_VEDTAK)
 
+    fun erRevurderingEllerTekniskEndring() = type == REVURDERING || type == TEKNISK_ENDRING
+
     fun erLovendring() = opprettetÅrsak == BehandlingÅrsak.LOVENDRING_2024
 
     fun erOvergangsordning() = opprettetÅrsak == BehandlingÅrsak.OVERGANGSORDNING_2024

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -33,12 +33,12 @@ class RelatertBehandlingUtleder(
         }
 
         if (behandling.erRevurderingEllerTekniskEndring()) {
-            val sisteVedtatteKontantstøttebehandling = behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id)
-            if (sisteVedtatteKontantstøttebehandling == null) {
+            val forrigeVedtatteKontantstøttebehandling = behandlingService.hentForrigeBehandlingSomErVedtatt(behandling)
+            if (forrigeVedtatteKontantstøttebehandling == null) {
                 logger.warn("Forventer en vedtatt kontantstøttebehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
                 return null
             }
-            return RelatertBehandling.fraKontantstøttebehandling(sisteVedtatteKontantstøttebehandling)
+            return RelatertBehandling.fraKontantstøttebehandling(forrigeVedtatteKontantstøttebehandling)
         }
 
         return null

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper
 import no.nav.familie.ks.sak.common.util.TIDENES_MORGEN
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagBehandlingStegTilstand
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
@@ -25,8 +26,10 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.SøknadGrunnlagService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.domene.SøknadGrunnlag
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
@@ -51,13 +54,16 @@ import no.nav.familie.ks.sak.kjerne.tilbakekreving.domene.TilbakekrevingReposito
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollRepository
 import no.nav.familie.ks.sak.korrigertvedtak.KorrigertVedtakRepository
 import no.nav.familie.ks.sak.statistikk.saksstatistikk.SakStatistikkService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import java.time.LocalDateTime
 
 class BehandlingServiceTest {
     private val mockBehandlingRepository = mockk<BehandlingRepository>()
@@ -314,5 +320,149 @@ class BehandlingServiceTest {
         verify(exactly = 1) { mockBehandlingRepository.hentBehandling(behandling.id) }
         verify { mockLoggService wasNot called }
         verify(exactly = 0) { mockBehandlingRepository.save(behandling) }
+    }
+
+    @Nested
+    inner class HentForrigeBehandlingSomErVedtatt {
+        @Test
+        fun `skal hente forrige vedtatte behandling basert på den innsendte behandlingen`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val fagsak = lagFagsak()
+
+            val behandling1 =
+                lagBehandling(
+                    id = 1L,
+                    fagsak = fagsak,
+                    type = BehandlingType.REVURDERING,
+                    aktivertTidspunkt = nåtidspunkt,
+                    resultat = Behandlingsresultat.INNVILGET,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING,
+                            ),
+                        )
+                    },
+                )
+
+            val behandling2 =
+                lagBehandling(
+                    id = 2L,
+                    fagsak = fagsak,
+                    type = BehandlingType.REVURDERING,
+                    aktivertTidspunkt = nåtidspunkt.minusSeconds(1),
+                    resultat = Behandlingsresultat.INNVILGET,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING,
+                            ),
+                        )
+                    },
+                )
+
+            val behandling3 =
+                lagBehandling(
+                    id = 3L,
+                    fagsak = fagsak,
+                    type = BehandlingType.REVURDERING,
+                    aktivertTidspunkt = nåtidspunkt.minusSeconds(2),
+                    resultat = Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING,
+                            ),
+                        )
+                    },
+                )
+
+            val behandling4 =
+                lagBehandling(
+                    id = 4L,
+                    fagsak = fagsak,
+                    type = BehandlingType.REVURDERING,
+                    aktivertTidspunkt = nåtidspunkt.minusSeconds(3),
+                    resultat = Behandlingsresultat.INNVILGET,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING,
+                            ),
+                        )
+                    },
+                )
+
+            val behandling5 =
+                lagBehandling(
+                    id = 5L,
+                    fagsak = fagsak,
+                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    aktivertTidspunkt = nåtidspunkt.minusSeconds(4),
+                    resultat = Behandlingsresultat.INNVILGET,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.AVSLUTT_BEHANDLING,
+                            ),
+                        )
+                    },
+                )
+
+            every { mockBehandlingRepository.finnBehandlinger(fagsak.id) } returns
+                listOf(
+                    behandling1,
+                    behandling2,
+                    behandling3,
+                    behandling4,
+                    behandling5,
+                )
+
+            // Act
+            val forrigeBehandlingSomErVedtatt = behandlingService.hentForrigeBehandlingSomErVedtatt(behandling2)
+
+            // Assert
+            assertThat(forrigeBehandlingSomErVedtatt?.id).isEqualTo(behandling4.id)
+        }
+
+        @Test
+        fun `skal returnere null hvis ingen tidligere vedtatte behandlinger blir funnet`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+
+            val fagsak = lagFagsak()
+
+            val behandling =
+                lagBehandling(
+                    id = 1L,
+                    fagsak = fagsak,
+                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    aktivertTidspunkt = nåtidspunkt,
+                    resultat = Behandlingsresultat.IKKE_VURDERT,
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            lagBehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.REGISTRERE_SØKNAD,
+                            ),
+                        )
+                    },
+                )
+
+            every { mockBehandlingRepository.finnBehandlinger(fagsak.id) } returns listOf(behandling)
+
+            // Act
+            val forrigeBehandlingSomErVedtatt = behandlingService.hentForrigeBehandlingSomErVedtatt(behandling)
+
+            // Assert
+            assertThat(forrigeBehandlingSomErVedtatt).isNull()
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtlederTest.kt
@@ -166,7 +166,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.INNVILGET,
                 )
 
-            every { behandlingService.hentSisteBehandlingSomErVedtatt(revurdering.fagsak.id) } returns sisteVedtatteKontantstøttebehandling
+            every { behandlingService.hentForrigeBehandlingSomErVedtatt(revurdering) } returns sisteVedtatteKontantstøttebehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(revurdering)
@@ -200,7 +200,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.INNVILGET,
                 )
 
-            every { behandlingService.hentSisteBehandlingSomErVedtatt(tekniskEndring.fagsak.id) } returns sisteVedtatteKontantstøttebehandling
+            every { behandlingService.hentForrigeBehandlingSomErVedtatt(tekniskEndring) } returns sisteVedtatteKontantstøttebehandling
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(tekniskEndring)
@@ -233,7 +233,7 @@ class RelatertBehandlingUtlederTest {
                     resultat = Behandlingsresultat.IKKE_VURDERT,
                 )
 
-            every { behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id) } returns null
+            every { behandlingService.hentForrigeBehandlingSomErVedtatt(behandling) } returns null
 
             // Act
             val relatertBehandling = relatertBehandlingUtleder.utledRelatertBehandling(behandling)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

Tilpasser logikken slik at det bedre samsvarer med logikken som allerede eksisterte på BA-sak [her](https://github.com/navikt/familie-ba-sak/blob/main/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/SaksstatistikkService.kt#L53-L57). Hadde kopiert over og modifisert den feil i en tidligere PR.

Relevant ba-sak PR: https://github.com/navikt/familie-ba-sak/pull/5190

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
