### PR TITLE
NAV-24773: Sørger for at fritekster som er lagt inn i revurderinger med årsak klage ikke slettes ved oppdatering av begrunnelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -127,7 +127,9 @@ class VedtaksperiodeService(
             validerEndretUtbetalingsbegrunnelse(vedtaksperiodeMedBegrunnelser, andelerTilkjentYtelse, persongrunnlag)
         }
 
-        if (!vedtaksperiodeMedBegrunnelser.støtterFritekst(sanityBegrunnelser)) {
+        val alleBegrunnelserStøtterFritekst = behandling.erRevurderingKlage()
+
+        if (!vedtaksperiodeMedBegrunnelser.støtterFritekst(sanityBegrunnelser, alleBegrunnelserStøtterFritekst)) {
             vedtaksperiodeMedBegrunnelser.fritekster.clear()
         }
 
@@ -311,21 +313,24 @@ class VedtaksperiodeService(
     fun hentUtvidetVedtaksperiodeMedBegrunnelser(vedtaksperiodeId: Long): UtvidetVedtaksperiodeMedBegrunnelser {
         val vedtaksperiodeMedBegrunnelser = vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(vedtaksperiodeId = vedtaksperiodeId)
 
-        val behandlingId = vedtaksperiodeMedBegrunnelser.vedtak.behandling.id
+        val behandling = vedtaksperiodeMedBegrunnelser.vedtak.behandling
 
-        val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandlingId)
+        val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id)
 
         val andelerTilkjentYtelse =
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(
-                behandlingId = behandlingId,
+                behandlingId = behandling.id,
             )
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
+
+        val alleBegrunnelserStøtterFritekst = behandling.erRevurderingKlage()
 
         return vedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
             personopplysningGrunnlag = personopplysningGrunnlag,
             andelerTilkjentYtelse = andelerTilkjentYtelse,
             sanityBegrunnelser = sanityBegrunnelser,
+            alleBegrunnelserStøtterFritekst = alleBegrunnelserStøtterFritekst,
         )
     }
 
