### PR TITLE
Logikk for å ha flere personer på en endret utbetaling andel

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelRequestDto.kt
@@ -10,7 +10,8 @@ import java.time.YearMonth
 
 data class EndretUtbetalingAndelRequestDto(
     val id: Long,
-    val personIdent: String,
+    val personIdent: String?,
+    val personIdenter: List<String>?,
     val prosent: BigDecimal,
     val fom: YearMonth,
     val tom: YearMonth,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/EndretUtbetalingAndelResponsDto.kt
@@ -9,6 +9,7 @@ import java.time.YearMonth
 data class EndretUtbetalingAndelResponsDto(
     val id: Long?,
     val personIdent: String?,
+    val personIdenter: List<String>?,
     val prosent: BigDecimal?,
     val fom: YearMonth?,
     val tom: YearMonth?,

--- a/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/internal/LagBrevTester.kt
@@ -277,7 +277,7 @@ private fun hentEndretUtbetalingRader(endredeUtbetalinger: List<EndretUtbetaling
         ?.filterIsInstance<IUtfyltEndretUtbetalingAndel>()
         ?.joinToString("") {
             """
-      | ${it.person.aktør.aktørId} |${it.behandlingId}|${
+      | ${it.personer.joinToString(", ") { person -> person.aktør.aktørId }} |${it.behandlingId}|${
                 it.fom.førsteDagIInneværendeMåned().tilddMMyyyy()
             }|${
                 it.tom.sisteDagIInneværendeMåned().tilddMMyyyy()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtils.kt
@@ -55,8 +55,8 @@ object BehandlingsresultatEndringUtils {
                 val nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør }
                 val forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør }
 
-                val nåværendeEndretAndelerForPerson = nåværendeEndretAndeler.filter { it.person?.aktør == aktør }
-                val forrigeEndretAndelerForPerson = forrigeEndretAndeler.filter { it.person?.aktør == aktør }
+                val nåværendeEndretAndelerForPerson = nåværendeEndretAndeler.filter { it.personer.any { person -> person.aktør == aktør } }
+                val forrigeEndretAndelerForPerson = forrigeEndretAndeler.filter { it.personer.any { person -> person.aktør == aktør } }
 
                 val nåværendeKompetanserForPerson = nåværendeKompetanser.filter { it.barnAktører.contains(aktør) }
                 val forrigeKompetanserForPerson = forrigeKompetanser.filter { it.barnAktører.contains(aktør) }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -108,7 +108,7 @@ object BehandlingsresultatOpphørUtils {
 
         return personerMedAndeler.flatMap { aktør ->
             val andelerGruppertPerTypePåPerson = this.filter { it.aktør == aktør }.groupBy { it.type }
-            val endretUtbetalingAndelerPåPerson = endretAndeler.filter { it.person?.aktør == aktør }
+            val endretUtbetalingAndelerPåPerson = endretAndeler.filter { it.personer.any { person -> person.aktør == aktør } }
 
             andelerGruppertPerTypePåPerson.values.flatMap { andelerPerType ->
                 filtrerBortIrrelevanteAndelerPerPersonOgType(andelerPerType, endretUtbetalingAndelerPåPerson)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtils.kt
@@ -83,7 +83,7 @@ object BehandlingsresultatSøknadUtils {
                     utledSøknadResultatFraAndelerTilkjentYtelsePerPersonOgType(
                         forrigeAndelerForPerson = forrigeAndeler.filter { it.aktør == aktør && it.type.tilYtelseType() == ytelseType },
                         nåværendeAndelerForPerson = nåværendeAndeler.filter { it.aktør == aktør && it.type.tilYtelseType() == ytelseType },
-                        endretUtbetalingAndelerForPerson = endretUtbetalingAndeler.filter { it.person?.aktør == aktør },
+                        endretUtbetalingAndelerForPerson = endretUtbetalingAndeler.filter { it.personer.any { person -> person.aktør == aktør } },
                     )
                 }
             }
@@ -151,7 +151,7 @@ object BehandlingsresultatSøknadUtils {
         personerFremstiltKravFor: List<Aktør>,
     ): Boolean =
         nåværendeEndretUtbetalingAndeler
-            .filter { personerFremstiltKravFor.contains(it.person?.aktør) }
+            .filter { it.personer.any { person -> personerFremstiltKravFor.contains(person.aktør) } }
             .any { it.erEksplisittAvslagPåSøknad == true }
 
     internal fun List<Søknadsresultat>.kombinerSøknadsresultater(behandlingÅrsak: BehandlingÅrsak): Søknadsresultat {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -96,7 +96,7 @@ private class AndelTilkjentYtelseOgEndreteUtbetalingerKombinator(
         andelTilkjentYtelse: AndelTilkjentYtelse,
         endretUtbetalingAndel: EndretUtbetalingAndel,
     ): Boolean =
-        andelTilkjentYtelse.aktør == endretUtbetalingAndel.person?.aktør &&
+        endretUtbetalingAndel.personer.any { person -> person.aktør == andelTilkjentYtelse.aktør } &&
             endretUtbetalingAndel.fom != null &&
             endretUtbetalingAndel.tom != null &&
             endretUtbetalingAndel.periode.overlapperHeltEllerDelvisMed(andelTilkjentYtelse.periode)
@@ -134,12 +134,12 @@ data class EndretUtbetalingAndelMedAndelerTilkjentYtelse(
     fun overlapperMed(månedPeriode: MånedPeriode) = endretUtbetalingAndel.overlapperMed(månedPeriode)
 
     val periode get() = endretUtbetalingAndel.periode
-    val person get() = endretUtbetalingAndel.person
+    val personer get() = endretUtbetalingAndel.personer
     val begrunnelse get() = endretUtbetalingAndel.begrunnelse
     val vedtaksbegrunnelser get() = endretUtbetalingAndel.vedtaksbegrunnelser
     val søknadstidspunkt get() = endretUtbetalingAndel.søknadstidspunkt
     val prosent get() = endretUtbetalingAndel.prosent
-    val aktivtFødselsnummer get() = endretUtbetalingAndel.person?.aktør?.aktivFødselsnummer()
+    val personIdenter get() = endretUtbetalingAndel.personer.map { it.aktør.aktivFødselsnummer() }
     val årsak get() = endretUtbetalingAndel.årsak
     val id get() = endretUtbetalingAndel.id
     val fom get() = endretUtbetalingAndel.fom

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseService.kt
@@ -33,7 +33,7 @@ class TilkjentYtelseService(
                 opprettetDato = LocalDate.now(),
                 endretDato = LocalDate.now(),
             )
-        val endretUtbetalingAndelerBarna = endretUtbetalingAndeler.filter { it.person?.type == PersonType.BARN }
+        val endretUtbetalingAndelerBarna = endretUtbetalingAndeler.filter { it.personer.any { person -> person.type == PersonType.BARN } }
 
         val andelerTilkjentYtelseBarnaUtenEndringer =
             beregnAndelTilkjentYtelseService.beregnAndelerTilkjentYtelse(personopplysningGrunnlag, vilkårsvurdering, tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContext.kt
@@ -186,7 +186,7 @@ class BegrunnelserForPeriodeContext(
                     ?.erDagenFør(utvidetVedtaksperiodeMedBegrunnelser.fom) ?: false
 
             val endringsperiodeGjelderSammePersonSomVedtaksperiode =
-                personResultater.any { person -> person.aktør.aktørId == endretUtbetalingAndel.person?.aktør?.aktørId }
+                personResultater.any { endretUtbetalingAndel.personer.any { person -> person.aktør == it.aktør } }
 
             val begrunnelseHarSammeÅrsakSomEndringsperiode =
                 begrunnelse.endringsårsaker.contains(endretUtbetalingAndel.årsak)
@@ -270,7 +270,7 @@ class BegrunnelserForPeriodeContext(
                 val endretUtbetalingAndelStarterSamtidigSomVedtaksperiode = endretUtbetalingAndel.fom == utvidetVedtaksperiodeMedBegrunnelser.fom?.toYearMonth()
 
                 endretUtbetalingAndelStarterFørVedtaksperiode || endretUtbetalingAndelStarterSamtidigSomVedtaksperiode
-            }.mapNotNull { it.person }
+            }.flatMap { it.personer }
             .toSet()
 
     private fun Map<Person, List<VilkårResultat>>.filtrerPåVilkårResultaterSomPasserMedVedtaksperiodeDatoEllerSanityBegrunnelseType(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
 import no.nav.familie.ks.sak.api.dto.SanityBegrunnelseMedEndringsårsakResponseDto
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -47,11 +48,18 @@ class EndretUtbetalingAndelService(
         val vilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id)
         val personopplysningGrunnlag =
             personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
-        val person =
-            personopplysningGrunnlag.personer.single { it.aktør.aktivFødselsnummer() == endretUtbetalingAndelRequestDto.personIdent }
+
+        val personIdenterPåEndretUtbetalingAndel =
+            endretUtbetalingAndelRequestDto.personIdenter
+                ?: endretUtbetalingAndelRequestDto.personIdent?.let { listOf(it) }
+                ?: throw FunksjonellFeil("Endret utbetaling andel må ha minst én person ident")
+
+        val personer =
+            personopplysningGrunnlag.personer.filter { it.aktør.aktivFødselsnummer() in personIdenterPåEndretUtbetalingAndel }
+
         val andelTilkjentYtelser = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id)
 
-        endretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(endretUtbetalingAndelRequestDto, person)
+        endretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(endretUtbetalingAndelRequestDto, personer)
 
         val andreEndredeAndelerPåBehandling =
             hentEndredeUtbetalingAndeler(behandling.id)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/EndretUtbetalingAndelTidslinjeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/EndretUtbetalingAndelTidslinjeService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering
 
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
-import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelService
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
@@ -10,31 +9,26 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.tilTidslinje
-import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.time.LocalDate
-
-@Service
-class EndretUtbetalingAndelTidslinjeService(
-    private val endretUtbetalingAndelService: EndretUtbetalingAndelService,
-) {
-    fun hentBarnasSkalIkkeUtbetalesTidslinjer(behandlingId: Long) =
-        endretUtbetalingAndelService
-            .hentEndredeUtbetalingAndeler(behandlingId)
-            .tilBarnasSkalIkkeUtbetalesTidslinjer()
-}
 
 internal fun Iterable<EndretUtbetalingAndel>.tilBarnasSkalIkkeUtbetalesTidslinjer(): Map<Aktør, Tidslinje<Boolean>> =
     this
         .filter { it.årsak in listOf(Årsak.ETTERBETALING_3MND, Årsak.ALLEREDE_UTBETALT) && it.prosent == BigDecimal.ZERO }
-        .filter { it.person?.type == PersonType.BARN }
-        .filter { it.person?.aktør != null }
-        .groupBy { checkNotNull(it.person?.aktør) }
-        .mapValues { (_, endringer) -> endringer.map { it.tilPeriode { true } }.tilTidslinje() }
+        .flatMap { andel ->
+            andel.personer
+                .filter { it.type == PersonType.BARN }
+                .map { it.aktør to andel }
+        }.groupBy({ it.first }, { it.second })
+        .mapValues { (_, endringer) ->
+            endringer
+                .map { it.tilPeriode() }
+                .tilTidslinje()
+        }
 
-private fun <T> EndretUtbetalingAndel.tilPeriode(mapper: (EndretUtbetalingAndel) -> T) =
+private fun EndretUtbetalingAndel.tilPeriode() =
     Periode(
         fom = this.fom?.førsteDagIInneværendeMåned() ?: LocalDate.now(),
         tom = this.tom?.sisteDagIInneværendeMåned() ?: LocalDate.now(),
-        verdi = mapper(this),
+        verdi = true,
     )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtil.kt
@@ -14,16 +14,16 @@ object EndringIEndretUtbetalingAndelUtil {
         nåværendeEndretAndeler: List<EndretUtbetalingAndel>,
         forrigeEndretAndeler: List<EndretUtbetalingAndel>,
     ): YearMonth? {
-        val nåværendeAktører = nåværendeEndretAndeler.mapNotNull { it.person?.aktør }
-        val forrigeAktører = forrigeEndretAndeler.mapNotNull { it.person?.aktør }
+        val nåværendeAktører = nåværendeEndretAndeler.flatMap { it.personer.map { person -> person.aktør } }.distinct()
+        val forrigeAktører = forrigeEndretAndeler.flatMap { it.personer.map { person -> person.aktør } }.distinct()
         val alleAktører = (nåværendeAktører + forrigeAktører).distinct()
 
         val endringIEndretUtbetalingTidslinjer =
             alleAktører
                 .map { aktør ->
                     lagEndringIEndretUbetalingAndelPerPersonTidslinje(
-                        nåværendeEndretAndelerForPerson = nåværendeEndretAndeler.filter { it.person?.aktør == aktør },
-                        forrigeEndretAndelerForPerson = forrigeEndretAndeler.filter { it.person?.aktør == aktør },
+                        nåværendeEndretAndelerForPerson = nåværendeEndretAndeler.filter { it.personer.any { person -> person.aktør == aktør } },
+                        forrigeEndretAndelerForPerson = forrigeEndretAndeler.filter { it.personer.any { person -> person.aktør == aktør } },
                     )
                 }.kombiner { finnesMinstEnEndringIPeriode(it) }
 

--- a/src/main/resources/db/migration/V40__person_til_endret_utbetaling.sql
+++ b/src/main/resources/db/migration/V40__person_til_endret_utbetaling.sql
@@ -1,0 +1,22 @@
+-- Lag en ny koblingstabell for personer og endret utbetaling andeler
+CREATE TABLE PERSON_TIL_ENDRET_UTBETALING_ANDEL
+(
+    fk_endret_utbetaling_andel_id BIGINT NOT NULL,
+    fk_person_id                  BIGINT NOT NULL,
+
+    PRIMARY KEY (fk_endret_utbetaling_andel_id, fk_person_id),
+    CONSTRAINT fk_endret_utbetaling_andel FOREIGN KEY (fk_endret_utbetaling_andel_id)
+        REFERENCES ENDRET_UTBETALING_ANDEL (id) ON DELETE CASCADE,
+    CONSTRAINT fk_po_person FOREIGN KEY (fk_person_id)
+        REFERENCES PO_PERSON (id) ON UPDATE CASCADE
+);
+
+-- Migrere data fra ENDRET_UTBETALING_ANDEL til den nye tabellen
+INSERT INTO PERSON_TIL_ENDRET_UTBETALING_ANDEL (fk_endret_utbetaling_andel_id, fk_person_id)
+SELECT id AS endret_utbetaling_andel_id, fk_po_person_id AS person_id
+FROM ENDRET_UTBETALING_ANDEL
+WHERE fk_po_person_id IS NOT NULL;
+
+-- Dropp fk_po_person_id kolonnen fra ENDRET_UTBETALING_ANDEL
+ALTER TABLE ENDRET_UTBETALING_ANDEL
+    DROP COLUMN fk_po_person_id;

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -716,7 +716,7 @@ fun lagVilkårResultaterForDeltBosted(
 fun lagEndretUtbetalingAndel(
     id: Long = 0L,
     behandlingId: Long = 0L,
-    person: Person? = lagPerson(aktør = randomAktør()),
+    personer: Set<Person> = setOf(lagPerson(aktør = randomAktør())),
     prosent: BigDecimal? = null,
     periodeFom: YearMonth? = YearMonth.now().minusMonths(1),
     periodeTom: YearMonth? = YearMonth.now(),
@@ -729,7 +729,7 @@ fun lagEndretUtbetalingAndel(
     EndretUtbetalingAndel(
         id = id,
         behandlingId = behandlingId,
-        person = person,
+        personer = personer.toMutableSet(),
         prosent = prosent,
         fom = periodeFom,
         tom = periodeTom,
@@ -743,7 +743,7 @@ fun lagEndretUtbetalingAndel(
 fun lagEndretUtbetalingAndelMedAndelerTilkjentYtelse(
     id: Long = 0,
     behandlingId: Long = 0,
-    person: Person,
+    personer: Set<Person>,
     prosent: BigDecimal = BigDecimal.valueOf(100),
     fom: YearMonth = YearMonth.now().minusMonths(1),
     tom: YearMonth? = YearMonth.now(),
@@ -758,7 +758,7 @@ fun lagEndretUtbetalingAndelMedAndelerTilkjentYtelse(
         EndretUtbetalingAndel(
             id = id,
             behandlingId = behandlingId,
-            person = person,
+            personer = personer.toMutableSet(),
             prosent = prosent,
             fom = fom,
             tom = tom,
@@ -1543,16 +1543,17 @@ fun lagEndretUtbetalingAndelRequestDto(
     erEksplisittAvslagPåSøknad: Boolean? = false,
     begrunnelser: List<NasjonalEllerFellesBegrunnelse> = emptyList(),
 ) = EndretUtbetalingAndelRequestDto(
-    id,
-    personIdent,
-    prosent,
-    fom,
-    tom,
-    årsak,
-    søknadstidspunkt,
-    begrunnelse,
-    erEksplisittAvslagPåSøknad,
-    begrunnelser,
+    id = id,
+    personIdent = personIdent,
+    personIdenter = listOf(personIdent),
+    prosent = prosent,
+    fom = fom,
+    tom = tom,
+    årsak = årsak,
+    søknadstidspunkt = søknadstidspunkt,
+    begrunnelse = begrunnelse,
+    erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
+    vedtaksbegrunnelser = begrunnelser,
 )
 
 fun lagRefusjonEøs(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -366,13 +366,18 @@ fun lagEndredeUtbetalinger(
     persongrunnlag: Map<Long, PersonopplysningGrunnlag>,
 ) = nyeEndredeUtbetalingAndeler
     .map { rad ->
-        val aktørId = VedtaksperiodeMedBegrunnelserParser.parseAktørId(rad)
+        val aktørIder = VedtaksperiodeMedBegrunnelserParser.parseAktørIdListe(rad)
         val behandlingId = parseLong(Domenebegrep.BEHANDLING_ID, rad)
         EndretUtbetalingAndel(
             behandlingId = behandlingId,
             fom = parseValgfriDato(Domenebegrep.FRA_DATO, rad)?.toYearMonth(),
             tom = parseValgfriDato(Domenebegrep.TIL_DATO, rad)?.toYearMonth(),
-            person = persongrunnlag.finnPersonGrunnlagForBehandling(behandlingId).personer.find { aktørId == it.aktør.aktørId },
+            personer =
+                persongrunnlag
+                    .finnPersonGrunnlagForBehandling(behandlingId)
+                    .personer
+                    .filter { it.aktør.aktørId in aktørIder }
+                    .toMutableSet(),
             prosent =
                 parseValgfriLong(
                     VedtaksperiodeMedBegrunnelserParser.DomenebegrepEndretUtbetaling.PROSENT,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -230,7 +230,7 @@ class BehandlingsresultatEndringUtilsTest {
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
-                person = barn,
+                personer = setOf(barn),
                 prosent = BigDecimal.ZERO,
                 periodeFom = jan22,
                 periodeTom = aug22,
@@ -614,7 +614,7 @@ class BehandlingsresultatEndringUtilsTest {
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
-                person = barn,
+                personer = setOf(barn),
                 prosent = BigDecimal.ZERO,
                 periodeFom = jan22,
                 periodeTom = aug22,
@@ -636,7 +636,7 @@ class BehandlingsresultatEndringUtilsTest {
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
-                person = barn,
+                personer = setOf(barn),
                 prosent = BigDecimal.ZERO,
                 periodeFom = jan22,
                 periodeTom = aug22,
@@ -658,7 +658,7 @@ class BehandlingsresultatEndringUtilsTest {
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
-                person = barn,
+                personer = setOf(barn),
                 prosent = BigDecimal.ZERO,
                 periodeFom = jan22,
                 periodeTom = aug22,
@@ -681,7 +681,7 @@ class BehandlingsresultatEndringUtilsTest {
         val nåværendeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
-                person = barn,
+                personer = setOf(barn),
                 prosent = BigDecimal.ZERO,
                 periodeFom = jan22,
                 periodeTom = aug22,
@@ -704,7 +704,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val forrigeEndretAndelBarn1 =
             lagEndretUtbetalingAndel(
-                person = barn1,
+                personer = setOf(barn1),
                 prosent = BigDecimal.ZERO,
                 periodeFom = jan22,
                 periodeTom = aug22,
@@ -713,7 +713,7 @@ class BehandlingsresultatEndringUtilsTest {
 
         val forrigeEndretAndelBarn2 =
             lagEndretUtbetalingAndel(
-                person = barn2,
+                personer = setOf(barn2),
                 prosent = BigDecimal.ZERO,
                 periodeFom = jan22,
                 periodeTom = aug22,
@@ -723,8 +723,8 @@ class BehandlingsresultatEndringUtilsTest {
         val erEndringIEndretAndeler =
             listOf(barn1, barn2).any {
                 erEndringIEndretUtbetalingAndelerForPerson(
-                    forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.person == it },
-                    nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT)).filter { endretAndel -> endretAndel.person == it },
+                    forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.personer.contains(it) },
+                    nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT)).filter { endretAndel -> endretAndel.personer.contains(it) },
                 )
             }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -364,14 +364,14 @@ class BehandlingsresultatOpphørUtilsTest {
         val endretUtBetalingAndeler =
             listOf(
                 lagEndretUtbetalingAndel(
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = for3mndSiden,
                     periodeTom = for2mndSiden,
                     årsak = årsak,
                 ),
                 lagEndretUtbetalingAndel(
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = om4mnd,
                     periodeTom = om4mnd,
@@ -448,14 +448,14 @@ class BehandlingsresultatOpphørUtilsTest {
         val forrigeEndretAndeler =
             listOf(
                 lagEndretUtbetalingAndel(
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = for3mndSiden,
                     periodeTom = for2mndSiden,
                     årsak = Årsak.ALLEREDE_UTBETALT,
                 ),
                 lagEndretUtbetalingAndel(
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = for1mndSiden,
                     periodeTom = om4mnd,
@@ -497,7 +497,7 @@ class BehandlingsresultatOpphørUtilsTest {
         val forrigeEndretAndeler =
             listOf(
                 lagEndretUtbetalingAndel(
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = for3mndSiden,
                     periodeTom = for2mndSiden,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
@@ -153,7 +153,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
         val endretUtbetalingAndel =
             lagEndretUtbetalingAndel(
-                person = barn1Person,
+                personer = setOf(barn1Person),
                 periodeFom = jan22,
                 periodeTom = aug22,
                 prosent = BigDecimal(100),
@@ -194,7 +194,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
         val endretUtbetalingAndel =
             lagEndretUtbetalingAndel(
-                person = barn1Person,
+                personer = setOf(barn1Person),
                 periodeFom = jan22,
                 periodeTom = aug22,
                 prosent = BigDecimal(100),
@@ -282,7 +282,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
         val endretUtbetalingAndel =
             lagEndretUtbetalingAndel(
-                person = barn1Person,
+                personer = setOf(barn1Person),
                 periodeFom = jan22,
                 periodeTom = aug22,
                 prosent = BigDecimal(100),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -71,7 +71,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
                 // overlappende periode, kommer med andelTilkjentYtelse
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søkerPerson,
+                    personer = setOf(søkerPerson),
                     prosent = BigDecimal(100),
                     periodeFom = YearMonth.now().minusMonths(2),
                     periodeTom = YearMonth.now().minusMonths(1),
@@ -79,7 +79,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
                 // ikke overlappende perioder, kommer ikke med andelTilkjentYtelse
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søkerPerson,
+                    personer = setOf(søkerPerson),
                     prosent = BigDecimal(100),
                     periodeFom = YearMonth.now().minusMonths(10),
                     periodeTom = YearMonth.now().minusMonths(9),
@@ -129,7 +129,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
                 // overlappende periode, kommer med andelTilkjentYtelse
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søkerPerson,
+                    personer = setOf(søkerPerson),
                     prosent = BigDecimal(100),
                     periodeFom = fom,
                     periodeTom = tom,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/EndretUtbetalingAndelValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/EndretUtbetalingAndelValidatorTest.kt
@@ -62,7 +62,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søkerPerson,
+                    personer = setOf(søkerPerson),
                     prosent = BigDecimal(50),
                     periodeFom = YearMonth.now().minusMonths(1),
                     periodeTom = YearMonth.now().plusMonths(7),
@@ -98,7 +98,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søkerPerson,
+                    personer = setOf(søkerPerson),
                     prosent = BigDecimal(50),
                     periodeFom = YearMonth.now().minusMonths(2),
                     periodeTom = YearMonth.now().plusMonths(5),
@@ -134,7 +134,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søkerPerson,
+                    personer = setOf(søkerPerson),
                     prosent = BigDecimal(50),
                     periodeFom = YearMonth.now().minusMonths(1),
                     periodeTom = YearMonth.now().plusMonths(5),
@@ -168,7 +168,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søkerPerson,
+                    personer = setOf(søkerPerson),
                     prosent = BigDecimal(50),
                     periodeFom = YearMonth.now().minusMonths(1),
                     periodeTom = YearMonth.now().plusMonths(4),
@@ -191,7 +191,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = barnPerson,
+                    personer = setOf(barnPerson),
                     periodeFom = YearMonth.now().minusMonths(5),
                     periodeTom = YearMonth.now().minusMonths(4),
                     prosent = BigDecimal.ZERO,
@@ -211,7 +211,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = barnPerson,
+                    personer = setOf(barnPerson),
                     periodeFom = YearMonth.now().minusMonths(5),
                     periodeTom = YearMonth.now().minusMonths(4),
                     prosent = null,
@@ -243,7 +243,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = barnPerson,
+                    personer = setOf(barnPerson),
                     periodeFom = YearMonth.now().minusMonths(5),
                     periodeTom = YearMonth.now().minusMonths(4),
                     prosent = BigDecimal.ZERO,
@@ -274,7 +274,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = barnPerson,
+                    personer = setOf(barnPerson),
                     periodeFom = YearMonth.now().minusMonths(5),
                     periodeTom = YearMonth.now().minusMonths(4),
                     prosent = BigDecimal.ZERO,
@@ -310,7 +310,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = barnPerson,
+                    personer = setOf(barnPerson),
                     periodeFom = YearMonth.now().minusMonths(3),
                     periodeTom = YearMonth.now().minusMonths(2),
                     prosent = BigDecimal(100),
@@ -337,7 +337,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = barnPerson,
+                    personer = setOf(barnPerson),
                     periodeFom = YearMonth.now().minusMonths(1),
                     periodeTom = YearMonth.now().plusMonths(2),
                     prosent = BigDecimal.ZERO,
@@ -364,7 +364,7 @@ class EndretUtbetalingAndelValidatorTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = barnPerson,
+                    personer = setOf(barnPerson),
                     periodeFom = YearMonth.now().minusMonths(5),
                     periodeTom = YearMonth.now().minusMonths(4),
                     prosent = BigDecimal.ZERO,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/EndretUtbetalingAndelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/EndretUtbetalingAndelTest.kt
@@ -33,7 +33,7 @@ class EndretUtbetalingAndelTest {
         assertDoesNotThrow {
             lagEndretUtbetalingAndel(
                 behandlingId = behandling.id,
-                person = person,
+                personer = setOf(person),
                 prosent = BigDecimal(50),
             ).validerUtfyltEndring()
         }
@@ -44,7 +44,7 @@ class EndretUtbetalingAndelTest {
         val endretUtbetalingAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = behandling.id,
-                person = person,
+                personer = setOf(person),
             )
         val exception =
             assertThrows<RuntimeException> {
@@ -61,7 +61,7 @@ class EndretUtbetalingAndelTest {
         val endretUtbetalingAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = behandling.id,
-                person = person,
+                personer = setOf(person),
                 prosent = BigDecimal(50),
                 periodeFom = YearMonth.now(),
                 periodeTom = YearMonth.now().minusYears(1),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/endretUtbetaling/AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/endretUtbetaling/AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest.kt
@@ -152,7 +152,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndelForBarn1 =
                 lagEndretUtbetalingAndelMedAndelerTilkjentYtelse(
                     behandlingId = behandling.id,
-                    person = barn1,
+                    personer = setOf(barn1),
                     prosent = BigDecimal.ZERO,
                     årsak = Årsak.ETTERBETALING_3MND,
                     fom = fom,
@@ -215,7 +215,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndelMedAndelerTilkjentYtelse(
                     behandlingId = behandling.id,
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     årsak = Årsak.ALLEREDE_UTBETALT,
                     fom = YearMonth.now().minusMonths(7),
@@ -278,7 +278,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søker,
+                    personer = setOf(søker),
                     periodeFom = fom,
                     periodeTom = tom,
                     prosent = BigDecimal.ZERO,
@@ -333,7 +333,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søker,
+                    personer = setOf(søker),
                     periodeFom = fom1,
                     periodeTom = tom2,
                     prosent = BigDecimal.ZERO,
@@ -345,7 +345,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndel2 =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søker,
+                    personer = setOf(søker),
                     periodeFom = tom2.nesteMåned(),
                     prosent = endretProsent,
                 )
@@ -395,7 +395,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søker,
+                    personer = setOf(søker),
                     periodeFom = fom,
                     periodeTom = tom,
                     prosent = BigDecimal(100),
@@ -445,7 +445,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søker,
+                    personer = setOf(søker),
                     periodeFom = fom,
                     periodeTom = tom,
                     prosent = BigDecimal(0),
@@ -501,7 +501,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = behandling.id,
-                    person = søker,
+                    personer = setOf(søker),
                     periodeFom = fom,
                     periodeTom = tom,
                     prosent = BigDecimal(0),
@@ -545,7 +545,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
                                     andeler = emptyList(),
                                     endretUtbetalingAndel =
                                         lagEndretUtbetalingAndel(
-                                            person = barn,
+                                            personer = setOf(barn),
                                             prosent = BigDecimal.ZERO,
                                             årsak = Årsak.ETTERBETALING_3MND,
                                         ),
@@ -569,7 +569,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
                                     andeler = emptyList(),
                                     endretUtbetalingAndel =
                                         lagEndretUtbetalingAndel(
-                                            person = barn,
+                                            personer = setOf(barn),
                                             prosent = BigDecimal.ZERO,
                                             årsak = Årsak.ALLEREDE_UTBETALT,
                                         ),
@@ -594,7 +594,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             // Arrange
             val barn = lagPerson(personType = PersonType.BARN)
             val endretUtbetalingAndel =
-                lagEndretUtbetalingAndel(person = barn, prosent = BigDecimal.ZERO, årsak = Årsak.ALLEREDE_UTBETALT)
+                lagEndretUtbetalingAndel(personer = setOf(barn), prosent = BigDecimal.ZERO, årsak = Årsak.ALLEREDE_UTBETALT)
 
             val periode1 =
                 Periode(
@@ -697,7 +697,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             val barn = lagPerson(personType = PersonType.BARN)
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     årsak = Årsak.ALLEREDE_UTBETALT,
                     periodeFom = YearMonth.now().minusMonths(9),
@@ -825,7 +825,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
                                     andeler = emptyList(),
                                     endretUtbetalingAndel =
                                         lagEndretUtbetalingAndel(
-                                            person = barn,
+                                            personer = setOf(barn),
                                             prosent = BigDecimal.ZERO,
                                             årsak = Årsak.ETTERBETALING_3MND,
                                         ),
@@ -846,7 +846,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
             assertThat(andel.endreteUtbetalinger.size).isEqualTo(1)
             assertThat(andel.endreteUtbetalinger.single().prosent).isEqualTo(BigDecimal.ZERO)
             assertThat(andel.endreteUtbetalinger.single().årsak).isEqualTo(Årsak.ETTERBETALING_3MND)
-            assertThat(andel.endreteUtbetalinger.single().person).isEqualTo(barn)
+            assertThat(andel.endreteUtbetalinger.single().personer).containsOnly(barn)
 
             assertThat(andel.andel.tilkjentYtelse).isEqualTo(tilkjentYtelse)
             assertThat(andel.andel.aktør).isEqualTo(barn.aktør)
@@ -881,7 +881,7 @@ class AndelTilkjentYtelseMedEndretUtbetalingBehandlerTest {
                                         andeler = emptyList(),
                                         endretUtbetalingAndel =
                                             lagEndretUtbetalingAndel(
-                                                person = barn,
+                                                personer = setOf(barn),
                                                 prosent = BigDecimal.ZERO,
                                                 årsak = Årsak.ETTERBETALING_3MND,
                                             ),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -487,7 +487,7 @@ fun lagBrevPeriodeContext(
             persongrunnlag.barna.map {
                 EndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = it,
+                    personer = mutableSetOf(it),
                     fom = YearMonth.of(2020, 12),
                     tom = vedtaksperiodeMedBegrunnelser.fom?.toYearMonth()?.minusMonths(1),
                     årsak = Årsak.ETTERBETALING_3MND,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -108,7 +108,7 @@ class EndretUtbetalingAndelServiceTest {
 
         assertThat(tomEndretUtbetalingAndelMedBehandlingSatt.behandlingId, Is(behandling.id))
         assertThat(tomEndretUtbetalingAndelMedBehandlingSatt.årsak, Is(nullValue()))
-        assertThat(tomEndretUtbetalingAndelMedBehandlingSatt.person, Is(nullValue()))
+        assertThat(tomEndretUtbetalingAndelMedBehandlingSatt.personer, Is(emptySet()))
         assertThat(tomEndretUtbetalingAndelMedBehandlingSatt.tom, Is(nullValue()))
         assertThat(tomEndretUtbetalingAndelMedBehandlingSatt.fom, Is(nullValue()))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -6,14 +6,20 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelRequestDto
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagEndretUtbetalingAndel
+import no.nav.familie.ks.sak.data.lagPerson
+import no.nav.familie.ks.sak.data.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseType
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.BegrunnelseType
@@ -22,9 +28,16 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAnde
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.Årsak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.YearMonth
 import org.hamcrest.CoreMatchers.`is` as Is
 
 class EndretUtbetalingAndelServiceTest {
@@ -177,5 +190,106 @@ class EndretUtbetalingAndelServiceTest {
         // Assert
         assertThat(endringsårsakbegrunnelser.size, Is(9))
         assertThat(endringsårsakbegrunnelser[BegrunnelseType.AVSLAG]?.size, Is(2))
+    }
+
+    @Test
+    fun `Skal håndtere EndretUtbetalingAndelRequestDto med blanding av nytt og gammelt felt for personIdent(er)`() {
+        // Arrange
+        val behandling = lagBehandling()
+        val barn1 = lagPerson(personType = PersonType.BARN)
+        val barn2 = lagPerson(personType = PersonType.BARN)
+
+        val endretUtbetalingAndel = EndretUtbetalingAndel(behandlingId = behandling.id)
+
+        val andelerTilkjentYtelse =
+            listOf(
+                lagAndelTilkjentYtelse(
+                    person = barn1,
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 1),
+                ),
+                lagAndelTilkjentYtelse(
+                    person = barn2,
+                    fom = YearMonth.of(2025, 1),
+                    tom = YearMonth.of(2025, 1),
+                ),
+            )
+
+        val lagretEndretUtbetalingAndel = slot<EndretUtbetalingAndel>()
+
+        every { endretUtbetalingAndelRepository.getReferenceById(any()) } returns endretUtbetalingAndel
+        every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns lagTestPersonopplysningGrunnlag(behandling.id, barn1, barn2)
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId = behandling.id) } returns andelerTilkjentYtelse
+        every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(behandlingId = behandling.id) } returns listOf(endretUtbetalingAndel)
+        every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandlingId = behandling.id) } returns Vilkårsvurdering(behandling = behandling)
+        every { endretUtbetalingAndelRepository.saveAndFlush(capture(lagretEndretUtbetalingAndel)) } returns mockk()
+        every { beregningService.oppdaterTilkjentYtelsePåBehandling(any(), any(), any(), any()) } returns mockk()
+
+        var endretUtbetalingAndelRequestDto =
+            EndretUtbetalingAndelRequestDto(
+                id = 0,
+                personIdent = null,
+                personIdenter = null,
+                prosent = BigDecimal.ZERO,
+                fom = YearMonth.of(2025, 1),
+                tom = YearMonth.of(2025, 1),
+                årsak = Årsak.ALLEREDE_UTBETALT,
+                søknadstidspunkt = LocalDate.now(),
+                begrunnelse = "Test begrunnelse",
+                erEksplisittAvslagPåSøknad = false,
+                vedtaksbegrunnelser = emptyList(),
+            )
+
+        // Act & Assert
+        assertThrows<FunksjonellFeil> {
+            endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
+                behandling = behandling,
+                endretUtbetalingAndelRequestDto = endretUtbetalingAndelRequestDto,
+            )
+        }
+
+        // Arrange
+        endretUtbetalingAndelRequestDto =
+            endretUtbetalingAndelRequestDto.copy(
+                personIdenter = null,
+                personIdent = barn1.aktør.aktivFødselsnummer(),
+            )
+
+        // Act & Assert
+        assertDoesNotThrow {
+            endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
+                behandling = behandling,
+                endretUtbetalingAndelRequestDto = endretUtbetalingAndelRequestDto,
+            )
+        }
+
+        // Assert
+        assertThat(lagretEndretUtbetalingAndel.captured).isEqualTo(
+            endretUtbetalingAndel.copy(
+                personer = mutableSetOf(barn1),
+            ),
+        )
+
+        // Arrange
+        endretUtbetalingAndelRequestDto =
+            endretUtbetalingAndelRequestDto.copy(
+                personIdenter = listOf(barn1.aktør.aktivFødselsnummer(), barn2.aktør.aktivFødselsnummer()),
+                personIdent = barn1.aktør.aktivFødselsnummer(),
+            )
+
+        // Act & Assert
+        assertDoesNotThrow {
+            endretUtbetalingAndelService.oppdaterEndretUtbetalingAndelOgOppdaterTilkjentYtelse(
+                behandling = behandling,
+                endretUtbetalingAndelRequestDto = endretUtbetalingAndelRequestDto,
+            )
+        }
+
+        // Assert
+        assertThat(lagretEndretUtbetalingAndel.captured).isEqualTo(
+            endretUtbetalingAndel.copy(
+                personer = mutableSetOf(barn1, barn2),
+            ),
+        )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/domene/EndretUtbetalingAndelKtTest.kt
@@ -29,11 +29,11 @@ class EndretUtbetalingAndelKtTest {
                     erEksplisittAvslagPåSøknad = false,
                 )
 
-            val person = lagPerson(aktør = randomAktør())
+            val personer = setOf(lagPerson(aktør = randomAktør()))
 
             val endretUtbetalingAndel =
                 lagEndretUtbetalingAndel(
-                    person = person,
+                    personer = personer,
                     prosent = BigDecimal(50),
                     periodeFom = YearMonth.now().minusMonths(2),
                     periodeTom = YearMonth.now().plusMonths(2),
@@ -46,13 +46,13 @@ class EndretUtbetalingAndelKtTest {
             val oppdatertEndretUtbetalingAndel =
                 endretUtbetalingAndel.fraEndretUtbetalingAndelRequestDto(
                     endretUtbetalingAndelRequestDto,
-                    person,
+                    personer,
                 )
 
             // Assert
             assertThat(oppdatertEndretUtbetalingAndel.id).isEqualTo(endretUtbetalingAndel.id)
             assertThat(oppdatertEndretUtbetalingAndel.behandlingId).isEqualTo(endretUtbetalingAndel.id)
-            assertThat(oppdatertEndretUtbetalingAndel.person).isEqualTo(person)
+            assertThat(oppdatertEndretUtbetalingAndel.personer).isEqualTo(personer)
             assertThat(oppdatertEndretUtbetalingAndel.prosent).isEqualTo(endretUtbetalingAndelRequestDto.prosent)
             assertThat(oppdatertEndretUtbetalingAndel.fom).isEqualTo(endretUtbetalingAndelRequestDto.fom)
             assertThat(oppdatertEndretUtbetalingAndel.tom).isEqualTo(endretUtbetalingAndelRequestDto.tom)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/DeltBostedBuilder.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/util/DeltBostedBuilder.kt
@@ -79,7 +79,7 @@ fun Iterable<DeltBosted>.tilEndreteUtebetalingAndeler(): List<EndretUtbetalingAn
                 val endretUtbetalingAndel: EndretUtbetalingAndel =
                     lagEndretUtbetalingAndel(
                         behandlingId = deltBosted.behandlingId,
-                        person = barn,
+                        personer = setOf(barn),
                         periodeFom = deltBosted.fom!!,
                         periodeTom = deltBosted.tom!!,
                         prosent = deltBosted.prosent!!.toBigDecimal(),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
@@ -30,7 +30,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -54,7 +54,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -80,7 +80,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndelBarn1 =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn1,
+                    personer = setOf(barn1),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -90,7 +90,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndelBarn2 =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn2,
+                    personer = setOf(barn2),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -118,7 +118,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -146,7 +146,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -174,7 +174,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndelBarn1 =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn1,
+                    personer = setOf(barn1),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -184,7 +184,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndelBarn2 =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn2,
+                    personer = setOf(barn2),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -195,8 +195,8 @@ class EndringIEndretUtbetalingAndelUtilTest {
                 listOf(barn1, barn2)
                     .map {
                         EndringIEndretUtbetalingAndelUtil.lagEndringIEndretUbetalingAndelPerPersonTidslinje(
-                            forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.person == it },
-                            nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT)).filter { endretAndel -> endretAndel.person == it },
+                            forrigeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2).filter { endretAndel -> endretAndel.personer.contains(it) },
+                            nåværendeEndretAndelerForPerson = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT)).filter { endretAndel -> endretAndel.personer.contains(it) },
                         )
                     }.flatMap { it.tilPerioder() }
                     .filter { it.verdi == true }
@@ -212,7 +212,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,
@@ -240,7 +240,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
             val nåværendeEndretAndel =
                 lagEndretUtbetalingAndel(
                     behandlingId = 0,
-                    person = barn,
+                    personer = setOf(barn),
                     prosent = BigDecimal.ZERO,
                     periodeFom = jan22,
                     periodeTom = aug22,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/EndretUtbetalingAndelControllerTest.kt
@@ -76,7 +76,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                 endretUtbetalingAndelRepository.saveAndFlush(
                     lagEndretUtbetalingAndel(
                         behandlingId = behandling.id,
-                        person = søkerPerson,
+                        personer = setOf(søkerPerson),
                     ),
                 )
 
@@ -141,7 +141,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                 endretUtbetalingAndelRepository.saveAndFlush(
                     lagEndretUtbetalingAndel(
                         behandlingId = behandling.id,
-                        person = søkerPerson,
+                        personer = setOf(søkerPerson),
                     ),
                 )
 
@@ -212,7 +212,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                 endretUtbetalingAndelRepository.saveAndFlush(
                     lagEndretUtbetalingAndel(
                         behandlingId = behandling.id,
-                        person = søkerPerson,
+                        personer = setOf(søkerPerson),
                     ),
                 )
 
@@ -270,7 +270,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                 endretUtbetalingAndelRepository.saveAndFlush(
                     lagEndretUtbetalingAndel(
                         behandlingId = behandling.id,
-                        person = søkerPerson,
+                        personer = setOf(søkerPerson),
                     ),
                 )
 
@@ -302,7 +302,7 @@ class EndretUtbetalingAndelControllerTest : OppslagSpringRunnerTest() {
                 endretUtbetalingAndelRepository.saveAndFlush(
                     lagEndretUtbetalingAndel(
                         behandlingId = behandling.id,
-                        person = søkerPerson,
+                        personer = setOf(søkerPerson),
                     ),
                 )
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25446

Legger til ny tabell, migrering av eksisterende data og endrer felt på entitet for å kunne ha flere personer knyttet til en endret utbetaling andel, og oppdaterer logikk og tester.