### PR TITLE
Bruk Azure AD ved sjekk av enhet sb har tilgang til

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Nav Familie-->
         <prosessering.version>2.20250409144459_df36248</prosessering.version>
-        <felles-kontrakter.version>3.0_20250401151544_aae9e33</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250520105353_6584047</felles-kontrakter.version>
         <felles.version>3.20250422130733_4d831f9</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250422132745_dfaa902</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.stønadsstatistikk>2.0_20250422132745_dfaa902</familie.kontrakter.stønadsstatistikk>

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
@@ -16,8 +16,6 @@ import no.nav.familie.kontrakter.felles.dokdist.DistribuerJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokdist.Distribusjonstidspunkt
 import no.nav.familie.kontrakter.felles.dokdist.Distribusjonstype
 import no.nav.familie.kontrakter.felles.dokdist.ManuellAdresse
-import no.nav.familie.kontrakter.felles.enhet.Enhet
-import no.nav.familie.kontrakter.felles.enhet.HentEnheterNavIdentHarTilgangTilRequest
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
 import no.nav.familie.kontrakter.felles.journalpost.TilgangsstyrtJournalpost
@@ -29,6 +27,7 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
+import no.nav.familie.kontrakter.felles.saksbehandler.SaksbehandlerGrupper
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.familie.ks.sak.api.dto.ManuellAdresseInfo
 import no.nav.familie.ks.sak.api.dto.OppdaterJournalpostRequestDto
@@ -36,7 +35,7 @@ import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordel
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjeneste
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjenesteRessurs
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjenesteUtenRespons
-import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.Companion.erGyldigBehandlendeKontantstøtteEnhet
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -281,15 +280,26 @@ class IntegrasjonClient(
         }
     }
 
-    fun hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent: NavIdent): List<Enhet> {
-        val uri = URI.create("$integrasjonUri/enhetstilganger")
-        return kallEksternTjenesteRessurs<List<Enhet>>(
-            tjeneste = "enhetstilganger",
-            uri = uri,
-            formål = "Hent enheter en NAV-ident har tilgang til",
-        ) {
-            postForEntity(uri, HentEnheterNavIdentHarTilgangTilRequest(navIdent, Tema.KON))
-        }.filter { erGyldigBehandlendeKontantstøtteEnhet(it.enhetsnummer) }
+    fun hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent: NavIdent): List<KontantstøtteEnhet> {
+        val uri =
+            UriComponentsBuilder
+                .fromUri(integrasjonUri)
+                .pathSegment("saksbehandler", navIdent.ident, "grupper")
+                .build()
+                .toUri()
+
+        val saksbehandlerSineGrupper =
+            kallEksternTjenesteRessurs<SaksbehandlerGrupper>(
+                tjeneste = "saksbehandler",
+                uri = uri,
+                formål = "Henter gruppene til saksbehandler",
+            ) {
+                getForEntity(uri)
+            }
+
+        return saksbehandlerSineGrupper.value.mapNotNull { navn ->
+            KontantstøtteEnhet.entries.find { it.gruppenavn == navn.displayName }
+        }
     }
 
     @Cacheable("enhet", cacheManager = "kodeverkCache")

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/KontantstøtteEnhet.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/KontantstøtteEnhet.kt
@@ -3,15 +3,16 @@ package no.nav.familie.ks.sak.kjerne.arbeidsfordeling
 enum class KontantstøtteEnhet(
     val enhetsnummer: String,
     val enhetsnavn: String,
+    val gruppenavn: String,
 ) {
-    VIKAFOSSEN("2103", "NAV Vikafossen"),
-    DRAMMEN("4806", "NAV Familie- og pensjonsytelser Drammen"),
-    VADSØ("4820", "NAV Familie- og pensjonsytelser Vadsø"),
-    OSLO("4833", "NAV Familie- og pensjonsytelser Oslo 1"),
-    STORD("4842", "NAV Familie- og pensjonsytelser Stord"),
-    STEINKJER("4817", "NAV Familie- og pensjonsytelser Steinkjer"),
-    BERGEN("4812", "NAV Familie- og pensjonsytelser Bergen"),
-    MIDLERTIDIG_ENHET("4863", "Midlertidig enhet"),
+    VIKAFOSSEN("2103", "NAV Vikafossen", "0000-GA-ENHET_2103"),
+    DRAMMEN("4806", "NAV Familie- og pensjonsytelser Drammen", "0000-GA-ENHET_4806"),
+    VADSØ("4820", "NAV Familie- og pensjonsytelser Vadsø", "0000-GA-ENHET_4820"),
+    OSLO("4833", "NAV Familie- og pensjonsytelser Oslo 1", "0000-GA-ENHET_4833"),
+    STORD("4842", "NAV Familie- og pensjonsytelser Stord", "0000-GA-ENHET_4842"),
+    STEINKJER("4817", "NAV Familie- og pensjonsytelser Steinkjer", "0000-GA-ENHET_4817"),
+    BERGEN("4812", "NAV Familie- og pensjonsytelser Bergen", "0000-GA-ENHET_4812"),
+    MIDLERTIDIG_ENHET("4863", "Midlertidig enhet", "0000-GA-ENHET_4863"),
     ;
 
     override fun toString(): String = "$enhetsnavn ($enhetsnummer)"

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ks.sak.kjerne.arbeidsfordeling
 
 import no.nav.familie.kontrakter.felles.NavIdent
-import no.nav.familie.kontrakter.felles.enhet.Enhet
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.containsExactly
@@ -130,7 +129,7 @@ class TilpassArbeidsfordelingService(
         )
     }
 