@@ -340,12 +345,15 @@ class VedtaksperiodeService(
 
         val sanityBegrunnelser = sanityService.hentSanityBegrunnelser()
 
+        val alleBegrunnelserStøtterFritekst = behandling.erRevurderingKlage()
+
         val utvidetVedtaksperioderMedBegrunnelser =
             vedtaksperioderMedBegrunnelser.map {
                 it.tilUtvidetVedtaksperiodeMedBegrunnelser(
                     andelerTilkjentYtelse = andelerTilkjentYtelse,
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     sanityBegrunnelser = sanityBegrunnelser,
+                    alleBegrunnelserStøtterFritekst = alleBegrunnelserStøtterFritekst,
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/UtvidetVedtaksperiodeMedBegrunnelser.kt
@@ -37,6 +37,7 @@ fun VedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
     personopplysningGrunnlag: PersonopplysningGrunnlag,
     andelerTilkjentYtelse: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,
     sanityBegrunnelser: List<SanityBegrunnelse>,
+    alleBegrunnelserStøtterFritekst: Boolean,
     dagensDato: LocalDate = LocalDate.now(),
 ): UtvidetVedtaksperiodeMedBegrunnelser {
     val utbetalingsperiodeDetaljer =
@@ -55,7 +56,7 @@ fun VedtaksperiodeMedBegrunnelser.tilUtvidetVedtaksperiodeMedBegrunnelser(
         eøsBegrunnelser = this.eøsBegrunnelser.toList(),
         fritekster = this.fritekster.sortedBy { it.id }.map { it.fritekst },
         utbetalingsperiodeDetaljer = utbetalingsperiodeDetaljer,
-        støtterFritekst = this.støtterFritekst(sanityBegrunnelser),
+        støtterFritekst = this.støtterFritekst(sanityBegrunnelser, alleBegrunnelserStøtterFritekst),
     )
 }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -150,11 +150,10 @@ data class VedtaksperiodeMedBegrunnelser(
     fun støtterFritekst(
         sanityBegrunnelser: List<SanityBegrunnelse>,
         alleBegrunnelserStøtterFritekst: Boolean,
-    ) =
-        alleBegrunnelserStøtterFritekst ||
-            (type !== Vedtaksperiodetype.UTBETALING) ||
-            begrunnelser.any { it.nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser) } ||
-            eøsBegrunnelser.any { it.begrunnelse.støtterFritekst(sanityBegrunnelser) }
+    ) = alleBegrunnelserStøtterFritekst ||
+        (type !== Vedtaksperiodetype.UTBETALING) ||
+        begrunnelser.any { it.nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser) } ||
+        eøsBegrunnelser.any { it.begrunnelse.støtterFritekst(sanityBegrunnelser) }
 
     private fun validerIkkeDelvisOverlappIAndelTilkjentYtelserOgVedtaksperiodeBegrunnelse(
         andelTilkjentYtelserIPeriode: List<AndelTilkjentYtelseMedEndreteUtbetalinger>,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeMedBegrunnelser.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/domene/VedtaksperiodeMedBegrunnelser.kt
@@ -147,8 +147,12 @@ data class VedtaksperiodeMedBegrunnelser(
             -> emptyList()
         }
 
-    fun støtterFritekst(sanityBegrunnelser: List<SanityBegrunnelse>) =
-        (type !== Vedtaksperiodetype.UTBETALING) ||
+    fun støtterFritekst(
+        sanityBegrunnelser: List<SanityBegrunnelse>,
+        alleBegrunnelserStøtterFritekst: Boolean,
+    ) =
+        alleBegrunnelserStøtterFritekst ||
+            (type !== Vedtaksperiodetype.UTBETALING) ||
             begrunnelser.any { it.nasjonalEllerFellesBegrunnelse.støtterFritekst(sanityBegrunnelser) } ||
             eøsBegrunnelser.any { it.begrunnelse.støtterFritekst(sanityBegrunnelser) }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -412,12 +412,15 @@ class StepDefinition {
         behandlingId: Long,
     ): List<UtvidetVedtaksperiodeMedBegrunnelser> {
         val vedtaksperioderMedBegrunnelser = vedtaksperioderMedBegrunnelser[behandlingId]!!
+        val behandling = behandlinger[behandlingId]!!
+
         return vedtaksperioderMedBegrunnelser.map {
             it.tilUtvidetVedtaksperiodeMedBegrunnelser(
                 personopplysningGrunnlag = personopplysningGrunnlagMap[behandlingId]!!,
                 andelerTilkjentYtelse = hentAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId),
                 dagensDato = dagensDato,
                 sanityBegrunnelser = emptyList(),
+                alleBegrunnelserStøtterFritekst = behandling.erRevurderingKlage(),
             )
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeServiceTest.kt
@@ -266,7 +266,7 @@ internal class VedtaksperiodeServiceTest {
             val støtterFritekst = vedtaksperiodeMedBegrunnelse.støtterFritekst(sanityBegrunnelser = emptyList(), alleBegrunnelserStøtterFritekst = true)
 
             // Assert
-            assertThat(støtterFritekst)
+            assertThat(støtterFritekst).isTrue
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -509,6 +509,7 @@ fun lagBrevPeriodeContext(
                 persongrunnlag,
                 andelTilkjentYtelserMedEndreteUtbetalinger,
                 emptyList(),
+                false,
             ),
         sanityBegrunnelser = lagSanityBegrunnelserFraDump(),
         personopplysningGrunnlag = persongrunnlag,


### PR DESCRIPTION
Favro: [NAV-24773](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24773)

### 💰 Hva skal gjøres, og hvorfor?
Når man forsøkte å legge til en ny begrunnelse eller fjerne en begrunnelse i en vedtaksperiode som allerede hadde en fritekst, ble friteksten slettet. Dette skjedde pga validering av om de valgte begrunnelsene støttet fritekst eller ikke. Fra før har vi kun støttet fritekster for `OPPHØR` og `AVSLAG`, men nå skal fritekster støttes for alle vedtaksperiodetyper i revurderinger med årsak klage.

Korrigerer her sjekken for når fritekster skal slettes og ikke.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. 
- [x] Jeg har skrevet tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
