### PR TITLE
NAV-24658: Legger til logikk for å koble eksterne behandlinger med en relasjon. Rapporterer relatert behandling til DVH.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/OpprettBehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/OpprettBehandlingDto.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.api.dto
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.NyEksternBehandlingRelasjon
 import java.time.LocalDate
 
 data class OpprettBehandlingDto(
@@ -12,4 +13,5 @@ data class OpprettBehandlingDto(
     val behandlingÅrsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
     val saksbehandlerIdent: String? = null,
     val søknadMottattDato: LocalDate? = null,
+    val nyEksternBehandlingRelasjon: NyEksternBehandlingRelasjon? = null,
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
@@ -7,7 +7,6 @@ import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.OpprettBehandlingService
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.klage.KlageService
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 // Kalles av familie-klage
 @RestController
@@ -51,7 +51,7 @@ class EksternKlageController(
     }
 
     @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage")
-    fun opprettRevurderingKlage(
+    fun opprettRevurderingKlageGammel(
         @PathVariable fagsakId: Long,
     ): Ressurs<OpprettRevurderingResponse> {
         tilgangService.validerTilgangTilHandlingOgFagsak(
@@ -64,7 +64,32 @@ class EksternKlageController(
         if (!SikkerhetContext.kallKommerFraKlage()) {
             throw Feil("Kallet utføres ikke av en autorisert klient")
         }
-        return Ressurs.success(opprettBehandlingService.validerOgOpprettRevurderingKlage(fagsakId, BehandlingÅrsak.KLAGE))
+        return Ressurs.success(opprettBehandlingService.validerOgOpprettRevurderingKlage(fagsakId = fagsakId, klagebehandlingId = null))
+    }
+
+    @PostMapping("fagsak/{fagsakId}/klagebehandling/{klagebehandlingId}/opprett-revurdering-klage")
+    fun opprettRevurderingKlage(
+        @PathVariable fagsakId: Long,
+        @PathVariable klagebehandlingId: UUID,
+    ): Ressurs<OpprettRevurderingResponse> {
+        tilgangService.validerTilgangTilHandlingOgFagsak(
+            fagsakId = fagsakId,
+            handling = "Opprett revurdering med årask klage på fagsak=$fagsakId",
+            event = AuditLoggerEvent.CREATE,
+            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
+        )
+
+        if (!SikkerhetContext.kallKommerFraKlage()) {
+            throw Feil("Kallet utføres ikke av en autorisert klient")
+        }
+
+        val opprettRevurderingResponse =
+            opprettBehandlingService.validerOgOpprettRevurderingKlage(
+                fagsakId = fagsakId,
+                klagebehandlingId = klagebehandlingId,
+            )
+
+        return Ressurs.success(opprettRevurderingResponse)
     }
 
     @GetMapping("fagsaker/{fagsakId}/vedtak")

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
@@ -50,13 +50,14 @@ class EksternKlageController(
         return Ressurs.success(opprettBehandlingService.kanOppretteRevurdering(fagsakId))
     }
 
+    @Deprecated(message = "Erstattet av metoden 'opprettRevurderingKlage'")
     @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage")
     fun opprettRevurderingKlageGammel(
         @PathVariable fagsakId: Long,
     ): Ressurs<OpprettRevurderingResponse> {
         tilgangService.validerTilgangTilHandlingOgFagsak(
             fagsakId = fagsakId,
-            handling = "Opprett revurdering med årask klage på fagsak=$fagsakId",
+            handling = "Opprett revurdering med årask klage på fagsak=$fagsakId.",
             event = AuditLoggerEvent.CREATE,
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
         )

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -15,4 +15,7 @@ enum class FeatureToggle(
 
     // NAV-24034
     BRUK_NY_SAKSBEHANDLER_NAVN_FORMAT_I_SIGNATUR("familie-ks-sak.bruk-ny-saksbehandler-navn-format-i-signatur"),
+
+    // NAV-24658
+    SETT_RELATERT_BEHANDLING_FOR_REVURDERING_KLAGE_I_SAKSSTATISTIKK("familie-ks-sak.sett-relatert-behandling-for-revurdering-klage-i-saksstatistikk"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonRepository.kt
@@ -7,4 +7,10 @@ import org.springframework.data.jpa.repository.Query
 interface EksternBehandlingRelasjonRepository : JpaRepository<EksternBehandlingRelasjon, Long> {
     @Query("SELECT ebr FROM EksternBehandlingRelasjon ebr where ebr.internBehandlingId = :internBehandlingId")
     fun findAllByInternBehandlingId(internBehandlingId: Long): List<EksternBehandlingRelasjon>
+
+    @Query("SELECT ebr FROM EksternBehandlingRelasjon ebr where ebr.internBehandlingId = :internBehandlingId and ebr.eksternBehandlingFagsystem = :fagsystem")
+    fun findByInternBehandlingIdOgFagsystem(
+        internBehandlingId: Long,
+        fagsystem: EksternBehandlingRelasjon.Fagsystem,
+    ): EksternBehandlingRelasjon?
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonRepository.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ks.sak.kjerne.behandling
+
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface EksternBehandlingRelasjonRepository : JpaRepository<EksternBehandlingRelasjon, Long> {
+    @Query("SELECT ebr FROM EksternBehandlingRelasjon ebr where ebr.internBehandlingId = :internBehandlingId")
+    fun findAllByInternBehandlingId(internBehandlingId: Long): List<EksternBehandlingRelasjon>
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ks.sak.kjerne.behandling
 
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,14 +14,5 @@ class EksternBehandlingRelasjonService(
     fun finnEksternBehandlingRelasjon(
         behandlingId: Long,
         fagsystem: EksternBehandlingRelasjon.Fagsystem,
-    ): EksternBehandlingRelasjon? {
-        val eksternBehandlingRelasjoner =
-            eksternBehandlingRelasjonRepository
-                .findAllByInternBehandlingId(behandlingId)
-                .filter { it.eksternBehandlingFagsystem == fagsystem }
-        if (eksternBehandlingRelasjoner.size > 1) {
-            throw Feil("Forventet maks 1 ekstern behandling relasjon av type $fagsystem for behandling $behandlingId")
-        }
-        return eksternBehandlingRelasjoner.singleOrNull()
-    }
+    ): EksternBehandlingRelasjon? = eksternBehandlingRelasjonRepository.findByInternBehandlingIdOgFagsystem(behandlingId, fagsystem)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonService.kt
@@ -1,0 +1,28 @@
+package no.nav.familie.ks.sak.kjerne.behandling
+
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class EksternBehandlingRelasjonService(
+    private val eksternBehandlingRelasjonRepository: EksternBehandlingRelasjonRepository,
+) {
+    @Transactional
+    fun lagreEksternBehandlingRelasjon(eksternBehandlingRelasjon: EksternBehandlingRelasjon): EksternBehandlingRelasjon = eksternBehandlingRelasjonRepository.save(eksternBehandlingRelasjon)
+
+    fun finnEksternBehandlingRelasjon(
+        behandlingId: Long,
+        fagsystem: EksternBehandlingRelasjon.Fagsystem,
+    ): EksternBehandlingRelasjon? {
+        val eksternBehandlingRelasjoner =
+            eksternBehandlingRelasjonRepository
+                .findAllByInternBehandlingId(behandlingId)
+                .filter { it.eksternBehandlingFagsystem == fagsystem }
+        if (eksternBehandlingRelasjoner.size > 1) {
+            throw Feil("Forventet maks 1 ekstern behandling relasjon av type $fagsystem for behandling $behandlingId")
+        }
+        return eksternBehandlingRelasjoner.singleOrNull()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
@@ -20,6 +20,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
+import no.nav.familie.ks.sak.kjerne.behandling.domene.NyEksternBehandlingRelasjon
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.util.UUID
 
 @Service
 class OpprettBehandlingService(
@@ -47,6 +50,7 @@ class OpprettBehandlingService(
     private val stegService: StegService,
     private val behandlingMetrikker: BehandlingMetrikker,
     private val unleashService: UnleashNextMedContextService,
+    private val eksternBehandlingRelasjonService: EksternBehandlingRelasjonService,
 ) {
     @Transactional
     fun opprettBehandling(opprettBehandlingRequest: OpprettBehandlingDto): Behandling {
@@ -98,6 +102,16 @@ class OpprettBehandlingService(
                 aktivBehandling = aktivBehandling,
                 sisteVedtattBehandling = sisteVedtattBehandling,
             )
+
+        if (opprettBehandlingRequest.nyEksternBehandlingRelasjon != null) {
+            eksternBehandlingRelasjonService.lagreEksternBehandlingRelasjon(
+                EksternBehandlingRelasjon.opprettFraNyEksternBehandlingRelasjon(
+                    internBehandlingId = lagretBehandling.id,
+                    nyEksternBehandlingRelasjon = opprettBehandlingRequest.nyEksternBehandlingRelasjon,
+                ),
+            )
+        }
+
         vedtakService.opprettOgInitierNyttVedtakForBehandling(lagretBehandling) // initierer vedtak
         loggService.opprettBehandlingLogg(lagretBehandling) // lag historikkinnslag
         // Oppretter BehandleSak oppgave via task. Ruller tasken tilbake, hvis behandling opprettelse feiler
@@ -152,20 +166,20 @@ class OpprettBehandlingService(
     @Transactional
     fun validerOgOpprettRevurderingKlage(
         fagsakId: Long,
-        behandlingÅrsak: BehandlingÅrsak,
+        klagebehandlingId: UUID?,
     ): OpprettRevurderingResponse {
         val fagsak = hentFagsak(fagsakId)
 
         val resultat = utledKanOppretteRevurdering(fagsak)
         return when (resultat) {
-            is KanOppretteRevurdering -> opprettRevurderingKlage(fagsak, behandlingÅrsak)
+            is KanOppretteRevurdering -> opprettRevurderingKlage(fagsak, klagebehandlingId)
             is KanIkkeOppretteRevurdering -> OpprettRevurderingResponse(IkkeOpprettet(resultat.årsak.ikkeOpprettetÅrsak))
         }
     }
 
     private fun opprettRevurderingKlage(
         fagsak: Fagsak,
-        behandlingÅrsak: BehandlingÅrsak,
+        klagebehandlingId: UUID?,
     ): OpprettRevurderingResponse =
         try {
             val forrigeBehandling = hentSisteBehandlingSomErVedtatt(fagsakId = fagsak.id)
@@ -175,7 +189,8 @@ class OpprettBehandlingService(
                     kategori = forrigeBehandling?.kategori ?: BehandlingKategori.NASJONAL,
                     søkersIdent = fagsak.aktør.aktivFødselsnummer(),
                     behandlingType = BehandlingType.REVURDERING,
-                    behandlingÅrsak = behandlingÅrsak,
+                    behandlingÅrsak = BehandlingÅrsak.KLAGE,
+                    nyEksternBehandlingRelasjon = klagebehandlingId?.let { NyEksternBehandlingRelasjon.opprettForKlagebehandling(it) },
                 )
 
             val revurdering = opprettBehandling(behandlingDto)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjon.kt
@@ -18,15 +18,15 @@ data class EksternBehandlingRelasjon(
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ekstern_behandling_relasjon_seq_generator")
     @SequenceGenerator(name = "ekstern_behandling_relasjon_seq_generator", sequenceName = "ekstern_behandling_relasjon_seq", allocationSize = 50)
     val id: Long = 0,
-    @Column(name = "intern_behandling_id", nullable = false)
+    @Column(name = "fk_behandling_id", nullable = false)
     val internBehandlingId: Long,
     @Column(name = "ekstern_behandling_id", nullable = false)
     val eksternBehandlingId: String,
     @Enumerated(EnumType.STRING)
     @Column(name = "ekstern_behandling_fagsystem", nullable = false)
     val eksternBehandlingFagsystem: Fagsystem,
-    @Column(name = "opprettet_tidspunkt", nullable = false)
-    val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
+    @Column(name = "opprettet_tid", nullable = false)
+    val opprettetTid: LocalDateTime = LocalDateTime.now(),
 ) {
     enum class Fagsystem {
         KLAGE,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjon.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "EksternBehandlingRelasjon")
+@Table(name = "EKSTERN_BEHANDLING_RELASJON")
+data class EksternBehandlingRelasjon(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ekstern_behandling_relasjon_seq_generator")
+    @SequenceGenerator(name = "ekstern_behandling_relasjon_seq_generator", sequenceName = "ekstern_behandling_relasjon_seq", allocationSize = 50)
+    val id: Long = 0,
+    @Column(name = "intern_behandling_id", nullable = false)
+    val internBehandlingId: Long,
+    @Column(name = "ekstern_behandling_id", nullable = false)
+    val eksternBehandlingId: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ekstern_behandling_fagsystem", nullable = false)
+    val eksternBehandlingFagsystem: Fagsystem,
+    @Column(name = "opprettet_tidspunkt", nullable = false)
+    val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
+) {
+    enum class Fagsystem {
+        KLAGE,
+        TILBAKEKREVING,
+    }
+
+    companion object Factory {
+        fun opprettFraNyEksternBehandlingRelasjon(
+            internBehandlingId: Long,
+            nyEksternBehandlingRelasjon: NyEksternBehandlingRelasjon,
+        ) = EksternBehandlingRelasjon(
+            internBehandlingId = internBehandlingId,
+            eksternBehandlingId = nyEksternBehandlingRelasjon.eksternBehandlingId,
+            eksternBehandlingFagsystem = nyEksternBehandlingRelasjon.eksternBehandlingFagsystem,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/NyEksternBehandlingRelasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/NyEksternBehandlingRelasjon.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import java.util.UUID
+
+data class NyEksternBehandlingRelasjon(
+    val eksternBehandlingId: String,
+    val eksternBehandlingFagsystem: EksternBehandlingRelasjon.Fagsystem,
+) {
+    companion object Factory {
+        fun opprettForKlagebehandling(
+            klagebehandlingId: UUID,
+        ): NyEksternBehandlingRelasjon =
+            NyEksternBehandlingRelasjon(
+                eksternBehandlingId = klagebehandlingId.toString(),
+                eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandling.kt
@@ -1,38 +1,33 @@
 package no.nav.familie.ks.sak.statistikk.saksstatistikk
 
-import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import java.time.LocalDateTime
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
 
 data class RelatertBehandling(
     val id: String,
-    val vedtattTidspunkt: LocalDateTime,
     val fagsystem: Fagsystem,
 ) {
     enum class Fagsystem {
         KS,
         KLAGE,
+        TILBAKEKREVING,
     }
 
     companion object Factory {
         fun fraKontantstøttebehandling(kontantstøttebehandling: Behandling) =
             RelatertBehandling(
                 id = kontantstøttebehandling.id.toString(),
-                vedtattTidspunkt = kontantstøttebehandling.aktivertTidspunkt,
                 fagsystem = Fagsystem.KS,
             )
 
-        fun fraKlagebehandling(klagebehandling: KlagebehandlingDto): RelatertBehandling {
-            val vedtaksdato = klagebehandling.vedtaksdato
-            if (vedtaksdato == null) {
-                throw Feil("Forventer vedtaksdato for klagebehandling ${klagebehandling.id}")
-            }
-            return RelatertBehandling(
-                id = klagebehandling.id.toString(),
-                vedtattTidspunkt = vedtaksdato,
-                fagsystem = Fagsystem.KLAGE,
+        fun fraEksternBehandlingRelasjon(eksternBehandlingRelasjon: EksternBehandlingRelasjon): RelatertBehandling =
+            RelatertBehandling(
+                id = eksternBehandlingRelasjon.eksternBehandlingId,
+                fagsystem =
+                    when (eksternBehandlingRelasjon.eksternBehandlingFagsystem) {
+                        EksternBehandlingRelasjon.Fagsystem.KLAGE -> Fagsystem.KLAGE
+                        EksternBehandlingRelasjon.Fagsystem.TILBAKEKREVING -> Fagsystem.TILBAKEKREVING
+                    },
             )
-        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -3,7 +3,9 @@ package no.nav.familie.ks.sak.statistikk.saksstatistikk
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.EksternBehandlingRelasjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Lazy
@@ -12,17 +14,27 @@ import org.springframework.stereotype.Component
 @Component
 class RelatertBehandlingUtleder(
     @Lazy private val behandlingService: BehandlingService,
+    private val eksternBehandlingRelasjonService: EksternBehandlingRelasjonService,
     private val unleashService: UnleashNextMedContextService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(RelatertBehandlingUtleder::class.java)
 
     fun utledRelatertBehandling(behandling: Behandling): RelatertBehandling? {
-        if (!unleashService.isEnabled(FeatureToggle.KAN_BEHANDLE_KLAGE, false)) {
-            return null
+        if (behandling.erRevurderingKlage() && unleashService.isEnabled(FeatureToggle.SETT_RELATERT_BEHANDLING_FOR_REVURDERING_KLAGE_I_SAKSSTATISTIKK, false)) {
+            val eksternKlagebehandlingRelasjon =
+                eksternBehandlingRelasjonService.finnEksternBehandlingRelasjon(
+                    behandlingId = behandling.id,
+                    fagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                )
+            if (eksternKlagebehandlingRelasjon == null) {
+                logger.warn("Forventer en ekstern klagebehandling relasjon for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
+                return null
+            }
+            return RelatertBehandling.fraEksternBehandlingRelasjon(eksternKlagebehandlingRelasjon)
         }
 
         if (behandling.erRevurderingKlage()) {
-            return null // TODO : NAV-24658 implementer logikk for å hente relatert klagebehandling, trengs ikke før prodsetting
+            return null
         }
 
         if (behandling.erRevurderingEllerTekniskEndring()) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingUtleder.kt
@@ -27,7 +27,7 @@ class RelatertBehandlingUtleder(
                     fagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
                 )
             if (eksternKlagebehandlingRelasjon == null) {
-                logger.warn("Forventer en ekstern klagebehandling relasjon for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
+                logger.warn("Forventer en ekstern klagebehandling relasjon for fagsak=${behandling.fagsak.id} og behandling=${behandling.id}")
                 return null
             }
             return RelatertBehandling.fraEksternBehandlingRelasjon(eksternKlagebehandlingRelasjon)
@@ -40,7 +40,7 @@ class RelatertBehandlingUtleder(
         if (behandling.erRevurderingEllerTekniskEndring()) {
             val forrigeVedtatteKontantstøttebehandling = behandlingService.hentForrigeBehandlingSomErVedtatt(behandling)
             if (forrigeVedtatteKontantstøttebehandling == null) {
-                logger.warn("Forventer en vedtatt kontantstøttebehandling for fagsak ${behandling.fagsak.id} og behandling ${behandling.id}")
+                logger.warn("Forventer en vedtatt kontantstøttebehandling for fagsak=${behandling.fagsak.id} og behandling=${behandling.id}")
                 return null
             }
             return RelatertBehandling.fraKontantstøttebehandling(forrigeVedtatteKontantstøttebehandling)

--- a/src/main/resources/db/migration/V37__legg_til_ekstern_behandling_relasjon.sql
+++ b/src/main/resources/db/migration/V37__legg_til_ekstern_behandling_relasjon.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS EKSTERN_BEHANDLING_RELASJON
+(
+    id                                  BIGINT PRIMARY KEY,
+    intern_behandling_id                BIGINT REFERENCES BEHANDLING (ID)           NOT NULL,
+    ekstern_behandling_id               VARCHAR(512)                                NOT NULL,
+    ekstern_behandling_fagsystem        VARCHAR(512)                                NOT NULL,
+    opprettet_tidspunkt                 TIMESTAMP(3)                                NOT NULL
+);
+
+CREATE SEQUENCE ekstern_behandling_relasjon_seq INCREMENT BY 50 START WITH 1000000 NO CYCLE;
+CREATE INDEX intern_behandling_id_idx ON EKSTERN_BEHANDLING_RELASJON (intern_behandling_id);

--- a/src/main/resources/db/migration/V38__endrer_ekstern_behandling_relasjon.sql
+++ b/src/main/resources/db/migration/V38__endrer_ekstern_behandling_relasjon.sql
@@ -1,0 +1,10 @@
+ALTER TABLE IF EXISTS EKSTERN_BEHANDLING_RELASJON RENAME COLUMN intern_behandling_id TO fk_behandling_id;
+ALTER TABLE IF EXISTS EKSTERN_BEHANDLING_RELASJON RENAME COLUMN opprettet_tidspunkt TO opprettet_tid;
+
+ALTER INDEX IF EXISTS intern_behandling_id_idx RENAME TO ekstern_behandling_relasjon_fk_behandling_id_idx;
+
+ALTER TABLE IF EXISTS EKSTERN_BEHANDLING_RELASJON ALTER COLUMN ekstern_behandling_id TYPE VARCHAR;
+ALTER TABLE IF EXISTS EKSTERN_BEHANDLING_RELASJON ALTER COLUMN ekstern_behandling_fagsystem TYPE VARCHAR;
+
+ALTER TABLE IF EXISTS EKSTERN_BEHANDLING_RELASJON ADD CONSTRAINT ekstern_behandling_relasjon_til_fk_behandling_id_fkey FOREIGN KEY (fk_behandling_id) REFERENCES behandling (id) ON DELETE CASCADE;
+ALTER TABLE IF EXISTS EKSTERN_BEHANDLING_RELASJON ADD CONSTRAINT unik_ekstern_behandling_relasjon UNIQUE (fk_behandling_id, ekstern_behandling_fagsystem);

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -55,6 +55,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
+import no.nav.familie.ks.sak.kjerne.behandling.domene.NyEksternBehandlingRelasjon
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus
 import no.nav.familie.ks.sak.kjerne.behandling.steg.VenteÅrsak
@@ -1610,12 +1612,10 @@ fun lagKlageinstansResultatDto(
 
 fun lagRelatertBehandling(
     id: String = "1",
-    vedtattTidspunkt: LocalDateTime = LocalDateTime.now(),
     fagsystem: RelatertBehandling.Fagsystem = RelatertBehandling.Fagsystem.KS,
 ): RelatertBehandling =
     RelatertBehandling(
         id = id,
-        vedtattTidspunkt = vedtattTidspunkt,
         fagsystem = fagsystem,
     )
 
@@ -1648,3 +1648,27 @@ fun lagBarnehagebarn(
     barnehagebarn.endretTidspunkt = endretTidspunkt
     return barnehagebarn
 }
+
+fun lagEksternBehandlingRelasjon(
+    id: Long = 0L,
+    internBehandlingId: Long = 1000L,
+    eksternBehandlingId: String = UUID.randomUUID().toString(),
+    eksternBehandlingFagsystem: EksternBehandlingRelasjon.Fagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+    opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
+): EksternBehandlingRelasjon =
+    EksternBehandlingRelasjon(
+        id = id,
+        internBehandlingId = internBehandlingId,
+        eksternBehandlingId = eksternBehandlingId,
+        eksternBehandlingFagsystem = eksternBehandlingFagsystem,
+        opprettetTidspunkt = opprettetTidspunkt,
+    )
+
+fun lagNyEksternBehandlingRelasjon(
+    eksternBehandlingId: String = UUID.randomUUID().toString(),
+    eksternBehandlingFagsystem: EksternBehandlingRelasjon.Fagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+): NyEksternBehandlingRelasjon =
+    NyEksternBehandlingRelasjon(
+        eksternBehandlingId = eksternBehandlingId,
+        eksternBehandlingFagsystem = eksternBehandlingFagsystem,
+    )

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -1661,7 +1661,7 @@ fun lagEksternBehandlingRelasjon(
         internBehandlingId = internBehandlingId,
         eksternBehandlingId = eksternBehandlingId,
         eksternBehandlingFagsystem = eksternBehandlingFagsystem,
-        opprettetTidspunkt = opprettetTidspunkt,
+        opprettetTid = opprettetTidspunkt,
     )
 
 fun lagNyEksternBehandlingRelasjon(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonServiceTest.kt
@@ -1,0 +1,129 @@
+package no.nav.familie.ks.sak.kjerne.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.data.lagEksternBehandlingRelasjon
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+import java.util.UUID
+
+class EksternBehandlingRelasjonServiceTest {
+    private val eksternBehandlingRelasjonRepository = mockk<EksternBehandlingRelasjonRepository>()
+    private val eksternBehandlingRelasjonService =
+        EksternBehandlingRelasjonService(
+            eksternBehandlingRelasjonRepository = eksternBehandlingRelasjonRepository,
+        )
+
+    @Nested
+    inner class LagreEksternBehandlingRelasjon {
+        @Test
+        fun `skal lagre ekstern behandling relasjon`() {
+            // Arrange
+            val eksternBehandlingRelasjon = lagEksternBehandlingRelasjon()
+
+            every { eksternBehandlingRelasjonRepository.save(any()) } returnsArgument 0
+
+            // Act
+            val lagretEksternBehandlingRelasjon = eksternBehandlingRelasjonService.lagreEksternBehandlingRelasjon(eksternBehandlingRelasjon)
+
+            // Assert
+            verify { eksternBehandlingRelasjonRepository.save(eksternBehandlingRelasjon) }
+            assertThat(lagretEksternBehandlingRelasjon).isEqualTo(eksternBehandlingRelasjon)
+        }
+    }
+
+    @Nested
+    inner class FinnEksternBehandlingRelasjon {
+        @Test
+        fun `skal finne ekstern behandling relasjon`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+            val behandlingId = 1L
+
+            val eksternBehandlingRelasjon1 =
+                lagEksternBehandlingRelasjon(
+                    id = 1L,
+                    internBehandlingId = behandlingId,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                    opprettetTidspunkt = nåtidspunkt.minusSeconds(1),
+                )
+
+            val eksternBehandlingRelasjon2 =
+                lagEksternBehandlingRelasjon(
+                    id = 2L,
+                    internBehandlingId = behandlingId,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.TILBAKEKREVING,
+                    opprettetTidspunkt = nåtidspunkt,
+                )
+
+            every {
+                eksternBehandlingRelasjonRepository.findAllByInternBehandlingId(behandlingId)
+            } returns
+                listOf(
+                    eksternBehandlingRelasjon1,
+                    eksternBehandlingRelasjon2,
+                )
+
+            // Act
+            val eksternBehandlingRelasjon =
+                eksternBehandlingRelasjonService.finnEksternBehandlingRelasjon(
+                    behandlingId = behandlingId,
+                    fagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                )
+
+            // Assert
+            assertThat(eksternBehandlingRelasjon).isEqualTo(eksternBehandlingRelasjon1)
+        }
+
+        @Test
+        fun `skal kaste exception om det finnes mer enn 1 ekstern behandling relasjon for et gitt fagsystem`() {
+            // Arrange
+            val nåtidspunkt = LocalDateTime.now()
+            val behandlingId = 1L
+
+            val eksternBehandlingRelasjon1 =
+                lagEksternBehandlingRelasjon(
+                    id = 1L,
+                    internBehandlingId = behandlingId,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                    opprettetTidspunkt = nåtidspunkt.minusSeconds(1),
+                )
+
+            val eksternBehandlingRelasjon2 =
+                lagEksternBehandlingRelasjon(
+                    id = 2L,
+                    internBehandlingId = behandlingId,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                    opprettetTidspunkt = nåtidspunkt,
+                )
+
+            every {
+                eksternBehandlingRelasjonRepository.findAllByInternBehandlingId(behandlingId)
+            } returns
+                listOf(
+                    eksternBehandlingRelasjon1,
+                    eksternBehandlingRelasjon2,
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    eksternBehandlingRelasjonService.finnEksternBehandlingRelasjon(
+                        behandlingId = behandlingId,
+                        fagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Forventet maks 1 ekstern behandling relasjon av type KLAGE for behandling $behandlingId")
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
@@ -376,7 +376,7 @@ class OpprettBehandlingServiceTest {
             assertThat(eksternBehandlingRelasjonSlot.captured.internBehandlingId).isEqualTo(behandling.id)
             assertThat(eksternBehandlingRelasjonSlot.captured.eksternBehandlingId).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingId)
             assertThat(eksternBehandlingRelasjonSlot.captured.eksternBehandlingFagsystem).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingFagsystem)
-            assertThat(eksternBehandlingRelasjonSlot.captured.opprettetTidspunkt).isNotNull()
+            assertThat(eksternBehandlingRelasjonSlot.captured.opprettetTid).isNotNull()
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
@@ -13,6 +14,7 @@ import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
 import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.lagNyEksternBehandlingRelasjon
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.oppgave.OpprettOppgaveTask
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
@@ -22,6 +24,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.StegService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
@@ -30,16 +33,14 @@ import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
+import java.util.UUID
 
 class OpprettBehandlingServiceTest {
     private val personidentService = mockk<PersonidentService>()
@@ -52,6 +53,7 @@ class OpprettBehandlingServiceTest {
     private val taskService = mockk<TaskService>()
     private val behandlingMetrikker = mockk<BehandlingMetrikker>()
     private val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
+    private val eksternBehandlingRelasjonService = mockk<EksternBehandlingRelasjonService>()
 
     private val opprettBehandlingService =
         OpprettBehandlingService(
@@ -65,6 +67,7 @@ class OpprettBehandlingServiceTest {
             stegService = stegService,
             behandlingMetrikker = behandlingMetrikker,
             unleashService = unleashNextMedContextService,
+            eksternBehandlingRelasjonService = eksternBehandlingRelasjonService,
         )
 
     private val søker = randomAktør()
@@ -76,276 +79,317 @@ class OpprettBehandlingServiceTest {
     fun beforeEach() {
         every { personidentService.hentAktør(any()) } returns søker
         every { fagsakRepository.finnFagsakForAktør(søker) } returns fagsak
-        every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns
-            behandling.copy(
-                status = BehandlingStatus.AVSLUTTET,
-                aktiv = true,
-            )
+        every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns behandling.copy(status = BehandlingStatus.AVSLUTTET, aktiv = true)
         every { behandlingRepository.hentBehandling(any()) } returns behandling
         every { behandlingRepository.finnBehandlinger(fagsak.id) } returns emptyList()
         every { behandlingRepository.saveAndFlush(any()) } returns behandling
         every { behandlingRepository.save(any()) } returns behandling
         every { arbeidsfordelingService.fastsettBehandlendeEnhet(any(), any()) } just runs
-
         every { vedtakService.opprettOgInitierNyttVedtakForBehandling(any()) } just runs
         every { loggService.opprettBehandlingLogg(any()) } just runs
-        every { taskService.save(any()) } returns
-            OpprettOppgaveTask.opprettTask(
-                behandling.id,
-                Oppgavetype.BehandleSak,
-                LocalDate.now(),
-            )
+        every { taskService.save(any()) } returns OpprettOppgaveTask.opprettTask(behandling.id, Oppgavetype.BehandleSak, LocalDate.now())
         every { stegService.utførSteg(any(), any()) } returns Unit
         every { behandlingMetrikker.tellNøkkelTallVedOpprettelseAvBehandling(behandling) } just runs
     }
 
-    @Test
-    fun `opprettBehandling - skal opprette behandling når det finnes en fagsak tilknyttet søker og det ikke allerede eksisterer en aktiv behandling som ikke er avsluttet`() {
-        val opprettetBehandling =
-            opprettBehandlingService.opprettBehandling(
+    @Nested
+    inner class OpprettBehandling {
+        @Test
+        fun `skal opprette behandling når det finnes en fagsak tilknyttet søker og det ikke allerede eksisterer en aktiv behandling som ikke er avsluttet`() {
+            // Arrange
+            val opprettBehandlingDto =
                 OpprettBehandlingDto(
                     søkersIdent = søkersIdent,
                     behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                     kategori = BehandlingKategori.NASJONAL,
-                ),
-            )
+                )
 
-        // Validerer at tidligere aktiv behandling blir satt til inaktiv
-        verify {
-            behandlingRepository.saveAndFlush(
-                withArg {
-                    assertFalse(it.aktiv)
-                },
-            )
+            // Act
+            val opprettetBehandling = opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+
+            // Assert
+            // Validerer at tidligere aktiv behandling blir satt til inaktiv
+            verify {
+                behandlingRepository.saveAndFlush(
+                    withArg {
+                        assertThat(it.aktiv).isFalse()
+                    },
+                )
+            }
+            // Validerer at ny behandling blir satt til aktiv og inneholder forventede felter
+            verify {
+                behandlingRepository.save(
+                    withArg {
+                        assertThat(it.aktiv).isTrue()
+                        assertThat(BehandlingÅrsak.SØKNAD).isEqualTo(it.opprettetÅrsak)
+                        assertThat(BehandlingType.FØRSTEGANGSBEHANDLING).isEqualTo(it.type)
+                        assertThat(BehandlingKategori.NASJONAL).isEqualTo(it.kategori)
+                        assertThat(BehandlingSteg.REGISTRERE_PERSONGRUNNLAG).isEqualTo(it.steg)
+                        assertThat(fagsak).isEqualTo(it.fagsak)
+                    },
+                )
+            }
+            // Validerer at "BehandleSak"-oppgave blir opprettet
+            verify(exactly = 2) { taskService.save(any()) }
+            assertThat(opprettetBehandling).isNotNull()
         }
 
-        // Validerer at ny behandling blir satt til aktiv og inneholder forventede felter
-        verify {
-            behandlingRepository.save(
-                withArg {
-                    assertTrue(it.aktiv)
-                    assertEquals(BehandlingÅrsak.SØKNAD, it.opprettetÅrsak)
-                    assertEquals(BehandlingType.FØRSTEGANGSBEHANDLING, it.type)
-                    assertEquals(BehandlingKategori.NASJONAL, it.kategori)
-                    assertEquals(BehandlingSteg.REGISTRERE_PERSONGRUNNLAG, it.steg)
-                    assertEquals(fagsak, it.fagsak)
-                },
-            )
+        @Test
+        fun `skal kaste feil dersom det ikke finnes noen fagsak tilknyttet søker`() {
+            // Arrange
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    kategori = BehandlingKategori.NASJONAL,
+                )
+
+            every { fagsakRepository.finnFagsakForAktør(søker) } returns null
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+                }
+            assertThat(exception.message).isEqualTo("Kan ikke lage behandling på person uten tilknyttet fagsak.")
         }
 
-        // Validerer at "BehandleSak"-oppgave blir opprettet
-        verify(exactly = 2) { taskService.save(any()) }
-
-        assertNotNull(opprettetBehandling)
-    }
-
-    @Test
-    fun `opprettBehandling - skal kaste feil dersom det ikke finnes noen fagsak tilknyttet søker`() {
-        every { fagsakRepository.finnFagsakForAktør(søker) } returns null
-
-        val funksjonellFeil =
-            assertThrows<FunksjonellFeil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                        kategori = BehandlingKategori.NASJONAL,
-                    ),
-                )
-            }
-
-        assertEquals("Kan ikke lage behandling på person uten tilknyttet fagsak.", funksjonellFeil.melding)
-    }
-
-    @ParameterizedTest
-    @EnumSource(
-        value = BehandlingStatus::class,
-        names = ["OPPRETTET", "UTREDES", "FATTER_VEDTAK", "IVERKSETTER_VEDTAK"],
-    )
-    fun `opprettBehandling - skal kaste feil dersom det allerede finnes en aktiv behandling som ikke er avsluttet`(
-        behandlingStatus: BehandlingStatus,
-    ) {
-        every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns
-            behandling.copy(
-                aktiv = true,
-                status = behandlingStatus,
-            )
-
-        val funksjonellFeil =
-            assertThrows<FunksjonellFeil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                        kategori = BehandlingKategori.NASJONAL,
-                    ),
-                )
-            }
-
-        assertEquals(
-            "Kan ikke lage ny behandling. Fagsaken har en aktiv behandling som ikke er ferdigstilt.",
-            funksjonellFeil.melding,
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["OPPRETTET", "UTREDES", "FATTER_VEDTAK", "IVERKSETTER_VEDTAK"],
         )
-    }
-
-    @ParameterizedTest
-    @EnumSource(
-        value = BehandlingType::class,
-        names = ["FØRSTEGANGSBEHANDLING", "REVURDERING"],
-    )
-    fun `opprettBehandling - skal kaste feil dersom behandlingkategori ikke er satt og behandlingstype er FØRSTEGANGSBEHANDLING eller REVURDERING og behandlingsårsak er SØKNAD`(
-        behandlingType: BehandlingType,
-    ) {
-        val funksjonellFeil =
-            assertThrows<FunksjonellFeil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = behandlingType,
-                    ),
+        fun `skal kaste feil dersom det allerede finnes en aktiv behandling som ikke er avsluttet`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            // Arrange
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    kategori = BehandlingKategori.NASJONAL,
                 )
-            }
-        assertEquals(
-            "Behandling med type ${behandlingType.visningsnavn} og årsak Søknad krever behandlingskategori",
-            funksjonellFeil.melding,
+
+            every {
+                behandlingRepository.findByFagsakAndAktiv(fagsak.id)
+            } returns
+                behandling.copy(
+                    aktiv = true,
+                    status = behandlingStatus,
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+                }
+
+            assertThat(exception.message).isEqualTo("Kan ikke lage ny behandling. Fagsaken har en aktiv behandling som ikke er ferdigstilt.")
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingType::class,
+            names = ["FØRSTEGANGSBEHANDLING", "REVURDERING"],
         )
-    }
-
-    @ParameterizedTest
-    @EnumSource(
-        value = BehandlingÅrsak::class,
-        names = ["SØKNAD", "BARNEHAGELISTE"],
-    )
-    fun `opprettBehandling - skal kaste feil dersom behandlingType er TEKNISK_ENDRING og behandlingÅrsak ikke samsvarer`(
-        behandlingÅrsak: BehandlingÅrsak,
-    ) {
-        val funksjonellFeil =
-            assertThrows<Feil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = BehandlingType.TEKNISK_ENDRING,
-                        behandlingÅrsak = behandlingÅrsak,
-                    ),
+        fun `skal kaste feil dersom behandlingkategori ikke er satt og behandlingstype er FØRSTEGANGSBEHANDLING eller REVURDERING og behandlingsårsak er SØKNAD`(
+            behandlingType: BehandlingType,
+        ) {
+            // Arrange
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = behandlingType,
                 )
-            }
-        assertEquals(
-            "Behandling med TEKNISK_ENDRING og årsak $behandlingÅrsak samsvarer ikke.",
-            funksjonellFeil.message,
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    opprettBehandlingService.opprettBehandling(
+                        opprettBehandlingDto,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Behandling med type ${behandlingType.visningsnavn} og årsak Søknad krever behandlingskategori")
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingÅrsak::class,
+            names = ["SØKNAD", "BARNEHAGELISTE"],
         )
-    }
-
-    @ParameterizedTest
-    @EnumSource(
-        value = BehandlingÅrsak::class,
-        names = ["ÅRLIG_KONTROLL", "DØDSFALL", "NYE_OPPLYSNINGER", "KLAGE", "KORREKSJON_VEDTAKSBREV", "SATSENDRING"],
-    )
-    fun `opprettBehandling - skal kaste feil dersom behandlingType er TEKNISK_ENDRING eller FØRSTEGANGSBEHANDLING og behandlingÅrsak ikke samsvarer`(
-        behandlingÅrsak: BehandlingÅrsak,
-    ) {
-        var funksjonellFeil =
-            assertThrows<Feil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = BehandlingType.TEKNISK_ENDRING,
-                        behandlingÅrsak = behandlingÅrsak,
-                    ),
+        fun `skal kaste feil dersom behandlingType er TEKNISK_ENDRING og behandlingÅrsak ikke samsvarer`(
+            behandlingÅrsak: BehandlingÅrsak,
+        ) {
+            // Arrange
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.TEKNISK_ENDRING,
+                    behandlingÅrsak = behandlingÅrsak,
                 )
-            }
-        assertEquals(
-            "Behandling med TEKNISK_ENDRING og årsak $behandlingÅrsak samsvarer ikke.",
-            funksjonellFeil.message,
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+                }
+            assertThat(exception.message).isEqualTo("Behandling med TEKNISK_ENDRING og årsak $behandlingÅrsak samsvarer ikke.")
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingÅrsak::class,
+            names = ["ÅRLIG_KONTROLL", "DØDSFALL", "NYE_OPPLYSNINGER", "KLAGE", "KORREKSJON_VEDTAKSBREV", "SATSENDRING"],
         )
-
-        funksjonellFeil =
-            assertThrows {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                        behandlingÅrsak = behandlingÅrsak,
-                    ),
+        fun `skal kaste feil dersom behandlingType er TEKNISK_ENDRING eller FØRSTEGANGSBEHANDLING og behandlingÅrsak ikke samsvarer`(
+            behandlingÅrsak: BehandlingÅrsak,
+        ) {
+            // Arrange
+            val opprettBehandlingDtoTekniskEndring =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.TEKNISK_ENDRING,
+                    behandlingÅrsak = behandlingÅrsak,
                 )
-            }
-        assertEquals(
-            "Behandling med FØRSTEGANGSBEHANDLING og årsak $behandlingÅrsak samsvarer ikke.",
-            funksjonellFeil.message,
+
+            // Act & assert
+            var exception =
+                assertThrows<Feil> {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDtoTekniskEndring)
+                }
+            assertThat(exception.message).isEqualTo("Behandling med TEKNISK_ENDRING og årsak $behandlingÅrsak samsvarer ikke.")
+
+            // Arrange
+            val opprettBehandlingDtoFørstegangsbehandling =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    behandlingÅrsak = behandlingÅrsak,
+                )
+
+            // Act & assert
+            exception =
+                assertThrows {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDtoFørstegangsbehandling)
+                }
+            assertThat(exception.message).isEqualTo("Behandling med FØRSTEGANGSBEHANDLING og årsak $behandlingÅrsak samsvarer ikke.")
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingType::class,
+            names = ["FØRSTEGANGSBEHANDLING", "REVURDERING"],
         )
-    }
-
-    @ParameterizedTest
-    @EnumSource(
-        value = BehandlingType::class,
-        names = ["FØRSTEGANGSBEHANDLING", "REVURDERING"],
-    )
-    fun `opprettBehandling - skal kaste feil dersom behandlingType er FØRSTEGANGSBEHANDLING eller REVURDERING og behandlingÅrsak er TEKNISK_ENDRING`(
-        behandlingType: BehandlingType,
-    ) {
-        val funksjonellFeil =
-            assertThrows<Feil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = behandlingType,
-                        behandlingÅrsak = BehandlingÅrsak.TEKNISK_ENDRING,
-                    ),
+        fun `skal kaste feil dersom behandlingType er FØRSTEGANGSBEHANDLING eller REVURDERING og behandlingÅrsak er TEKNISK_ENDRING`(
+            behandlingType: BehandlingType,
+        ) {
+            // Arrange
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = behandlingType,
+                    behandlingÅrsak = BehandlingÅrsak.TEKNISK_ENDRING,
                 )
-            }
-        assertEquals(
-            "Behandling med $behandlingType og årsak TEKNISK_ENDRING samsvarer ikke.",
-            funksjonellFeil.message,
-        )
-    }
 
-    @Test
-    fun `opprettBehandling - skal kaste feil dersom behandlingType er REVURDERING og det ikke finnes noen avsluttede vedtatte behandlinger på fagsaken til søker`() {
-        every { behandlingRepository.finnBehandlinger(fagsak.id) } returns
-            listOf(
-                lagBehandling(
-                    fagsak,
-                    opprettetÅrsak = BehandlingÅrsak.SØKNAD,
-                ).copy(status = BehandlingStatus.UTREDES),
-            )
-        val funksjonellFeil =
-            assertThrows<Feil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = BehandlingType.REVURDERING,
-                        behandlingÅrsak = BehandlingÅrsak.BARNEHAGELISTE,
-                    ),
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+                }
+            assertThat(exception.message).isEqualTo("Behandling med $behandlingType og årsak TEKNISK_ENDRING samsvarer ikke.")
+        }
+
+        @Test
+        fun `skal kaste feil dersom behandlingType er REVURDERING og det ikke finnes noen avsluttede vedtatte behandlinger på fagsaken til søker`() {
+            // Arrange
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.REVURDERING,
+                    behandlingÅrsak = BehandlingÅrsak.BARNEHAGELISTE,
                 )
-            }
-        assertEquals(
-            "Kan ikke opprette revurdering på $fagsak uten noen andre behandlinger som er vedtatt.",
-            funksjonellFeil.message,
-        )
-    }
 
-    @Test
-    fun `opprettBehandling - skal kaste feil dersom behandlingsårsak er IVERKSETTE_KA_VEDTAK og toggle ikke er skrudd på`() {
-        every { unleashNextMedContextService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK) } returns false
-
-        val funksjonellFeil =
-            assertThrows<FunksjonellFeil> {
-                opprettBehandlingService.opprettBehandling(
-                    OpprettBehandlingDto(
-                        søkersIdent = søkersIdent,
-                        behandlingType = BehandlingType.REVURDERING,
-                        behandlingÅrsak = BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
-                    ),
+            every { behandlingRepository.finnBehandlinger(fagsak.id) } returns
+                listOf(
+                    lagBehandling(
+                        fagsak,
+                        opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+                    ).copy(status = BehandlingStatus.UTREDES),
                 )
-            }
 
-        assertThat(funksjonellFeil.melding).isEqualTo("Kan ikke opprette behandling med årsak Iverksette KA-vedtak.")
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+                }
+            assertThat(exception.message).isEqualTo("Kan ikke opprette revurdering på $fagsak uten noen andre behandlinger som er vedtatt.")
+        }
+
+        @Test
+        fun `skal kaste feil dersom behandlingsårsak er IVERKSETTE_KA_VEDTAK og toggle ikke er skrudd på`() {
+            // Arrange
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.REVURDERING,
+                    behandlingÅrsak = BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+                )
+
+            every { unleashNextMedContextService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK) } returns false
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+                }
+            assertThat(exception.melding).isEqualTo("Kan ikke opprette behandling med årsak Iverksette KA-vedtak.")
+        }
+
+        @Test
+        fun `skal opprette behandling og lagre ned ekstern behandling relasjon`() {
+            // Arrange
+            val nyEksternBehandlingRelasjon =
+                lagNyEksternBehandlingRelasjon(
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                )
+
+            val opprettBehandlingDto =
+                OpprettBehandlingDto(
+                    søkersIdent = søkersIdent,
+                    behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    behandlingÅrsak = BehandlingÅrsak.SØKNAD,
+                    kategori = BehandlingKategori.NASJONAL,
+                    nyEksternBehandlingRelasjon = nyEksternBehandlingRelasjon,
+                )
+
+            val eksternBehandlingRelasjonSlot = slot<EksternBehandlingRelasjon>()
+
+            every { eksternBehandlingRelasjonService.lagreEksternBehandlingRelasjon(capture(eksternBehandlingRelasjonSlot)) } returnsArgument 0
+
+            // Act
+            val opprettetBehandling = opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
+
+            // Assert
+            assertThat(opprettetBehandling).isNotNull()
+            assertThat(eksternBehandlingRelasjonSlot.captured.id).isEqualTo(0L)
+            assertThat(eksternBehandlingRelasjonSlot.captured.internBehandlingId).isEqualTo(behandling.id)
+            assertThat(eksternBehandlingRelasjonSlot.captured.eksternBehandlingId).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingId)
+            assertThat(eksternBehandlingRelasjonSlot.captured.eksternBehandlingFagsystem).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingFagsystem)
+            assertThat(eksternBehandlingRelasjonSlot.captured.opprettetTidspunkt).isNotNull()
+        }
     }
 
-    @Test
-    fun `hentBehandling - skal hente behandling fra behandlingRepository`() {
-        val hentetBehandling = opprettBehandlingService.hentBehandling(behandling.id)
+    @Nested
+    inner class HentBehandling {
+        @Test
+        fun `skal hente behandling fra behandlingRepository`() {
+            // Act
+            val hentetBehandling = opprettBehandlingService.hentBehandling(behandling.id)
 
-        assertNotNull(hentetBehandling)
-        verify(exactly = 1) { behandlingRepository.hentBehandling(behandling.id) }
+            // Assert
+            assertThat(hentetBehandling).isNotNull()
+            verify(exactly = 1) { behandlingRepository.hentBehandling(behandling.id) }
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjonTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjonTest.kt
@@ -32,7 +32,7 @@ class EksternBehandlingRelasjonTest {
             assertThat(eksternBehandlingRelasjon.internBehandlingId).isEqualTo(internBehandlingId)
             assertThat(eksternBehandlingRelasjon.eksternBehandlingId).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingId)
             assertThat(eksternBehandlingRelasjon.eksternBehandlingFagsystem).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingFagsystem)
-            assertThat(eksternBehandlingRelasjon.opprettetTidspunkt).isNotNull()
+            assertThat(eksternBehandlingRelasjon.opprettetTid).isNotNull()
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjonTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/EksternBehandlingRelasjonTest.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import no.nav.familie.ks.sak.data.lagNyEksternBehandlingRelasjon
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class EksternBehandlingRelasjonTest {
+    @Nested
+    inner class OpprettFraNyEksternBehandlingRelasjon {
+        @Test
+        fun `skal opprette fra ny ekstern behandling relasjon`() {
+            // Arrange
+            val internBehandlingId = 0L
+
+            val nyEksternBehandlingRelasjon =
+                lagNyEksternBehandlingRelasjon(
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                )
+
+            // Act
+            val eksternBehandlingRelasjon =
+                EksternBehandlingRelasjon.opprettFraNyEksternBehandlingRelasjon(
+                    internBehandlingId = internBehandlingId,
+                    nyEksternBehandlingRelasjon = nyEksternBehandlingRelasjon,
+                )
+
+            // Assert
+            assertThat(eksternBehandlingRelasjon.id).isEqualTo(0L)
+            assertThat(eksternBehandlingRelasjon.internBehandlingId).isEqualTo(internBehandlingId)
+            assertThat(eksternBehandlingRelasjon.eksternBehandlingId).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingId)
+            assertThat(eksternBehandlingRelasjon.eksternBehandlingFagsystem).isEqualTo(nyEksternBehandlingRelasjon.eksternBehandlingFagsystem)
+            assertThat(eksternBehandlingRelasjon.opprettetTidspunkt).isNotNull()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/NyEksternBehandlingRelasjonTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/NyEksternBehandlingRelasjonTest.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ks.sak.kjerne.behandling.domene
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class NyEksternBehandlingRelasjonTest {
+    @Nested
+    inner class OpprettForKlagebehandling {
+        @Test
+        fun `skal opprette ekstern behandling relasjon for klagebehandling`() {
+            // Arrange
+            val klagebehandlingId = UUID.randomUUID()
+
+            // Act
+            val nyEksternBehandlingRelasjon = NyEksternBehandlingRelasjon.opprettForKlagebehandling(klagebehandlingId)
+
+            // Assert
+            assertThat(nyEksternBehandlingRelasjon.eksternBehandlingId).isEqualTo(klagebehandlingId.toString())
+            assertThat(nyEksternBehandlingRelasjon.eksternBehandlingFagsystem).isEqualTo(EksternBehandlingRelasjon.Fagsystem.KLAGE)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/statistikk/saksstatistikk/RelatertBehandlingTest.kt
@@ -1,72 +1,50 @@
 package no.nav.familie.ks.sak.statistikk.saksstatistikk
 
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.data.lagKlagebehandlingDto
+import no.nav.familie.ks.sak.data.lagEksternBehandlingRelasjon
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import java.time.LocalDateTime
-import java.util.UUID
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 class RelatertBehandlingTest {
     @Nested
     inner class FraKontantstøttebehandling {
         @Test
-        fun `skal lage relatert behandling fra kontatstøttebehandling`() {
+        fun `skal opprette fra kontantstøttebehandling`() {
             // Arrange
-            val kontantstøttebehandling =
-                lagBehandling(
-                    id = 1L,
-                    aktivertTidspunkt = LocalDateTime.now(),
-                )
+            val behandling = lagBehandling()
 
             // Act
-            val relatertBehandling = RelatertBehandling.fraKontantstøttebehandling(kontantstøttebehandling)
+            val relatertBehandling = RelatertBehandling.fraKontantstøttebehandling(behandling)
 
             // Assert
-            assertThat(relatertBehandling.id).isEqualTo(kontantstøttebehandling.id.toString())
+            assertThat(relatertBehandling.id).isEqualTo(behandling.id.toString())
             assertThat(relatertBehandling.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KS)
-            assertThat(relatertBehandling.vedtattTidspunkt).isEqualTo(kontantstøttebehandling.aktivertTidspunkt)
         }
     }
 
     @Nested
-    inner class FraKlagebehandling {
-        @Test
-        fun `skal lage relatert behandling fra klagebehandling`() {
+    inner class FraEksternBehandlingRelasjon {
+        @ParameterizedTest
+        @EnumSource(value = EksternBehandlingRelasjon.Fagsystem::class)
+        fun `skal opprette fra ekstern behandling relasjon`(
+            fagsystem: EksternBehandlingRelasjon.Fagsystem,
+        ) {
             // Arrange
-            val klagebehandling =
-                lagKlagebehandlingDto(
-                    id = UUID.randomUUID(),
-                    vedtaksdato = LocalDateTime.now(),
+            val eksternBehandlingRelasjon =
+                lagEksternBehandlingRelasjon(
+                    eksternBehandlingFagsystem = fagsystem,
                 )
 
             // Act
-            val relatertBehandling = RelatertBehandling.fraKlagebehandling(klagebehandling)
+            val relatertBehandling = RelatertBehandling.fraEksternBehandlingRelasjon(eksternBehandlingRelasjon)
 
             // Assert
-            assertThat(relatertBehandling.id).isEqualTo(klagebehandling.id.toString())
-            assertThat(relatertBehandling.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.KLAGE)
-            assertThat(relatertBehandling.vedtattTidspunkt).isEqualTo(klagebehandling.vedtaksdato)
-        }
-
-        @Test
-        fun `skal kaste exception om klagebehandling mangler vedtaksdato`() {
-            // Arrange
-            val klagebehandling =
-                lagKlagebehandlingDto(
-                    id = UUID.randomUUID(),
-                    vedtaksdato = null,
-                )
-
-            // Act & assert
-            val exception =
-                assertThrows<Feil> {
-                    RelatertBehandling.fraKlagebehandling(klagebehandling)
-                }
-            assertThat(exception.message).isEqualTo("Forventer vedtaksdato for klagebehandling ${klagebehandling.id}")
+            assertThat(relatertBehandling.id).isEqualTo(eksternBehandlingRelasjon.eksternBehandlingId)
+            assertThat(relatertBehandling.fagsystem).isEqualTo(RelatertBehandling.Fagsystem.valueOf(fagsystem.name))
         }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/EksternBehandlingRelasjonRepositoryTest.kt
@@ -1,0 +1,128 @@
+package no.nav.familie.ks.sak.kjerne.behandling
+
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagEksternBehandlingRelasjon
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
+import no.nav.familie.ks.sak.kjerne.behandling.domene.EksternBehandlingRelasjon
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+
+class EksternBehandlingRelasjonRepositoryTest(
+    @Autowired private val eksternBehandlingRelasjonRepository: EksternBehandlingRelasjonRepository,
+) : OppslagSpringRunnerTest() {
+    @Nested
+    inner class FindAllByInternBehandlingId {
+        @Test
+        fun `skal finne alle eksterne behandling relasjoner for intern behandling id`() {
+            // Arrange
+            val søker = opprettOgLagreSøker()
+            val fagsak = opprettOgLagreFagsak(lagFagsak(aktør = søker))
+            val behandling = opprettOgLagreBehandling(lagBehandling(fagsak = fagsak))
+
+            val eksternBehandlingRelasjon1 =
+                lagEksternBehandlingRelasjon(
+                    internBehandlingId = behandling.id,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                )
+
+            val eksternBehandlingRelasjon2 =
+                lagEksternBehandlingRelasjon(
+                    internBehandlingId = behandling.id,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.TILBAKEKREVING,
+                )
+
+            eksternBehandlingRelasjonRepository.saveAll(
+                listOf(
+                    eksternBehandlingRelasjon1,
+                    eksternBehandlingRelasjon2,
+                ),
+            )
+
+            // Act
+            val eksternBehandlingRelasjoner =
+                eksternBehandlingRelasjonRepository.findAllByInternBehandlingId(
+                    internBehandlingId = behandling.id,
+                )
+
+            // Assert
+            assertThat(eksternBehandlingRelasjoner).hasSize(2)
+            assertThat(eksternBehandlingRelasjoner).anySatisfy {
+                assertThat(it.id).isNotNull()
+                assertThat(it.internBehandlingId).isEqualTo(behandling.id)
+                assertThat(it.eksternBehandlingId).isEqualTo(eksternBehandlingRelasjon1.eksternBehandlingId)
+                assertThat(it.eksternBehandlingFagsystem).isEqualTo(eksternBehandlingRelasjon1.eksternBehandlingFagsystem)
+                assertThat(it.opprettetTidspunkt).isNotNull()
+            }
+            assertThat(eksternBehandlingRelasjoner).anySatisfy {
+                assertThat(it.id).isNotNull()
+                assertThat(it.internBehandlingId).isEqualTo(behandling.id)
+                assertThat(it.eksternBehandlingId).isEqualTo(eksternBehandlingRelasjon2.eksternBehandlingId)
+                assertThat(it.eksternBehandlingFagsystem).isEqualTo(eksternBehandlingRelasjon2.eksternBehandlingFagsystem)
+                assertThat(it.opprettetTidspunkt).isNotNull()
+            }
+        }
+
+        @Test
+        fun `skal returnere en tom liste om ingen ekstern behandling relasjon finnes for den etterspurte interne behandling iden`() {
+            // Arrange
+            val søker = opprettOgLagreSøker()
+            val fagsak = opprettOgLagreFagsak(lagFagsak(aktør = søker))
+            val behandling1 =
+                opprettOgLagreBehandling(
+                    lagBehandling(
+                        fagsak = fagsak,
+                        aktiv = false,
+                        resultat = Behandlingsresultat.INNVILGET,
+                        status = BehandlingStatus.AVSLUTTET,
+                    ),
+                )
+            val behandling2 =
+                opprettOgLagreBehandling(
+                    lagBehandling(
+                        fagsak = fagsak,
+                        aktiv = false,
+                        resultat = Behandlingsresultat.INNVILGET,
+                        status = BehandlingStatus.AVSLUTTET,
+                    ),
+                )
+
+            val eksternBehandlingRelasjon1 =
+                lagEksternBehandlingRelasjon(
+                    internBehandlingId = behandling2.id,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.KLAGE,
+                )
+
+            val eksternBehandlingRelasjon2 =
+                lagEksternBehandlingRelasjon(
+                    internBehandlingId = behandling2.id,
+                    eksternBehandlingId = UUID.randomUUID().toString(),
+                    eksternBehandlingFagsystem = EksternBehandlingRelasjon.Fagsystem.TILBAKEKREVING,
+                )
+
+            eksternBehandlingRelasjonRepository.saveAll(
+                listOf(
+                    eksternBehandlingRelasjon1,
+                    eksternBehandlingRelasjon2,
+                ),
+            )
+
+            // Act
+            val eksternBehandlingRelasjoner =
+                eksternBehandlingRelasjonRepository.findAllByInternBehandlingId(
+                    internBehandlingId = behandling1.id,
+                )
+
+            // Assert
+            assertThat(eksternBehandlingRelasjoner).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

Når man oppretter en revurdering klage fra en ekstern kilde ønsker man å opprette en `EksternBehandlingRelasjon` som tar vare på IDen til revurderingen, samt den eksterne behandlingsiden og det eksterne fagsystemet. Dette blir lagret som en `EksternBehandlingRelasjon` i databasen.

Når man skal sende saksstatistikk til DVH av en revurdering klage ønsker man å sende `relatertBehandlingId` og `relatertBehandlingFagsystem`. Man bruker nå `EksternBehandlingRelasjon` som blir lagret ned ved opprettelsen av klagerevurderingen til å populere disse feltene. 

Relatert familie-klage PR: https://github.com/navikt/familie-klage/pull/632
Relatert familie-ba-sak PR: https://github.com/navikt/familie-ba-sak/pull/5211

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta det ved behov.
