### PR TITLE
Vi kan ikke tillate innvilgelser som er lengre fram i tid enn 1mnd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSteg.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat
 
 import no.nav.familie.ks.sak.common.BehandlingId
+import no.nav.familie.ks.sak.common.ClockProvider
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
@@ -19,6 +20,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 class BehandlingsresultatSteg(
@@ -33,6 +35,7 @@ class BehandlingsresultatSteg(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val overgangsordningAndelService: OvergangsordningAndelService,
     private val adopsjonService: AdopsjonService,
+    private val clockProvider: ClockProvider,
 ) : IBehandlingSteg {
     override fun getBehandlingssteg(): BehandlingSteg = BehandlingSteg.BEHANDLINGSRESULTAT
 
@@ -55,6 +58,7 @@ class BehandlingsresultatSteg(
             endretUtbetalingMedAndeler = endretUtbetalingMedAndeler,
             personResultaterForBarn = personResultaterForBarn,
             adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(BehandlingId(behandlingId)),
+            dagensDato = LocalDate.now(clockProvider.get()),
         )
 
         if (behandling.erOvergangsordning()) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtils.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValidator
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import java.time.LocalDate
 
 object BehandlingsresultatValideringUtils {
     internal fun validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
@@ -36,6 +37,7 @@ object BehandlingsresultatValideringUtils {
         endretUtbetalingMedAndeler: List<EndretUtbetalingAndelMedAndelerTilkjentYtelse>,
         personResultaterForBarn: List<PersonResultat>,
         adopsjonerIBehandling: List<Adopsjon>,
+        dagensDato: LocalDate,
     ) {
         val alleBarnetsAlderVilkårResultater = personResultaterForBarn.flatMap { it.vilkårResultater.filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.BARNETS_ALDER } }
 
@@ -45,6 +47,7 @@ object BehandlingsresultatValideringUtils {
             personopplysningGrunnlag = personopplysningGrunnlag,
             alleBarnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater,
             adopsjonerIBehandling = adopsjonerIBehandling,
+            dagensDato = dagensDato,
         )
 
         // valider EndretUtbetalingAndel

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -90,7 +90,7 @@ object TilkjentYtelseValidator {
 
             if (stønadFom > dagensDato.toYearMonth().plusMonths(1)) {
                 throw FunksjonellFeil(
-                    melding = "Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 2 måneder fram i tid. Dette gjelder barn født ${relevantBarn.fødselsdato}.",
+                    melding = "Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 1 måned fram i tid. Dette gjelder barn født ${relevantBarn.fødselsdato}.",
                 )
             }
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -29,6 +29,7 @@ import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.tilPerioder
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Period
 import java.time.YearMonth
@@ -39,6 +40,7 @@ object TilkjentYtelseValidator {
         personopplysningGrunnlag: PersonopplysningGrunnlag,
         alleBarnetsAlderVilkårResultater: List<VilkårResultat>,
         adopsjonerIBehandling: List<Adopsjon>,
+        dagensDato: LocalDate,
     ) {
         val søker = personopplysningGrunnlag.søker
         val barna = personopplysningGrunnlag.barna
@@ -84,6 +86,12 @@ object TilkjentYtelseValidator {
                     "Kontantstøtte kan maks utbetales for $maksAntallMånederMedUtbetaling måneder. Du er i ferd med å utbetale $antallMånederUtbetalt måneder for barn med fnr ${aktør.aktivFødselsnummer()}. " +
                         "Kontroller datoene på vilkårene eller ta kontakt med Team BAKS"
                 throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
+            }
+
+            if (stønadFom > dagensDato.toYearMonth().plusMonths(1)) {
+                throw FunksjonellFeil(
+                    melding = "Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 2 måneder fram i tid. Dette gjelder barn født ${relevantBarn.fødselsdato}.",
+                )
             }
         }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.validerAtB
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -76,6 +77,7 @@ internal class TilkjentYtelseValidatorTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                     adopsjonerIBehandling = emptyList(),
+                    dagensDato = LocalDate.of(2025, 4, 1),
                 )
             }
         val feilmelding =
@@ -125,6 +127,7 @@ internal class TilkjentYtelseValidatorTest {
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                     adopsjonerIBehandling = emptyList(),
+                    dagensDato = LocalDate.of(2025, 4, 1),
                 )
             }
         val feilmelding =
@@ -166,6 +169,7 @@ internal class TilkjentYtelseValidatorTest {
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                     adopsjonerIBehandling = emptyList(),
+                    dagensDato = LocalDate.of(2025, 4, 1),
                 )
             }
         val feilmelding =
