### PR TITLE
Vi skal tillate overlapp av andeler for februar 2025 også

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -189,11 +189,11 @@ object TilkjentYtelseValidator {
                     }
                 }.map { it.first }
 
-        val periodeMedTillatOverlappÉnMåned = MånedPeriode(YearMonth.of(2024, 8), YearMonth.of(2025, 2))
+        val periodeMedTillatOverlappEnMåned = MånedPeriode(YearMonth.of(2024, 8), YearMonth.of(2025, 2))
         return when {
             overlappendeMåneder.isEmpty() -> false
             overlappendeMåneder.size > 1 -> true
-            else -> !periodeMedTillatOverlappÉnMåned.inkluderer(overlappendeMåneder.first())
+            else -> !periodeMedTillatOverlappEnMåned.inkluderer(overlappendeMåneder.first())
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -189,7 +189,7 @@ object TilkjentYtelseValidator {
                     }
                 }.map { it.first }
 
-        val periodeMedTillatOverlappÉnMåned = MånedPeriode(YearMonth.of(2024, 8), YearMonth.of(2025, 1))
+        val periodeMedTillatOverlappÉnMåned = MånedPeriode(YearMonth.of(2024, 8), YearMonth.of(2025, 2))
         return when {
             overlappendeMåneder.isEmpty() -> false
             overlappendeMåneder.size > 1 -> true


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24803

Det er noen visse måneder vi tillater at det finnes overlapp. Februar 2025 skal være en av dem.