### PR TITLE
Legger til feltet: erEgenAnsatt i søk respons + splitt ut FagsakDeltager

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakController.kt
@@ -2,10 +2,8 @@ package no.nav.familie.ks.sak.api
 
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.ks.sak.api.dto.FagsakDeltagerResponsDto
 import no.nav.familie.ks.sak.api.dto.FagsakRequestDto
 import no.nav.familie.ks.sak.api.dto.MinimalFagsakResponsDto
-import no.nav.familie.ks.sak.api.dto.SøkParamDto
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -38,15 +36,6 @@ class FagsakController(
     private val personidentService: PersonidentService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(FagsakController::class.java)
-
-    @PostMapping(path = ["/sok"])
-    fun søkFagsak(
-        @RequestBody søkParam: SøkParamDto,
-    ): ResponseEntity<Ressurs<List<FagsakDeltagerResponsDto>>> {
-        logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} søker fagsak")
-        val fagsakDeltagere = fagsakService.hentFagsakDeltagere(søkParam.personIdent)
-        return ResponseEntity.ok().body(Ressurs.success(fagsakDeltagere))
-    }
 
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun hentEllerOpprettFagsak(

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakDeltagerController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/FagsakDeltagerController.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.ks.sak.api
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.ks.sak.api.dto.FagsakDeltagerResponsDto
+import no.nav.familie.ks.sak.api.dto.SøkParamDto
+import no.nav.familie.ks.sak.kjerne.fagsak.FagsakDeltagerService
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/fagsaker/sok")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class FagsakDeltagerController(
+    private val fagsakDeltagerService: FagsakDeltagerService,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(FagsakDeltagerController::class.java)
+
+    @PostMapping
+    fun søkFagsak(
+        @RequestBody søkParam: SøkParamDto,
+    ): ResponseEntity<Ressurs<List<FagsakDeltagerResponsDto>>> {
+        logger.info("${SikkerhetContext.hentSaksbehandlerNavn()} søker fagsak")
+        val fagsakDeltagere = fagsakDeltagerService.hentFagsakDeltagere(søkParam.personIdent)
+        return ResponseEntity.ok().body(Ressurs.success(fagsakDeltagere))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/PersonController.kt
@@ -4,6 +4,7 @@ import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.PersonInfoDto
+import no.nav.familie.ks.sak.api.dto.leggTilEgenAnsattStatus
 import no.nav.familie.ks.sak.api.dto.tilPersonInfoDto
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
@@ -47,6 +48,7 @@ class PersonController(
                 ?: personOpplysningerService
                     .hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
                     .tilPersonInfoDto(personIdent)
+                    .leggTilEgenAnsattStatus(integrasjonService)
         return ResponseEntity.ok(Ressurs.success(personinfo))
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/PersonController.kt
@@ -4,7 +4,6 @@ import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.PersonInfoDto
-import no.nav.familie.ks.sak.api.dto.leggTilEgenAnsattStatus
 import no.nav.familie.ks.sak.api.dto.tilPersonInfoDto
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
@@ -48,7 +47,6 @@ class PersonController(
                 ?: personOpplysningerService
                     .hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
                     .tilPersonInfoDto(personIdent)
-                    .leggTilEgenAnsattStatus(integrasjonService)
         return ResponseEntity.ok(Ressurs.success(personinfo))
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/FagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/FagsakSøk.kt
@@ -19,7 +19,7 @@ data class FagsakDeltagerResponsDto(
     val navn: String? = null,
     val ident: String = "",
     val rolle: FagsakDeltagerRolle,
-    val kjønn: KJOENN? = KJOENN.UKJENT,
+    val kjønn: KJOENN = KJOENN.UKJENT,
     val fagsakId: Long? = null,
     val fagsakStatus: FagsakStatus? = null,
     val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/FagsakSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/FagsakSøk.kt
@@ -24,6 +24,7 @@ data class FagsakDeltagerResponsDto(
     val fagsakStatus: FagsakStatus? = null,
     val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,
     val harTilgang: Boolean = true,
+    val erEgenAnsatt: Boolean? = null,
 ) {
     override fun toString(): String = "FagsakDeltagerResponsDto(rolle=$rolle, fagsakId=$fagsakId)"
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfoMaskert
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
 import java.time.LocalDate
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 
 data class PersonInfoDto(
     val personIdent: String,
@@ -20,6 +21,7 @@ data class PersonInfoDto(
     val kommunenummer: String = "ukjent",
     val dødsfallDato: String? = null,
     val bostedsadresse: BostedsadresseDto? = null,
+    val erEgenAnsatt: Boolean? = null,
 )
 
 data class ForelderBarnRelasjonInfoDto(
@@ -28,6 +30,7 @@ data class ForelderBarnRelasjonInfoDto(
     val navn: String,
     val fødselsdato: LocalDate?,
     val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,
+    val erEgenAnsatt: Boolean? = null,
 )
 
 data class ForelderBarnRelasjonInfoMaskertDto(
@@ -82,3 +85,15 @@ private fun ForelderBarnRelasjonInfo.tilForelderBarnRelasjonInfoDto() =
         fødselsdato = this.fødselsdato,
         adressebeskyttelseGradering = this.adressebeskyttelseGradering,
     )
+
+fun PersonInfoDto.leggTilEgenAnsattStatus(integrasjonService: IntegrasjonService): PersonInfoDto {
+    val personIdenter = this.forelderBarnRelasjon.map { it.personIdent } + this.personIdent
+    val erEgenAnsattMap = integrasjonService.sjekkErEgenAnsattBulk(personIdenter)
+    return this.copy(
+        erEgenAnsatt = erEgenAnsattMap.getOrDefault(this.personIdent, null),
+        forelderBarnRelasjon =
+            this.forelderBarnRelasjon.map {
+                it.copy(erEgenAnsatt = erEgenAnsattMap.getOrDefault(it.personIdent, null))
+            },
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
@@ -87,4 +87,3 @@ private fun ForelderBarnRelasjonInfo.tilForelderBarnRelasjonInfoDto() =
         adressebeskyttelseGradering = this.adressebeskyttelseGradering,
         erEgenAnsatt = this.erEgenAnsatt,
     )
-

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ks.sak.api.dto
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.KJOENN
-import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfoMaskert
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
@@ -3,11 +3,11 @@ package no.nav.familie.ks.sak.api.dto
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.KJOENN
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfoMaskert
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
 import java.time.LocalDate
-import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 
 data class PersonInfoDto(
     val personIdent: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/PersonDto.kt
@@ -68,6 +68,7 @@ fun PdlPersonInfo.tilPersonInfoDto(personIdent: String): PersonInfoDto {
         forelderBarnRelasjonMaskert = this.forelderBarnRelasjonerMaskert.map { it.tilForelderBarnRelasjonInfoMaskertDto() },
         kommunenummer = kommunenummer,
         dødsfallDato = dødsfallDato,
+        erEgenAnsatt = this.erEgenAnsatt,
     )
 }
 
@@ -84,16 +85,6 @@ private fun ForelderBarnRelasjonInfo.tilForelderBarnRelasjonInfoDto() =
         navn = this.navn ?: "",
         fødselsdato = this.fødselsdato,
         adressebeskyttelseGradering = this.adressebeskyttelseGradering,
+        erEgenAnsatt = this.erEgenAnsatt,
     )
 
-fun PersonInfoDto.leggTilEgenAnsattStatus(integrasjonService: IntegrasjonService): PersonInfoDto {
-    val personIdenter = this.forelderBarnRelasjon.map { it.personIdent } + this.personIdent
-    val erEgenAnsattMap = integrasjonService.sjekkErEgenAnsattBulk(personIdenter)
-    return this.copy(
-        erEgenAnsatt = erEgenAnsattMap.getOrDefault(this.personIdent, null),
-        forelderBarnRelasjon =
-            this.forelderBarnRelasjon.map {
-                it.copy(erEgenAnsatt = erEgenAnsattMap.getOrDefault(it.personIdent, null))
-            },
-    )
-}

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/FagsakMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/FagsakMapper.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.api.mapper
 
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.kontrakter.felles.personopplysning.KJOENN
 import no.nav.familie.ks.sak.api.dto.FagsakDeltagerResponsDto
 import no.nav.familie.ks.sak.api.dto.FagsakDeltagerRolle
 import no.nav.familie.ks.sak.api.dto.MinimalBehandlingResponsDto
@@ -25,7 +26,7 @@ object FagsakMapper {
             navn = personInfo?.navn,
             ident = ident,
             rolle = rolle,
-            kjønn = personInfo?.kjønn,
+            kjønn = personInfo?.kjønn ?: KJOENN.UKJENT,
             fagsakId = fagsak?.id,
             fagsakStatus = fagsak?.status,
             adressebeskyttelseGradering = adressebeskyttelseGradering,

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
@@ -524,6 +524,21 @@ class IntegrasjonClient(
         }
     }
 
+    fun sjekkErEgenAnsattBulk(personIdenter: List<String>): Map<String, Boolean> {
+        val url = URI.create("$integrasjonUri/egenansatt/bulk")
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "skjermede-personer-pip",
+            uri = url,
+            formål = "Sjekk om personer er egen ansatt",
+        ) {
+            postForEntity<Ressurs<Map<String, Boolean>>>(
+                url,
+                personIdenter,
+            )
+        }
+    }
+
     private fun lagManuellAdresse(manuellAdresseInfo: ManuellAdresseInfo?) =
         manuellAdresseInfo?.let {
             ManuellAdresse(

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
@@ -524,7 +524,7 @@ class IntegrasjonClient(
         }
     }
 
-    fun sjekkErEgenAnsattBulk(personIdenter: List<String>): Map<String, Boolean> {
+    fun sjekkErEgenAnsatt(personIdenter: Set<String>): Map<String, Boolean> {
         val url = URI.create("$integrasjonUri/egenansatt/bulk")
 
         return kallEksternTjenesteRessurs(

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonService.kt
@@ -41,4 +41,6 @@ class IntegrasjonService(
     fun hentJournalpost(journalpostId: String): Journalpost = integrasjonClient.hentJournalpost(journalpostId)
 
     fun hentAInntektUrl(personIdent: PersonIdent) = integrasjonClient.hentAInntektUrl(personIdent)
+
+    fun sjekkErEgenAnsattBulk(personIdenter: List<String>) = integrasjonClient.sjekkErEgenAnsattBulk(personIdenter)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonService.kt
@@ -42,5 +42,5 @@ class IntegrasjonService(
 
     fun hentAInntektUrl(personIdent: PersonIdent) = integrasjonClient.hentAInntektUrl(personIdent)
 
-    fun sjekkErEgenAnsattBulk(personIdenter: List<String>) = integrasjonClient.sjekkErEgenAnsattBulk(personIdenter)
+    fun sjekkErEgenAnsattBulk(personIdenter: Set<String>) = integrasjonClient.sjekkErEgenAnsatt(personIdenter)
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlUtil.kt
@@ -71,6 +71,7 @@ fun tilPersonInfo(
     pdlPersonData: PdlPersonData,
     forelderBarnRelasjoner: Set<ForelderBarnRelasjonInfo> = emptySet(),
     maskertForelderBarnRelasjoner: Set<ForelderBarnRelasjonInfoMaskert> = emptySet(),
+    erEgenAnsatt: Boolean? = null,
 ): PdlPersonInfo =
     PdlPersonInfo(
         fødselsdato = LocalDate.parse(pdlPersonData.foedselsdato.first().foedselsdato),
@@ -85,6 +86,7 @@ fun tilPersonInfo(
         sivilstander = pdlPersonData.sivilstand,
         dødsfall = hentDødsfallDataFraListeMedDødsfall(pdlPersonData.doedsfall),
         kontaktinformasjonForDoedsbo = pdlPersonData.kontaktinformasjonForDoedsbo.firstOrNull(),
+        erEgenAnsatt = erEgenAnsatt,
     )
 
 fun List<Adressebeskyttelse>.tilAdressebeskyttelse() =

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
@@ -26,7 +26,7 @@ class PersonopplysningerService(
     fun hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør: Aktør): PdlPersonInfo {
         val pdlPersonData = hentPersoninfoMedQuery(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON)
         val relasjonsidenter = pdlPersonData.forelderBarnRelasjon.mapNotNull { it.relatertPersonsIdent }
-        val egenAnsattPerIdent = integrasjonService.sjekkErEgenAnsattBulk(listOf(aktør.aktivFødselsnummer()) + relasjonsidenter)
+        val egenAnsattPerIdent = integrasjonService.sjekkErEgenAnsattBulk(setOf(aktør.aktivFødselsnummer()) + relasjonsidenter)
 
         val forelderBarnRelasjoner: Set<ForelderBarnRelasjonInfo> =
             pdlPersonData.forelderBarnRelasjon

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
@@ -6,7 +6,6 @@ import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROL
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import no.nav.familie.ks.sak.common.exception.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ks.sak.config.PersonInfoQuery
-import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.integrasjon.logger
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
@@ -23,12 +22,11 @@ class PersonopplysningerService(
     private val pdlClient: PdlClient,
     private val integrasjonService: IntegrasjonService,
     private val personidentService: PersonidentService,
-    private val integrasjonClient: IntegrasjonClient,
 ) {
     fun hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør: Aktør): PdlPersonInfo {
         val pdlPersonData = hentPersoninfoMedQuery(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON)
         val relasjonsidenter = pdlPersonData.forelderBarnRelasjon.mapNotNull { it.relatertPersonsIdent }
-        val egenAnsattPerIdent = integrasjonClient.sjekkErEgenAnsattBulk(listOf(aktør.aktivFødselsnummer()) + relasjonsidenter)
+        val egenAnsattPerIdent = integrasjonService.sjekkErEgenAnsattBulk(listOf(aktør.aktivFødselsnummer()) + relasjonsidenter)
 
         val forelderBarnRelasjoner: Set<ForelderBarnRelasjonInfo> =
             pdlPersonData.forelderBarnRelasjon

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
@@ -89,14 +89,12 @@ class PersonopplysningerService(
                     )
                 }.toSet()
 
-        val personInfo =
-            tilPersonInfo(
-                pdlPersonData,
-                forelderBarnRelasjonerMedAdressebeskyttelseGradering,
-                forelderBarnRelasjonMaskert,
-            )
-
-        return personInfo.copy(erEgenAnsatt = egenAnsattPerIdent.getOrDefault(aktør.aktivFødselsnummer(), null))
+        return tilPersonInfo(
+            pdlPersonData,
+            forelderBarnRelasjonerMedAdressebeskyttelseGradering,
+            forelderBarnRelasjonMaskert,
+            egenAnsattPerIdent.getOrDefault(aktør.aktivFødselsnummer(), null),
+        )
     }
 
     fun hentAdressebeskyttelseSomSystembruker(aktør: Aktør): ADRESSEBESKYTTELSEGRADERING = pdlClient.hentAdressebeskyttelse(aktør).tilAdressebeskyttelse()

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlPersonInfo.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlPersonInfo.kt
@@ -31,6 +31,7 @@ data class PdlPersonInfo(
     val statsborgerskap: List<Statsborgerskap>? = emptyList(),
     val dødsfall: DødsfallData? = null,
     val kontaktinformasjonForDoedsbo: PdlKontaktinformasjonForDødsbo? = null,
+    val erEgenAnsatt: Boolean? = null,
 )
 
 fun List<Bostedsadresse>.filtrerUtKunNorskeBostedsadresser() = this.filter { it.vegadresse != null || it.matrikkeladresse != null || it.ukjentBosted != null }
@@ -41,6 +42,7 @@ data class ForelderBarnRelasjonInfo(
     val navn: String? = null,
     val fødselsdato: LocalDate? = null,
     val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,
+    val erEgenAnsatt: Boolean? = null,
 ) {
     override fun toString(): String = "ForelderBarnRelasjon(personIdent=XXX, relasjonsrolle=$relasjonsrolle, navn=XXX, fødselsdato=$fødselsdato)"
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerService.kt
@@ -1,0 +1,162 @@
+package no.nav.familie.ks.sak.kjerne.fagsak
+
+import no.nav.familie.ks.sak.api.dto.FagsakDeltagerResponsDto
+import no.nav.familie.ks.sak.api.dto.FagsakDeltagerRolle
+import no.nav.familie.ks.sak.api.mapper.FagsakMapper.lagFagsakDeltagerResponsDto
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
+import no.nav.familie.ks.sak.integrasjon.pdl.PersonopplysningerService
+import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonRepository
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.Period
+
+@Service
+class FagsakDeltagerService(
+    private val personidentService: PersonidentService,
+    private val integrasjonService: IntegrasjonService,
+    private val personopplysningerService: PersonopplysningerService,
+    private val fagsakRepository: FagsakRepository,
+    private val personRepository: PersonRepository,
+    private val behandlingRepository: BehandlingRepository,
+) {
+    fun hentFagsakDeltagere(personIdent: String): List<FagsakDeltagerResponsDto> {
+        val aktør = personidentService.hentAktør(personIdent)
+
+        // returnerer maskert fagsak deltaker hvis saksbehandler ikke har tilgang til aktøren
+        hentMaskertFagsakdeltakerVedManglendeTilgang(aktør)?.let { return listOf(it) }
+
+        val personInfoMedRelasjoner = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+
+        // finner fagsak på aktør og henter assosierte fagsak deltagere
+        val assosierteFagsakDeltagere =
+            hentForelderdeltagereFraBehandling(aktør, personInfoMedRelasjoner).toMutableList()
+
+        val erBarn = Period.between(personInfoMedRelasjoner.fødselsdato, LocalDate.now()).years < 18
+
+        // fagsaker som ikke finnes i assosierteForeldreDeltagere, er barn
+        val fagsakForBarn = fagsakRepository.finnFagsakForAktør(aktør)
+
+        if (assosierteFagsakDeltagere.none { it.ident == aktør.aktivFødselsnummer() && it.fagsakId == fagsakForBarn?.id }) {
+            assosierteFagsakDeltagere.add(
+                lagFagsakDeltagerResponsDto(
+                    personInfo = personInfoMedRelasjoner,
+                    ident = aktør.aktivFødselsnummer(),
+                    // Vi setter rollen til Ukjent når det ikke er barn
+                    rolle = if (erBarn) FagsakDeltagerRolle.BARN else FagsakDeltagerRolle.UKJENT,
+                    fagsak = fagsakForBarn,
+                    adressebeskyttelseGradering = personInfoMedRelasjoner.adressebeskyttelseGradering,
+                ),
+            )
+        }
+
+        // Hvis søkparam(aktør) er barn og søker til barn ikke har behandling ennå, hentes det søker til barnet
+        if (erBarn) {
+            leggTilForeldreDeltagerSomIkkeHarBehandling(personInfoMedRelasjoner, assosierteFagsakDeltagere)
+        }
+        val fagsakDeltagereMedEgenAnsattStatus = settEgenAnsattStatusPåFagsakDeltagere(assosierteFagsakDeltagere)
+
+        return fagsakDeltagereMedEgenAnsattStatus
+    }
+
+    private fun hentForelderdeltagereFraBehandling(
+        aktør: Aktør,
+        personInfoMedRelasjoner: PdlPersonInfo,
+    ): List<FagsakDeltagerResponsDto> {
+        val assosierteFagsakDeltagerMap = mutableMapOf<Long, FagsakDeltagerResponsDto>()
+        personRepository.findByAktør(aktør).filter { it.personopplysningGrunnlag.aktiv }.forEach { person ->
+            val behandling = behandlingRepository.hentBehandling(person.personopplysningGrunnlag.behandlingId)
+            val fagsak = behandling.fagsak // Behandling opprettet alltid med søker aktør
+            if (assosierteFagsakDeltagerMap.containsKey(fagsak.id)) return@forEach
+            val fagsakDeltagerRespons: FagsakDeltagerResponsDto =
+                when {
+                    // når søkparam er samme som aktør til behandlingen
+                    fagsak.aktør == aktør ->
+                        lagFagsakDeltagerResponsDto(
+                            personInfo = personInfoMedRelasjoner,
+                            ident = fagsak.aktør.aktivFødselsnummer(),
+                            rolle = FagsakDeltagerRolle.FORELDER,
+                            fagsak = behandling.fagsak,
+                            adressebeskyttelseGradering = personInfoMedRelasjoner.adressebeskyttelseGradering,
+                        )
+
+                    else -> { // søkparam(aktør) er ikke søkers aktør, da hentes her forelder til søkparam(aktør)
+                        val maskertForelder = hentMaskertFagsakdeltakerVedManglendeTilgang(fagsak.aktør)
+                        maskertForelder?.copy(rolle = FagsakDeltagerRolle.FORELDER)
+                            ?: run {
+                                val personInfo = personopplysningerService.hentPersoninfoEnkel(fagsak.aktør)
+                                lagFagsakDeltagerResponsDto(
+                                    personInfo = personInfo,
+                                    ident = fagsak.aktør.aktivFødselsnummer(),
+                                    rolle = FagsakDeltagerRolle.FORELDER,
+                                    adressebeskyttelseGradering = personInfo.adressebeskyttelseGradering,
+                                    fagsak = fagsak,
+                                )
+                            }
+                    }
+                }
+            assosierteFagsakDeltagerMap[fagsak.id] = fagsakDeltagerRespons
+        }
+        return assosierteFagsakDeltagerMap.values.toList()
+    }
+
+    private fun leggTilForeldreDeltagerSomIkkeHarBehandling(
+        personInfoMedRelasjoner: PdlPersonInfo,
+        assosierteFagsakDeltagere: MutableList<FagsakDeltagerResponsDto>,
+    ) {
+        personInfoMedRelasjoner.forelderBarnRelasjoner.filter { it.harForelderRelasjon() }.forEach { relasjon ->
+            if (assosierteFagsakDeltagere.none { it.ident == relasjon.aktør.aktivFødselsnummer() }) {
+                val maskertForelder = hentMaskertFagsakdeltakerVedManglendeTilgang(relasjon.aktør)
+                when {
+                    maskertForelder != null -> assosierteFagsakDeltagere.add(maskertForelder.copy(rolle = FagsakDeltagerRolle.FORELDER))
+                    else -> {
+                        val forelderInfo = personopplysningerService.hentPersoninfoEnkel(relasjon.aktør)
+                        val fagsak = fagsakRepository.finnFagsakForAktør(relasjon.aktør)
+                        assosierteFagsakDeltagere.add(
+                            lagFagsakDeltagerResponsDto(
+                                personInfo = forelderInfo,
+                                ident = relasjon.aktør.aktivFødselsnummer(),
+                                rolle = FagsakDeltagerRolle.FORELDER,
+                                fagsak = fagsak,
+                                adressebeskyttelseGradering = forelderInfo.adressebeskyttelseGradering,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere: List<FagsakDeltagerResponsDto>): List<FagsakDeltagerResponsDto> {
+        val egenAnsattPerIdent = integrasjonService.sjekkErEgenAnsattBulk(fagsakDeltagere.map { it.ident })
+        return fagsakDeltagere.map { fagsakDeltager ->
+            fagsakDeltager.copy(
+                erEgenAnsatt = egenAnsattPerIdent.getOrDefault(fagsakDeltager.ident, null),
+            )
+        }
+    }
+
+    private fun hentMaskertFagsakdeltakerVedManglendeTilgang(aktør: Aktør): FagsakDeltagerResponsDto? {
+        val harTilgang = integrasjonService.sjekkTilgangTilPerson(aktør.aktivFødselsnummer()).harTilgang
+
+        return when {
+            !harTilgang -> {
+                val adressebeskyttelse = personopplysningerService.hentAdressebeskyttelseSomSystembruker(aktør)
+
+                lagFagsakDeltagerResponsDto(
+                    rolle = FagsakDeltagerRolle.UKJENT,
+                    adressebeskyttelseGradering = adressebeskyttelse,
+                    harTilgang = false,
+                )
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerService.kt
@@ -132,7 +132,7 @@ class FagsakDeltagerService(
     }
 
     fun settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere: List<FagsakDeltagerResponsDto>): List<FagsakDeltagerResponsDto> {
-        val egenAnsattPerIdent = integrasjonService.sjekkErEgenAnsattBulk(fagsakDeltagere.map { it.ident })
+        val egenAnsattPerIdent = integrasjonService.sjekkErEgenAnsattBulk(fagsakDeltagere.map { it.ident }.toSet())
         return fagsakDeltagere.map { fagsakDeltager ->
             fagsakDeltager.copy(
                 erEgenAnsatt = egenAnsattPerIdent.getOrDefault(fagsakDeltager.ident, null),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
@@ -1,22 +1,15 @@
 package no.nav.familie.ks.sak.kjerne.fagsak
 
 import io.micrometer.core.instrument.Metrics
-import no.nav.familie.ks.sak.api.dto.FagsakDeltagerResponsDto
-import no.nav.familie.ks.sak.api.dto.FagsakDeltagerRolle
 import no.nav.familie.ks.sak.api.dto.FagsakRequestDto
 import no.nav.familie.ks.sak.api.dto.MinimalFagsakResponsDto
 import no.nav.familie.ks.sak.api.dto.tilUtbetalingsperiodeResponsDto
 import no.nav.familie.ks.sak.api.mapper.FagsakMapper.lagBehandlingResponsDto
-import no.nav.familie.ks.sak.api.mapper.FagsakMapper.lagFagsakDeltagerResponsDto
 import no.nav.familie.ks.sak.api.mapper.FagsakMapper.lagMinimalFagsakResponsDto
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.ClockProvider
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
-import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
-import no.nav.familie.ks.sak.integrasjon.pdl.PersonopplysningerService
-import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
@@ -38,15 +31,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
-import java.time.Period
 import java.time.YearMonth
 
 @Service
 class FagsakService(
     private val personidentService: PersonidentService,
-    private val integrasjonService: IntegrasjonService,
-    private val personopplysningerService: PersonopplysningerService,
     private val personopplysningGrunnlagRepository: PersonopplysningGrunnlagRepository,
     private val fagsakRepository: FagsakRepository,
     private val personRepository: PersonRepository,
@@ -57,49 +46,9 @@ class FagsakService(
     private val andelerTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val clockProvider: ClockProvider,
     private val adopsjonService: AdopsjonService,
-    private val integrasjonClient: IntegrasjonClient,
 ) {
     private val antallFagsakerOpprettetFraManuell =
         Metrics.counter("familie.ks.sak.fagsak.opprettet", "saksbehandling", "manuell")
-
-    fun hentFagsakDeltagere(personIdent: String): List<FagsakDeltagerResponsDto> {
-        val aktør = personidentService.hentAktør(personIdent)
-
-        // returnerer maskert fagsak deltaker hvis saksbehandler ikke har tilgang til aktøren
-        hentMaskertFagsakdeltakerVedManglendeTilgang(aktør)?.let { return listOf(it) }
-
-        val personInfoMedRelasjoner = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
-
-        // finner fagsak på aktør og henter assosierte fagsak deltagere
-        val assosierteFagsakDeltagere =
-            hentForelderdeltagereFraBehandling(aktør, personInfoMedRelasjoner).toMutableList()
-
-        val erBarn = Period.between(personInfoMedRelasjoner.fødselsdato, LocalDate.now()).years < 18
-
-        // fagsaker som ikke finnes i assosierteForeldreDeltagere, er barn
-        val fagsakForBarn = fagsakRepository.finnFagsakForAktør(aktør)
-
-        if (assosierteFagsakDeltagere.none { it.ident == aktør.aktivFødselsnummer() && it.fagsakId == fagsakForBarn?.id }) {
-            assosierteFagsakDeltagere.add(
-                lagFagsakDeltagerResponsDto(
-                    personInfo = personInfoMedRelasjoner,
-                    ident = aktør.aktivFødselsnummer(),
-                    // Vi setter rollen til Ukjent når det ikke er barn
-                    rolle = if (erBarn) FagsakDeltagerRolle.BARN else FagsakDeltagerRolle.UKJENT,
-                    fagsak = fagsakForBarn,
-                    adressebeskyttelseGradering = personInfoMedRelasjoner.adressebeskyttelseGradering,
-                ),
-            )
-        }
-
-        // Hvis søkparam(aktør) er barn og søker til barn ikke har behandling ennå, hentes det søker til barnet
-        if (erBarn) {
-            leggTilForeldreDeltagerSomIkkeHarBehandling(personInfoMedRelasjoner, assosierteFagsakDeltagere)
-        }
-        val fagsakDeltagereMedEgenAnsattStatus = settEgenAnsattStatusPåFagsakDeltagere(assosierteFagsakDeltagere)
-
-        return fagsakDeltagereMedEgenAnsattStatus
-    }
 
     @Transactional
     fun hentEllerOpprettFagsak(fagsakRequest: FagsakRequestDto): MinimalFagsakResponsDto {
@@ -188,103 +137,6 @@ class FagsakService(
         )
         fagsak.status = nyStatus
         return lagre(fagsak)
-    }
-
-    private fun hentForelderdeltagereFraBehandling(
-        aktør: Aktør,
-        personInfoMedRelasjoner: PdlPersonInfo,
-    ): List<FagsakDeltagerResponsDto> {
-        val assosierteFagsakDeltagerMap = mutableMapOf<Long, FagsakDeltagerResponsDto>()
-        personRepository.findByAktør(aktør).filter { it.personopplysningGrunnlag.aktiv }.forEach { person ->
-            val behandling = behandlingRepository.hentBehandling(person.personopplysningGrunnlag.behandlingId)
-            val fagsak = behandling.fagsak // Behandling opprettet alltid med søker aktør
-            if (assosierteFagsakDeltagerMap.containsKey(fagsak.id)) return@forEach
-            val fagsakDeltagerRespons: FagsakDeltagerResponsDto =
-                when {
-                    // når søkparam er samme som aktør til behandlingen
-                    fagsak.aktør == aktør ->
-                        lagFagsakDeltagerResponsDto(
-                            personInfo = personInfoMedRelasjoner,
-                            ident = fagsak.aktør.aktivFødselsnummer(),
-                            rolle = FagsakDeltagerRolle.FORELDER,
-                            fagsak = behandling.fagsak,
-                            adressebeskyttelseGradering = personInfoMedRelasjoner.adressebeskyttelseGradering,
-                        )
-
-                    else -> { // søkparam(aktør) er ikke søkers aktør, da hentes her forelder til søkparam(aktør)
-                        val maskertForelder = hentMaskertFagsakdeltakerVedManglendeTilgang(fagsak.aktør)
-                        maskertForelder?.copy(rolle = FagsakDeltagerRolle.FORELDER)
-                            ?: run {
-                                val personInfo = personopplysningerService.hentPersoninfoEnkel(fagsak.aktør)
-                                lagFagsakDeltagerResponsDto(
-                                    personInfo = personInfo,
-                                    ident = fagsak.aktør.aktivFødselsnummer(),
-                                    rolle = FagsakDeltagerRolle.FORELDER,
-                                    adressebeskyttelseGradering = personInfo.adressebeskyttelseGradering,
-                                    fagsak = fagsak,
-                                )
-                            }
-                    }
-                }
-            assosierteFagsakDeltagerMap[fagsak.id] = fagsakDeltagerRespons
-        }
-        return assosierteFagsakDeltagerMap.values.toList()
-    }
-
-    private fun leggTilForeldreDeltagerSomIkkeHarBehandling(
-        personInfoMedRelasjoner: PdlPersonInfo,
-        assosierteFagsakDeltagere: MutableList<FagsakDeltagerResponsDto>,
-    ) {
-        personInfoMedRelasjoner.forelderBarnRelasjoner.filter { it.harForelderRelasjon() }.forEach { relasjon ->
-            if (assosierteFagsakDeltagere.none { it.ident == relasjon.aktør.aktivFødselsnummer() }) {
-                val maskertForelder = hentMaskertFagsakdeltakerVedManglendeTilgang(relasjon.aktør)
-                when {
-                    maskertForelder != null -> assosierteFagsakDeltagere.add(maskertForelder.copy(rolle = FagsakDeltagerRolle.FORELDER))
-                    else -> {
-                        val forelderInfo = personopplysningerService.hentPersoninfoEnkel(relasjon.aktør)
-                        val fagsak = fagsakRepository.finnFagsakForAktør(relasjon.aktør)
-                        assosierteFagsakDeltagere.add(
-                            lagFagsakDeltagerResponsDto(
-                                personInfo = forelderInfo,
-                                ident = relasjon.aktør.aktivFødselsnummer(),
-                                rolle = FagsakDeltagerRolle.FORELDER,
-                                fagsak = fagsak,
-                                adressebeskyttelseGradering = forelderInfo.adressebeskyttelseGradering,
-                            ),
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    fun settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere: List<FagsakDeltagerResponsDto>): List<FagsakDeltagerResponsDto> {
-        val egenAnsattPerIdent = integrasjonClient.sjekkErEgenAnsattBulk(fagsakDeltagere.map { it.ident })
-        return fagsakDeltagere.map { fagsakDeltager ->
-            fagsakDeltager.copy(
-                erEgenAnsatt = egenAnsattPerIdent.getOrDefault(fagsakDeltager.ident, null),
-            )
-        }
-    }
-
-    private fun hentMaskertFagsakdeltakerVedManglendeTilgang(aktør: Aktør): FagsakDeltagerResponsDto? {
-        val harTilgang = integrasjonService.sjekkTilgangTilPerson(aktør.aktivFødselsnummer()).harTilgang
-
-        return when {
-            !harTilgang -> {
-                val adressebeskyttelse = personopplysningerService.hentAdressebeskyttelseSomSystembruker(aktør)
-
-                lagFagsakDeltagerResponsDto(
-                    rolle = FagsakDeltagerRolle.UKJENT,
-                    adressebeskyttelseGradering = adressebeskyttelse,
-                    harTilgang = false,
-                )
-            }
-
-            else -> {
-                null
-            }
-        }
     }
 
     fun hentFagsak(fagsakId: Long): Fagsak =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
@@ -258,7 +258,7 @@ class FagsakService(
         }
     }
 
-    internal fun settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere: MutableList<FagsakDeltagerResponsDto>): List<FagsakDeltagerResponsDto> {
+    fun settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere: List<FagsakDeltagerResponsDto>): List<FagsakDeltagerResponsDto> {
         val egenAnsattPerIdent = integrasjonClient.sjekkErEgenAnsattBulk(fagsakDeltagere.map { it.ident })
         return fagsakDeltagere.map { fagsakDeltager ->
             fagsakDeltager.copy(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.cucumber.mocking
 
 import io.mockk.mockk
 import mockAdopsjonService
+import mockIntegrasjonClient
 import no.nav.familie.ks.sak.common.TestClockProvider
 import no.nav.familie.ks.sak.cucumber.StepDefinition
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
@@ -56,6 +57,7 @@ class CucumberMock(
     val arbeidsfordelingServiceMock = mockk<ArbeidsfordelingService>()
     val praksisendring2024Service = mockPraksisendring2024Service()
     val adopsjonServiceMock = mockAdopsjonService()
+    val integrasjonClientMock = mockIntegrasjonClient()
 
     val beregnAndelTilkjentYtelseService =
         BeregnAndelTilkjentYtelseService(
@@ -102,6 +104,7 @@ class CucumberMock(
             andelerTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
             clockProvider = clockProvider,
             adopsjonService = adopsjonServiceMock,
+            integrasjonClient = integrasjonClientMock,
         )
 
     val beregningService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -92,8 +92,6 @@ class CucumberMock(
     val fagsakService =
         FagsakService(
             personidentService = personidentService,
-            integrasjonService = integrasjonServiceMock,
-            personopplysningerService = personopplysningerServiceMock,
             personopplysningGrunnlagRepository = personopplysningGrunnlagRepositoryMock,
             fagsakRepository = fagsakRepositoryMock,
             personRepository = personRepository,
@@ -104,7 +102,6 @@ class CucumberMock(
             andelerTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
             clockProvider = clockProvider,
             adopsjonService = adopsjonServiceMock,
-            integrasjonClient = integrasjonClientMock,
         )
 
     val beregningService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockIntegrasjonClient.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockIntegrasjonClient.kt
@@ -4,8 +4,8 @@ import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 
 fun mockIntegrasjonClient(): IntegrasjonClient =
     mockk<IntegrasjonClient>().apply {
-        every { sjekkErEgenAnsattBulk(any()) } answers {
-            val personIdenter = firstArg<List<String>>()
+        every { sjekkErEgenAnsatt(any()) } answers {
+            val personIdenter = firstArg<Set<String>>()
             personIdenter.associateWith { false }
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockIntegrasjonClient.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/MockIntegrasjonClient.kt
@@ -1,0 +1,11 @@
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+
+fun mockIntegrasjonClient(): IntegrasjonClient =
+    mockk<IntegrasjonClient>().apply {
+        every { sjekkErEgenAnsattBulk(any()) } answers {
+            val personIdenter = firstArg<List<String>>()
+            personIdenter.associateWith { false }
+        }
+    }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ks.sak.common.exception.PdlPersonKanIkkeBehandlesIFagsyste
 import no.nav.familie.ks.sak.config.PersonInfoQuery
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomPersonident
-import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlFødselsDato
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlNavn
@@ -22,10 +21,9 @@ import java.time.LocalDate
 
 class PersonopplysningerServiceTest {
     private val pdlClient = mockk<PdlClient>()
-    private val integrasjonService = mockk<IntegrasjonService>()
+    private val integrasjonService = mockk<IntegrasjonService>(relaxed = true)
     private val personidentService = mockk<PersonidentService>()
-    private val integrasjonClient = mockk<IntegrasjonClient>()
-    private val personopplysningerService = PersonopplysningerService(pdlClient, integrasjonService, personidentService, integrasjonClient)
+    private val personopplysningerService = PersonopplysningerService(pdlClient, integrasjonService, personidentService)
 
     @Nested
     inner class HentPersonInfoMedRelasjonerOgRegisterinformasjon {
@@ -118,6 +116,53 @@ class PersonopplysningerServiceTest {
 
             // Assert
             assertThat(pdlPersonInfo.forelderBarnRelasjoner).isEmpty()
+        }
+
+        @Test
+        fun `Skal mappe egen ansatt status basert på respons fra integrasjoner`() {
+            // Arrange
+            val aktør = randomAktør()
+            val barnAktør = randomAktør()
+            val fødselsdato = LocalDate.of(2000, 2, 2)
+
+            val forelderBarnRelasjon =
+                ForelderBarnRelasjon(
+                    relatertPersonsIdent = barnAktør.aktivFødselsnummer(),
+                    relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
+                )
+
+            val pdlPersonData =
+                PdlPersonData(
+                    forelderBarnRelasjon = listOf(forelderBarnRelasjon),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
+
+            val pdlRelasjonData =
+                PdlPersonData(
+                    navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
+
+            every { pdlClient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
+            every { personidentService.hentAktør(barnAktør.aktivFødselsnummer()) } returns barnAktør
+            every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnAktør.aktivFødselsnummer(), true)
+            every { pdlClient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
+            every { pdlClient.hentAdressebeskyttelse(any()) } returns emptyList()
+
+            every {
+                integrasjonService.sjekkErEgenAnsattBulk(match { it.containsAll(listOf(barnAktør.aktivFødselsnummer(), aktør.aktivFødselsnummer())) })
+            } returns mapOf(barnAktør.aktivFødselsnummer() to false, aktør.aktivFødselsnummer() to true)
+
+            // Act
+            val pdlPersonInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+
+            // Assert
+            assertThat(pdlPersonInfo.erEgenAnsatt).isTrue()
+            assertThat(pdlPersonInfo.forelderBarnRelasjoner.single().erEgenAnsatt).isFalse()
         }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ks.sak.common.exception.PdlPersonKanIkkeBehandlesIFagsyste
 import no.nav.familie.ks.sak.config.PersonInfoQuery
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomPersonident
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlFødselsDato
 import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlNavn
@@ -23,7 +24,8 @@ class PersonopplysningerServiceTest {
     private val pdlClient = mockk<PdlClient>()
     private val integrasjonService = mockk<IntegrasjonService>()
     private val personidentService = mockk<PersonidentService>()
-    private val personopplysningerService = PersonopplysningerService(pdlClient, integrasjonService, personidentService)
+    private val integrasjonClient = mockk<IntegrasjonClient>()
+    private val personopplysningerService = PersonopplysningerService(pdlClient, integrasjonService, personidentService, integrasjonClient)
 
     @Nested
     inner class HentPersonInfoMedRelasjonerOgRegisterinformasjon {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerServiceTest.kt
@@ -1,0 +1,200 @@
+package no.nav.familie.ks.sak.kjerne.fagsak
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
+import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
+import no.nav.familie.ks.sak.api.dto.FagsakDeltagerResponsDto
+import no.nav.familie.ks.sak.api.dto.FagsakDeltagerRolle
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.data.randomFnr
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
+import no.nav.familie.ks.sak.integrasjon.pdl.PersonopplysningerService
+import no.nav.familie.ks.sak.integrasjon.pdl.domene.ForelderBarnRelasjonInfo
+import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlPersonInfo
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
+import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Kjønn
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonRepository
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class FagsakDeltagerServiceTest {
+    private val personidentService = mockk<PersonidentService>()
+    private val integrasjonService = mockk<IntegrasjonService>(relaxed = true)
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val fagsakRepository = mockk<FagsakRepository>()
+    private val personRepository = mockk<PersonRepository>()
+    private val behandlingRepository = mockk<BehandlingRepository>()
+
+    private val fagsakService =
+        FagsakDeltagerService(
+            personidentService = personidentService,
+            integrasjonService = integrasjonService,
+            personopplysningerService = personopplysningerService,
+            fagsakRepository = fagsakRepository,
+            personRepository = personRepository,
+            behandlingRepository = behandlingRepository,
+        )
+
+    @Test
+    fun `Skal returnere maskert deltaker dersom saksbehandler ikke har tilgang til aktør med bestemt personident`() {
+        every { personidentService.hentAktør(any()) } returns randomAktør()
+        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", false)
+        every { personopplysningerService.hentAdressebeskyttelseSomSystembruker(any()) } returns ADRESSEBESKYTTELSEGRADERING.FORTROLIG
+
+        val fagsakdeltakere = fagsakService.hentFagsakDeltagere(randomFnr())
+        assertEquals(1, fagsakdeltakere.size)
+        assertEquals(ADRESSEBESKYTTELSEGRADERING.FORTROLIG, fagsakdeltakere.first().adressebeskyttelseGradering)
+    }
+
+    @Test
+    fun `Skal returnere søker dersom metode kalles med søkers ident og saksbehandler har tilgang til identen`() {
+        val søkersFødselsdato = LocalDate.of(1985, 5, 1)
+        val søkerPersonident = "01058512345"
+        val søkerAktør = randomAktør(søkerPersonident)
+
+        val barnPersonident = "01052212345"
+        val barnAktør = randomAktør(barnPersonident)
+
+        val barnIdenter = listOf(barnPersonident)
+
+        every { personidentService.hentAktør(any()) } returns søkerAktør
+        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", true)
+        every { personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns
+            PdlPersonInfo(
+                søkersFødselsdato,
+                forelderBarnRelasjoner = setOf(ForelderBarnRelasjonInfo(barnAktør, FORELDERBARNRELASJONROLLE.BARN)),
+            )
+        every { personRepository.findByAktør(any()) } returns
+            listOf(
+                Person(
+                    aktør = søkerAktør,
+                    type = PersonType.SØKER,
+                    fødselsdato = søkersFødselsdato,
+                    kjønn = Kjønn.MANN,
+                    personopplysningGrunnlag = lagPersonopplysningGrunnlag(1, søkerPersonident, barnIdenter),
+                ),
+            )
+        val fagsak = lagFagsak(søkerAktør)
+        every { behandlingRepository.hentBehandling(any()) } returns
+            lagBehandling(
+                fagsak = fagsak,
+                opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+            )
+        every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
+
+        val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
+        assertEquals(1, fagsakdeltakere.size)
+        assertEquals(søkerPersonident, fagsakdeltakere.single().ident)
+    }
+
+    @Test
+    fun `Skal returnere barn og forelder dersom metode kalles med barne-ident og saksbehandler har tilgang til barnet og forelderen`() {
+        val søkersFødselsdato = LocalDate.of(1985, 5, 1)
+        val søkerPersonident = "01058512345"
+        val søkerAktør = randomAktør(søkerPersonident)
+
+        val barnFødselsdato = LocalDate.of(2022, 5, 1)
+        val barnPersonident = "01052212345"
+        val barnAktør = randomAktør(barnPersonident)
+
+        every { personidentService.hentAktør(any()) } returns barnAktør
+        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", true)
+        every { personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns
+            PdlPersonInfo(
+                barnFødselsdato,
+                forelderBarnRelasjoner = setOf(ForelderBarnRelasjonInfo(søkerAktør, FORELDERBARNRELASJONROLLE.FAR)),
+            )
+        every { personRepository.findByAktør(any()) } returns
+            listOf(
+                Person(
+                    aktør = barnAktør,
+                    type = PersonType.BARN,
+                    fødselsdato = barnFødselsdato,
+                    kjønn = Kjønn.MANN,
+                    personopplysningGrunnlag = lagPersonopplysningGrunnlag(1, barnPersonident, emptyList()),
+                ),
+            )
+        val fagsak = lagFagsak(søkerAktør)
+        every { behandlingRepository.hentBehandling(any()) } returns
+            lagBehandling(
+                fagsak = fagsak,
+                opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+            )
+        every { personopplysningerService.hentPersoninfoEnkel(any()) } returns
+            PdlPersonInfo(
+                søkersFødselsdato,
+                forelderBarnRelasjoner =
+                    setOf(
+                        ForelderBarnRelasjonInfo(barnAktør, FORELDERBARNRELASJONROLLE.BARN),
+                    ),
+            )
+        every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
+
+        val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
+        assertEquals(2, fagsakdeltakere.size)
+
+        val barnDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.BARN }
+        val forelderDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.FORELDER }
+
+        assertEquals(barnPersonident, barnDeltaker?.ident)
+        assertEquals(søkerPersonident, forelderDeltaker?.ident)
+    }
+
+    @Test
+    fun `Setter korrekt egen ansatt status basert på respons fra integrasjoner`() {
+        // Arrange
+        val erEgenAnsattIdent = randomFnr()
+        val erIkkeEgenAnsattIdent = randomFnr()
+        val manglerDataIdent = randomFnr()
+
+        val fagsakDeltagere =
+            mutableListOf(
+                FagsakDeltagerResponsDto(
+                    ident = erEgenAnsattIdent,
+                    rolle = FagsakDeltagerRolle.FORELDER,
+                ),
+                FagsakDeltagerResponsDto(
+                    ident = erIkkeEgenAnsattIdent,
+                    rolle = FagsakDeltagerRolle.BARN,
+                ),
+                FagsakDeltagerResponsDto(
+                    ident = manglerDataIdent,
+                    rolle = FagsakDeltagerRolle.FORELDER,
+                ),
+            )
+
+        every {
+            integrasjonService.sjekkErEgenAnsattBulk(
+                match { it.containsAll(listOf(erEgenAnsattIdent, erIkkeEgenAnsattIdent, manglerDataIdent)) },
+            )
+        } answers {
+            mapOf(
+                erEgenAnsattIdent to true,
+                erIkkeEgenAnsattIdent to false,
+            )
+        }
+
+        // Act
+        val fagsakDeltagereMedEgenAnsattStatus = fagsakService.settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere)
+
+        // Assert
+        assertThat(fagsakDeltagereMedEgenAnsattStatus.map { it.ident to it.erEgenAnsatt })
+            .containsExactlyInAnyOrder(
+                erEgenAnsattIdent to true,
+                erIkkeEgenAnsattIdent to false,
+                manglerDataIdent to null,
+            )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakDeltagerServiceTest.kt
@@ -49,17 +49,22 @@ class FagsakDeltagerServiceTest {
 
     @Test
     fun `Skal returnere maskert deltaker dersom saksbehandler ikke har tilgang til aktør med bestemt personident`() {
+        // Arrange
         every { personidentService.hentAktør(any()) } returns randomAktør()
         every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", false)
         every { personopplysningerService.hentAdressebeskyttelseSomSystembruker(any()) } returns ADRESSEBESKYTTELSEGRADERING.FORTROLIG
 
+        // Act
         val fagsakdeltakere = fagsakService.hentFagsakDeltagere(randomFnr())
-        assertEquals(1, fagsakdeltakere.size)
-        assertEquals(ADRESSEBESKYTTELSEGRADERING.FORTROLIG, fagsakdeltakere.first().adressebeskyttelseGradering)
+
+        // Assert
+        assertThat(1).isEqualTo(fagsakdeltakere.size)
+        assertThat(ADRESSEBESKYTTELSEGRADERING.FORTROLIG).isEqualTo(fagsakdeltakere.first().adressebeskyttelseGradering)
     }
 
     @Test
     fun `Skal returnere søker dersom metode kalles med søkers ident og saksbehandler har tilgang til identen`() {
+        // Arrange
         val søkersFødselsdato = LocalDate.of(1985, 5, 1)
         val søkerPersonident = "01058512345"
         val søkerAktør = randomAktør(søkerPersonident)
@@ -94,13 +99,17 @@ class FagsakDeltagerServiceTest {
             )
         every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
 
+        // Act
         val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
-        assertEquals(1, fagsakdeltakere.size)
-        assertEquals(søkerPersonident, fagsakdeltakere.single().ident)
+
+        // Assert
+        assertThat(1).isEqualTo(fagsakdeltakere.size)
+        assertThat(søkerPersonident).isEqualTo(fagsakdeltakere.single().ident)
     }
 
     @Test
     fun `Skal returnere barn og forelder dersom metode kalles med barne-ident og saksbehandler har tilgang til barnet og forelderen`() {
+        // Arrange
         val søkersFødselsdato = LocalDate.of(1985, 5, 1)
         val søkerPersonident = "01058512345"
         val søkerAktør = randomAktør(søkerPersonident)
@@ -142,18 +151,20 @@ class FagsakDeltagerServiceTest {
             )
         every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
 
+        // Act
         val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
-        assertEquals(2, fagsakdeltakere.size)
 
+        // Assert
+        assertThat(2).isEqualTo(fagsakdeltakere.size)
         val barnDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.BARN }
         val forelderDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.FORELDER }
-
-        assertEquals(barnPersonident, barnDeltaker?.ident)
-        assertEquals(søkerPersonident, forelderDeltaker?.ident)
+        assertThat(barnPersonident).isEqualTo(barnDeltaker?.ident)
+        assertThat(søkerPersonident).isEqualTo(forelderDeltaker?.ident)
     }
 
     @Test
     fun `Setter korrekt egen ansatt status basert på respons fra integrasjoner`() {
+        // Arrange
         // Arrange
         val erEgenAnsattIdent = randomFnr()
         val erIkkeEgenAnsattIdent = randomFnr()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -35,12 +35,13 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonReposi
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
 import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
-import org.assertj.core.api.Assertions.assertThat
 
 class FagsakServiceTest {
     private val personidentService = mockk<PersonidentService>()
@@ -81,348 +82,363 @@ class FagsakServiceTest {
         every { adopsjonService.hentAlleAdopsjonerForBehandling(any()) } returns emptyList()
     }
 
-    @Test
-    fun `hentFagsakDeltagere - skal returnere maskert deltaker dersom saksbehandler ikke har tilgang til aktør med bestemt personident`() {
-        every { personidentService.hentAktør(any()) } returns randomAktør()
-        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", false)
-        every { personopplysningerService.hentAdressebeskyttelseSomSystembruker(any()) } returns ADRESSEBESKYTTELSEGRADERING.FORTROLIG
+    @Nested
+    inner class HentFagsakDeltagere {
+        @Test
+        fun `Skal returnere maskert deltaker dersom saksbehandler ikke har tilgang til aktør med bestemt personident`() {
+            every { personidentService.hentAktør(any()) } returns randomAktør()
+            every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", false)
+            every { personopplysningerService.hentAdressebeskyttelseSomSystembruker(any()) } returns ADRESSEBESKYTTELSEGRADERING.FORTROLIG
 
-        val fagsakdeltakere = fagsakService.hentFagsakDeltagere(randomFnr())
-        assertEquals(1, fagsakdeltakere.size)
-        assertEquals(ADRESSEBESKYTTELSEGRADERING.FORTROLIG, fagsakdeltakere.first().adressebeskyttelseGradering)
-    }
-
-    @Test
-    fun `hentFagsakDeltagere - skal returnere søker dersom metode kalles med søkers ident og saksbehandler har tilgang til identen`() {
-        val søkersFødselsdato = LocalDate.of(1985, 5, 1)
-        val søkerPersonident = "01058512345"
-        val søkerAktør = randomAktør(søkerPersonident)
-
-        val barnPersonident = "01052212345"
-        val barnAktør = randomAktør(barnPersonident)
-
-        val barnIdenter = listOf(barnPersonident)
-
-        every { personidentService.hentAktør(any()) } returns søkerAktør
-        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", true)
-        every { personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns
-            PdlPersonInfo(
-                søkersFødselsdato,
-                forelderBarnRelasjoner = setOf(ForelderBarnRelasjonInfo(barnAktør, FORELDERBARNRELASJONROLLE.BARN)),
-            )
-        every { personRepository.findByAktør(any()) } returns
-            listOf(
-                Person(
-                    aktør = søkerAktør,
-                    type = PersonType.SØKER,
-                    fødselsdato = søkersFødselsdato,
-                    kjønn = Kjønn.MANN,
-                    personopplysningGrunnlag = lagPersonopplysningGrunnlag(1, søkerPersonident, barnIdenter),
-                ),
-            )
-        val fagsak = lagFagsak(søkerAktør)
-        every { behandlingRepository.hentBehandling(any()) } returns
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD,
-            )
-        every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
-
-        val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
-        assertEquals(1, fagsakdeltakere.size)
-        assertEquals(søkerPersonident, fagsakdeltakere.single().ident)
-    }
-
-    @Test
-    fun `hentFagsakDeltagere - skal returnere barn og forelder dersom metode kalles med barne-ident og saksbehandler har tilgang til barnet og forelderen`() {
-        val søkersFødselsdato = LocalDate.of(1985, 5, 1)
-        val søkerPersonident = "01058512345"
-        val søkerAktør = randomAktør(søkerPersonident)
-
-        val barnFødselsdato = LocalDate.of(2022, 5, 1)
-        val barnPersonident = "01052212345"
-        val barnAktør = randomAktør(barnPersonident)
-
-        every { personidentService.hentAktør(any()) } returns barnAktør
-        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", true)
-        every { personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns
-            PdlPersonInfo(
-                barnFødselsdato,
-                forelderBarnRelasjoner = setOf(ForelderBarnRelasjonInfo(søkerAktør, FORELDERBARNRELASJONROLLE.FAR)),
-            )
-        every { personRepository.findByAktør(any()) } returns
-            listOf(
-                Person(
-                    aktør = barnAktør,
-                    type = PersonType.BARN,
-                    fødselsdato = barnFødselsdato,
-                    kjønn = Kjønn.MANN,
-                    personopplysningGrunnlag = lagPersonopplysningGrunnlag(1, barnPersonident, emptyList()),
-                ),
-            )
-        val fagsak = lagFagsak(søkerAktør)
-        every { behandlingRepository.hentBehandling(any()) } returns
-            lagBehandling(
-                fagsak = fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD,
-            )
-        every { personopplysningerService.hentPersoninfoEnkel(any()) } returns
-            PdlPersonInfo(
-                søkersFødselsdato,
-                forelderBarnRelasjoner =
-                    setOf(
-                        ForelderBarnRelasjonInfo(barnAktør, FORELDERBARNRELASJONROLLE.BARN),
-                    ),
-            )
-        every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
-
-        val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
-        assertEquals(2, fagsakdeltakere.size)
-
-        val barnDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.BARN }
-        val forelderDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.FORELDER }
-
-        assertEquals(barnPersonident, barnDeltaker?.ident)
-        assertEquals(søkerPersonident, forelderDeltaker?.ident)
-    }
-
-    @Test
-    fun `hentFagsakDeltagere - setter korrekt egen ansatt status basert på respons fra integrasjoner`() {
-        // Arrange
-        val erEgenAnsattIdent = randomFnr()
-        val erIkkeEgenAnsattIdent = randomFnr()
-        val manglerDataIdent = randomFnr()
-
-        val fagsakDeltagere =
-            mutableListOf(
-                FagsakDeltagerResponsDto(
-                    ident = erEgenAnsattIdent,
-                    rolle = FagsakDeltagerRolle.FORELDER,
-                ),
-                FagsakDeltagerResponsDto(
-                    ident = erIkkeEgenAnsattIdent,
-                    rolle = FagsakDeltagerRolle.BARN,
-                ),
-                FagsakDeltagerResponsDto(
-                    ident = manglerDataIdent,
-                    rolle = FagsakDeltagerRolle.FORELDER,
-                ),
-            )
-
-        every {
-            integrasjonClient.sjekkErEgenAnsattBulk(
-                match { it.containsAll(listOf(erEgenAnsattIdent, erIkkeEgenAnsattIdent, manglerDataIdent)) },
-            )
-        } answers {
-            mapOf(
-                erEgenAnsattIdent to true,
-                erIkkeEgenAnsattIdent to false,
-            )
+            val fagsakdeltakere = fagsakService.hentFagsakDeltagere(randomFnr())
+            assertEquals(1, fagsakdeltakere.size)
+            assertEquals(ADRESSEBESKYTTELSEGRADERING.FORTROLIG, fagsakdeltakere.first().adressebeskyttelseGradering)
         }
 
-        // Act
-        val populertFagsakDeltagere = fagsakService.settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere)
+        @Test
+        fun `Skal returnere søker dersom metode kalles med søkers ident og saksbehandler har tilgang til identen`() {
+            val søkersFødselsdato = LocalDate.of(1985, 5, 1)
+            val søkerPersonident = "01058512345"
+            val søkerAktør = randomAktør(søkerPersonident)
 
-        // Assert
-        assertThat(populertFagsakDeltagere.map { it.ident to it.erEgenAnsatt })
-            .containsExactlyInAnyOrder(
-                erEgenAnsattIdent to true,
-                erIkkeEgenAnsattIdent to false,
-                manglerDataIdent to null,
-            )
-    }
+            val barnPersonident = "01052212345"
+            val barnAktør = randomAktør(barnPersonident)
 
-    @Test
-    fun `hentEllerOpprettFagsak - skal returnere eksisterende fagsak når forespurt personIdent eller aktørId har fagsak i db`() {
-        val fødselsnummer = randomFnr()
-        val aktør = randomAktør(fødselsnummer)
-        val fagsak = lagFagsak(aktør)
+            val barnIdenter = listOf(barnPersonident)
 
-        every { personidentService.hentOgLagreAktør(aktør.aktørId, true) } returns aktør
-        every { personidentService.hentOgLagreAktør(fødselsnummer, true) } returns aktør
-        every { fagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
-        every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns
-            lagBehandling(
-                fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD,
-            )
-        every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(any()) } returns emptyList()
-        every { personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(any()) } returns lagPersonopplysningGrunnlag()
-        every { behandlingRepository.finnBehandlinger(fagsak.id) } returns emptyList()
-
-        var minimalFagsak =
-            fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
-
-        assertEquals(fagsak.id, minimalFagsak.id)
-        assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
-
-        minimalFagsak =
-            fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = fødselsnummer))
-
-        assertEquals(fagsak.id, minimalFagsak.id)
-        assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
-    }
-
-    @Test
-    fun `hentEllerOpprettFagsak - skal returnere eksisterende fagsak med behandlinger når forespurt personIdent eller aktørId har fagsak i db`() {
-        val fødselsnummer = randomFnr()
-        val aktør = randomAktør(fødselsnummer)
-        val fagsak = lagFagsak(aktør)
-
-        val behandling =
-            lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD).apply { aktiv = true }
-
-        every { personidentService.hentOgLagreAktør(aktør.aktørId, true) } returns aktør
-        every { personidentService.hentOgLagreAktør(fødselsnummer, true) } returns aktør
-        every { fagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
-        every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns
-            lagBehandling(
-                fagsak,
-                opprettetÅrsak = BehandlingÅrsak.SØKNAD,
-            )
-        every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(any()) } returns emptyList()
-        every { personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(any()) } returns lagPersonopplysningGrunnlag()
-        every { behandlingRepository.finnBehandlinger(fagsak.id) } returns listOf(behandling)
-        every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mockk(relaxed = true)
-
-        var minimalFagsak =
-            fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
-
-        assertEquals(fagsak.id, minimalFagsak.id)
-        assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
-
-        minimalFagsak =
-            fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = fødselsnummer))
-
-        assertEquals(fagsak.id, minimalFagsak.id)
-        assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
-        assertEquals(minimalFagsak.behandlinger.size, 1)
-        assertEquals(behandling.id, minimalFagsak.behandlinger[0].behandlingId)
-    }
-
-    @Test
-    fun `hentEllerOpprettFagsak - skal returnere ny fagsak når forespurt personIdent eller aktørId ikke har fagsak i db`() {
-        val fødselsnummer = randomFnr()
-        val aktør = randomAktør(fødselsnummer)
-        val fagsak = lagFagsak(aktør)
-
-        every { personidentService.hentOgLagreAktør(aktør.aktørId, true) } returns aktør
-        every { personidentService.hentOgLagreAktør(fødselsnummer, true) } returns aktør
-        every { fagsakRepository.finnFagsakForAktør(aktør) } returns null
-        every { fagsakRepository.save(fagsak) } returns fagsak
-        every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns null
-        every { taskService.save(any()) } returns mockk()
-        every { behandlingRepository.finnBehandlinger(fagsak.id) } returns emptyList()
-
-        var minimalFagsak =
-            fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
-
-        assertEquals(fagsak.id, minimalFagsak.id)
-        assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
-
-        minimalFagsak =
-            fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = fødselsnummer))
-
-        assertEquals(fagsak.id, minimalFagsak.id)
-        assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
-    }
-
-    @Test
-    fun `hentEllerOpprettFagsak - skal kaste Feil dersom verken personident eller aktørId er satt i FagsakRequestDto`() {
-        val feil =
-            assertThrows<Feil> {
-                fagsakService.hentEllerOpprettFagsak(
-                    FagsakRequestDto(
-                        personIdent = null,
-                        aktørId = null,
+            every { personidentService.hentAktør(any()) } returns søkerAktør
+            every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", true)
+            every { personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns
+                PdlPersonInfo(
+                    søkersFødselsdato,
+                    forelderBarnRelasjoner = setOf(ForelderBarnRelasjonInfo(barnAktør, FORELDERBARNRELASJONROLLE.BARN)),
+                )
+            every { personRepository.findByAktør(any()) } returns
+                listOf(
+                    Person(
+                        aktør = søkerAktør,
+                        type = PersonType.SØKER,
+                        fødselsdato = søkersFødselsdato,
+                        kjønn = Kjønn.MANN,
+                        personopplysningGrunnlag = lagPersonopplysningGrunnlag(1, søkerPersonident, barnIdenter),
                     ),
+                )
+            val fagsak = lagFagsak(søkerAktør)
+            every { behandlingRepository.hentBehandling(any()) } returns
+                lagBehandling(
+                    fagsak = fagsak,
+                    opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+                )
+            every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
+
+            val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
+            assertEquals(1, fagsakdeltakere.size)
+            assertEquals(søkerPersonident, fagsakdeltakere.single().ident)
+        }
+
+        @Test
+        fun `Skal returnere barn og forelder dersom metode kalles med barne-ident og saksbehandler har tilgang til barnet og forelderen`() {
+            val søkersFødselsdato = LocalDate.of(1985, 5, 1)
+            val søkerPersonident = "01058512345"
+            val søkerAktør = randomAktør(søkerPersonident)
+
+            val barnFødselsdato = LocalDate.of(2022, 5, 1)
+            val barnPersonident = "01052212345"
+            val barnAktør = randomAktør(barnPersonident)
+
+            every { personidentService.hentAktør(any()) } returns barnAktør
+            every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang("test", true)
+            every { personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(any()) } returns
+                PdlPersonInfo(
+                    barnFødselsdato,
+                    forelderBarnRelasjoner = setOf(ForelderBarnRelasjonInfo(søkerAktør, FORELDERBARNRELASJONROLLE.FAR)),
+                )
+            every { personRepository.findByAktør(any()) } returns
+                listOf(
+                    Person(
+                        aktør = barnAktør,
+                        type = PersonType.BARN,
+                        fødselsdato = barnFødselsdato,
+                        kjønn = Kjønn.MANN,
+                        personopplysningGrunnlag = lagPersonopplysningGrunnlag(1, barnPersonident, emptyList()),
+                    ),
+                )
+            val fagsak = lagFagsak(søkerAktør)
+            every { behandlingRepository.hentBehandling(any()) } returns
+                lagBehandling(
+                    fagsak = fagsak,
+                    opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+                )
+            every { personopplysningerService.hentPersoninfoEnkel(any()) } returns
+                PdlPersonInfo(
+                    søkersFødselsdato,
+                    forelderBarnRelasjoner =
+                        setOf(
+                            ForelderBarnRelasjonInfo(barnAktør, FORELDERBARNRELASJONROLLE.BARN),
+                        ),
+                )
+            every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
+
+            val fagsakdeltakere = fagsakService.hentFagsakDeltagere(søkerPersonident)
+            assertEquals(2, fagsakdeltakere.size)
+
+            val barnDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.BARN }
+            val forelderDeltaker = fagsakdeltakere.find { it.rolle == FagsakDeltagerRolle.FORELDER }
+
+            assertEquals(barnPersonident, barnDeltaker?.ident)
+            assertEquals(søkerPersonident, forelderDeltaker?.ident)
+        }
+
+        @Test
+        fun `Setter korrekt egen ansatt status basert på respons fra integrasjoner`() {
+            // Arrange
+            val erEgenAnsattIdent = randomFnr()
+            val erIkkeEgenAnsattIdent = randomFnr()
+            val manglerDataIdent = randomFnr()
+
+            val fagsakDeltagere =
+                mutableListOf(
+                    FagsakDeltagerResponsDto(
+                        ident = erEgenAnsattIdent,
+                        rolle = FagsakDeltagerRolle.FORELDER,
+                    ),
+                    FagsakDeltagerResponsDto(
+                        ident = erIkkeEgenAnsattIdent,
+                        rolle = FagsakDeltagerRolle.BARN,
+                    ),
+                    FagsakDeltagerResponsDto(
+                        ident = manglerDataIdent,
+                        rolle = FagsakDeltagerRolle.FORELDER,
+                    ),
+                )
+
+            every {
+                integrasjonClient.sjekkErEgenAnsattBulk(
+                    match { it.containsAll(listOf(erEgenAnsattIdent, erIkkeEgenAnsattIdent, manglerDataIdent)) },
+                )
+            } answers {
+                mapOf(
+                    erEgenAnsattIdent to true,
+                    erIkkeEgenAnsattIdent to false,
                 )
             }
 
-        assertEquals(
-            "Hverken aktørid eller personident er satt på fagsak-requesten. Klarer ikke opprette eller hente fagsak.",
-            feil.message,
-        )
-        assertEquals(
-            "Fagsak er forsøkt opprettet uten ident. Dette er en systemfeil, vennligst ta kontakt med systemansvarlig.",
-            feil.frontendFeilmelding,
-        )
+            // Act
+            val fagsakDeltagereMedEgenAnsattStatus = fagsakService.settEgenAnsattStatusPåFagsakDeltagere(fagsakDeltagere)
+
+            // Assert
+            assertThat(fagsakDeltagereMedEgenAnsattStatus.map { it.ident to it.erEgenAnsatt })
+                .containsExactlyInAnyOrder(
+                    erEgenAnsattIdent to true,
+                    erIkkeEgenAnsattIdent to false,
+                    manglerDataIdent to null,
+                )
+        }
     }
 
-    @Test
-    fun `hentMinimalFagsak - skal returnere fagsak med tilhørende behandlinger når forespurt fagsakId finnes i db`() {
-        val fagsak = lagFagsak(randomAktør())
-        val barnehagelisteBehandling =
-            lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.BARNEHAGELISTE).apply { aktiv = true }
+    @Nested
+    inner class HentEllerOpprettFagsak {
+        @Test
+        fun `Skal returnere eksisterende fagsak når forespurt personIdent eller aktørId har fagsak i db`() {
+            val fødselsnummer = randomFnr()
+            val aktør = randomAktør(fødselsnummer)
+            val fagsak = lagFagsak(aktør)
 
-        every { fagsakRepository.finnFagsak(any()) } returns fagsak
-        every { behandlingRepository.finnBehandlinger(fagsak.id) } returns
-            listOf(
+            every { personidentService.hentOgLagreAktør(aktør.aktørId, true) } returns aktør
+            every { personidentService.hentOgLagreAktør(fødselsnummer, true) } returns aktør
+            every { fagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
+            every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns
                 lagBehandling(
                     fagsak,
                     opprettetÅrsak = BehandlingÅrsak.SØKNAD,
-                ).apply { aktiv = false },
-                barnehagelisteBehandling,
+                )
+            every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(any()) } returns emptyList()
+            every { personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(any()) } returns lagPersonopplysningGrunnlag()
+            every { behandlingRepository.finnBehandlinger(fagsak.id) } returns emptyList()
+
+            var minimalFagsak =
+                fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
+
+            assertEquals(fagsak.id, minimalFagsak.id)
+            assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
+
+            minimalFagsak =
+                fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = fødselsnummer))
+
+            assertEquals(fagsak.id, minimalFagsak.id)
+            assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
+        }
+
+        @Test
+        fun `Skal returnere eksisterende fagsak med behandlinger når forespurt personIdent eller aktørId har fagsak i db`() {
+            val fødselsnummer = randomFnr()
+            val aktør = randomAktør(fødselsnummer)
+            val fagsak = lagFagsak(aktør)
+
+            val behandling =
+                lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD).apply { aktiv = true }
+
+            every { personidentService.hentOgLagreAktør(aktør.aktørId, true) } returns aktør
+            every { personidentService.hentOgLagreAktør(fødselsnummer, true) } returns aktør
+            every { fagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
+            every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns
+                lagBehandling(
+                    fagsak,
+                    opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+                )
+            every { andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(any()) } returns emptyList()
+            every { personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(any()) } returns lagPersonopplysningGrunnlag()
+            every { behandlingRepository.finnBehandlinger(fagsak.id) } returns listOf(behandling)
+            every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mockk(relaxed = true)
+
+            var minimalFagsak =
+                fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
+
+            assertEquals(fagsak.id, minimalFagsak.id)
+            assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
+
+            minimalFagsak =
+                fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = fødselsnummer))
+
+            assertEquals(fagsak.id, minimalFagsak.id)
+            assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
+            assertEquals(minimalFagsak.behandlinger.size, 1)
+            assertEquals(behandling.id, minimalFagsak.behandlinger[0].behandlingId)
+        }
+
+        @Test
+        fun `Skal returnere ny fagsak når forespurt personIdent eller aktørId ikke har fagsak i db`() {
+            val fødselsnummer = randomFnr()
+            val aktør = randomAktør(fødselsnummer)
+            val fagsak = lagFagsak(aktør)
+
+            every { personidentService.hentOgLagreAktør(aktør.aktørId, true) } returns aktør
+            every { personidentService.hentOgLagreAktør(fødselsnummer, true) } returns aktør
+            every { fagsakRepository.finnFagsakForAktør(aktør) } returns null
+            every { fagsakRepository.save(fagsak) } returns fagsak
+            every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns null
+            every { taskService.save(any()) } returns mockk()
+            every { behandlingRepository.finnBehandlinger(fagsak.id) } returns emptyList()
+
+            var minimalFagsak =
+                fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
+
+            assertEquals(fagsak.id, minimalFagsak.id)
+            assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
+
+            minimalFagsak =
+                fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = fødselsnummer))
+
+            assertEquals(fagsak.id, minimalFagsak.id)
+            assertEquals(fagsak.aktør.aktivFødselsnummer(), minimalFagsak.søkerFødselsnummer)
+        }
+
+        @Test
+        fun `Skal kaste Feil dersom verken personident eller aktørId er satt i FagsakRequestDto`() {
+            val feil =
+                assertThrows<Feil> {
+                    fagsakService.hentEllerOpprettFagsak(
+                        FagsakRequestDto(
+                            personIdent = null,
+                            aktørId = null,
+                        ),
+                    )
+                }
+
+            assertEquals(
+                "Hverken aktørid eller personident er satt på fagsak-requesten. Klarer ikke opprette eller hente fagsak.",
+                feil.message,
             )
-        every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns barnehagelisteBehandling
-        every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mockk(relaxed = true)
-        val fagsakResponse = fagsakService.hentMinimalFagsak(fagsak.id)
-
-        assertEquals(fagsak.id, fagsakResponse.id)
-        assertEquals(2, fagsakResponse.behandlinger.size)
+            assertEquals(
+                "Fagsak er forsøkt opprettet uten ident. Dette er en systemfeil, vennligst ta kontakt med systemansvarlig.",
+                feil.frontendFeilmelding,
+            )
+        }
     }
 
-    @Test
-    fun `hentMinimalFagsak - skal kaste FunksjonellFeil dersom fagsak med fagsakId ikke finnes i db`() {
-        every { fagsakRepository.finnFagsak(any()) } returns null
+    @Nested
+    inner class HentMinimalFagsak {
+        @Test
+        fun `Skal returnere fagsak med tilhørende behandlinger når forespurt fagsakId finnes i db`() {
+            val fagsak = lagFagsak(randomAktør())
+            val barnehagelisteBehandling =
+                lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.BARNEHAGELISTE).apply { aktiv = true }
 
-        val funksjonellFeil = assertThrows<FunksjonellFeil> { fagsakService.hentMinimalFagsak(404L) }
+            every { fagsakRepository.finnFagsak(any()) } returns fagsak
+            every { behandlingRepository.finnBehandlinger(fagsak.id) } returns
+                listOf(
+                    lagBehandling(
+                        fagsak,
+                        opprettetÅrsak = BehandlingÅrsak.SØKNAD,
+                    ).apply { aktiv = false },
+                    barnehagelisteBehandling,
+                )
+            every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns barnehagelisteBehandling
+            every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mockk(relaxed = true)
+            val fagsakResponse = fagsakService.hentMinimalFagsak(fagsak.id)
 
-        assertEquals("Finner ikke fagsak med id 404", funksjonellFeil.message)
+            assertEquals(fagsak.id, fagsakResponse.id)
+            assertEquals(2, fagsakResponse.behandlinger.size)
+        }
+
+        @Test
+        fun `Skal kaste FunksjonellFeil dersom fagsak med fagsakId ikke finnes i db`() {
+            every { fagsakRepository.finnFagsak(any()) } returns null
+
+            val funksjonellFeil = assertThrows<FunksjonellFeil> { fagsakService.hentMinimalFagsak(404L) }
+
+            assertEquals("Finner ikke fagsak med id 404", funksjonellFeil.message)
+        }
     }
 
-    @Test
-    fun `hentFagsak - skal returnere fagsak når det finnes en fagsak med forespurt fagsakId i db`() {
-        val fagsak = lagFagsak(randomAktør())
-        every { fagsakRepository.finnFagsak(any()) } returns fagsak
+    @Nested
+    inner class HentFagsak {
+        @Test
+        fun `Skal returnere fagsak når det finnes en fagsak med forespurt fagsakId i db`() {
+            val fagsak = lagFagsak(randomAktør())
+            every { fagsakRepository.finnFagsak(any()) } returns fagsak
 
-        val hentetFagsak = fagsakService.hentFagsak(fagsak.id)
+            val hentetFagsak = fagsakService.hentFagsak(fagsak.id)
 
-        assertEquals(fagsak.id, hentetFagsak.id)
+            assertEquals(fagsak.id, hentetFagsak.id)
+        }
+
+        @Test
+        fun `Skal kaste Funksjonell feil dersom fagsak med fagsakId ikke finnes i db`() {
+            every { fagsakRepository.finnFagsak(any()) } returns null
+
+            val funksjonellFeil = assertThrows<FunksjonellFeil> { fagsakService.hentFagsak(404L) }
+
+            assertEquals("Finner ikke fagsak med id 404", funksjonellFeil.message)
+        }
     }
 
-    @Test
-    fun `hentFagsak - skal kaste Funksjonell feil dersom fagsak med fagsakId ikke finnes i db`() {
-        every { fagsakRepository.finnFagsak(any()) } returns null
+    @Nested
+    inner class HentFagsakForPeson {
+        @Test
+        fun `Skal returnere fagsak dersom fagsak tilknyttet aktør med forespurt personident finnes i db`() {
+            val aktør = randomAktør()
+            val fagsak = lagFagsak(aktør)
 
-        val funksjonellFeil = assertThrows<FunksjonellFeil> { fagsakService.hentFagsak(404L) }
+            every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
+            every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
 
-        assertEquals("Finner ikke fagsak med id 404", funksjonellFeil.message)
-    }
+            val fagsakForPerson = fagsakService.hentFagsakForPerson(aktør)
 
-    @Test
-    fun `hentFagsakForPeson - skal returnere fagsak dersom fagsak tilknyttet aktør med forespurt personident finnes i db`() {
-        val aktør = randomAktør()
-        val fagsak = lagFagsak(aktør)
+            assertEquals(fagsak.id, fagsakForPerson.id)
+            assertEquals(fagsak.aktør, fagsakForPerson.aktør)
+        }
 
-        every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
-        every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
+        @Test
+        fun `Skal kaste Feil dersom fagsak tilknyttet aktør med forespurt personident ikke finnes i db`() {
+            val aktør = randomAktør()
 
-        val fagsakForPerson = fagsakService.hentFagsakForPerson(aktør)
+            every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
+            every { fagsakRepository.finnFagsakForAktør(any()) } returns null
 
-        assertEquals(fagsak.id, fagsakForPerson.id)
-        assertEquals(fagsak.aktør, fagsakForPerson.aktør)
-    }
+            val feil = assertThrows<Feil> { fagsakService.hentFagsakForPerson(aktør) }
 
-    @Test
-    fun `hentFagsakForPeson - skal kaste Feil dersom fagsak tilknyttet aktør med forespurt personident ikke finnes i db`() {
-        val aktør = randomAktør()
-
-        every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
-        every { fagsakRepository.finnFagsakForAktør(any()) } returns null
-
-        val feil = assertThrows<Feil> { fagsakService.hentFagsakForPerson(aktør) }
-
-        assertEquals("Fant ikke fagsak på person", feil.message)
+            assertEquals("Fant ikke fagsak på person", feil.message)
+        }
     }
 }


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Legger til feltet erEgenAnsatt i FagsakDeltagerResponsDto for rendring-logikk av ikoner. Verdien hentes fra integrasjoner og blir gjort med et bulk-kall for alle fagsakdeltagere. 

Bonus: setter default-verdi på kjønn til UKJENT fremfor null.

Den største endringen er at FagsakDeltager er splittet ut fra FagsakService/Controller. Et forsøk på å gjøre fagsak-klassene litt mindre. FagsakDeltager er uansett kun knyttet opp mot søk. Derfor er det passende å trekke det ut til en egen controller og service.

Det er noe overlapp med endepunktene som returnerer RestFagsakIdOgTilknyttetAktørId som også bruker "/søk"-pathen. Har valgt å ikke dra dette inn, og så får vi heller trekke det ut i en annen runde. Der kan det være mer aktuelt å endre på endepunkt-pathen. Man kan vel se på det som et oppslag fremfor et søk.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
