### PR TITLE
Vi henter inn seneste vilkår ved fortsatt innvilget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -661,14 +661,20 @@ class BrevPeriodeContext(
         )
 
     private fun Person.hentAntallTimerBarnehageplass(): BigDecimal {
-        val forskjøvetBarnehageplassPeriodeSomErSamtidigSomVedtaksperiode =
-            hentForskjøvedeVilkårResultaterSomErSamtidigSomVedtaksperiode()[this.aktør]
-                ?.get(Vilkår.BARNEHAGEPLASS)
-                ?.tilPerioderIkkeNull()
+        val forskjøvetBarnehageplassPeriodeSomPasserVedtaksperiode =
+            if (utvidetVedtaksperiodeMedBegrunnelser.type == Vedtaksperiodetype.FORTSATT_INNVILGET) {
+                hentForskjøvedeVilkårResultater()[this.aktør]
+                    ?.get(Vilkår.BARNEHAGEPLASS)
+                    ?.tilPerioderIkkeNull()
+            } else {
+                hentForskjøvedeVilkårResultaterSomErSamtidigSomVedtaksperiode()[this.aktør]
+                    ?.get(Vilkår.BARNEHAGEPLASS)
+                    ?.tilPerioderIkkeNull()
+            }
 
         val antallTimerIBarnehageplassVilkår =
-            forskjøvetBarnehageplassPeriodeSomErSamtidigSomVedtaksperiode
-                ?.singleOrNull() // Skal være maks ett barnehageresultat i periode, ellers burde vi ha splittet opp vedtaksperioden.
+            forskjøvetBarnehageplassPeriodeSomPasserVedtaksperiode
+                ?.maxByOrNull { it.fom ?: TIDENES_ENDE }
                 ?.verdi
                 ?.antallTimer
 

--- a/src/test/resources/cucumber/fortsatt-innvilget.feature
+++ b/src/test/resources/cucumber/fortsatt-innvilget.feature
@@ -80,3 +80,74 @@ Egenskap: Fortsatt innvilget
     Så forvent følgende brevbegrunnelser for behandling 2 i periode - til -
       | Begrunnelse                           | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Målform | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder |
       | FORTSATT_INNVILGET_BARN_BOR_MED_SOKER | STANDARD | Nei           | 07.05.22             | 1           | NB      | 7 500 |                  | 0                           | Ja                     |
+
+  Scenario: Ved fortsatt innvilget skal den seneste barnehageplass vilkåret brukes når vi henter inn antall timer.
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         |
+      | 2            | 1        | 1                   | SØKNAD           | NASJONAL            | UTREDES           |
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 03.01.1998  |
+      | 1            | 2       | BARN       | 04.06.2024  |
+      | 1            | 3       | BARN       | 04.06.2024  |
+      | 2            | 1       | SØKER      | 03.01.1998  |
+      | 2            | 2       | BARN       | 04.06.2024  |
+      | 2            | 3       | BARN       | 04.06.2024  |
+
+    Og følgende dagens dato 21.08.2025
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 03.01.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 03.01.2003 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 03.06.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 04.06.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 04.06.2024 | 31.07.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 04.06.2025 | 04.02.2026 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.08.2025 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   | 27           |
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 03.06.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 04.06.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               |                  | 04.06.2024 | 31.07.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 3       | BARNETS_ALDER                |                  | 04.06.2025 | 04.02.2026 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               |                  | 01.08.2025 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   | 27           |
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 03.01.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 03.01.2003 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 03.06.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 04.06.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               |                  | 04.06.2024 | 31.07.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 3       | BARNETS_ALDER                |                  | 04.06.2025 | 04.02.2026 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS               |                  | 01.08.2025 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   | 27           |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 03.06.1998 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOR_MED_SØKER,BOSATT_I_RIKET |                  | 04.06.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 04.06.2024 | 31.07.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 04.06.2025 | 04.02.2026 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.08.2025 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   | 27           |
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Og når behandlingsresultatet er utledet for behandling 2
+
+    Så forvent at behandlingsresultatet er FORTSATT_INNVILGET på behandling 2
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato | Til dato | Vedtaksperiodetype | Kommentar |
+      |          |          | FORTSATT_INNVILGET |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato | Til dato | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser                        | Ugyldige begrunnelser |
+      |          |          | FORTSATT_INNVILGET |                                | FORTSATT_INNVILGET_DELTIDSPLASS_I_BARNEHAGE |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato | Til dato | Standardbegrunnelser                        | Eøsbegrunnelser | Fritekster |
+      |          |          | FORTSATT_INNVILGET_DELTIDSPLASS_I_BARNEHAGE |                 |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode - til -
+      | Begrunnelse                                 | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | Måned og år før vedtaksperiode |
+      | FORTSATT_INNVILGET_DELTIDSPLASS_I_BARNEHAGE | STANDARD |               | 04.06.24 og 04.06.24 | 2           |                                      | 3 000 |                  | 27 og 27                    | Ja                     |         |                                |

--- a/src/test/resources/cucumber/vedtaksperioder/opphør.feature
+++ b/src/test/resources/cucumber/vedtaksperioder/opphør.feature
@@ -62,7 +62,7 @@ Egenskap: Opphørsperiode
 
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.08.2024 til -
       | Begrunnelse                                   | Type     | Antall barn | Barnas fødselsdatoer | Gjelder søker | Beløp | Måned og år begrunnelsen gjelder for | Gjelder andre forelder | Antall timer barnehageplass | Måned og år før vedtaksperiode |
-      | OPPHØR_TILLEGSTEKST_FOR_REGLER_FØR_01_08_2024 | STANDARD | 1           | 20.03.23             | Nei           | 0     | august 2024                          | true                   | 0                           | juli 2024                      |
+      | OPPHØR_TILLEGSTEKST_FOR_REGLER_FØR_01_08_2024 | STANDARD | 1           | 20.03.23             | Nei           | 0     | august 2024                          | true                   | 40                          | juli 2024                      |
 
 
   Scenario: Opphørsperioder som oppstår i mellom perioder skal ha tom dato, opphørsperioder som oppstår


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26008

Vanligvis når vi henter inn antall timer et barn har gått på barnehagen i begrunnelsene, så henter vi først vilkårene som passer perioden. Dette fungerer ikke bra når det gjelder fortsatt innvilget perioder, da de periodene har null i fom og tom.
Det ender opp med at vi da ikke henter inn riktig vilkår.

Endrer på det slik at vi alltid henter inn seneste fom ved fortsatt innvilgelse.