### PR TITLE
Legg til bosatt på svalbard valg i utdypende vilkårsvurdering for bosatt i riket

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/UtdypendeVilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/UtdypendeVilkårsvurdering.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.common.util.konverterStringTilEnums
 
 enum class UtdypendeVilkårsvurdering {
     VURDERING_ANNET_GRUNNLAG,
+    BOSATT_PÅ_SVALBARD,
     DELT_BOSTED,
     DELT_BOSTED_SKAL_IKKE_DELES,
     ADOPSJON,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25335

Legger til muligheten til å velge bosatt på svalbard som utdypende vilkårsvurdering i bosatt i riket vilkåret.

<img width="601" alt="bosatt_på_svalbard" src="https://github.com/user-attachments/assets/0a298c48-a81a-4cae-a118-8ae58e76fb48" />
<img width="519" alt="bosatt på svalbard" src="https://github.com/user-attachments/assets/2f4656ab-60db-44f1-81d5-853132010834" />

FrontendPR: https://github.com/navikt/familie-ks-sak-frontend/pull/1230
