### PR TITLE
Sørger for at støtterFritekst blir satt til true dersom behandling er…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
@@ -50,7 +50,7 @@ fun UtvidetVedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser
         utbetalingsperiodeDetaljer = this.utbetalingsperiodeDetaljer.map { it.tilUtbetalingsperiodeDetaljDto(adopsjonerIBehandling) },
         gyldigeBegrunnelser = this.gyldigeBegrunnelser.map { it.enumnavnTilString() },
         eøsBegrunnelser = this.eøsBegrunnelser.map { it.tilEøsBegrunnelseDto(sanityBegrunnelser, alleBegrunnelserSkalStøtteFritekst) },
-        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.støtterFritekst,
+        støtterFritekst = alleBegrunnelserSkalStøtteFritekst || this.støtterFritekst,
     )
 
 data class BegrunnelseDto(
@@ -65,7 +65,7 @@ fun NasjonalEllerFellesBegrunnelseDB.tilVedtaksbegrunnelseDto(
 ) = BegrunnelseDto(
     begrunnelse = nasjonalEllerFellesBegrunnelse.enumnavnTilString(),
     begrunnelseType = nasjonalEllerFellesBegrunnelse.begrunnelseType,
-    støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser),
+    støtterFritekst = alleBegrunnelserSkalStøtteFritekst || nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser),
 )
 
 fun EØSBegrunnelseDB.tilEøsBegrunnelseDto(
@@ -74,5 +74,5 @@ fun EØSBegrunnelseDB.tilEøsBegrunnelseDto(
 ) = BegrunnelseDto(
     begrunnelse = this.begrunnelse.enumnavnTilString(),
     begrunnelseType = this.begrunnelse.begrunnelseType,
-    støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.begrunnelse.støtterFritekst(sanityBegrunnelser),
+    støtterFritekst = alleBegrunnelserSkalStøtteFritekst || this.begrunnelse.støtterFritekst(sanityBegrunnelser),
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VedtaksperiodeDto.kt
@@ -50,7 +50,7 @@ fun UtvidetVedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser
         utbetalingsperiodeDetaljer = this.utbetalingsperiodeDetaljer.map { it.tilUtbetalingsperiodeDetaljDto(adopsjonerIBehandling) },
         gyldigeBegrunnelser = this.gyldigeBegrunnelser.map { it.enumnavnTilString() },
         eøsBegrunnelser = this.eøsBegrunnelser.map { it.tilEøsBegrunnelseDto(sanityBegrunnelser, alleBegrunnelserSkalStøtteFritekst) },
-        støtterFritekst = this.støtterFritekst,
+        støtterFritekst = if (alleBegrunnelserSkalStøtteFritekst) true else this.støtterFritekst,
     )
 
 data class BegrunnelseDto(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -24,7 +24,6 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak.LOVENDRING_2024
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
@@ -168,7 +167,7 @@ class BehandlingService(
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
 
         // For revurderinger med årsak klage skal fritekst støttes på alle begrunnelser
-        val alleBegrunnelserSkalStøtteFritekst = behandling.type == BehandlingType.REVURDERING && behandling.erKlage()
+        val alleBegrunnelserSkalStøtteFritekst = behandling.erRevurderingKlage()
 
         val vedtak =
             vedtakRepository.findByBehandlingAndAktivOptional(behandlingId)?.let {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeUtil.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.vedtaksperiode.domene.VedtaksperiodeMedBegrunnelser
 
 fun validerVedtaksperiodeMedBegrunnelser(vedtaksperiodeMedBegrunnelser: VedtaksperiodeMedBegrunnelser) {
-    if ((vedtaksperiodeMedBegrunnelser.type == Vedtaksperiodetype.OPPHØR || vedtaksperiodeMedBegrunnelser.type == Vedtaksperiodetype.AVSLAG) && vedtaksperiodeMedBegrunnelser.harFriteksterUtenStandardbegrunnelser()) {
+    if (vedtaksperiodeMedBegrunnelser.harFriteksterUtenStandardbegrunnelser()) {
         val fritekstUtenStandardbegrunnelserFeilmelding =
             "Fritekst kan kun brukes i kombinasjon med en eller flere begrunnelser. " + "Legg først til en ny begrunnelse eller fjern friteksten(e)."
         throw FunksjonellFeil(


### PR DESCRIPTION
Favro: [NAV-24773](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24773)

Problem med at fritekst fortsatt ikke dukket opp når den skulle det. Grunnen var at `støtterFritekst` ikke ble satt til true på `vedtaksperioden`.

Implementasjon skiller seg litt fra ba-sak, så legger her inn at `støtterFritekst` blir satt til true på vedtaksperioden dersom behandling er en revurdering med årsak klage.