-    private fun hentEnheterNavIdentHarTilgangTil(navIdent: NavIdent): List<Enhet> {
+    private fun hentEnheterNavIdentHarTilgangTil(navIdent: NavIdent): List<KontantstøtteEnhet> {
         val enheterNavIdentHarTilgangTil = integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent)
         if (enheterNavIdentHarTilgangTil.isEmpty()) {
             logger.warn("Nav-Ident har ikke tilgang til noen enheter. Se SecureLogs for detaljer.")
@@ -145,7 +144,7 @@ class TilpassArbeidsfordelingService(
         throw Feil("Kan ikke håndtere $kontantstøtteEnhet om man mangler NAV-ident.")
     }
 
-    private fun List<Enhet>.inneholderKunVikafossen(): Boolean = this.map { it.enhetsnummer }.containsExactly(KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer)
+    private fun List<KontantstøtteEnhet>.inneholderKunVikafossen(): Boolean = this.map { it.enhetsnummer }.containsExactly(KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer)
 
     private fun NavIdent.erSystemIdent(): Boolean = this.ident == SYSTEM_FORKORTELSE
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClientTest.kt
@@ -62,8 +62,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/oppgave/v4"))
-                .willReturn(WireMock.okJson(readFile("hentOppgaverEnkelKONResponse.json"))),
+                .post(urlEqualTo("/oppgave/v4"))
+                .willReturn(okJson(readFile("hentOppgaverEnkelKONResponse.json"))),
         )
 
         // Act
@@ -80,8 +80,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/arbeidsfordeling/enhet/KON"))
-                .willReturn(WireMock.okJson(readFile("hentBehandlendeEnhetEnkelResponse.json"))),
+                .post(urlEqualTo("/arbeidsfordeling/enhet/KON"))
+                .willReturn(okJson(readFile("hentBehandlendeEnhetEnkelResponse.json"))),
         )
 
         // Act
@@ -98,8 +98,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .get(WireMock.urlEqualTo("/arbeidsfordeling/nav-kontor/200"))
-                .willReturn(WireMock.okJson(readFile("hentEnhetEnkelResponse.json"))),
+                .get(urlEqualTo("/arbeidsfordeling/nav-kontor/200"))
+                .willReturn(okJson(readFile("hentEnhetEnkelResponse.json"))),
         )
 
         // Act
@@ -117,8 +117,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .get(WireMock.urlEqualTo("/oppgave/200"))
-                .willReturn(WireMock.okJson(readFile("finnOppgaveMedIdEnkelResponse.json"))),
+                .get(urlEqualTo("/oppgave/200"))
+                .willReturn(okJson(readFile("finnOppgaveMedIdEnkelResponse.json"))),
         )
 
         // Act
