### PR TITLE
Fjern validering av barnets alder under 1 år og legg til begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
@@ -295,6 +295,10 @@ enum class NasjonalEllerFellesBegrunnelse : IBegrunnelse {
         override val begrunnelseType = BegrunnelseType.AVSLAG
         override val sanityApiNavn = "avslagFulltidsplassIBarnehageAugust2024"
     },
+    AVSLAG_BARN_UNDER_12_MÅNEDER {
+        override val begrunnelseType = BegrunnelseType.AVSLAG
+        override val sanityApiNavn = "avslagBarnUnder12maaneder"
+    },
     OPPHØR_VURDERING_IKKE_MEDLEM_I_FOLKETRYGDEN_I_5_ÅR {
         override val begrunnelseType = BegrunnelseType.OPPHØR
         override val sanityApiNavn = "opphorVurderingIkkeMedlemIFolketrygdenI5Aar"

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
@@ -13,7 +13,6 @@ import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
 import no.nav.familie.ks.sak.api.dto.tilSøknadGrunnlag
 import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
-import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.data.lagPdlPersonInfo
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 
@@ -191,25 +189,5 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
         verify { personOpplysningerService wasNot called }
         verify { arbeidsfordelingService wasNot called }
-    }
-
-    @Test
-    fun `utførSteg - skal kaste feil dersom barn fyller 1 år senere enn inneværende måned`() {
-        val søknadDto =
-            SøknadDto(
-                søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
-                barnaMedOpplysninger =
-                    listOf(
-                        BarnMedOpplysningerDto(
-                            ident = barn1.aktivFødselsnummer(),
-                            fødselsdato = LocalDate.now().minusMonths(11),
-                        ),
-                    ),
-                endringAvOpplysningerBegrunnelse = "",
-            )
-
-        assertThrows<FunksjonellFeil> {
-            registrereSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto, false))
-        }
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24724

Vi fjerner validering av at barn ikke kan være under 1 år når vi behandler behandlingene.
Det skal heller gis avslag på disse, som er derfor jeg også har lagt inn en ny begrunnelse.

<img width="470" alt="Screenshot 2025-04-22 at 18 44 43" src="https://github.com/user-attachments/assets/e2b28d97-0bec-4c3d-a833-658b14d0f386" />
