### PR TITLE
Vi fikser feil når vi skal sjekke etter vilkår ved opphør i første periode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -413,9 +413,9 @@ class BegrunnelserForPeriodeContext(
 
                 val senesteVilkårSomIkkeErOppfyltPåPersonPerVilkårType =
                     vilkårResultaterPåPerson
+                        .filter { !it.erOppfylt() }
                         .groupBy { it.vilkårType }
                         .map { (_, vilkår) -> vilkår.maxBy { it.periodeFom ?: TIDENES_MORGEN } }
-                        .filter { !it.erOppfylt() }
 
                 val senesteVilkårSomIkkeErOppfyltForrigeEllerDennePerioden =
                     senesteVilkårSomIkkeErOppfyltPåPersonPerVilkårType.filter {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -364,6 +364,7 @@ class StepDefinition {
         forventedeStandardBegrunnelser.forEach { forventet ->
             val faktisk =
                 hentUtvidedeVedtaksperioderMedBegrunnelser(behandlingId)
+                    .sortedBy { it.fom }
                     .mapIndexed { index, utvidetVedtaksperiodeMedBegrunnelser ->
                         utvidetVedtaksperiodeMedBegrunnelser.copy(
                             gyldigeBegrunnelser =

--- a/src/test/resources/cucumber/opphør-første-periode.feature
+++ b/src/test/resources/cucumber/opphør-første-periode.feature
@@ -334,3 +334,85 @@ Egenskap: Opphør første periode
     Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.05.2025 til -
       | Begrunnelse                                                    | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | Måned og år før vedtaksperiode |
       | OPPHØR_BRUKER_MELDER_FULLTIDSPLASS_I_BARNEHAGEN_FØRSTE_PERIODE | STANDARD |               | 04.01.24             | 1           | mai 2025                             | 0     |                  | 45                          | Ja                     |         | april 2025                     |
+
+  Scenario: Ved opphør av tidligere innvilget perioder så skal det kunne begrunnes med opphørs begrunnelser som har første periode som trigger
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | BARNEHAGELISTE   | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 20.01.1994  |
+      | 1            | 2       | BARN       | 02.01.2024  |
+      | 2            | 1       | SØKER      | 20.01.1994  |
+      | 2            | 2       | BARN       | 02.01.2024  |
+
+    Og følgende dagens dato 25.05.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 20.01.1994 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 20.01.1999 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 12.09.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 02.01.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 02.01.2024 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 02.02.2025 | 02.08.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 20.01.1994 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 20.01.1999 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 12.09.1998 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 02.01.2024 | 10.11.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 02.01.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 11.11.2024 | 28.02.2025 | IKKE_OPPFYLT | Nei                  |                      |                  | Nei                                   | 45           |
+      | 2       | BARNETS_ALDER                |                  | 02.01.2025 | 02.09.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.03.2025 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+
+    Og med følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.02.2025 | 31.08.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.04.2025 | 31.08.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+    Og når behandlingsresultatet er utledet for behandling 2
+    Så forvent at behandlingsresultatet er ENDRET_UTBETALING på behandling 2
+
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.02.2025 | 31.03.2025 | OPPHØR             |           |
+      | 01.04.2025 | 31.08.2025 | UTBETALING         |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                             | Ugyldige begrunnelser |
+      | 01.02.2025 | 31.03.2025 | OPPHØR             |                                | OPPHØR_FULLTIDSPLASS_I_BARNEHAGEN_FØRSTE_PERIODE |                       |
+      | 01.04.2025 | 31.08.2025 | UTBETALING         |                                | INNVILGET_IKKE_BARNEHAGE                         |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser                                           | Eøsbegrunnelser | Fritekster |
+      | 01.02.2025 | 31.03.2025 | OPPHØR_BRUKER_MELDER_FULLTIDSPLASS_I_BARNEHAGEN_FØRSTE_PERIODE |                 |            |
+      | 01.04.2025 | 31.08.2025 | INNVILGET_IKKE_BARNEHAGE                                       |                 |            |
+
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.02.2025 til 31.03.2025
+      | Begrunnelse                                                    | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | Måned og år før vedtaksperiode |
+      | OPPHØR_BRUKER_MELDER_FULLTIDSPLASS_I_BARNEHAGEN_FØRSTE_PERIODE | STANDARD |               | 02.01.24             | 1           | november 2024                        | 0     |                  | 45                          | Ja                     |         | januar 2025                    |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.04.2025 til 31.08.2025
+      | Begrunnelse              | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | Måned og år før vedtaksperiode |
+      | INNVILGET_IKKE_BARNEHAGE | STANDARD |               | 02.01.24             | 1           | april 2025                           | 7 500 |                  | 0                           | Ja                     |         | mars 2025                      |
+


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25253

Når vi skal sjekke begrunnelser som har trigger første periode så ønsker vi å hente ut `senesteVilkårSomIkkeErOppfyltPåPersonPerVilkårType`. Denne har en bug per i dag der vi tar maxBy først, og dersom det er et oppfylt vilkår som kommer senere enn det ikke oppfylte, så vil den erstatte det ikke oppfylte. Da funker det ikke å kjøre .filter { !it.erOppfylt() } senere, man må filtrere først.