### PR TITLE
Det skal giis fortsatt innvilget dersom bruker søker igjen uten relevante endringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -49,7 +49,7 @@ object BehandlingsresultatUtils {
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.ENDRING, Opphørsresultat.OPPHØRT) -> throw ugyldigBehandlingsresultatFeil("Endret og opphørt")
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.ENDRING, Opphørsresultat.FORTSATT_OPPHØRT) -> throw ugyldigBehandlingsresultatFeil("Endret og fortsatt opphørt")
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.OPPHØRT) -> throw ugyldigBehandlingsresultatFeil("Opphørt")
-            sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT) -> throw ugyldigBehandlingsresultatFeil("Fortsatt opphørt")
+            sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT) -> FORTSATT_OPPHØRT
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.IKKE_OPPHØRT) -> FORTSATT_INNVILGET
 
             sjekkResultat(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.OPPHØRT) -> INNVILGET_ENDRET_OG_OPPHØRT

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -49,7 +49,7 @@ object BehandlingsresultatUtils {
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.ENDRING, Opphørsresultat.OPPHØRT) -> throw ugyldigBehandlingsresultatFeil("Endret og opphørt")
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.ENDRING, Opphørsresultat.FORTSATT_OPPHØRT) -> throw ugyldigBehandlingsresultatFeil("Endret og fortsatt opphørt")
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.OPPHØRT) -> throw ugyldigBehandlingsresultatFeil("Opphørt")
-            sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT) -> FORTSATT_OPPHØRT
+            sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT) -> FORTSATT_INNVILGET // Ved søknad og opphørsresultat fortsatt opphørt skal vi gi fortsatt innvilget pga ingen hjemmel for å avslå
             sjekkResultat(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.IKKE_OPPHØRT) -> FORTSATT_INNVILGET
 
             sjekkResultat(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.OPPHØRT) -> INNVILGET_ENDRET_OG_OPPHØRT

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -52,6 +52,7 @@ internal class BehandlingsresultatUtilsTest {
         fun hentKombinasjonerOgBehandlingsResultat() =
             Stream.of(
                 Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.IKKE_OPPHØRT, Behandlingsresultat.FORTSATT_INNVILGET),
+                Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT, Behandlingsresultat.FORTSATT_OPPHØRT),
                 Arguments.of(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.OPPHØRT, Behandlingsresultat.INNVILGET_ENDRET_OG_OPPHØRT),
                 Arguments.of(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.FORTSATT_OPPHØRT, Behandlingsresultat.INNVILGET_OG_ENDRET),
                 Arguments.of(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.IKKE_OPPHØRT, Behandlingsresultat.INNVILGET_OG_ENDRET),
@@ -82,7 +83,6 @@ internal class BehandlingsresultatUtilsTest {
         fun hentUgyldigeKombinasjoner() =
             Stream.of(
                 Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.OPPHØRT),
-                Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT),
                 Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.ENDRING, Opphørsresultat.OPPHØRT),
                 Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.ENDRING, Opphørsresultat.FORTSATT_OPPHØRT),
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -52,7 +52,7 @@ internal class BehandlingsresultatUtilsTest {
         fun hentKombinasjonerOgBehandlingsResultat() =
             Stream.of(
                 Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.IKKE_OPPHØRT, Behandlingsresultat.FORTSATT_INNVILGET),
-                Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT, Behandlingsresultat.FORTSATT_OPPHØRT),
+                Arguments.of(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER, Endringsresultat.INGEN_ENDRING, Opphørsresultat.FORTSATT_OPPHØRT, Behandlingsresultat.FORTSATT_INNVILGET),
                 Arguments.of(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.OPPHØRT, Behandlingsresultat.INNVILGET_ENDRET_OG_OPPHØRT),
                 Arguments.of(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.FORTSATT_OPPHØRT, Behandlingsresultat.INNVILGET_OG_ENDRET),
                 Arguments.of(Søknadsresultat.INNVILGET, Endringsresultat.ENDRING, Opphørsresultat.IKKE_OPPHØRT, Behandlingsresultat.INNVILGET_OG_ENDRET),

--- a/src/test/resources/cucumber/fremtidig-opphør.feature
+++ b/src/test/resources/cucumber/fremtidig-opphør.feature
@@ -134,3 +134,69 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
     Så forvent følgende vedtaksperioder på behandling 2
       | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
       | 01.06.2024 |          | OPPHØR             |           |
