### PR TITLE
Sett riktig enhet på klagesaker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.klage
 
+import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
@@ -15,6 +16,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.UUID
@@ -47,7 +49,8 @@ class KlageService(
         }
 
         val aktivtFødselsnummer = fagsak.aktør.aktivFødselsnummer()
-        val enhetId = integrasjonClient.hentBehandlendeEnhetForPersonIdentMedRelasjoner(aktivtFødselsnummer).enhetId
+        val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
+        val enhetsnummer = integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(saksbehandlerIdent)).first().enhetsnummer
 
         return klageClient.opprettKlage(
             OpprettKlagebehandlingRequest(
@@ -56,7 +59,7 @@ class KlageService(
                 eksternFagsakId = fagsak.id.toString(),
                 fagsystem = Fagsystem.KS,
                 klageMottatt = klageMottattDato,
-                behandlendeEnhet = enhetId,
+                behandlendeEnhet = enhetsnummer,
                 behandlingsårsak = Klagebehandlingsårsak.ORDINÆR,
             ),
         )


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24892) 
Samme som [denne](https://github.com/navikt/familie-ba-sak/pull/5266) i BA-sak.

### 💰 Hva skal gjøres, og hvorfor?
Når det opprettes klage-behandling skal behandlende enhet automatisk settes til èn av enhetene saksbehandler har tilgang til, i stedet for enheten med geografisk tilgang til enheten. 
Henter ut saksbehandler og finner enhet via familie-integrasjoner.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har testet i dev 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
