### PR TITLE
Send med saksbehandler id til frontend

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/TotrinnskontrollDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/TotrinnskontrollDto.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 
 data class TotrinnskontrollDto(
     val saksbehandler: String,
+    val saksbehandlerId: String,
     val beslutter: String? = null,
     val godkjent: Boolean = false,
     val opprettetTidspunkt: LocalDateTime,
@@ -16,4 +17,5 @@ fun Totrinnskontroll.tilTotrinnskontrollDto() =
         beslutter = this.beslutter,
         godkjent = this.godkjent,
         opprettetTidspunkt = this.opprettetTidspunkt,
+        saksbehandlerId = this.saksbehandlerId
     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/TotrinnskontrollDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/TotrinnskontrollDto.kt
@@ -17,5 +17,5 @@ fun Totrinnskontroll.tilTotrinnskontrollDto() =
         beslutter = this.beslutter,
         godkjent = this.godkjent,
         opprettetTidspunkt = this.opprettetTidspunkt,
-        saksbehandlerId = this.saksbehandlerId
+        saksbehandlerId = this.saksbehandlerId,
     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/Totrinnskontroll.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/Totrinnskontroll.kt
@@ -45,5 +45,10 @@ data class Totrinnskontroll(
     @Convert(converter = StringListConverter::class)
     var kontrollerteSider: List<String> = emptyList(),
 ) : BaseEntitet() {
-    fun erUgyldig() = godkjent && saksbehandler == beslutter && saksbehandler != SikkerhetContext.SYSTEM_NAVN &&  saksbehandlerId == beslutterId
+    fun erUgyldig(): Boolean {
+        val sammePerson = saksbehandler == beslutter || saksbehandlerId == beslutterId
+        val ikkeSystem = saksbehandler != SikkerhetContext.SYSTEM_NAVN
+
+        return godkjent && sammePerson && ikkeSystem
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/Totrinnskontroll.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/Totrinnskontroll.kt
@@ -45,5 +45,5 @@ data class Totrinnskontroll(
     @Convert(converter = StringListConverter::class)
     var kontrollerteSider: List<String> = emptyList(),
 ) : BaseEntitet() {
-    fun erUgyldig() = godkjent && saksbehandler == beslutter && saksbehandler != SikkerhetContext.SYSTEM_NAVN
+    fun erUgyldig() = godkjent && saksbehandler == beslutter && saksbehandler != SikkerhetContext.SYSTEM_NAVN &&  saksbehandlerId == beslutterId
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/TotrinnskontrollTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/TotrinnskontrollTest.kt
@@ -1,0 +1,74 @@
+package no.nav.familie.ks.sak.kjerne.totrinnskontroll.domene
+
+import junit.framework.TestCase.assertTrue
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class TotrinnskontrollTest {
+    private val behandling = lagBehandling()
+
+    @Nested
+    inner class ErUgyldigTest {
+        @Test
+        fun `Skal returnere true dersom det er samme person som beslutter`() {
+            val kontroll =
+                Totrinnskontroll(
+                    behandling = behandling,
+                    godkjent = true,
+                    saksbehandler = "NAV-Bruker",
+                    saksbehandlerId = "X123",
+                    beslutter = "NAV-Bruker",
+                    beslutterId = "X123",
+                )
+            assertTrue(kontroll.erUgyldig())
+        }
+
+        @Test
+        fun `Skal returnere false dersom det er samme person som beslutter men det er system brukeren`() {
+            val kontroll =
+                Totrinnskontroll(
+                    behandling = behandling,
+                    godkjent = true,
+                    saksbehandler = SikkerhetContext.SYSTEM_NAVN,
+                    saksbehandlerId = "VL",
+                    beslutter = SikkerhetContext.SYSTEM_NAVN,
+                    beslutterId = "VL",
+                )
+
+            assertFalse(kontroll.erUgyldig())
+        }
+
+        @Test
+        fun `Skal returnere false dersom det er forskjellige brukere som har fattet vedtak og besluttet`() {
+            val kontroll =
+                Totrinnskontroll(
+                    behandling = behandling,
+                    godkjent = true,
+                    saksbehandler = "Bruker1",
+                    saksbehandlerId = "ID1",
+                    beslutter = "Bruker2",
+                    beslutterId = "ID2",
+                )
+
+            assertFalse(kontroll.erUgyldig())
+        }
+
+        @Test
+        fun `Skal returnere true dersom id'ne er det samme selvom navn er annerledes på saksbehandler og beslutter`() {
+            val kontroll =
+                Totrinnskontroll(
+                    behandling = behandling,
+                    godkjent = true,
+                    saksbehandler = "X1",
+                    saksbehandlerId = "samme-id",
+                    beslutter = "Y1",
+                    beslutterId = "samme-id",
+                )
+
+            assertTrue(kontroll.erUgyldig())
+        }
+    }
+}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25337

Per nå sammenlignes det på visningsnavn når man sjekker om noen er beslutter eller saksbehandler av eget vedtak.

Dette er ikke bra practice fordi:

For kode 6/19 saker settes alle navn til Anonym Nav bruker, og da fungerer ikke logikken.
En SB og Beslutter med samme navn vil føre til at systemet tror at beslutter er SB.

Vi sender derfor saksbehandlerID med til frontend som sammenlignes med innlogget id.