### PR TITLE
sorter slik at null-verdier kommer sist på barnehagebarn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BarnehagebarnRequestParams.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BarnehagebarnRequestParams.kt
@@ -14,9 +14,9 @@ data class BarnehagebarnRequestParams(
 
 fun BarnehagebarnRequestParams.toSort() =
     if (sortAsc) {
-        Sort.by(getCorrectSortBy(sortBy)).ascending()
+        Sort.by(Sort.Order(Sort.Direction.ASC, getCorrectSortBy(sortBy), Sort.NullHandling.NULLS_LAST))
     } else {
-        Sort.by(getCorrectSortBy(sortBy)).descending()
+        Sort.by(Sort.Order(Sort.Direction.DESC, getCorrectSortBy(sortBy), Sort.NullHandling.NULLS_LAST))
     }
 
 private fun getCorrectSortBy(sortBy: String): String =


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når man sorterer på avvik for barnehagebarn sorteres det i rekkefølgen Nei, Ja, null eller null, Ja, Nei. Siden er det er mange tilfeller med null og Nei betyr det at det er vanskelig for saksbehandler å finne sakene der det faktisk er avvik. 

Endrer sortering slik at null-verdier alltid kommer sist.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
