### PR TITLE
Fikset transient instance must be saved before current operation ved avslag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeService.kt
@@ -205,9 +205,8 @@ class VedtaksperiodeService(
         vedtak: Vedtak,
     ) {
         vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(vedtak)
-        vedtaksperiodeHentOgPersisterService.lagre(
-            genererVedtaksperioderMedBegrunnelser(vedtak),
-        )
+        val genererteVedtaksperioderMedBegrunnelser = genererVedtaksperioderMedBegrunnelser(vedtak)
+        vedtaksperiodeHentOgPersisterService.lagre(genererteVedtaksperioderMedBegrunnelser)
     }
 
     fun genererVedtaksperioderMedBegrunnelser(
@@ -638,6 +637,7 @@ class VedtaksperiodeService(
                     EØSBegrunnelseDB(vedtaksperiodeMedBegrunnelser = this, begrunnelse = eøsBegrunnelse)
                 },
             )
+            vedtaksperiodeHentOgPersisterService.lagre(this)
         }
 
     private fun leggTilAvslagsbegrunnelseForUregistrertBarn(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -742,7 +742,7 @@ class StepDefinition {
         return VedtaksperiodeService(
             behandlingRepository = behandlingRepository,
             personopplysningGrunnlagService = mockPersonopplysningGrunnlagService(),
-            vedtaksperiodeHentOgPersisterService = mockk(),
+            vedtaksperiodeHentOgPersisterService = mockk(relaxed = true),
             vedtakRepository = mockk(),
             vilkårsvurderingRepository = vilkårsvurderingRepository,
             sanityService = mockk(),


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
NAV-24942
En behandling feilet ved generering av vedtaksperioder med:
Not-null property references a transient value - transient instance must be saved before current operation

Dette skjer fordi det ble lagd en ny Vedtaksperiode for avslag. Etterpå blir denne klonet og endret på, men den forrige var ikke lagret.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ x Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
