### PR TITLE
Tilbake: eget endepunkt for henting av tilbakekrevingsbehandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingController.kt
@@ -1,16 +1,20 @@
 package no.nav.familie.ks.sak.api
 
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandling
 import no.nav.familie.ks.sak.api.dto.FagsakIdDto
 import no.nav.familie.ks.sak.api.dto.ForhåndsvisTilbakekrevingVarselbrevDto
 import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.TilbakekrevingService
+import no.nav.familie.ks.sak.kjerne.tilbakekreving.TilbakekrevingsbehandlingHentService
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,7 +28,23 @@ import org.springframework.web.bind.annotation.RestController
 class TilbakekrevingController(
     private val tilgangService: TilgangService,
     private val tilbakekrevingService: TilbakekrevingService,
+    private val tilbakekrevingsbehandlingHentService: TilbakekrevingsbehandlingHentService
 ) {
+    @GetMapping(path =["/{fagsakId}/hent-tilbakekrevingsbehandlinger"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun hentTilbakekrevingsbehandlinger(
+        @PathVariable fagsakId: Long,
+    ): Ressurs<List<Behandling>> {
+        tilgangService.validerTilgangTilHandlingOgFagsak(
+            fagsakId = fagsakId,
+            event = AuditLoggerEvent.ACCESS,
+            minimumBehandlerRolle = BehandlerRolle.VEILEDER,
+            handling = "hente tilbakekrevingsbehandlinger",
+        )
+
+        val tilbakekrevingsbehandlinger = tilbakekrevingsbehandlingHentService.hentTilbakekrevingsbehandlinger(fagsakId)
+        return Ressurs.success(tilbakekrevingsbehandlinger)
+    }
+
     @PostMapping("/{behandlingId}/forhaandsvis-tilbakekreving-varselbrev")
     fun hentForhåndsvisningVarselbrev(
         @PathVariable behandlingId: Long,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.kontrakter.felles.tilbakekreving.Behandling
 import no.nav.familie.ks.sak.api.dto.FagsakIdDto
 import no.nav.familie.ks.sak.api.dto.ForhåndsvisTilbakekrevingVarselbrevDto
 import no.nav.familie.ks.sak.config.BehandlerRolle
-import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.TilbakekrevingService
 import no.nav.familie.ks.sak.kjerne.tilbakekreving.TilbakekrevingsbehandlingHentService
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
@@ -28,9 +27,9 @@ import org.springframework.web.bind.annotation.RestController
 class TilbakekrevingController(
     private val tilgangService: TilgangService,
     private val tilbakekrevingService: TilbakekrevingService,
-    private val tilbakekrevingsbehandlingHentService: TilbakekrevingsbehandlingHentService
+    private val tilbakekrevingsbehandlingHentService: TilbakekrevingsbehandlingHentService,
 ) {
-    @GetMapping(path =["/{fagsakId}/hent-tilbakekrevingsbehandlinger"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping(path = ["/{fagsakId}/hent-tilbakekrevingsbehandlinger"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun hentTilbakekrevingsbehandlinger(
         @PathVariable fagsakId: Long,
     ): Ressurs<List<Behandling>> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingController.kt
@@ -29,7 +29,7 @@ class TilbakekrevingController(
     private val tilbakekrevingService: TilbakekrevingService,
     private val tilbakekrevingsbehandlingHentService: TilbakekrevingsbehandlingHentService,
 ) {
-    @GetMapping(path = ["/{fagsakId}/hent-tilbakekrevingsbehandlinger"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping(path = ["/fagsak/{fagsakId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun hentTilbakekrevingsbehandlinger(
         @PathVariable fagsakId: Long,
     ): Ressurs<List<Behandling>> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageController.kt
@@ -32,7 +32,7 @@ class KlageController(
             fagsakId = fagsakId,
             event = AuditLoggerEvent.CREATE,
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
-            handling = "Vis og lagre vedtaksbrev",
+            handling = "opprette klagebehandling",
         )
         klageService.opprettKlage(fagsakId = fagsakId, klageMottattDato = opprettKlageDto.klageMottattDato)
         return Ressurs.success(fagsakId)
@@ -46,7 +46,7 @@ class KlageController(
             fagsakId = fagsakId,
             event = AuditLoggerEvent.ACCESS,
             minimumBehandlerRolle = BehandlerRolle.VEILEDER,
-            handling = "Vis og lagre vedtaksbrev",
+            handling = "hente klagebehandlinger",
         )
         return Ressurs.success(klageService.hentKlagebehandlingerPåFagsak(fagsakId))
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
@@ -1,0 +1,110 @@
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.api
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.restassured.RestAssured
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandling
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsresultatstype
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsstatus
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingstype
+import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsårsakstype
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.common.exception.IntegrasjonException
+import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.kjerne.tilbakekreving.TilbakekrevingsbehandlingHentService
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+import java.util.*
+import org.hamcrest.CoreMatchers.`is` as Is
+
+class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
+    @MockkBean
+    private lateinit var tilbakekrevingsbehandlingHentService: TilbakekrevingsbehandlingHentService
+
+    private val controllerUrl = "/api/tilbakekreving"
+
+    @BeforeEach
+    fun setup(){
+        RestAssured.port = port
+
+        every { tilbakekrevingsbehandlingHentService.hentTilbakekrevingsbehandlinger(any()) } returns emptyList()
+    }
+
+    @Test
+    fun `hentTilbakekrevingsbehandlinger - skal returnere unauthorized dersom brukeren ikke har token for å hente behandling`(){
+        When {
+            get("$controllerUrl/fagsak/123456")
+        } Then {
+            statusCode(HttpStatus.UNAUTHORIZED.value())
+            body("status", Is("FEILET"))
+        }
+    }
+
+    @Test
+    fun `hentTilbakekrevingsbehandlinger - skal returnere 403 dersom brukeren ikke har rettigheter til å hente tilbakekrevingsbehandlinger`() {
+        val token = lokalTestToken(behandlerRolle = BehandlerRolle.UKJENT)
+
+        Given {
+            header("Authorization", "Bearer $token")
+        } When {
+            get("$controllerUrl/fagsak/123456")
+        } Then {
+            statusCode(HttpStatus.FORBIDDEN.value())
+        }
+    }
+
+    @Test
+    fun `hentTilbakekrevingsbehandlinger - skal returnere liste med tilbakekrevingsbehandlinger og 200 OK dersom behandlinger er hentet fra familie-tilbake`() {
+        val token = lokalTestToken(behandlerRolle = BehandlerRolle.VEILEDER)
+
+        val tilbakekrevingsbehandling = Behandling(
+            behandlingId = UUID.randomUUID(),
+            opprettetTidspunkt = LocalDateTime.now(),
+            aktiv = true,
+            årsak = Behandlingsårsakstype.REVURDERING_OPPLYSNINGER_OM_VILKÅR,
+            type = Behandlingstype.TILBAKEKREVING,
+            status = Behandlingsstatus.AVSLUTTET,
+            vedtaksdato = LocalDateTime.now(),
+            resultat = Behandlingsresultatstype.FULL_TILBAKEBETALING
+        )
+        every { tilbakekrevingsbehandlingHentService.hentTilbakekrevingsbehandlinger(fagsakId = 123456) } returns listOf(tilbakekrevingsbehandling)
+
+        Given {
+            header("Authorization", "Bearer $token")
+        } When {
+            get("$controllerUrl/fagsak/123456")
+        } Then {
+            statusCode(HttpStatus.OK.value())
+            body("status", Is("SUKSESS"))
+            body("data", hasSize<Int>(1))
+            body("data[0].behandlingId", Is(tilbakekrevingsbehandling.behandlingId.toString()))
+            body("data[0].resultat", Is(tilbakekrevingsbehandling.resultat.toString()))
+            body("data[0].årsak", Is(tilbakekrevingsbehandling.årsak.toString()))
+            body("data[0].type", Is(tilbakekrevingsbehandling.type.toString()))
+        }
+    }
+
+    @Test
+    fun `hentTilbakekrevingsbehandlinger - skal dersom behandlinger er hentet fra familie-tilbake`() {
+        val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
+
+        every { tilbakekrevingsbehandlingHentService.hentTilbakekrevingsbehandlinger(fagsakId = 123456) } throws IntegrasjonException("Feilet")
+
+        Given {
+            header("Authorization", "Bearer $token")
+        } When {
+            get("$controllerUrl/fagsak/123456")
+        } Then {
+            statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+            body("status", Is("FEILET"))
+            body("melding", Is("Feilet"))
+        }
+    }
+
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
@@ -37,7 +37,7 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `hentTilbakekrevingsbehandlinger - skal returnere unauthorized dersom brukeren ikke har token for å hente behandling`() {
+    fun `hentTilbakekrevingsbehandlinger - skal returnere 401 unauthorized dersom brukeren ikke har token for å hente behandling`() {
         When {
             get("$controllerUrl/fagsak/123456")
         } Then {
@@ -92,7 +92,7 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `hentTilbakekrevingsbehandlinger - skal dersom behandlinger er hentet fra familie-tilbake`() {
+    fun `hentTilbakekrevingsbehandlinger - skal feile dersom kall mot familie-tilbake feiler`() {
         val token = lokalTestToken(behandlerRolle = BehandlerRolle.BESLUTTER)
 
         every { tilbakekrevingsbehandlingHentService.hentTilbakekrevingsbehandlinger(fagsakId = 123456) } throws IntegrasjonException("Feilet")

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 import org.hamcrest.CoreMatchers.`is` as Is
 
 class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
@@ -30,14 +30,14 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
     private val controllerUrl = "/api/tilbakekreving"
 
     @BeforeEach
-    fun setup(){
+    fun setup() {
         RestAssured.port = port
 
         every { tilbakekrevingsbehandlingHentService.hentTilbakekrevingsbehandlinger(any()) } returns emptyList()
     }
 
     @Test
-    fun `hentTilbakekrevingsbehandlinger - skal returnere unauthorized dersom brukeren ikke har token for å hente behandling`(){
+    fun `hentTilbakekrevingsbehandlinger - skal returnere unauthorized dersom brukeren ikke har token for å hente behandling`() {
         When {
             get("$controllerUrl/fagsak/123456")
         } Then {
@@ -63,16 +63,17 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
     fun `hentTilbakekrevingsbehandlinger - skal returnere liste med tilbakekrevingsbehandlinger og 200 OK dersom behandlinger er hentet fra familie-tilbake`() {
         val token = lokalTestToken(behandlerRolle = BehandlerRolle.VEILEDER)
 
-        val tilbakekrevingsbehandling = Behandling(
-            behandlingId = UUID.randomUUID(),
-            opprettetTidspunkt = LocalDateTime.now(),
-            aktiv = true,
-            årsak = Behandlingsårsakstype.REVURDERING_OPPLYSNINGER_OM_VILKÅR,
-            type = Behandlingstype.TILBAKEKREVING,
-            status = Behandlingsstatus.AVSLUTTET,
-            vedtaksdato = LocalDateTime.now(),
-            resultat = Behandlingsresultatstype.FULL_TILBAKEBETALING
-        )
+        val tilbakekrevingsbehandling =
+            Behandling(
+                behandlingId = UUID.randomUUID(),
+                opprettetTidspunkt = LocalDateTime.now(),
+                aktiv = true,
+                årsak = Behandlingsårsakstype.REVURDERING_OPPLYSNINGER_OM_VILKÅR,
+                type = Behandlingstype.TILBAKEKREVING,
+                status = Behandlingsstatus.AVSLUTTET,
+                vedtaksdato = LocalDateTime.now(),
+                resultat = Behandlingsresultatstype.FULL_TILBAKEBETALING,
+            )
         every { tilbakekrevingsbehandlingHentService.hentTilbakekrevingsbehandlinger(fagsakId = 123456) } returns listOf(tilbakekrevingsbehandling)
 
         Given {
@@ -106,5 +107,4 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
             body("melding", Is("Feilet"))
         }
     }
-
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24805

For å sørge for at tilbakekreving ikke tar ned løsningene våre så trenger vi å hente tilbakekrevingsbehandlinger i eget endepunkt. Lager endepunktet i denne PRen (som henter tilbakekrevingsbehandlinger på samme måte som i minimal fagsak), så frontend kan ta dette i bruk. Når det er gjort i frontend kan vi slette uthenting av tilbakekrevingsbehandlinger ved innhenting av minimal fagsak.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Ja, url'en til endepunktet vil jeg gjerne ha tilbakemelding om. Vurderte å kun ha fagsakId, men når man inspiserer nettverkskall får man kun opp en id i listen og det gjør det vanskelig å finne ut hva kallet gjelder. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
