### PR TITLE
Fiks utledning av opphørsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -51,13 +51,13 @@ object BehandlingsresultatOpphørUtils {
             )
 
         val harTidligereOpphørsDatoEnnForrigeBehandling = forrigeBehandlingOpphørsdato?.let { it > nåværendeBehandlingOpphørsdato } ?: true
-        val tidligereOpphørsDatoHarPassert = forrigeBehandlingOpphørsdato?.let { it < nåMåned } ?: true
+        val tidligereOpphørsDatoHarPassertEllerFinnesIkke = forrigeBehandlingOpphørsdato?.let { it < nåMåned } ?: true
 
         return when {
             // Rekkefølgen av sjekkene er viktig for å komme fram til riktig opphørsresultat.
             nåværendeBehandlingOpphørsdato == null && forrigeBehandlingOpphørsdato == null -> Opphørsresultat.FORTSATT_OPPHØRT
             nåværendeBehandlingOpphørsdato == null -> Opphørsresultat.IKKE_OPPHØRT // Både forrige og nåværende behandling har ingen andeler
-            nåværendeBehandlingOpphørsdato <= cutOffDato && tidligereOpphørsDatoHarPassert && nåværendeBehandlingOpphørsdato != forrigeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige opphørsdato har passert
+            nåværendeBehandlingOpphørsdato <= cutOffDato && tidligereOpphørsDatoHarPassertEllerFinnesIkke && nåværendeBehandlingOpphørsdato != forrigeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige opphørsdato har passert
             nåværendeBehandlingOpphørsdato <= cutOffDato && harTidligereOpphørsDatoEnnForrigeBehandling -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige har senere opphørsdato
             nåværendeBehandlingOpphørsdato <= cutOffDato && nåværendeBehandlingOpphørsdato == forrigeBehandlingOpphørsdato -> Opphørsresultat.FORTSATT_OPPHØRT
             else -> Opphørsresultat.IKKE_OPPHØRT

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtils.kt
@@ -51,11 +51,13 @@ object BehandlingsresultatOpphørUtils {
             )
 
         val harTidligereOpphørsDatoEnnForrigeBehandling = forrigeBehandlingOpphørsdato?.let { it > nåværendeBehandlingOpphørsdato } ?: true
+        val tidligereOpphørsDatoHarPassert = forrigeBehandlingOpphørsdato?.let { it < nåMåned } ?: true
 
         return when {
             // Rekkefølgen av sjekkene er viktig for å komme fram til riktig opphørsresultat.
             nåværendeBehandlingOpphørsdato == null && forrigeBehandlingOpphørsdato == null -> Opphørsresultat.FORTSATT_OPPHØRT
             nåværendeBehandlingOpphørsdato == null -> Opphørsresultat.IKKE_OPPHØRT // Både forrige og nåværende behandling har ingen andeler
+            nåværendeBehandlingOpphørsdato <= cutOffDato && tidligereOpphørsDatoHarPassert && nåværendeBehandlingOpphørsdato != forrigeBehandlingOpphørsdato -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige opphørsdato har passert
             nåværendeBehandlingOpphørsdato <= cutOffDato && harTidligereOpphørsDatoEnnForrigeBehandling -> Opphørsresultat.OPPHØRT // Nåværende behandling er opphørt og forrige har senere opphørsdato
             nåværendeBehandlingOpphørsdato <= cutOffDato && nåværendeBehandlingOpphørsdato == forrigeBehandlingOpphørsdato -> Opphørsresultat.FORTSATT_OPPHØRT
             else -> Opphørsresultat.IKKE_OPPHØRT

--- a/src/test/resources/cucumber/behandlingsresultat/innvilget_og_opphørt.feature
+++ b/src/test/resources/cucumber/behandlingsresultat/innvilget_og_opphørt.feature
@@ -1,7 +1,7 @@
 # language: no
 # encoding: UTF-8
 
-Egenskap: Innvilgelse og opphør av kontantstøtt
+Egenskap: Innvilgelse og opphør av kontantstøtte
 
   Bakgrunn:
     Gitt følgende fagsaker

--- a/src/test/resources/cucumber/behandlingsresultat/innvilget_og_opphørt.feature
+++ b/src/test/resources/cucumber/behandlingsresultat/innvilget_og_opphørt.feature
@@ -1,0 +1,67 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Innvilgelse og opphør av kontantstøtt
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | LOVENDRING_2024  | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | SØKNAD           | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 22.12.1988  |
+      | 1            | 2       | BARN       | 03.05.2023  |
+      | 2            | 1       | SØKER      | 22.12.1988  |
+      | 2            | 2       | BARN       | 03.05.2023  |
+      | 2            | 3       | BARN       | 07.05.2024  |
+
+  Scenario: Ved innvilgelse og opphørt i samme vedtak skal behandlingsresultatet bli INNVILGET_OG_OPPHØRT
+    Og følgende dagens dato 12.08.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 22.12.1988 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 22.12.1993 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 26.08.1995 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 03.05.2023 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 03.05.2023 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 03.05.2024 | 31.07.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 01.08.2024 | 03.12.2024 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 22.12.1988 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 22.12.1993 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 26.08.1995 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 03.05.2023 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 03.05.2023 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 03.05.2024 | 31.07.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 01.08.2024 | 03.12.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 26.08.1995 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 07.05.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               |                  | 07.05.2024 | 03.08.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 3       | BARNETS_ALDER                |                  | 07.05.2025 | 07.01.2026 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               |                  | 04.08.2025 |            | IKKE_OPPFYLT | Nei                  |                      |                  | Nei                                   | 45           |
+
+    Og med følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.06.2024 | 31.12.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og andeler er beregnet for behandling 2
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.06.2024 | 31.12.2024 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+      | 3       | 01.06.2025 | 31.07.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og når behandlingsresultatet er utledet for behandling 2
+
+    Så forvent at behandlingsresultatet er INNVILGET_OG_OPPHØRT på behandling 2

--- a/src/test/resources/cucumber/opphør-første-periode.feature
+++ b/src/test/resources/cucumber/opphør-første-periode.feature
@@ -396,6 +396,7 @@ Egenskap: Opphør første periode
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
       | 01.02.2025 | 31.03.2025 | OPPHØR             |           |
       | 01.04.2025 | 31.08.2025 | UTBETALING         |           |
+      | 01.09.2025 |            | OPPHØR             |           |
 
     Så forvent at følgende begrunnelser er gyldige for behandling 2
       | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                             | Ugyldige begrunnelser |

--- a/src/test/resources/cucumber/overgangsordning.feature
+++ b/src/test/resources/cucumber/overgangsordning.feature
@@ -59,7 +59,7 @@ Egenskap: Overgangsordning
       | 2       | 01.02.2024 | 31.08.2024 | 3000  | ORDINÆR_KONTANTSTØTTE | 40      | 7500 | 3000                   |                          |
       | 2       | 01.09.2024 | 31.10.2024 | 1500  | OVERGANGSORDNING      | 20      | 7500 | 1500                   |                          |
     Og når behandlingsresultatet er utledet for behandling 2
-    Så forvent at behandlingsresultatet er ENDRET_UTBETALING på behandling 2
+    Så forvent at behandlingsresultatet er ENDRET_OG_OPPHØRT på behandling 2
 
 
     Og vedtaksperioder er laget for behandling 2

--- a/src/test/resources/cucumber/reduksjon-antall-timer-barnehage.feature
+++ b/src/test/resources/cucumber/reduksjon-antall-timer-barnehage.feature
@@ -51,6 +51,7 @@ Egenskap: Reduksjon antall timer i barnehage
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
       | 01.02.2025 | 28.02.2025 | UTBETALING         |           |
       | 01.03.2025 | 31.08.2025 | UTBETALING         |           |
+      | 01.09.2025 |            | OPPHØR             |           |
 
     Så forvent at følgende begrunnelser er gyldige for behandling 1
       | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser             | Ugyldige begrunnelser |
@@ -64,4 +65,4 @@ Egenskap: Reduksjon antall timer i barnehage
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.03.2025 til 31.08.2025
       | Begrunnelse                      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp  | Antall timer barnehageplass | Gjelder andre forelder | Måned og år før vedtaksperiode |
-      | REDUKSJON_TILDELT_BARNEHAGEPLASS | STANDARD | nei           | 09.01.24             | 1           | mars 2025                         | 13 500 | 8                           | true                   | februar 2025                   |
+      | REDUKSJON_TILDELT_BARNEHAGEPLASS | STANDARD | nei           | 09.01.24             | 1           | mars 2025                            | 13 500 | 8                           | true                   | februar 2025                   |

--- a/src/test/resources/cucumber/reduksjon-framtidig-opphør.feature
+++ b/src/test/resources/cucumber/reduksjon-framtidig-opphør.feature
@@ -49,10 +49,11 @@ Egenskap: Reduksjon framtidig opphør barnehageplass - søker melder om framtidi
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
       | 01.02.2025 | 31.05.2025 | UTBETALING         |           |
       | 01.06.2025 | 31.08.2025 | UTBETALING         |           |
+      | 01.09.2025 |            | OPPHØR             |           |
 
     Så forvent at følgende begrunnelser er gyldige for behandling 1
       | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser     | Ugyldige begrunnelser                     |
-      | 01.02.2025 | 31.05.2025 | UTBETALING         |                                | INNVILGET_IKKE_BARNEHAGE | REDUKSJON_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS                                          |
+      | 01.02.2025 | 31.05.2025 | UTBETALING         |                                | INNVILGET_IKKE_BARNEHAGE | REDUKSJON_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |
       | 01.06.2025 | 31.08.2025 | UTBETALING         |                                |                          | REDUKSJON_FRAMTIDIG_OPPHØR_BARNEHAGEPLASS |
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.06.2025 til 31.08.2025

--- a/src/test/resources/cucumber/reduksjon-måned-og-år-begrunnelsen-gjelder-for.feature
+++ b/src/test/resources/cucumber/reduksjon-måned-og-år-begrunnelsen-gjelder-for.feature
@@ -61,6 +61,8 @@ Egenskap: Reduksjon pga færre antall timer i barnehage etter lovendring 2025
     Så forvent følgende vedtaksperioder på behandling 2
       | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
       | 01.03.2025 | 31.08.2025 | UTBETALING         |           |
+      | 01.09.2025 |            | OPPHØR             |           |
+
 
     Så forvent at følgende begrunnelser er gyldige for behandling 2
       | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser             | Ugyldige begrunnelser |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25889

Når vi utleder om behandlingsresultatet skal inneholde OPPHØRT så ser vi på opphørsdato på nåværende andeler og forrige andeler. Vi må ta hensyn til at det kommer nye barn med opphørsdato som ligger lengre fram i tid enn forrige opphørsdato, men som fortsatt leder til opphørt.