### PR TITLE
Summer overgangsordningandeler før intern konsistensavstemming 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
@@ -72,7 +72,7 @@ class InternKonsistensavstemmingService(
         }
     }
 
-    private fun hentFagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap(
+    fun hentFagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap(
         fagsakIder: Set<Long>,
     ): Map<Long, Pair<List<AndelTilkjentYtelse>, Utbetalingsoppdrag?>> {
         val scope = CoroutineScope(SupervisorJob())

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingService.kt
@@ -9,6 +9,8 @@ import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.andelerIOvergangsordningUtbetalingsmåned
+import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreOgPraksisendringAndeler
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.task.overstyrTaskMedNyCallId
 import no.nav.familie.log.IdUtils
@@ -99,6 +101,7 @@ class InternKonsistensavstemmingService(
         return andelTilkjentYtelseRepository
             .finnAndelerTilkjentYtelseForBehandlinger(behandlinger.map { it.id })
             .groupBy { it.behandlingId }
+            .mapValues { (_, andeler) -> (andeler.ordinæreOgPraksisendringAndeler() + andeler.andelerIOvergangsordningUtbetalingsmåned()) }
             .mapKeys { (behandlingId, _) -> behandlinger.find { it.id == behandlingId }?.fagsak?.id!! }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -9,16 +9,12 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.kontrakter.felles.oppdrag.Opphør
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
-import no.nav.familie.ks.sak.common.util.MånedPeriode
-import no.nav.familie.ks.sak.common.util.overlapperHeltEllerDelvisMed
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import no.nav.familie.ks.sak.kjerne.beregning.domene.andelerIOvergangsordningUtbetalingsmåned
 import no.nav.familie.ks.sak.kjerne.beregning.domene.ordinæreOgPraksisendringAndeler
-import no.nav.familie.ks.sak.kjerne.beregning.domene.overgangsordningAndelerPerAktør
-import no.nav.familie.ks.sak.kjerne.beregning.domene.totalKalkulertUtbetalingsbeløpForPeriode
-import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.time.YearMonth
@@ -75,7 +71,9 @@ class UtbetalingsoppdragGenerator {
             if (andelTilkjentYtelse.type == YtelseType.OVERGANGSORDNING) {
                 val overgangsordningsAndelerForAktørSisteTilkjentYtelse =
                     forrigeTilkjentYtelse
-                        .overgangsordningAndelerOgOrdinærForOvergangsordningUtbetalingsmånedTilAndelDataLongId()
+                        .andelerTilkjentYtelse
+                        .andelerIOvergangsordningUtbetalingsmåned()
+                        .map { it.tilAndelDataLongId() }
                         .filter { it.personIdent == identOgType.ident }
                         // Vi henter ut andeler som har fom/tom i desember siden uavhengig av hva fom/tom er på andelen så blir den justert til desember opp mot oppdrag for overgangsordning
                         .singleOrNull { it.fom == OVERGANGSORDNING_UTBETALINGSMÅNED && it.tom == OVERGANGSORDNING_UTBETALINGSMÅNED }
@@ -102,49 +100,8 @@ class UtbetalingsoppdragGenerator {
         )
 
     private fun TilkjentYtelse.tilAndelDataLongId(): List<AndelDataLongId> =
-        this.ordinæreOgPraksisendringAndelerTilAndelDataLongId() +
-            this.overgangsordningAndelerOgOrdinærForOvergangsordningUtbetalingsmånedTilAndelDataLongId()
-
-    private fun TilkjentYtelse.ordinæreOgPraksisendringAndelerTilAndelDataLongId(): List<AndelDataLongId> =
-        this
-            .andelerTilkjentYtelse
-            .ordinæreOgPraksisendringAndeler()
+        (andelerTilkjentYtelse.ordinæreOgPraksisendringAndeler() + andelerTilkjentYtelse.andelerIOvergangsordningUtbetalingsmåned())
             .map { it.tilAndelDataLongId() }
-
-    private fun TilkjentYtelse.overgangsordningAndelerOgOrdinærForOvergangsordningUtbetalingsmånedTilAndelDataLongId(): List<AndelDataLongId> {
-        val ordinærAndelerPerBarnIOvergangsordningUtbetalingsmåned =
-            ordinæreOgPraksisendringAndelerPerBarnIOvergangsordningUtbetalingMåned()
-        return this
-            .andelerTilkjentYtelse
-            .overgangsordningAndelerPerAktør()
-            .map { (aktør, overgangsordningAndeler) ->
-                val førsteAndel = overgangsordningAndeler.minBy { it.stønadFom }
-                val kalkulertUtbetalingsbeløp =
-                    overgangsordningAndeler.sumOf { it.totalKalkulertUtbetalingsbeløpForPeriode() } +
-                        (ordinærAndelerPerBarnIOvergangsordningUtbetalingsmåned[aktør]?.kalkulertUtbetalingsbeløp ?: 0)
-                AndelDataLongId(
-                    id = førsteAndel.id,
-                    fom = OVERGANGSORDNING_UTBETALINGSMÅNED,
-                    tom = OVERGANGSORDNING_UTBETALINGSMÅNED,
-                    beløp = kalkulertUtbetalingsbeløp,
-                    personIdent = aktør.aktivFødselsnummer(),
-                    type = førsteAndel.type.tilYtelseType(),
-                    periodeId = førsteAndel.periodeOffset,
-                    forrigePeriodeId = førsteAndel.forrigePeriodeOffset,
-                    kildeBehandlingId = førsteAndel.kildeBehandlingId,
-                )
-            }
-    }
-
-    private fun TilkjentYtelse.ordinæreOgPraksisendringAndelerPerBarnIOvergangsordningUtbetalingMåned(): Map<Aktør, AndelTilkjentYtelse?> =
-        andelerTilkjentYtelse
-            .ordinæreOgPraksisendringAndeler()
-            .groupBy { it.aktør }
-            .mapValues { (_, andeler) ->
-                andeler.find { andel ->
-                    andel.periode.overlapperHeltEllerDelvisMed(MånedPeriode(OVERGANGSORDNING_UTBETALINGSMÅNED, OVERGANGSORDNING_UTBETALINGSMÅNED))
-                }
-            }
 }
 
 enum class YtelsetypeKS(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingServiceTest.kt
@@ -1,0 +1,111 @@
+package no.nav.familie.ks.sak.integrasjon.økonomi.internkonsistensavstemming
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag.KodeEndring.ENDR
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode.SatsType.MND
+import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
+import no.nav.familie.ks.sak.integrasjon.oppdrag.UtbetalingsoppdragMedBehandlingOgFagsak
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+
+class InternKonsistensavstemmingServiceTest {
+    private val behandlingService = mockk<BehandlingService>()
+    private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+    private val oppdragKlient = mockk<OppdragKlient>()
+    private val internKonsistensavstemmingService =
+        InternKonsistensavstemmingService(
+            oppdragKlient = oppdragKlient,
+            behandlingService = behandlingService,
+            andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            fagsakRepository = mockk(),
+            taskService = mockk(),
+        )
+
+    @Test
+    fun `skal summere overgangsordningandeler i intern konsistensavstemming`() {
+        val behandling = lagBehandling()
+        val fagsakId = behandling.fagsak.id
+        val aktør = behandling.fagsak.aktør
+
+        val ordinæreAndel =
+            lagAndelTilkjentYtelse(
+                behandling = behandling,
+                aktør = aktør,
+                stønadFom = YearMonth.of(2024, 2),
+                stønadTom = YearMonth.of(2024, 8),
+                kalkulertUtbetalingsbeløp = 7500,
+                ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
+            )
+
+        val overgangsordningAndel =
+            lagAndelTilkjentYtelse(
+                behandling = behandling,
+                aktør = aktør,
+                stønadFom = YearMonth.of(2024, 9),
+                stønadTom = YearMonth.of(2024, 12),
+                kalkulertUtbetalingsbeløp = 7500,
+                ytelseType = YtelseType.OVERGANGSORDNING,
+            )
+
+        val utbetalingsoppdragMedBehandlingOgFagsak =
+            UtbetalingsoppdragMedBehandlingOgFagsak(
+                fagsakId = fagsakId,
+                behandlingId = behandling.id,
+                utbetalingsoppdrag =
+                    Utbetalingsoppdrag(
+                        kodeEndring = ENDR,
+                        fagSystem = "KS",
+                        saksnummer = "1143961",
+                        aktoer = aktør.aktivFødselsnummer(),
+                        saksbehandlerId = "VL",
+                        avstemmingTidspunkt = LocalDateTime.now(),
+                        utbetalingsperiode =
+                            listOf(
+                                Utbetalingsperiode(
+                                    erEndringPåEksisterendePeriode = false,
+                                    opphør = null,
+                                    periodeId = 1,
+                                    forrigePeriodeId = 0,
+                                    datoForVedtak = LocalDate.of(2024, 12, 18),
+                                    klassifisering = "KS",
+                                    vedtakdatoFom = LocalDate.of(2024, 12, 1),
+                                    vedtakdatoTom = LocalDate.of(2024, 12, 31),
+                                    sats = BigDecimal.valueOf(30000),
+                                    satsType = MND,
+                                    utbetalesTil = aktør.aktivFødselsnummer(),
+                                    behandlingId = behandling.id,
+                                    utbetalingsgrad = null,
+                                ),
+                            ),
+                        gOmregning = false,
+                    ),
+            )
+
+        every { behandlingService.hentSisteBehandlingSomErAvsluttetEllerSendtTilØkonomiPerFagsak(any()) } returns listOf(behandling)
+        every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(any()) } returns listOf(ordinæreAndel, overgangsordningAndel)
+        every { oppdragKlient.hentSisteUtbetalingsoppdragForFagsaker(any()) } returns listOf(utbetalingsoppdragMedBehandlingOgFagsak)
+
+        val (andeler, utbetalingsoppdrag) =
+            internKonsistensavstemmingService.hentFagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap(fagsakIder = setOf(fagsakId)).getValue(fagsakId)
+
+        assertThat(
+            erForskjellMellomAndelerOgOppdrag(
+                andeler = andeler,
+                utbetalingsoppdrag = utbetalingsoppdrag,
+                fagsakId = fagsakId,
+            ),
+        ).isFalse()
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-25634

Før andeler sendes til oppdrag blir andelene for overgangsordning summert inn i én andel der fom og tom settes til desember 2024.

Dette må også gjøres for andelene før intern konsistensavstemming gjennomføres.

Flytter funksjonen som summerer overgangsordningandelene inn i AndelTilkjentYtelse.kt, slik at den er tilgjengelig i InternKonsistensavstemmingService, og mapper over andelene for overgangsordning der.