### PR TITLE
NAV-24943: Oppretter alltid fagsak ved journalføring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/OppgaveController.kt
@@ -140,8 +140,7 @@ class OppgaveController(
     @PostMapping(path = ["/{oppgaveId}/ferdigstillOgKnyttjournalpost"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun ferdigstillOppgaveOgKnyttJournalpostTilBehandling(
         @PathVariable oppgaveId: Long,
-        @RequestBody @Valid
-        request: FerdigstillOppgaveKnyttJournalpostDto,
+        @RequestBody @Valid request: FerdigstillOppgaveKnyttJournalpostDto,
     ): ResponseEntity<Ressurs<String?>> {
         tilgangService.validerTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/FerdigstillOppgaveKnyttJournalpostDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/FerdigstillOppgaveKnyttJournalpostDto.kt
@@ -13,7 +13,7 @@ data class FerdigstillOppgaveKnyttJournalpostDto(
     val tilknyttedeBehandlinger: List<TilknyttetBehandling> = emptyList(),
     val opprettOgKnyttTilNyBehandling: Boolean = false,
     val navIdent: String? = null,
-    val bruker: NavnOgIdent? = null,
+    val bruker: NavnOgIdent,
     val nyBehandlingstype: JournalføringBehandlingstype? = null,
     val nyBehandlingsårsak: BehandlingÅrsak? = null,
     val kategori: BehandlingKategori? = null,

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/journalføring/InnkommendeJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/journalføring/InnkommendeJournalføringService.kt
@@ -80,16 +80,9 @@ class InnkommendeJournalføringService(
         journalpostId: String,
         oppgaveId: String,
     ): String {
+        val fagsakId = fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(request.bruker.id)).id
         val tilknyttedeBehandlinger = request.tilknyttedeBehandlinger.toMutableList()
         val journalpost = integrasjonClient.hentJournalpost(journalpostId)
-
-        val fagsakId =
-            request.fagsakId
-                ?: if (request.opprettOgKnyttTilNyBehandling) {
-                    fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(request.bruker.id)).id
-                } else {
-                    throw Feil("Forventet fagsak ved journalføring for journalpostId=$journalpostId og oppgaveId=$oppgaveId")
-                }
 
         if (request.opprettOgKnyttTilNyBehandling) {
             if (request.nyBehandlingstype == JournalføringBehandlingstype.KLAGE) {
@@ -197,16 +190,9 @@ class InnkommendeJournalføringService(
         request: FerdigstillOppgaveKnyttJournalpostDto,
         oppgaveId: Long,
     ): String {
+        val fagsakId = fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(request.bruker.id)).id
         val tilknyttedeBehandlinger: MutableList<TilknyttetBehandling> = request.tilknyttedeBehandlinger.toMutableList()
         val journalpost = hentJournalpost(request.journalpostId)
-
-        val fagsakId =
-            request.fagsakId
-                ?: if (request.opprettOgKnyttTilNyBehandling) {
-                    fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(request.bruker!!.id)).id
-                } else {
-                    throw Feil("Forventet fagsak ved journalføring for journalpostId=${request.journalpostId} og oppgaveId=$oppgaveId")
-                }
 
         if (request.opprettOgKnyttTilNyBehandling) {
             if (request.nyBehandlingstype == JournalføringBehandlingstype.KLAGE) {
@@ -214,7 +200,7 @@ class InnkommendeJournalføringService(
                 val klageBehandlingId = klageService.opprettKlage(fagsakId, klageMottattDato)
                 tilknyttedeBehandlinger.add(TilknyttetBehandling(behandlingstype = JournalføringBehandlingstype.KLAGE, behandlingId = klageBehandlingId.toString()))
             } else {
-                if (request.bruker == null || request.navIdent == null || request.nyBehandlingstype == null || request.nyBehandlingsårsak == null || request.kategori == null) {
+                if (request.navIdent == null || request.nyBehandlingstype == null || request.nyBehandlingsårsak == null || request.kategori == null) {
                     secureLogger.info("Obligatoriske felter er ikke sendt med ved oppretting av ny behandling: $request")
                     throw Feil("Obligatoriske felter er ikke sendt med for oppretting av ny behandling for journalpostId=${request.journalpostId}. Se secure logs for detaljer.")
                 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -31,9 +31,12 @@ import no.nav.familie.kontrakter.felles.simulering.SimulertPostering
 import no.nav.familie.ks.sak.api.dto.BarnMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.BrevmottakerDto
 import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
+import no.nav.familie.ks.sak.api.dto.MinimalBehandlingResponsDto
+import no.nav.familie.ks.sak.api.dto.MinimalFagsakResponsDto
 import no.nav.familie.ks.sak.api.dto.RegistrerSøknadDto
 import no.nav.familie.ks.sak.api.dto.SøkerMedOpplysningerDto
 import no.nav.familie.ks.sak.api.dto.SøknadDto
+import no.nav.familie.ks.sak.api.dto.UtbetalingsperiodeResponsDto
 import no.nav.familie.ks.sak.barnehagelister.domene.Barnehagebarn
 import no.nav.familie.ks.sak.common.util.NullablePeriode
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
@@ -1671,4 +1674,25 @@ fun lagNyEksternBehandlingRelasjon(
     NyEksternBehandlingRelasjon(
         eksternBehandlingId = eksternBehandlingId,
         eksternBehandlingFagsystem = eksternBehandlingFagsystem,
+    )
+
+fun lagMinimalFagsakResponsDto(
+    opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
+    id: Long = 0L,
+    søkerFødselsnummer: String = "12345678903",
+    status: FagsakStatus = FagsakStatus.OPPRETTET,
+    underBehandling: Boolean = false,
+    løpendeKategori: BehandlingKategori? = null,
+    behandlinger: List<MinimalBehandlingResponsDto> = emptyList(),
+    gjeldendeUtbetalingsperioder: List<UtbetalingsperiodeResponsDto> = emptyList(),
+): MinimalFagsakResponsDto =
+    MinimalFagsakResponsDto(
+        opprettetTidspunkt = opprettetTidspunkt,
+        id = id,
+        søkerFødselsnummer = søkerFødselsnummer,
+        status = status,
+        underBehandling = underBehandling,
+        løpendeKategori = løpendeKategori,
+        behandlinger = behandlinger,
+        gjeldendeUtbetalingsperioder = gjeldendeUtbetalingsperioder,
     )


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-24943](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24943)

Etter en prat med Anna kom vi fram til at vi alltid skal opprette en fagsak på bruker.id når det journalføres. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta ved behov.
