### PR TITLE
Fjerner toggle for henting av klagebehandlinger fra nytt endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -11,7 +11,4 @@ enum class FeatureToggle(
 
     // Ikke operasjonelle
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
-
-    // NAV-25831
-    BRUK_NYTT_ENDEPUNKT_FOR_HENTING_AV_KLAGEBEHANDLINGER("familie-ba-sak.bruk-nytt-endepunkt-for-henting-av-klagebehandlinger"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageClient.kt
@@ -35,24 +35,6 @@ class KlageClient(
         }
     }
 
-    fun hentKlagebehandlinger(eksternIder: Set<Long>): Map<Long, List<KlagebehandlingDto>> {
-        val uri =
-            UriComponentsBuilder
-                .fromUri(familieKlageUri)
-                .pathSegment("api/ekstern/behandling/${Fagsystem.KS}")
-                .queryParam("eksternFagsakId", eksternIder.joinToString(","))
-                .build()
-                .toUri()
-
-        return kallEksternTjenesteRessurs(
-            tjeneste = "klage",
-            uri = uri,
-            formål = "Hent klagebehandlinger",
-        ) {
-            getForEntity(uri)
-        }
-    }
-
     fun hentKlagebehandlinger(fagsakId: Long): List<KlagebehandlingDto> {
         val uri =
             UriComponentsBuilder

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenter.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenter.kt
@@ -4,28 +4,15 @@ import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
 import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
 import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
-import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import org.springframework.stereotype.Component
-import kotlin.collections.get
 
 @Component
 class KlagebehandlingHenter(
     private val klageClient: KlageClient,
-    private val unleashNextMedContextService: UnleashNextMedContextService,
 ) {
     fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> {
-        val klagerPåFagsak =
-            if (unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NYTT_ENDEPUNKT_FOR_HENTING_AV_KLAGEBEHANDLINGER)) {
-                klageClient.hentKlagebehandlinger(fagsakId)
-            } else {
-                klageClient.hentKlagebehandlinger(setOf(fagsakId))[fagsakId]
-            }
-        if (klagerPåFagsak == null) {
-            throw Feil("Fikk ikke fagsakId=$fagsakId tilbake fra kallet til klage.")
-        }
+        val klagerPåFagsak = klageClient.hentKlagebehandlinger(fagsakId)
         return klagerPåFagsak.map { it.brukVedtaksdatoFraKlageinstansHvisOversendt() }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingHenterTest.kt
@@ -6,15 +6,12 @@ import no.nav.familie.kontrakter.felles.klage.BehandlingEventType
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
 import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagKlagebehandlingDto
 import no.nav.familie.ks.sak.data.lagKlageinstansResultatDto
 import no.nav.familie.ks.sak.kjerne.klage.KlageClient
 import no.nav.familie.ks.sak.kjerne.klage.KlagebehandlingHenter
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -24,17 +21,10 @@ import java.util.UUID
 
 class KlagebehandlingHenterTest {
     private val klageClient = mockk<KlageClient>()
-    private val unleashNextMedContextService = mockk<UnleashNextMedContextService>()
     private val klagebehandlingHenter =
         KlagebehandlingHenter(
             klageClient = klageClient,
-            unleashNextMedContextService = unleashNextMedContextService,
         )
-
-    @BeforeEach
-    fun setUp() {
-        every { unleashNextMedContextService.isEnabled(any<FeatureToggle>()) } returns true
-    }
 
     @Nested
     inner class HentKlagebehandlingerPåFagsak {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -121,8 +121,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun setup() {
-        val fagsakId = slot<Long>()
-        every { klageClient.hentKlagebehandlinger(capture(fagsakId)) } returns emptyList()
+        every { klageClient.hentKlagebehandlinger(any()) } returns emptyList()
 
         opprettSøkerFagsakOgBehandling(fagsakStatus = FagsakStatus.LØPENDE)
         lagreArbeidsfordeling(lagArbeidsfordelingPåBehandling(behandlingId = behandling.id))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -121,10 +121,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun setup() {
-        val fagsakIderSlot = slot<Set<Long>>()
-        every { klageClient.hentKlagebehandlinger(capture(fagsakIderSlot)) } answers {
-            fagsakIderSlot.captured.associateWith { emptyList() }
-        }
+        val fagsakId = slot<Long>()
+        every { klageClient.hentKlagebehandlinger(capture(fagsakId)) } returns emptyList()
 
         opprettSøkerFagsakOgBehandling(fagsakStatus = FagsakStatus.LØPENDE)
         lagreArbeidsfordeling(lagArbeidsfordelingPåBehandling(behandlingId = behandling.id))


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Fjerner toggle som styrer hvorvidt vi skal bruke nytt eller gammelt endepunkt for henting av klagebehandlinger fra familie-klage.

Toggle har vært på i prod en stund og nytt endepunkt ser ut til å fungere.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester. 

Ikke relevant

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
