### PR TITLE
Valider tilbakekrevingsvalg når det besluttes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingService.kt
@@ -48,6 +48,8 @@ class TilbakekrevingService(
 ) {
     fun harÅpenTilbakekrevingsbehandling(fagsakId: Long): Boolean = tilbakekrevingKlient.harÅpenTilbakekrevingsbehandling(fagsakId)
 
+    fun finnTilbakekrevingsbehandling(behandlingId: Long): Tilbakekreving? = tilbakekrevingRepository.findByBehandlingId(behandlingId)
+
     @Transactional
     fun lagreTilbakekreving(
         tilbakekrevingRequestDto: TilbakekrevingRequestDto,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24809

Vi har fått en sak i BA sak produksjon der det eksisterte feilutbetaling på brukeren når saken ble sendt til godkjenning.
Men i mellomtiden så har det feilutbetalte beløpet blitt slettet hos økonomi, også har beslutter godkjent vedtaket.

Dette fører til en ugyldig state for behandlingen, og vi ønsker å forhindre dette. Denne fiksen er gjort for BA, nå overføres den til KS.

Jeg har derfor:

- Lagt til en ekstra validering når det besluttes at hvis det feilutbetalte beløpet er 0, og man har aktivt valgt å opprette en tilbakekrevingssak så skal det nå kastes en feil som ber SB1 å gå tilbake til behandlingsresultatet og gå videre.