@@ -217,6 +221,7 @@ internal class TilkjentYtelseValidatorTest {
                 ),
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterBarn1 + barnetsAlderVilkårResultaterBarn2,
                 adopsjonerIBehandling = emptyList(),
+                dagensDato = LocalDate.of(2025, 4, 1),
             )
         }
     }
@@ -247,6 +252,7 @@ internal class TilkjentYtelseValidatorTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                     adopsjonerIBehandling = emptyList(),
+                    dagensDato = LocalDate.of(2025, 4, 1),
                 )
             }
 
@@ -287,6 +293,7 @@ internal class TilkjentYtelseValidatorTest {
                         ),
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                     adopsjonerIBehandling = emptyList(),
+                    dagensDato = LocalDate.of(2025, 4, 1),
                 )
             }
 
@@ -533,6 +540,7 @@ internal class TilkjentYtelseValidatorTest {
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                 adopsjonerIBehandling = emptyList(),
+                dagensDato = LocalDate.of(2025, 4, 1),
             )
         }
     }
@@ -561,6 +569,7 @@ internal class TilkjentYtelseValidatorTest {
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                 adopsjonerIBehandling = emptyList(),
+                dagensDato = LocalDate.of(2025, 4, 1),
             )
         }
     }
@@ -589,8 +598,41 @@ internal class TilkjentYtelseValidatorTest {
                 personopplysningGrunnlag = personopplysningGrunnlag,
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                 adopsjonerIBehandling = emptyList(),
+                dagensDato = LocalDate.of(2025, 4, 1),
             )
         }
+    }
+
+    @Test
+    fun `Det skal kastes feil dersom det forsøkes å innvilge mer enn 1 måned fram i tid`() {
+        val andeler =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    behandling = behandling,
+                    aktør = barn.aktør,
+                    stønadFom = YearMonth.of(2025, 6),
+                    stønadTom = YearMonth.of(2025, 7),
+                    sats = 5000,
+                ),
+            )
+
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(andeler)
+
+        val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 7, 1), adopsjonsdato = LocalDate.of(2023, 10, 10))
+
+        val feilmelding =
+            assertThrows<FunksjonellFeil> {
+                validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
+                    tilkjentYtelse = tilkjentYtelse,
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
+                    adopsjonerIBehandling = emptyList(),
+                    dagensDato = LocalDate.of(2025, 4, 1),
+                )
+            }.frontendFeilmelding
+
+        assertThat(feilmelding).isEqualTo("Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 2 måneder fram i tid. Dette gjelder barn født 2021-01-01.")
     }
 
     @Test
@@ -618,6 +660,7 @@ internal class TilkjentYtelseValidatorTest {
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
                     adopsjonerIBehandling = emptyList(),
+                    dagensDato = LocalDate.of(2025, 4, 1),
                 )
             }
         assertEquals(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -632,7 +632,7 @@ internal class TilkjentYtelseValidatorTest {
                 )
             }.frontendFeilmelding
 
-        assertThat(feilmelding).isEqualTo("Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 2 måneder fram i tid. Dette gjelder barn født 2021-01-01.")
+        assertThat(feilmelding).isEqualTo("Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 1 måned fram i tid. Dette gjelder barn født 2021-01-01.")
     }
 
     @Test


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25030

Vi kan ikke tillate innvilgelser lengre fram i tid enn 1mnd i kontantstøtte.
Dette har vært mulig opp til nå med nytt regelverk grunnet karantene perioden som gis, slik at ks innvilges 2mnd senere.