### PR TITLE
Nedgrader surefire fordi 3.5.3 har en bug som gjør at den ikke plukker opp Cucumber feil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <!-- Plugin -->
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <ktlint-cli.version>1.7.1</ktlint-cli.version>
-        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <maven-enforcer-plugin.version>3.6.1</maven-enforcer-plugin.version>
         <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
https://github.com/navikt/familie-ba-sak/pull/5594
Feil i cucumber plukkes ikke opp. Dette pga en bug i surefire i 3.5.3.
Diskuteres her: https://github.com/cucumber/cucumber-jvm/issues/2984

