### PR TITLE
Avvik ved forskjellig antall timer når det er fulltid barnehageplass

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -20,7 +20,10 @@ WITH lopende_andel_i_aktiv_behandling_for_ident
                AND b.aktiv),
      avvik_antall_timer_vilkar_resultat_og_barnehagebarn
          AS (SELECT bb.id                                          as barnehagebarn_id,
-                    vr.antall_timer != bb.antall_timer_i_barnehage as avvik
+                    CASE
+                        WHEN bb.antall_timer_i_barnehage < 33 THEN vr.antall_timer != bb.antall_timer_i_barnehage
+                        ELSE vr.antall_timer <= 33
+                    END as avvik
              FROM barnehagebarn bb
                       JOIN personident p ON bb.ident = p.foedselsnummer and p.aktiv
                       JOIN person_resultat pr ON pr.fk_aktoer_id = p.fk_aktoer_id

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
@@ -177,7 +177,7 @@ class BarnehagebarnServiceHentBarnIntegrasjonsTest(
 
         // Act
         val barnehagebarn =
-            barnehagebarnService.hentBarnehagebarnForVisning(barnehagebarnRequestParams = barnehagebarnRequestParams1).content
+            barnehagebarnService.hentBarnehagebarnForVisning(barnehagebarnRequestParams = barnehagebarnRequestParams).content
 
         // Assert
         assertThat(barnehagebarn.size).`as`("Forventet 1 barn, fikk ${barnehagebarn.size}").isEqualTo(1)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
@@ -166,7 +166,7 @@ class BarnehagebarnServiceHentBarnIntegrasjonsTest(
         scripts = ["/barnehagelister/barnehagebarn-med-fulltid-barnehageplass.sql"],
         executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
     )
-    fun `hentBarnehageBarn oppgir ikke avvik sålenge barnet har fulltidsplass selv hvis det er forskjellig antall timer`() {
+    fun `hentBarnehageBarn oppgir ikke avvik så lenge barnet har fulltidsplass selv hvis det er forskjellig antall timer`() {
         // Arrange
         val barnehagebarnRequestParams1 =
             BarnehagebarnRequestParams(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
@@ -168,7 +168,7 @@ class BarnehagebarnServiceHentBarnIntegrasjonsTest(
     )
     fun `hentBarnehageBarn oppgir ikke avvik så lenge barnet har fulltidsplass selv hvis det er forskjellig antall timer`() {
         // Arrange
-        val barnehagebarnRequestParams1 =
+        val barnehagebarnRequestParams =
             BarnehagebarnRequestParams(
                 ident = null,
                 kommuneNavn = null,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
@@ -163,6 +163,30 @@ class BarnehagebarnServiceHentBarnIntegrasjonsTest(
 
     @Test
     @Sql(
+        scripts = ["/barnehagelister/barnehagebarn-med-fulltid-barnehageplass.sql"],
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+    )
+    fun `hentBarnehageBarn oppgir ikke avvik sålenge barnet har fulltidsplass selv hvis det er forskjellig antall timer`() {
+        // Arrange
+        val barnehagebarnRequestParams1 =
+            BarnehagebarnRequestParams(
+                ident = null,
+                kommuneNavn = null,
+                kunLøpendeAndel = false,
+            )
+
+        // Act
+        val barnehagebarn =
+            barnehagebarnService.hentBarnehagebarnForVisning(barnehagebarnRequestParams = barnehagebarnRequestParams1).content
+
+        // Assert
+        assertThat(barnehagebarn.size).`as`("Forventet 1 barn, fikk ${barnehagebarn.size}").isEqualTo(1)
+
+        assertThat(barnehagebarn.single().avvik).`as`("Forventet ikke avvik").isEqualTo(false)
+    }
+
+    @Test
+    @Sql(
         scripts = ["/barnehagelister/barnehagebarn-forskjellig-endret-tid.sql"],
         executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
     )

--- a/src/test/resources/barnehagelister/barnehagebarn-med-fulltid-barnehageplass.sql
+++ b/src/test/resources/barnehagelister/barnehagebarn-med-fulltid-barnehageplass.sql
@@ -1,0 +1,33 @@
+TRUNCATE TABLE aktoer, personident, po_person, gr_personopplysninger, behandling, fagsak, tilkjent_ytelse, andel_tilkjent_ytelse, person_resultat, vilkar_resultat, barnehagebarn CASCADE;
+
+--har forskjellig antall timer i barnehagebarn og vilkårresultat men har fulltid i begge tilfeller
+INSERT INTO aktoer(aktoer_id) VALUES ('1234');
+
+--Søker
+INSERT INTO aktoer(aktoer_id) VALUES ('9876');
+
+INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('12345678901', '1234', true);
+INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('90123456789', '9876', true);
+
+INSERT INTO fagsak(id, fk_aktoer_id) VALUES (1, '9876');
+
+INSERT INTO behandling(id, fk_fagsak_id, behandling_type, aktivert_tid, aktiv, kategori, opprettet_aarsak) VALUES (1, 1, 'FØRSTEGANGSBEHANDLING', NOW(), true, 'NASJONAL', 'SØKNAD');
+
+INSERT INTO gr_personopplysninger(id, fk_behandling_id) VALUES (1, 1);
+
+INSERT INTO po_person(id, fk_gr_personopplysninger_id, type, fk_aktoer_id ) VALUES (1, 1, 'BARN', '1234');
+INSERT INTO po_person(id, fk_gr_personopplysninger_id, type, fk_aktoer_id ) VALUES (9, 1, 'SØKER', '9876');
+
+INSERT INTO vilkaarsvurdering(id, fk_behandling_id) VALUES (1, 1);
+
+INSERT INTO person_resultat(id, fk_aktoer_id, fk_vilkaarsvurdering_id) VALUES (1, '1234', 1);
+
+INSERT INTO vilkar_resultat(id, vilkar, periode_fom, periode_tom, resultat, fk_person_resultat_id, fk_behandling_id, antall_timer) VALUES (1, 'BARNEHAGEPLASS', CURRENT_TIMESTAMP - INTERVAL '3 months', null, 'OPPFYLT', 1, 1, 45);
+
+INSERT INTO tilkjent_ytelse(id, fk_behandling_id, opprettet_dato) VALUES (1, 1, CURRENT_TIMESTAMP);
+
+INSERT INTO andel_tilkjent_ytelse(id, fk_behandling_id, tilkjent_ytelse_id, fk_aktoer_id, kalkulert_utbetalingsbelop, stonad_fom, stonad_tom, type, sats, prosent) VALUES (1, 1, 1, '1234', 100, CURRENT_TIMESTAMP - INTERVAL '6 months', CURRENT_TIMESTAMP - INTERVAL '3 months', 'ORDINÆR_KONTANTSTØTTE', 100, 100);
+
+INSERT INTO barnehagebarn(id, ident, fom, tom, antall_timer_i_barnehage, kommune_navn, kommune_nr, arkiv_referanse, endret_tid) VALUES ('c7de9709-7817-4f3e-a822-5d4ca49a6914', '12345678901', CURRENT_DATE - INTERVAL '3 months', null, 50, 'Oslo', '1', '7698', CURRENT_TIMESTAMP);
+
+


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Når det er fulltid barnehageplass registrerer ofte barnehagene antallet timer de er oppe og ikke antallet timer barnet er i barnehage. Det gjør at det ofte er forskjell på hva som blir meldt inn fra barnehage og hva som blir registrert av saksbehandler.

Gjør slik at vi ikke sier at det er avvik dersom det er fulltidsbarnehageplass i vilkårresultatet og i barnehagelisten. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