@@ -137,8 +137,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/tilgang/v2/personer"))
-                .willReturn(WireMock.okJson(readFile("sjekkTilgangTilPersonerResponseMedTilgangTilAlle.json"))),
+                .post(urlEqualTo("/tilgang/v2/personer"))
+                .willReturn(okJson(readFile("sjekkTilgangTilPersonerResponseMedTilgangTilAlle.json"))),
         )
 
         mockkObject(SikkerhetContext)
@@ -157,8 +157,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/tilgang/v2/personer"))
-                .willReturn(WireMock.okJson(readFile("sjekkTilgangTilPersonerResponseMedIkkeTilgangTilAlle.json"))),
+                .post(urlEqualTo("/tilgang/v2/personer"))
+                .willReturn(okJson(readFile("sjekkTilgangTilPersonerResponseMedIkkeTilgangTilAlle.json"))),
         )
 
         mockkObject(SikkerhetContext)
@@ -179,8 +179,8 @@ internal class IntegrasjonClientTest {
 
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/oppgave/200/fordel?saksbehandler=$saksbehandler"))
-                .willReturn(WireMock.okJson(readFile("fordelOppgaveEnkelResponse.json"))),
+                .post(urlEqualTo("/oppgave/200/fordel?saksbehandler=$saksbehandler"))
+                .willReturn(okJson(readFile("fordelOppgaveEnkelResponse.json"))),
         )
 
         // Act
@@ -197,8 +197,8 @@ internal class IntegrasjonClientTest {
 
         wiremockServerItem.stubFor(
             WireMock
-                .patch(WireMock.urlEqualTo("/oppgave/200/enhet/testenhet?fjernMappeFraOppgave=true&nullstillTilordnetRessurs=true"))
-                .willReturn(WireMock.okJson(readFile("fordelOppgaveEnkelResponse.json"))),
+                .patch(urlEqualTo("/oppgave/200/enhet/testenhet?fjernMappeFraOppgave=true&nullstillTilordnetRessurs=true"))
+                .willReturn(okJson(readFile("fordelOppgaveEnkelResponse.json"))),
         )
 
         // Act
@@ -215,8 +215,8 @@ internal class IntegrasjonClientTest {
 
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/arkiv/dokument/testid/logiskVedlegg"))
-                .willReturn(WireMock.okJson(readFile("logiskVedleggEnkelResponse.json"))),
+                .post(urlEqualTo("/arkiv/dokument/testid/logiskVedlegg"))
+                .willReturn(okJson(readFile("logiskVedleggEnkelResponse.json"))),
         )
 
         // Act
@@ -231,8 +231,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .delete(WireMock.urlEqualTo("/arkiv/dokument/testDokumentId/logiskVedlegg/testId"))
-                .willReturn(WireMock.okJson(readFile("logiskVedleggEnkelResponse.json"))),
+                .delete(urlEqualTo("/arkiv/dokument/testDokumentId/logiskVedlegg/testId"))
+                .willReturn(okJson(readFile("logiskVedleggEnkelResponse.json"))),
         )
 
         // Act
@@ -249,8 +249,8 @@ internal class IntegrasjonClientTest {
 
         wiremockServerItem.stubFor(
             WireMock
-                .put(WireMock.urlEqualTo("/arkiv/v2/testJournalpostId"))
-                .willReturn(WireMock.okJson(readFile("oppdaterJournalpostEnkelResponse.json"))),
+                .put(urlEqualTo("/arkiv/v2/testJournalpostId"))
+                .willReturn(okJson(readFile("oppdaterJournalpostEnkelResponse.json"))),
         )
 
         // Act
@@ -265,8 +265,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .put(WireMock.urlEqualTo("/arkiv/v2/testJournalPost/ferdigstill?journalfoerendeEnhet=testEnhet"))
-                .willReturn(WireMock.okJson(readFile("logiskVedleggEnkelResponse.json"))),
+                .put(urlEqualTo("/arkiv/v2/testJournalPost/ferdigstill?journalfoerendeEnhet=testEnhet"))
+                .willReturn(okJson(readFile("logiskVedleggEnkelResponse.json"))),
         )
 
         // Act
