### PR TITLE
Fikser sjekk av ugyldig etterbetaling ved henlagte behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -44,6 +44,8 @@ class BeregningService(
             .filter { andelerTilkjentYtelse.any { aty -> aty.aktør == it } }
     }
 
+    fun finnTilkjentYtelseForBehandling(behandlingId: Long) = tilkjentYtelseRepository.hentOptionalTilkjentYtelseForBehandling(behandlingId)
+
     fun hentTilkjentYtelseForBehandling(behandlingId: Long) = tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(behandlingId)
 
     fun hentAndelerTilkjentYtelseMedUtbetalingerForBehandling(behandlingId: Long): List<AndelTilkjentYtelse> =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValideringService.kt
@@ -74,7 +74,7 @@ class TilkjentYtelseValideringService(
         }
 
     fun finnAktørerMedUgyldigEtterbetalingsperiode(behandlingId: Long): List<Aktør> {
-        val tilkjentYtelse = beregningService.hentTilkjentYtelseForBehandling(behandlingId = behandlingId)
+        val tilkjentYtelse = beregningService.finnTilkjentYtelseForBehandling(behandlingId = behandlingId) ?: return emptyList()
 
         val forrigeBehandling =
             behandlingService.hentSisteBehandlingSomErVedtatt(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValideringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValideringServiceTest.kt
@@ -195,38 +195,7 @@ class TilkjentYtelseValideringServiceTest {
     @Test
     fun `finnAktørerMedUgyldigEtterbetalingsperiode - skal returnere tom liste dersom tilkjent ytelse for nåværende behandling ikke finnes`() {
         // Arrange
-        val forrigeBehandling = lagBehandling(id = 0, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
-
-        val forrigeTilkjentYtelse =
-            TilkjentYtelse(
-                behandling = forrigeBehandling,
-                opprettetDato = LocalDate.now(),
-                endretDato = LocalDate.now(),
-                andelerTilkjentYtelse =
-                    mutableSetOf(
-                        lagAndelTilkjentYtelse(
-                            behandling = behandling,
-                            aktør = barn1,
-                            stønadFom = YearMonth.now().minusMonths(4),
-                            stønadTom = YearMonth.now(),
-                            sats = 8000,
-                        ),
-                        lagAndelTilkjentYtelse(
-                            behandling = behandling,
-                            aktør = barn2,
-                            stønadFom = YearMonth.now().minusMonths(4),
-                            stønadTom = YearMonth.now(),
-                            sats = 7000,
-                        ),
-                    ),
-            )
-
         every { beregningService.finnTilkjentYtelseForBehandling(behandlingId = behandling.id) } answers { null }
-        every { behandlingService.hentBehandling(behandlingId = behandling.id) } answers { behandling }
-        every { behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id) } answers { forrigeBehandling }
-        every { beregningService.hentTilkjentYtelseForBehandling(behandlingId = forrigeBehandling.id) } answers { forrigeTilkjentYtelse }
-        every { personidentService.hentAktør(barn1.aktørId) } answers { barn1 }
-        every { personidentService.hentAktør(barn2.aktørId) } answers { barn2 }
 
         // Act
         val aktørerMedUgyldigEtterbetalingsperiode =


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26023

Det skaper mye støy i loggene når SB prøver å gå til behandlingsresultat siden, og det ikke finnes tilkjent ytelse (Fordi det ikke har blitt opprettet enda, eller fordi behandlingen ble henlagt før det)

<img width="1050" height="486" alt="Screenshot 2025-08-20 at 14 32 13" src="https://github.com/user-attachments/assets/666ebc4a-51f0-4bee-b771-b592d38b3ebc" />
