### PR TITLE
NAV-24658: Fjerner logikk for å hente relatert behandling for revurdering klage og returner null, fungerte ikke som tiltenkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.ks.sak.statistikk.saksstatistikk
 
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.klage.KlageService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Lazy
@@ -14,7 +12,6 @@ import org.springframework.stereotype.Component
 @Component
 class RelatertBehandlingUtleder(
     @Lazy private val behandlingService: BehandlingService,
-    @Lazy private val klageService: KlageService,
     private val unleashService: UnleashNextMedContextService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(RelatertBehandlingUtleder::class.java)
@@ -25,11 +22,7 @@ class RelatertBehandlingUtleder(
         }
 
         if (behandling.erRevurderingKlage()) {
-            val forrigeVedtatteKlagebehandling = klageService.hentForrigeVedtatteKlagebehandling(behandling)
-            if (forrigeVedtatteKlagebehandling == null) {
-                throw Feil("Forventer en vedtatt klagebehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
-            }
-            return RelatertBehandling.fraKlagebehandling(forrigeVedtatteKlagebehandling)
+            return null // TODO : NAV-24658 implementer logikk for å hente relatert klagebehandling, trengs ikke før prodsetting
         }
 
         if (behandling.erRevurderingEllerTekniskEndring()) {


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

Det oppstod en feil når man oppretter en revurdering klage via løypen i familie-klage. Fjerner koden da vi kan gå i produksjon uten at dette er inne.

I koden som ble introdusert i ks-sak og ba-sak for å finne relatert behandling ID [her](https://github.com/navikt/familie-ba-sak/blob/main/src/main/kotlin/no/nav/familie/ba/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt#L25) og [her](https://github.com/navikt/familie-ks-sak/blob/main/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt#L30) forventer man en ferdig vedtatt klagebehandling. I familie-klage viser det seg at man oppretter en revurdering klage før klagebehandlingen er ferdigstilt og vedtatt, se [her](https://github.com/navikt/familie-klage/blob/main/src/main/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingService.kt#L72). 

I ks-sak og ba-sak koden forventer man at en vedtaksdato er satt, men den blir ikke satt før etter at man opprettet revurdering klage behandlingen. Det skjer [her](https://github.com/navikt/familie-klage/blob/main/src/main/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingService.kt#L74).

I ks-sak og ba-sak koden forventer man at klagebehandlingen har status FERDIGSTILT, men det blir ikke satt før etter at man har opprettet revurdering klage behandlingen. Det skjer [her](https://github.com/navikt/familie-klage/blob/main/src/main/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingService.kt#L74).

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