@@ -280,8 +280,8 @@ internal class IntegrasjonClientTest {
 
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/arkiv/v4"))
-                .willReturn(WireMock.okJson(readFile("journalførDokumentEnkelResponse.json"))),
+                .post(urlEqualTo("/arkiv/v4"))
+                .willReturn(okJson(readFile("journalførDokumentEnkelResponse.json"))),
         )
 
         // Act
@@ -298,8 +298,8 @@ internal class IntegrasjonClientTest {
 
         wiremockServerItem.stubFor(
             WireMock
-                .get(WireMock.urlEqualTo("/kodeverk/landkoder/$landKode"))
-                .willReturn(WireMock.okJson(readFile("hentLandEnkelResponse.json"))),
+                .get(urlEqualTo("/kodeverk/landkoder/$landKode"))
+                .willReturn(okJson(readFile("hentLandEnkelResponse.json"))),
         )
 
         // Act
@@ -314,8 +314,8 @@ internal class IntegrasjonClientTest {
         // Arrange
         wiremockServerItem.stubFor(
             WireMock
-                .post(WireMock.urlEqualTo("/dist/v1"))
-                .willReturn(WireMock.okJson(readFile("distribuerBrevEnkelResponse.json"))),
+                .post(urlEqualTo("/dist/v1"))
+                .willReturn(okJson(readFile("distribuerBrevEnkelResponse.json"))),
         )
 
         // Act
@@ -331,9 +331,8 @@ internal class IntegrasjonClientTest {
         val navIdent = NavIdent("1")
 
         wiremockServerItem.stubFor(
-            WireMock
-                .post(WireMock.urlEqualTo("/enhetstilganger"))
-                .willReturn(WireMock.okJson(readFile("enheterNavIdentHarTilgangTilResponse.json"))),
+            get(urlEqualTo("/saksbehandler/1/grupper"))
+                .willReturn(okJson(readFile("enheterNavIdentHarTilgangTilResponse.json"))),
         )
 
         // Act
@@ -346,8 +345,8 @@ internal class IntegrasjonClientTest {
             assertThat(it.enhetsnavn).isEqualTo(KontantstøtteEnhet.VADSØ.enhetsnavn)
         }
         assertThat(enheter).anySatisfy {
-            assertThat(it.enhetsnummer).isEqualTo(KontantstøtteEnhet.OSLO.enhetsnummer)
-            assertThat(it.enhetsnavn).isEqualTo(KontantstøtteEnhet.OSLO.enhetsnavn)
+            assertThat(it.enhetsnummer).isEqualTo(KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer)
+            assertThat(it.enhetsnavn).isEqualTo(KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn)
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
@@ -3,10 +3,8 @@ package no.nav.familie.ks.sak.kjerne.arbeidsfordeling
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.kontrakter.felles.NavIdent
-import no.nav.familie.kontrakter.felles.enhet.Enhet
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.data.lagEnhet
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
@@ -109,10 +107,7 @@ class TilpassArbeidsfordelingServiceTest {
                 )
             } returns
                 listOf(
-                    lagEnhet(
-                        enhetsnummer = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.VIKAFOSSEN,
                 )
 
             // Act
@@ -131,9 +126,7 @@ class TilpassArbeidsfordelingServiceTest {
         fun `skal returnere første enhetsnummer som NAV-identen har tilgang til når arbeidsfordeling er midlertidig enhet 4863`() {
             // Arrange
             val navIdent = NavIdent("1")
-            val enhetNavIdentHarTilgangTil2 = KontantstøtteEnhet.VIKAFOSSEN
-            val enhetNavIdentHarTilgangTil3 = KontantstøtteEnhet.OSLO
-            val enhetNavIdentHarTilgangTil4 = KontantstøtteEnhet.DRAMMEN
+            val enhetNavIdentHarTilgangTil = KontantstøtteEnhet.OSLO
 
             val arbeidsfordelingsenhet =
                 Arbeidsfordelingsenhet(
@@ -147,18 +140,9 @@ class TilpassArbeidsfordelingServiceTest {
                 )
             } returns
                 listOf(
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil2.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil2.enhetsnavn,
-                    ),
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil3.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil3.enhetsnavn,
-                    ),
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil4.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil4.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.VIKAFOSSEN,
+                    KontantstøtteEnhet.OSLO,
+                    KontantstøtteEnhet.DRAMMEN,
                 )
 
             // Act
@@ -169,8 +153,8 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             // Assert
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(enhetNavIdentHarTilgangTil3.enhetsnummer)
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(enhetNavIdentHarTilgangTil3.enhetsnavn)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(enhetNavIdentHarTilgangTil.enhetsnummer)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(enhetNavIdentHarTilgangTil.enhetsnavn)
         }
 
         @Test
@@ -212,14 +196,8 @@ class TilpassArbeidsfordelingServiceTest {
                 )
             } returns
                 listOf(
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil1.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil1.enhetsnavn,
-                    ),
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil2.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil2.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.STEINKJER,
+                    KontantstøtteEnhet.VADSØ,
                 )
 
             // Act
@@ -238,8 +216,7 @@ class TilpassArbeidsfordelingServiceTest {
         fun `skal returnere Vikafossen 2103 dersom arbeidsfordeling er Vikafossen 2103 og NAV-ident har tilgang til Vikafossen 2103`() {
             // Arrange
             val navIdent = NavIdent("1")
-            val enhetNavIdentHarTilgangTil1 = KontantstøtteEnhet.BERGEN
-            val enhetNavIdentHarTilgangTil2 = KontantstøtteEnhet.VIKAFOSSEN
+            val enhetNavIdentHarTilgangTil = KontantstøtteEnhet.VIKAFOSSEN
 
             val arbeidsfordelingsenhet =
                 Arbeidsfordelingsenhet(
@@ -253,14 +230,8 @@ class TilpassArbeidsfordelingServiceTest {
                 )
             } returns
                 listOf(
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil1.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil1.enhetsnavn,
-                    ),
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil2.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil2.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.BERGEN,
+                    KontantstøtteEnhet.VIKAFOSSEN,
                 )
 
             // Act
@@ -271,8 +242,8 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             // Assert
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(enhetNavIdentHarTilgangTil2.enhetsnummer)
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(enhetNavIdentHarTilgangTil2.enhetsnavn)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(enhetNavIdentHarTilgangTil.enhetsnummer)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(enhetNavIdentHarTilgangTil.enhetsnavn)
         }
 
         @Test
@@ -341,10 +312,7 @@ class TilpassArbeidsfordelingServiceTest {
                 )
             } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.VIKAFOSSEN,
                 )
 
             // Act
