### PR TITLE
Tillatt patching av identer som finnes på flere fagsaker så lenge fødesldato er riktig på alle fagsakene

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -109,21 +109,20 @@ internal class HåndterNyIdentServiceTest {
         }
 
         @Test
-        fun `håndterNyIdent kaster Feil når det eksisterer flere fagsaker for identer`() {
+        fun `håndterNyIdent skal ikke kaste feil når det eksisterer flere fagsaker for identer`() {
             // arrange
             every { fagsakService.hentFagsakerPåPerson(any()) } returns
                 listOf(
                     Fagsak(id = 1, aktør = gammelAktør),
                     Fagsak(id = 2, aktør = gammelAktør),
                 )
+            every { behandlingRepository.finnBehandlinger(any<Long>()) } returns listOf(gammelBehandling)
+            every { behandlingRepository.finnAktivtFødselsnummerForBehandlinger(any()) } returns listOf(1L to gammeltFnr)
 
-            // act & assert
-            val feil =
-                assertThrows<Feil> {
-                    håndterNyIdentService.håndterNyIdent(PersonIdent(nyttFnr))
-                }
+            val aktør = håndterNyIdentService.håndterNyIdent(PersonIdent(nyttFnr))
 
-            assertThat(feil.message).startsWith("Det eksisterer flere fagsaker på identer som skal merges")
+            assertThat(aktør).isNull()
+            verify(exactly = 1) { PatchMergetIdentTask.opprettTask(any()) }
         }
 
         @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
[NAV-24914](https://favro.com/organization/98c34fb974ce445eac854de0/?card=NAV-24914)
Vi har hatt en sjekk ved patching av fagsaker på at det er kun 1 fagsak og de casene som har mer enn 1 har måtte blitt tatt manuelt. Nå har vi patchet flere titalls manuelt og er ganske sikre på at patchescriptet fungere selv om ident finnes på flere fagsaker.

Så denne PR fjerner denne begrensningen og lar de automatisk patches.

https://github.com/navikt/familie-ba-sak/pull/5219
### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
