### PR TITLE
Endrer på logikken slik at det ikke er mulig å legge til perioder med fom/tom som er oppfylt samtidig som perioder med avslag uten dato. Og vice versa

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -189,13 +189,13 @@ private fun validerAvslagUtenPeriodeMedLøpende(
 
         endretVilkårResultat.erAvslagUtenPeriode() && filtrerteVilkårResultater.any { it.resultat == Resultat.OPPFYLT } ->
             throw FunksjonellFeil(
-                "Finnes oppfylte perioder ved forsøk på å legge til avslag uten periode ",
+                "Finnes oppfylte perioder ved forsøk på å legge til avslag uten periode.",
                 "Du kan ikke legge til avslagperiode uten datoer fordi det finnes oppfylte perioder på vilkåret. Disse må fjernes først.",
             )
 
         endretVilkårResultat.resultat == Resultat.OPPFYLT && filtrerteVilkårResultater.any { it.erAvslagUtenPeriode() } ->
             throw FunksjonellFeil(
-                "Finnes avslag uten periode ved forsøk på å legge til løpende oppfylt",
+                "Finnes avslag uten periode ved forsøk på å legge til oppfylt periode.",
                 "Du kan ikke legge til perioden fordi det er vurdert avslag uten datoer på vilkåret. Denne må fjernes først.",
             )
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -187,16 +187,16 @@ private fun validerAvslagUtenPeriodeMedLøpende(
         // For bor med søker-vilkåret kan avslag og innvilgelse være overlappende, da man kan f.eks. avslå full kontantstøtte, men innvilge delt
         endretVilkårResultat.vilkårType == Vilkår.BOR_MED_SØKER -> return
 
-        endretVilkårResultat.erAvslagUtenPeriode() && filtrerteVilkårResultater.any { it.resultat == Resultat.OPPFYLT && it.harFremtidigTom() } ->
+        endretVilkårResultat.erAvslagUtenPeriode() && filtrerteVilkårResultater.any { it.resultat == Resultat.OPPFYLT } ->
             throw FunksjonellFeil(
-                "Finnes løpende oppfylt ved forsøk på å legge til avslag uten periode ",
-                "Du kan ikke legge til avslag uten datoer fordi det finnes oppfylt løpende periode på vilkåret.",
+                "Finnes oppfylte perioder ved forsøk på å legge til avslag uten periode ",
+                "Du kan ikke legge til avslagperiode uten datoer fordi det finnes oppfylte perioder på vilkåret. Disse må fjernes først.",
             )
 
-        endretVilkårResultat.harFremtidigTom() && filtrerteVilkårResultater.any { it.erAvslagUtenPeriode() } ->
+        endretVilkårResultat.resultat == Resultat.OPPFYLT && filtrerteVilkårResultater.any { it.erAvslagUtenPeriode() } ->
             throw FunksjonellFeil(
                 "Finnes avslag uten periode ved forsøk på å legge til løpende oppfylt",
-                "Du kan ikke legge til løpende periode fordi det er vurdert avslag uten datoer på vilkåret.",
+                "Du kan ikke legge til perioden fordi det er vurdert avslag uten datoer på vilkåret. Denne må fjernes først.",
             )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -1,29 +1,28 @@
 package no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering
 
 import io.mockk.mockk
-import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.api.dto.VilkårResultatDto
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.lagVilkårsvurderingOppfylt
-import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class VilkårsvurderingUtilsTest {
     private val januar = LocalDate.of(2022, 1, 1)
     private val april = LocalDate.of(2022, 4, 1)
     private val august = LocalDate.of(2022, 8, 1)
     private val desember = LocalDate.of(2022, 12, 1)
-
-    private val søker = randomAktør()
-    private val barn1 = randomAktør()
-
-    private val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
     @Test
     fun `tilpassVilkårForEndretVilkår - skal splitte gammelt vilkår og oppdatere behandling ved ny periode i midten`() {
@@ -364,5 +363,101 @@ class VilkårsvurderingUtilsTest {
         val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
         assertEquals(LocalDate.of(2024, 7, 31), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
+    }
+
+    @Test
+    fun `endreVilkårResultat - Skal kastes funksjonell feil hvis det forsøkes å lage en oppfylt periode mens det finnes en avslagsperiode uten periode`() {
+        val person = mockk<PersonResultat>(relaxed = true)
+
+        val eksisterendeVilkårResultat =
+            listOf(
+                lagVilkårResultat(
+                    id = 1,
+                    personResultat = person,
+                    behandlingId = 1,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_OPPFYLT,
+                    vilkårType = Vilkår.BARNEHAGEPLASS,
+                    erEksplisittAvslagPåSøknad = true,
+                ),
+                lagVilkårResultat(
+                    id = 2,
+                    personResultat = person,
+                    behandlingId = 1,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_VURDERT,
+                    vilkårType = Vilkår.BARNEHAGEPLASS,
+                ),
+            )
+
+        val vilkårDto =
+            VilkårResultatDto(
+                id = 2,
+                vilkårType = Vilkår.BARNEHAGEPLASS,
+                periodeFom = januar,
+                periodeTom = desember,
+                resultat = Resultat.OPPFYLT,
+                endretTidspunkt = LocalDateTime.now(),
+                behandlingId = 1,
+                begrunnelse = "test",
+                endretAv = "VL",
+            )
+
+        val frontendFeilmelding =
+            assertThrows<FunksjonellFeil> {
+                endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
+            }.frontendFeilmelding
+
+        assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til perioden fordi det er vurdert avslag uten datoer på vilkåret. Denne må fjernes først.")
+    }
+
+    @Test
+    fun `endreVilkårResultat - Skal kastes funksjonell feil hvis det forsøkes å lage en avslagsperiode uten dato mens det finnes en oppfylt periode`() {
+        val person = mockk<PersonResultat>(relaxed = true)
+
+        val eksisterendeVilkårResultat =
+            listOf(
+                lagVilkårResultat(
+                    id = 1,
+                    personResultat = person,
+                    behandlingId = 1,
+                    periodeFom = januar,
+                    periodeTom = desember,
+                    resultat = Resultat.OPPFYLT,
+                    vilkårType = Vilkår.BARNEHAGEPLASS,
+                ),
+                lagVilkårResultat(
+                    id = 2,
+                    personResultat = person,
+                    behandlingId = 1,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_VURDERT,
+                    vilkårType = Vilkår.BARNEHAGEPLASS,
+                ),
+            )
+
+        val vilkårDto =
+            VilkårResultatDto(
+                id = 2,
+                vilkårType = Vilkår.BARNEHAGEPLASS,
+                periodeFom = null,
+                periodeTom = null,
+                resultat = Resultat.IKKE_OPPFYLT,
+                endretTidspunkt = LocalDateTime.now(),
+                behandlingId = 1,
+                begrunnelse = "test",
+                endretAv = "VL",
+                erEksplisittAvslagPåSøknad = true,
+            )
+
+        val frontendFeilmelding =
+            assertThrows<FunksjonellFeil> {
+                endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
+            }.frontendFeilmelding
+
+        assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til avslagperiode uten datoer fordi det finnes oppfylte perioder på vilkåret. Disse må fjernes først.")
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24708

Vi har en bug der hvis man har en avslagsperiode uten dato, og legger til en oppfylt periode uten tom dato, så kræsjer ting.
VI har en bug der hvis man har en oppfylt periode uten tom dato så legger til en avslagsperiode uten dato, så kræsjer ting.

Fikser dette ved å skuddsikre valideringen vår bedre.
Så lenge man har en avslagsperiode uten dato så kan man ikke legge på flere oppfylte perioder før avslagsperioden fjernes. Også vice versa