+
+  Scenario: Dersom bruker søker igjen og det ikke er noen relevante endringer så skal man få fortsatt opphørt  dersom man fikk opphørt sist gang
+
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | SØKNAD           | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 13.12.1982  |
+      | 1            | 2       | BARN       | 02.04.2024  |
+      | 2            | 1       | SØKER      | 13.12.1982  |
+      | 2            | 2       | BARN       | 02.04.2024  |
+
+    Og følgende dagens dato 12.05.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 20.08.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 02.04.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 02.04.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 02.04.2024 | 31.07.2025 | OPPFYLT      | Nei                  |                      |                  | Ja                                    |              |
+      | 2       | BARNETS_ALDER                |                  | 02.04.2025 | 02.12.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 20.08.2022 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 02.04.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 02.04.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 02.04.2024 | 31.07.2025 | OPPFYLT      | Nei                  |                      |                  | Ja                                    |              |
+      | 2       | BARNETS_ALDER                |                  | 02.04.2025 | 02.12.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.05.2025 | 31.07.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og når behandlingsresultatet er utledet for behandling 2
+
+    Så forvent at behandlingsresultatet er FORTSATT_OPPHØRT på behandling 2
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
+      | 01.08.2025 |          | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                   | Ugyldige begrunnelser |
+      | 01.08.2025 |          | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.08.2025 til -
+      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 02.04.24             | 1           |         | 0     | august 2025                          | false                  | 0                           | juli 2025                      |

--- a/src/test/resources/cucumber/fremtidig-opphør.feature
+++ b/src/test/resources/cucumber/fremtidig-opphør.feature
@@ -135,7 +135,7 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
       | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
       | 01.06.2024 |          | OPPHØR             |           |
 
-  Scenario: Dersom bruker søker igjen og det ikke er noen relevante endringer så skal man få fortsatt opphørt  dersom man fikk opphørt sist gang
+  Scenario: Dersom bruker søker igjen og det ikke er noen relevante endringer så skal man få fortsatt innvilget dersom man fikk opphørt sist gang
 
     Gitt følgende fagsaker
       | FagsakId |
@@ -185,18 +185,22 @@ Egenskap: Fremtidig opphør - søker har meldt ifra om fremtidig barnehageplass
 
     Og når behandlingsresultatet er utledet for behandling 2
 
-    Så forvent at behandlingsresultatet er FORTSATT_OPPHØRT på behandling 2
+    Så forvent at behandlingsresultatet er FORTSATT_INNVILGET på behandling 2
 
     Og vedtaksperioder er laget for behandling 2
 
     Så forvent følgende vedtaksperioder på behandling 2
-      | Fra dato   | Til dato | Vedtaksperiodetype | Kommentar |
-      | 01.08.2025 |          | OPPHØR             |           |
+      | Fra dato | Til dato | Vedtaksperiodetype | Kommentar |
+      |          |          | FORTSATT_INNVILGET |           |
 
     Så forvent at følgende begrunnelser er gyldige for behandling 2
-      | Fra dato   | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                   | Ugyldige begrunnelser |
-      | 01.08.2025 |          | OPPHØR             |                                | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |                       |
+      | Fra dato | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                                 | Ugyldige begrunnelser |
+      |          |          | FORTSATT_INNVILGET |                                | FORTSATT_INNVILGET_HAR_KONTANTSTOTTEN_DET_ER_SOKT_OM |                       |
 
-    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.08.2025 til -
-      | Begrunnelse                            | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
-      | OPPHØR_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS | STANDARD | 02.04.24             | 1           |         | 0     | august 2025                          | false                  | 0                           | juli 2025                      |
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato | Til dato | Standardbegrunnelser                                 | Eøsbegrunnelser | Fritekster |
+      |          |          | FORTSATT_INNVILGET_HAR_KONTANTSTOTTEN_DET_ER_SOKT_OM |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode - til -
+      | Begrunnelse                                          | Type     | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
+      | FORTSATT_INNVILGET_HAR_KONTANTSTOTTEN_DET_ER_SOKT_OM | STANDARD | 02.04.24             | 1           |         | 7 500 |                                      | false                  | 0                           |                                |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25108

Behandling 1 fikk opphørt grunnet fremtidig opphør i August.
Nå har bruker søkt på nytt, men det er ingen relevante endringer og SB får derfor feilmelding når det ikke gjøres avslag.

I denne saken er det fortsatt en løpende utbetaling, men det er lagt inn et framtidig opphør fra august.

I en sak der søker har løpende utbetaling, og sender en ny søknad, så endres ikke noen av vilkårene, og behandlingsresultatet skal bli fortsatt innvilget. De får da et fortsatt opphørt innvilget, med en begrunnelse for hvorfor de fortsatt får utbetalingen. Vi har ikke hjemmel for å avslå.
Hvis dette hadde vært en sak der utbetalingen allerede var opphørt, hadde det vært helt riktig å gi avslag, for da er ikke vilkårene lenger oppfylt (f.eks pga alder eller bhg plass).