@@ -364,8 +332,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val enhetNavIdentHarTilgangTil1 = KontantstøtteEnhet.OSLO
-            val enhetNavIdentHarTilgangTil2 = KontantstøtteEnhet.DRAMMEN
+            val enhetNavIdentHarTilgangTil = KontantstøtteEnhet.OSLO
 
             val arbeidsfordelingsenhet =
                 Arbeidsfordelingsenhet(
@@ -379,14 +346,8 @@ class TilpassArbeidsfordelingServiceTest {
                 )
             } returns
                 listOf(
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil1.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil1.enhetsnavn,
-                    ),
-                    lagEnhet(
-                        enhetsnummer = enhetNavIdentHarTilgangTil2.enhetsnummer,
-                        enhetsnavn = enhetNavIdentHarTilgangTil2.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.OSLO,
+                    KontantstøtteEnhet.DRAMMEN,
                 )
 
             // Act
@@ -397,8 +358,8 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             // Assert
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(enhetNavIdentHarTilgangTil1.enhetsnummer)
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(enhetNavIdentHarTilgangTil1.enhetsnavn)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(enhetNavIdentHarTilgangTil.enhetsnummer)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(enhetNavIdentHarTilgangTil.enhetsnavn)
         }
 
         @Test
@@ -420,18 +381,9 @@ class TilpassArbeidsfordelingServiceTest {
                 )
             } returns
                 listOf(
-                    lagEnhet(
-                        enhetsnummer = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                        enhetsnavn = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                    ),
-                    lagEnhet(
-                        enhetsnummer = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
-                    lagEnhet(
-                        enhetsnummer = arbeidsfordelingEnhet.enhetsnummer,
-                        enhetsnavn = arbeidsfordelingEnhet.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.MIDLERTIDIG_ENHET,
+                    KontantstøtteEnhet.VIKAFOSSEN,
+                    KontantstøtteEnhet.OSLO,
                 )
 
             // Act
@@ -478,10 +430,7 @@ class TilpassArbeidsfordelingServiceTest {
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                        enhetsnavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.VIKAFOSSEN,
                 )
 
             // Act
@@ -499,10 +448,7 @@ class TilpassArbeidsfordelingServiceTest {
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
                 listOf(
-                    Enhet(
-                        enhetsnummer = KontantstøtteEnhet.OSLO.enhetsnummer,
-                        enhetsnavn = KontantstøtteEnhet.OSLO.enhetsnavn,
-                    ),
+                    KontantstøtteEnhet.OSLO,
                 )
 
             // Act

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageServiceTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ks.sak.kjerne.klage
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import no.nav.familie.kontrakter.felles.enhet.Enhet
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
 import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
@@ -12,6 +11,7 @@ import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagKlagebehandlingDto
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
@@ -97,8 +97,8 @@ class KlageServiceTest {
         fun `skal sette enheten til saksbehandlers enhet ved opprettelse av klagebehandling`() {
             // Arrange
             val fagsak = lagFagsak()
-            val forventetEnhet = Enhet("1234", "testRiktig")
-            val enhetSomIkkeSkalVelges = Enhet("5432", "testFeil")
+            val forventetEnhet = KontantstøtteEnhet.VADSØ
+            val enhetSomIkkeSkalVelges = KontantstøtteEnhet.OSLO
 
             every { integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(any()) } returns listOf(forventetEnhet, enhetSomIkkeSkalVelges)
 

--- a/src/test/resources/familieintegrasjon/json/enheterNavIdentHarTilgangTilResponse.json
+++ b/src/test/resources/familieintegrasjon/json/enheterNavIdentHarTilgangTilResponse.json
@@ -1,14 +1,123 @@
 {
-  "data": [
-    {
-      "enhetsnummer": "4820",
-      "enhetsnavn": "NAV Familie- og pensjonsytelser Vadsø"
-    },
-    {
-      "enhetsnummer": "4833",
-      "enhetsnavn": "NAV Familie- og pensjonsytelser Oslo 1"
-    }
-  ],
+  "data": {
+    "value": [
+      {
+        "id": "93a26831-9866-4410-927b-74ff51a9107c",
+        "displayName": "0000-GA-Barnetrygd-Veileder"
+      },
+      {
+        "id": "9449c153-5a1e-44a7-84c6-7cc7a8867233",
+        "displayName": "0000-GA-Barnetrygd-Beslutter"
+      },
+      {
+        "id": "314fa714-f13c-4cdc-ac5c-e13ce08e241c",
+        "displayName": "0000-GA-Barnetrygd-Superbruker"
+      },
+      {
+        "id": "52fe1bef-224f-49df-a40a-29f92d4520f8",
+        "displayName": "0000-GA-Kontantstotte-Beslutter"
+      },
+      {
+        "id": "c7e0b108-7ae6-432c-9ab4-946174c240c0",
+        "displayName": "0000-GA-Kontantstotte"
+      },
+      {
+        "id": "71f503a2-c28f-4394-a05a-8da263ceca4a",
+        "displayName": "0000-GA-Kontantstotte-Veileder"
+      },
+      {
+        "id": "28e66e77-d879-47f1-8835-fea505cfce9f",
+        "displayName": "0000-GA-GOSYS_MEDLEMSKAP_ENDRER"
+      },
+      {
+        "id": "6c7b1e6e-fd83-400f-9e0d-0f9e1bc24e4f",
+        "displayName": "0000-GA-PERSON-ENDRE_UTENLANDSKID"
+      },
+      {
+        "id": "87ea7c87-08a2-43bc-83d6-0bfeee92185d",
+        "displayName": "0000-GA-GOSYS_KODE6"
+      },
+      {
+        "id": "ea930b6b-9397-44d9-b9e6-f4cf527a632a",
+        "displayName": "0000-GA-Fortrolig_Adresse"
+      },
+      {
+        "id": "69d4a70f-1c83-42a8-8fb8-2f5d54048647",
+        "displayName": "0000-GA-GOSYS_KODE7"
+      },
+      {
+        "id": "5ef775f2-61f8-4283-bf3d-8d03f428aa14",
+        "displayName": "0000-GA-Strengt_Fortrolig_Adresse"
+      },
+      {
+        "id": "90fc4535-ab74-444e-8969-1935b9563e00",
+        "displayName": "0000-GA-GOSYS_LESE_INN_DOKUMENTER"
+      },
+      {
+        "id": "d12fdb94-ea30-452b-ad43-af1a3ab30157",
+        "displayName": "Alle-i-IT"
+      },
+      {
+        "id": "928636f4-fd0d-4149-978e-a6fb68bb19de",
+        "displayName": "0000-GA-STDAPPS"
+      },
+      {
+        "id": "3db683fb-ba0d-4d1a-aa92-153b101d9c88",
+        "displayName": "0000-GA-EnGangIAaret"
+      },
+      {
+        "id": "5044535d-245d-49ef-9a78-2efea67ba0bc",
+        "displayName": "0000-GA-GOSYS_LESE_UT_DOKUMENTER"
+      },
+      {
+        "id": "174bec27-e954-453b-8486-4a80d9fc7636",
+        "displayName": "0000-GA-GOSYS"
+      },
+      {
+        "id": "d2987104-63b2-4110-83ac-20ff6afe24a2",
+        "displayName": "0000-GA-GOSYS_REGIONAL"
+      },
+      {
+        "id": "a9f5ef81-4e81-42e8-b368-0273071b64b9",
+        "displayName": "0000-GA-GOSYS_OPPGAVE_BEHANDLER"
+      },
+      {
+        "id": "dec3ee50-b683-4644-9507-520e8f054ac2",
+        "displayName": "GRP Alle brukere"
+      },
+      {
+        "id": "b81de253-f948-4bdd-9897-a61012e5ebec",
+        "displayName": "0000-GA-GOSYS_Administrer_oppgaver"
+      },
+      {
+        "id": "3e3b7296-c57a-4b2b-9463-177aa1c96dd9",
+        "displayName": "0000-GA-TEMA_BAR"
+      },
+      {
+        "id": "e2cf416e-eb2b-4c86-8b5b-8c5b00385bcf",
+        "displayName": "0000-GA-ENHET_2103"
+      },
+      {
+        "id": "a996c91f-6dd1-466d-bed0-06ddccab87f5",
+        "displayName": "0000-GA-ENHET_4820"
+      },
+      {
+        "id": "cfe01415-0fdb-45cd-a94c-370199fe9956",
+        "displayName": "0000-GA-TEMA_KON"
+      },
+      {
+        "id": "52ca6398-d62b-4e01-bd60-8d3e4708a946",
+        "displayName": "checkpoint_inline_incoming"
+      },
+      {
+        "id": "da471520-ea8f-4590-aca9-579321cfd9ed",
+        "displayName": "All Users"
+      }
+    ]
+  },
   "status": "SUKSESS",
-  "melding": "Fant enheter"
+  "melding": "Hent saksbehandler grupper OK",
+  "frontendFeilmelding": null,
+  "stacktrace": null,
+  "callId": null
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25115

Den 01.10.2025 så legges Axsys ned.
Per i dag bruker vi Axsys til å sjekke om en saksbehandler har tilgang til en enhet før vi eventuelt setter saksbehandleren som tilordnet ressurs i oppgaven som vi oppretter, f.eks BehandleSak oppgaver når behandlinger opprettes.

Ref https://nav-it.slack.com/archives/CDKEM1HC5/p1726835363824219 så har det kommet azure grupper som erstatter axsys:

0000-GA-TEMA_XXX (f.eks. 0000-GA-TEMA_PEN)
0000-GA-ENHET_XXXX (f.eks. 0000-GA-ENHET_4803)

Alle saksbehandlere som hadde fått tilgang gjennom Axsys til enhet 4803 skal nå tilhøre gruppen 0000-GA-ENHET_4803.

Jeg har lagt til et endepunkt i familie-integrasjoner som henter alle grupper til en saksbehandler.
Disse mappes over til kontantstøtte enheter i ks-sak, som er da enhetene bruker har tilgang til.