### PR TITLE
NAV-25500: Fjerner deprecated kode for oppretting av revurdering klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt
@@ -50,24 +50,6 @@ class EksternKlageController(
         return Ressurs.success(opprettBehandlingService.kanOppretteRevurdering(fagsakId))
     }
 
-    @Deprecated(message = "Erstattet av metoden 'opprettRevurderingKlage'")
-    @PostMapping("fagsaker/{fagsakId}/opprett-revurdering-klage")
-    fun opprettRevurderingKlageGammel(
-        @PathVariable fagsakId: Long,
-    ): Ressurs<OpprettRevurderingResponse> {
-        tilgangService.validerTilgangTilHandlingOgFagsak(
-            fagsakId = fagsakId,
-            handling = "Opprett revurdering med årask klage på fagsak=$fagsakId.",
-            event = AuditLoggerEvent.CREATE,
-            minimumBehandlerRolle = BehandlerRolle.SAKSBEHANDLER,
-        )
-
-        if (!SikkerhetContext.kallKommerFraKlage()) {
-            throw Feil("Kallet utføres ikke av en autorisert klient")
-        }
-        return Ressurs.success(opprettBehandlingService.validerOgOpprettRevurderingKlage(fagsakId = fagsakId, klagebehandlingId = null))
-    }
-
     @PostMapping("fagsak/{fagsakId}/klagebehandling/{klagebehandlingId}/opprett-revurdering-klage")
     fun opprettRevurderingKlage(
         @PathVariable fagsakId: Long,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
@@ -166,7 +166,7 @@ class OpprettBehandlingService(
     @Transactional
     fun validerOgOpprettRevurderingKlage(
         fagsakId: Long,
-        klagebehandlingId: UUID?,
+        klagebehandlingId: UUID,
     ): OpprettRevurderingResponse {
         val fagsak = hentFagsak(fagsakId)
 
@@ -179,7 +179,7 @@ class OpprettBehandlingService(
 
     private fun opprettRevurderingKlage(
         fagsak: Fagsak,
-        klagebehandlingId: UUID?,
+        klagebehandlingId: UUID,
     ): OpprettRevurderingResponse =
         try {
             val forrigeBehandling = hentSisteBehandlingSomErVedtatt(fagsakId = fagsak.id)
@@ -190,7 +190,7 @@ class OpprettBehandlingService(
                     søkersIdent = fagsak.aktør.aktivFødselsnummer(),
                     behandlingType = BehandlingType.REVURDERING,
                     behandlingÅrsak = BehandlingÅrsak.KLAGE,
-                    nyEksternBehandlingRelasjon = klagebehandlingId?.let { NyEksternBehandlingRelasjon.opprettForKlagebehandling(it) },
+                    nyEksternBehandlingRelasjon = NyEksternBehandlingRelasjon.opprettForKlagebehandling(klagebehandlingId),
                 )
 
             val revurdering = opprettBehandling(behandlingDto)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: [NAV-25500](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25500)

Fjerner endepunkt som ikke er i bruk lengre. Erstatte av [dette](https://github.com/navikt/familie-ks-sak/blob/898c489da513c91e4e74592101c320d0484fd707/src/main/kotlin/no/nav/familie/ks/sak/api/ekstern/EksternKlageController.kt#L53) endepunktet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
