### PR TITLE
Fiks ustabile enhetstester ved å unmoccke objectet sikkerhetcontext i alle testklasser man mockker den

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClientTest.kt
@@ -9,6 +9,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
@@ -29,6 +30,7 @@ import no.nav.familie.ks.sak.integrasjon.lagJournalpost
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -45,6 +47,14 @@ internal class IntegrasjonClientTest {
         wiremockServerItem = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
         wiremockServerItem.start()
         integrasjonClient = IntegrasjonClient(URI.create(wiremockServerItem.baseUrl()), restOperations)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        wiremockServerItem = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
+        wiremockServerItem.start()
+        integrasjonClient = IntegrasjonClient(URI.create(wiremockServerItem.baseUrl()), restOperations)
+        unmockkObject(SikkerhetContext)
     }
 
     @Test

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -63,6 +63,7 @@ import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ks.sak.statistikk.saksstatistikk.SendBehandlinghendelseTilDvhV2Task
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -163,6 +164,11 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
                 every { taskService.save(any()) } returns mockk()
             }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
     }
 
     @Test


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25143

Ved bygg av ks-sak så dukker denne feilen opp ofte:
```
java.lang.AssertionError: Verification failed: call 1 of 3: SikkerhetContext(object SikkerhetContext).hentSaksbehandlerNavn()). 56 matching calls found, but needs exactly 1 calls
Calls:
1) SikkerhetContext(object SikkerhetContext).erSystemKontekst()
2) SikkerhetContext(object SikkerhetContext).hentSaksbehandler()
3) SikkerhetContext(object SikkerhetContext).hentSaksbehandler()
4) SikkerhetContext(object SikkerhetContext).hentSaksbehandler()
5) SikkerhetContext(object SikkerhetContext).hentSaksbehandler()
```

Det blokkerer bygg og er sykt irriterende.
Det jeg tror skjer er at man i mange av testene våres bruker mockkObject på SikkerhetContext objektet, men når man er ferdig, så unmockker man den ikke. Dette påvirker de resterende testene, ihvertfall de som ønsker å sjekke at noen spesifikke metoder har kjørt X antall ganger.

I alle testklasser som bruker mockkObject(sikkerhetcontext) lager jeg derfor en teardown metode som unmockker den.


