### PR TITLE
Vi hopper over lagring av relasjon uten folkeregister ident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.personident
 
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ks.sak.integrasjon.pdl.PdlClient
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlIdent
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.hentAktivAktørId
@@ -120,7 +121,7 @@ class PersonidentService(
 
     private fun filtrerAktivtFødselsnummer(pdlIdenter: List<PdlIdent>) =
         pdlIdenter.singleOrNull { it.gruppe == "FOLKEREGISTERIDENT" }?.ident
-            ?: throw Error("Finner ikke aktiv ident i Pdl")
+            ?: throw PdlPersonKanIkkeBehandlesIFagsystem("Finner ikke aktiv ident i Pdl for personen")
 
     private fun filtrerAktørId(pdlIdenter: List<PdlIdent>): String =
         pdlIdenter.singleOrNull { it.gruppe == "AKTORID" }?.ident

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
@@ -1,0 +1,117 @@
+package no.nav.familie.ks.sak.integrasjon.pdl
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
+import no.nav.familie.kontrakter.felles.personopplysning.ForelderBarnRelasjon
+import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
+import no.nav.familie.ks.sak.common.exception.PdlPersonKanIkkeBehandlesIFagsystem
+import no.nav.familie.ks.sak.config.PersonInfoQuery
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.data.randomPersonident
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
+import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlFødselsDato
+import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlNavn
+import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonData
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PersonopplysningerServiceTest {
+    private val pdlClient = mockk<PdlClient>()
+    private val integrasjonService = mockk<IntegrasjonService>()
+    private val personidentService = mockk<PersonidentService>()
+    private val personopplysningerService = PersonopplysningerService(pdlClient, integrasjonService, personidentService)
+
+    @Test
+    fun `Skal returnere personopplysninger med relasjon hvis det finnes`() {
+        // Arrange
+        val aktør = randomAktør()
+        val barnAktør = randomAktør()
+        val barnIdent = randomPersonident(barnAktør)
+        val fødselsdato = LocalDate.of(2000, 2, 2)
+
+        val forelderBarnRelasjon =
+            ForelderBarnRelasjon(
+                relatertPersonsIdent = barnIdent.fødselsnummer,
+                relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
+            )
+
+        val pdlPersonData =
+            PdlPersonData(
+                forelderBarnRelasjon = listOf(forelderBarnRelasjon),
+                folkeregisteridentifikator = emptyList(),
+                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                bostedsadresse = emptyList(),
+            )
+
+        val pdlRelasjonData =
+            PdlPersonData(
+                navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
+                folkeregisteridentifikator = emptyList(),
+                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                bostedsadresse = emptyList(),
+            )
+
+        every { pdlClient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
+        every { personidentService.hentAktør(barnIdent.fødselsnummer) } returns barnAktør
+        every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
+        every { pdlClient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
+        every { pdlClient.hentAdressebeskyttelse(any()) } returns emptyList()
+
+        // Act
+        val pdlPersonInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+
+        // Assert
+        assertThat(pdlPersonInfo.forelderBarnRelasjoner).hasSize(1)
+
+        val barnRelasjon = pdlPersonInfo.forelderBarnRelasjoner.single()
+
+        assertThat(barnRelasjon.navn).isEqualTo("Fornavn Etternavn")
+        assertThat(barnRelasjon.aktør).isEqualTo(barnAktør)
+    }
+
+    @Test
+    fun `Dersom det kastes PdlPersonKanIkkeBehandlesIFagsystem skal man hoppe over personen i relasjonen`() {
+        // Arrange
+        val aktør = randomAktør()
+        val barnAktør = randomAktør()
+        val barnIdent = randomPersonident(barnAktør)
+        val fødselsdato = LocalDate.of(2000, 2, 2)
+
+        val forelderBarnRelasjon =
+            ForelderBarnRelasjon(
+                relatertPersonsIdent = barnIdent.fødselsnummer,
+                relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
+            )
+
+        val pdlPersonData =
+            PdlPersonData(
+                forelderBarnRelasjon = listOf(forelderBarnRelasjon),
+                folkeregisteridentifikator = emptyList(),
+                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                bostedsadresse = emptyList(),
+            )
+
+        val pdlRelasjonData =
+            PdlPersonData(
+                navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
+                folkeregisteridentifikator = emptyList(),
+                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                bostedsadresse = emptyList(),
+            )
+
+        every { pdlClient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
+        every { personidentService.hentAktør(barnIdent.fødselsnummer) } throws PdlPersonKanIkkeBehandlesIFagsystem("test")
+        every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
+        every { pdlClient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
+        every { pdlClient.hentAdressebeskyttelse(any()) } returns emptyList()
+
+        // Act
+        val pdlPersonInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+
+        // Assert
+        assertThat(pdlPersonInfo.forelderBarnRelasjoner).isEmpty()
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlNavn
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonData
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -24,94 +25,97 @@ class PersonopplysningerServiceTest {
     private val personidentService = mockk<PersonidentService>()
     private val personopplysningerService = PersonopplysningerService(pdlClient, integrasjonService, personidentService)
 
-    @Test
-    fun `Skal returnere personopplysninger med relasjon hvis det finnes`() {
-        // Arrange
-        val aktør = randomAktør()
-        val barnAktør = randomAktør()
-        val barnIdent = randomPersonident(barnAktør)
-        val fødselsdato = LocalDate.of(2000, 2, 2)
+    @Nested
+    inner class HentPersonInfoMedRelasjonerOgRegisterinformasjon {
+        @Test
+        fun `Skal returnere personopplysninger med relasjon hvis det finnes`() {
+            // Arrange
+            val aktør = randomAktør()
+            val barnAktør = randomAktør()
+            val barnIdent = randomPersonident(barnAktør)
+            val fødselsdato = LocalDate.of(2000, 2, 2)
 
-        val forelderBarnRelasjon =
-            ForelderBarnRelasjon(
-                relatertPersonsIdent = barnIdent.fødselsnummer,
-                relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
-            )
+            val forelderBarnRelasjon =
+                ForelderBarnRelasjon(
+                    relatertPersonsIdent = barnIdent.fødselsnummer,
+                    relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
+                )
 
-        val pdlPersonData =
-            PdlPersonData(
-                forelderBarnRelasjon = listOf(forelderBarnRelasjon),
-                folkeregisteridentifikator = emptyList(),
-                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
-                bostedsadresse = emptyList(),
-            )
+            val pdlPersonData =
+                PdlPersonData(
+                    forelderBarnRelasjon = listOf(forelderBarnRelasjon),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
 
-        val pdlRelasjonData =
-            PdlPersonData(
-                navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
-                folkeregisteridentifikator = emptyList(),
-                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
-                bostedsadresse = emptyList(),
-            )
+            val pdlRelasjonData =
+                PdlPersonData(
+                    navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
 
-        every { pdlClient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
-        every { personidentService.hentAktør(barnIdent.fødselsnummer) } returns barnAktør
-        every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
-        every { pdlClient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
-        every { pdlClient.hentAdressebeskyttelse(any()) } returns emptyList()
+            every { pdlClient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
+            every { personidentService.hentAktør(barnIdent.fødselsnummer) } returns barnAktør
+            every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
+            every { pdlClient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
+            every { pdlClient.hentAdressebeskyttelse(any()) } returns emptyList()
 
-        // Act
-        val pdlPersonInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+            // Act
+            val pdlPersonInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
 
-        // Assert
-        assertThat(pdlPersonInfo.forelderBarnRelasjoner).hasSize(1)
+            // Assert
+            assertThat(pdlPersonInfo.forelderBarnRelasjoner).hasSize(1)
 
-        val barnRelasjon = pdlPersonInfo.forelderBarnRelasjoner.single()
+            val barnRelasjon = pdlPersonInfo.forelderBarnRelasjoner.single()
 
-        assertThat(barnRelasjon.navn).isEqualTo("Fornavn Etternavn")
-        assertThat(barnRelasjon.aktør).isEqualTo(barnAktør)
-    }
+            assertThat(barnRelasjon.navn).isEqualTo("Fornavn Etternavn")
+            assertThat(barnRelasjon.aktør).isEqualTo(barnAktør)
+        }
 
-    @Test
-    fun `Dersom det kastes PdlPersonKanIkkeBehandlesIFagsystem skal man hoppe over personen i relasjonen`() {
-        // Arrange
-        val aktør = randomAktør()
-        val barnAktør = randomAktør()
-        val barnIdent = randomPersonident(barnAktør)
-        val fødselsdato = LocalDate.of(2000, 2, 2)
+        @Test
+        fun `Dersom det kastes PdlPersonKanIkkeBehandlesIFagsystem skal man hoppe over personen i relasjonen`() {
+            // Arrange
+            val aktør = randomAktør()
+            val barnAktør = randomAktør()
+            val barnIdent = randomPersonident(barnAktør)
+            val fødselsdato = LocalDate.of(2000, 2, 2)
 
-        val forelderBarnRelasjon =
-            ForelderBarnRelasjon(
-                relatertPersonsIdent = barnIdent.fødselsnummer,
-                relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
-            )
+            val forelderBarnRelasjon =
+                ForelderBarnRelasjon(
+                    relatertPersonsIdent = barnIdent.fødselsnummer,
+                    relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
+                )
 
-        val pdlPersonData =
-            PdlPersonData(
-                forelderBarnRelasjon = listOf(forelderBarnRelasjon),
-                folkeregisteridentifikator = emptyList(),
-                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
-                bostedsadresse = emptyList(),
-            )
+            val pdlPersonData =
+                PdlPersonData(
+                    forelderBarnRelasjon = listOf(forelderBarnRelasjon),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
 
-        val pdlRelasjonData =
-            PdlPersonData(
-                navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
-                folkeregisteridentifikator = emptyList(),
-                foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
-                bostedsadresse = emptyList(),
-            )
+            val pdlRelasjonData =
+                PdlPersonData(
+                    navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
 
-        every { pdlClient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
-        every { personidentService.hentAktør(barnIdent.fødselsnummer) } throws PdlPersonKanIkkeBehandlesIFagsystem("test")
-        every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
-        every { pdlClient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
-        every { pdlClient.hentAdressebeskyttelse(any()) } returns emptyList()
+            every { pdlClient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
+            every { personidentService.hentAktør(barnIdent.fødselsnummer) } throws PdlPersonKanIkkeBehandlesIFagsystem("test")
+            every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
+            every { pdlClient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
+            every { pdlClient.hentAdressebeskyttelse(any()) } returns emptyList()
 
-        // Act
-        val pdlPersonInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+            // Act
+            val pdlPersonInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
 
-        // Assert
-        assertThat(pdlPersonInfo.forelderBarnRelasjoner).isEmpty()
+            // Assert
+            assertThat(pdlPersonInfo.forelderBarnRelasjoner).isEmpty()
+        }
     }
 }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25300

Når man går videre fra registrer søknad så hentes alle relasjonene som barnet har, mor og far.
I dette tilfellet så har ikke far folkeregisterident, men bare NPID. Det kastes derfor en error per i dag.

Endrer på det slik at det er sånn at når relasjonene ikke har folkeregisterident, så hopper vi bare over dem slik at det ikke stanser saksbehandlingen. I dette tilfellet er relasjonen med far irrelevant, og det bør derfor ikke stoppe saksbehandling.