### PR TITLE
nedgrader mockk til fungerende versjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <rest-assured.version>5.5.1</rest-assured.version>
         <mock-oauth2-server.version>2.1.10</mock-oauth2-server.version>
         <testcontainers.postgresql.version>1.20.6</testcontainers.postgresql.version>
-        <mockk.version>1.14.0</mockk.version>
+        <mockk.version>1.13.17</mockk.version>
         <wiremock.version>3.12.1</wiremock.version>
         <okhttp3.version>4.9.0</okhttp3.version> <!-- Må settes for å kjøre opp mock-oauth2-server i unit-tester -->
         <springmockk.version>4.0.2</springmockk.version>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Mockk 1.14.0 er ustabil så nedgraderer til 1.13.17 slik at vi ikke får problemer
Se https://nav-it.slack.com/archives/C01G9BA8JKZ/p1745327944852449
