### PR TITLE
NAV-26038: Ser på fagsak aktør sin behandlende enhet og tilpasser det i forhold til enhetene saksbehandler har tilgang til for oppretting av klage request

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -12,4 +12,5 @@ enum class FeatureToggle(
     // Ikke operasjonelle
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
     IKKE_LAG_OPPHOERSPERIODE_AV_AVSLAAT_BEHANDLINGSRESULTAT("familie-ba-sak.ikke-lag-opphoersperiode-ved-avslaatt-behandlingsresultat"),
+    BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING("familie-ks-sak.bruk-ny-logikk-for-aa-finne-enhet-for-oppretting-av-klagebehandling"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/domene/Arbeidsfordelingsenhet.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/domene/Arbeidsfordelingsenhet.kt
@@ -1,6 +1,16 @@
 package no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene
 
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
+
 data class Arbeidsfordelingsenhet(
     val enhetId: String,
     val enhetNavn: String,
-)
+) {
+    companion object {
+        fun opprettFra(enhet: KontantstøtteEnhet): Arbeidsfordelingsenhet =
+            Arbeidsfordelingsenhet(
+                enhetId = enhet.enhetsnummer,
+                enhetNavn = enhet.enhetsnavn,
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingService.kt
@@ -67,18 +67,12 @@ class TilpassArbeidsfordelingService(
         val navIdentHarKunTilgangTilVikafossen = enheterNavIdentHarTilgangTil.inneholderKunVikafossen()
         if (navIdentHarKunTilgangTilVikafossen) {
             // Skal kun være lovt til å sette Vikafossen når det er eneste valgmulighet
-            return Arbeidsfordelingsenhet(
-                KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-            )
+            return Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
         }
         val enheterNavIdentHarTilgangTilForutenVikafossen = enheterNavIdentHarTilgangTil.filter { it.enhetsnummer != KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer }
         // Velger bare det første enhetsnummeret i tilfeller hvor man har flere, avklart med fag
         val nyBehandlendeEnhet = enheterNavIdentHarTilgangTilForutenVikafossen.first()
-        return Arbeidsfordelingsenhet(
-            nyBehandlendeEnhet.enhetsnummer,
-            nyBehandlendeEnhet.enhetsnavn,
-        )
+        return Arbeidsfordelingsenhet.opprettFra(nyBehandlendeEnhet)
     }
 
     private fun håndterVikafossenEnhet2103(
@@ -87,10 +81,7 @@ class TilpassArbeidsfordelingService(
         if (navIdent == null) {
             håndterNavIdentErNull(KontantstøtteEnhet.VIKAFOSSEN)
         }
-        return Arbeidsfordelingsenhet(
-            KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-            KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-        )
+        return Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
     }
 
     private fun håndterAndreEnheter(
@@ -99,34 +90,22 @@ class TilpassArbeidsfordelingService(
     ): Arbeidsfordelingsenhet {
         if (navIdent == null || navIdent.erSystemIdent()) {
             // navIdent er null ved automatisk journalføring
-            return Arbeidsfordelingsenhet(
-                arbeidsfordelingsenhet.enhetId,
-                arbeidsfordelingsenhet.enhetNavn,
-            )
+            return arbeidsfordelingsenhet
         }
         val enheterNavIdentHarTilgangTil = hentEnheterNavIdentHarTilgangTil(navIdent = navIdent)
         val navIdentHarKunTilgangTilVikafossen = enheterNavIdentHarTilgangTil.inneholderKunVikafossen()
         if (navIdentHarKunTilgangTilVikafossen) {
             // Skal kun være lovt til å sette Vikafossen når det er eneste valgmulighet
-            return Arbeidsfordelingsenhet(
-                KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-            )
+            return Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
         }
         val enheterNavIdentHarTilgangTilForutenVikafossen = enheterNavIdentHarTilgangTil.filter { it.enhetsnummer != KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer }
         val harTilgangTilBehandledeEnhet = enheterNavIdentHarTilgangTilForutenVikafossen.any { it.enhetsnummer == arbeidsfordelingsenhet.enhetId }
         if (!harTilgangTilBehandledeEnhet) {
             // Velger bare det første enhetsnummeret i tilfeller hvor man har flere, avklart med fag
             val nyBehandlendeEnhet = enheterNavIdentHarTilgangTilForutenVikafossen.first()
-            return Arbeidsfordelingsenhet(
-                nyBehandlendeEnhet.enhetsnummer,
-                nyBehandlendeEnhet.enhetsnavn,
-            )
+            return Arbeidsfordelingsenhet.opprettFra(nyBehandlendeEnhet)
         }
-        return Arbeidsfordelingsenhet(
-            arbeidsfordelingsenhet.enhetId,
-            arbeidsfordelingsenhet.enhetNavn,
-        )
+        return arbeidsfordelingsenhet
     }
 
     private fun hentEnheterNavIdentHarTilgangTil(navIdent: NavIdent): List<KontantstøtteEnhet> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageService.kt
@@ -1,23 +1,15 @@
 package no.nav.familie.ks.sak.kjerne.klage
 
-import no.nav.familie.kontrakter.felles.NavIdent
-import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
 import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
-import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
-import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
-import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
-import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
 import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
-import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.UUID
@@ -25,46 +17,21 @@ import java.util.UUID
 @Service
 class KlageService(
     private val fagsakService: FagsakService,
-    private val klageClient: KlageClient,
-    private val integrasjonClient: IntegrasjonClient,
     private val behandlingService: BehandlingService,
     private val vedtakService: VedtakService,
     private val tilbakekrevingKlient: TilbakekrevingKlient,
     private val klagebehandlingHenter: KlagebehandlingHenter,
+    private val klagebehandlingOppretter: KlagebehandlingOppretter,
 ) {
     fun opprettKlage(
         fagsakId: Long,
         klageMottattDato: LocalDate,
-    ): UUID {
-        val fagsak = fagsakService.hentFagsak(fagsakId)
-
-        return opprettKlage(fagsak, klageMottattDato)
-    }
+    ): UUID = klagebehandlingOppretter.opprettKlage(fagsakId, klageMottattDato)
 
     fun opprettKlage(
         fagsak: Fagsak,
         klageMottattDato: LocalDate,
-    ): UUID {
-        if (klageMottattDato.isAfter(LocalDate.now())) {
-            throw FunksjonellFeil("Kan ikke opprette klage med krav mottatt frem i tid")
-        }
-
-        val aktivtFødselsnummer = fagsak.aktør.aktivFødselsnummer()
-        val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
-        val enhetsnummer = integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(saksbehandlerIdent)).first().enhetsnummer
-
-        return klageClient.opprettKlage(
-            OpprettKlagebehandlingRequest(
-                ident = aktivtFødselsnummer,
-                stønadstype = Stønadstype.KONTANTSTØTTE,
-                eksternFagsakId = fagsak.id.toString(),
-                fagsystem = Fagsystem.KS,
-                klageMottatt = klageMottattDato,
-                behandlendeEnhet = enhetsnummer,
-                behandlingsårsak = Klagebehandlingsårsak.ORDINÆR,
-            ),
-        )
-    }
+    ): UUID = klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
 
     fun hentKlagebehandlingerPåFagsak(fagsakId: Long): List<KlagebehandlingDto> = klagebehandlingHenter.hentKlagebehandlingerPåFagsak(fagsakId)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretter.kt
@@ -1,0 +1,96 @@
+package no.nav.familie.ks.sak.kjerne.klage
+
+import no.nav.familie.kontrakter.felles.NavIdent
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
+import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import no.nav.familie.ks.sak.common.ClockProvider
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.TilpassArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
+import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.util.UUID
+
+@Component
+class KlagebehandlingOppretter(
+    private val fagsakService: FagsakService,
+    private val klageClient: KlageClient,
+    private val integrasjonClient: IntegrasjonClient,
+    private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
+    private val clockProvider: ClockProvider,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
+) {
+    private val logger = LoggerFactory.getLogger(KlagebehandlingOppretter::class.java)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    fun opprettKlage(
+        fagsakId: Long,
+        klageMottattDato: LocalDate,
+    ): UUID {
+        val fagsak = fagsakService.hentFagsak(fagsakId)
+        return opprettKlage(fagsak, klageMottattDato)
+    }
+
+    fun opprettKlage(
+        fagsak: Fagsak,
+        klageMottattDato: LocalDate,
+    ): UUID {
+        if (klageMottattDato.isAfter(LocalDate.now(clockProvider.get()))) {
+            throw FunksjonellFeil("Kan ikke opprette klage med krav mottatt frem i tid.")
+        }
+
+        val fødselsnummer = fagsak.aktør.aktivFødselsnummer()
+        val navIdent = NavIdent(SikkerhetContext.hentSaksbehandler())
+
+        val behandlendeEnhet =
+            if (unleashNextMedContextService.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING)) {
+                val arbeidsfordelingsenheter = integrasjonClient.hentBehandlendeEnheter(fødselsnummer)
+
+                if (arbeidsfordelingsenheter.isEmpty()) {
+                    logger.error("Fant ingen arbeidsfordelingsenheter for aktør. Se SecureLogs for detaljer.")
+                    secureLogger.error("Fant ingen arbeidsfordelingsenheter for aktør $fødselsnummer.")
+                    throw Feil("Fant ingen arbeidsfordelingsenhet for aktør.")
+                }
+
+                if (arbeidsfordelingsenheter.size > 1) {
+                    logger.error("Fant flere arbeidsfordelingsenheter for aktør. Se SecureLogs for detaljer.")
+                    secureLogger.error("Fant flere arbeidsfordelingsenheter for aktør $fødselsnummer.")
+                    throw Feil("Fant flere arbeidsfordelingsenheter for aktør.")
+                }
+
+                val tilpassetArbeidsfordelingsenhet =
+                    tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(
+                        arbeidsfordelingsenheter.single(),
+                        navIdent,
+                    )
+
+                tilpassetArbeidsfordelingsenhet.enhetId
+            } else {
+                integrasjonClient
+                    .hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent)
+                    .first()
+                    .enhetsnummer
+            }
+
+        return klageClient.opprettKlage(
+            OpprettKlagebehandlingRequest(
+                ident = fødselsnummer,
+                stønadstype = Stønadstype.KONTANTSTØTTE,
+                eksternFagsakId = fagsak.id.toString(),
+                fagsystem = Fagsystem.KS,
+                klageMottatt = klageMottattDato,
+                behandlendeEnhet = behandlendeEnhet,
+                behandlingsårsak = Klagebehandlingsårsak.ORDINÆR,
+            ),
+        )
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/domene/ArbeidsfordelingsenhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/domene/ArbeidsfordelingsenhetTest.kt
@@ -1,0 +1,23 @@
+package no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene
+
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class ArbeidsfordelingsenhetTest {
+    @Nested
+    inner class OpprettFra {
+        @ParameterizedTest
+        @EnumSource(KontantstøtteEnhet::class)
+        fun `skal opprette arbeidsfordelingsenhet fra barnetrygdenhet`(enhet: KontantstøtteEnhet) {
+            // Act
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(enhet)
+
+            // Assert
+            assertThat(arbeidsfordelingsenhet.enhetId).isEqualTo(enhet.enhetsnummer)
+            assertThat(arbeidsfordelingsenhet.enhetNavn).isEqualTo(enhet.enhetsnavn)
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/TilpassArbeidsfordelingServiceTest.kt
@@ -25,11 +25,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal kaste feil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident er null`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.MIDLERTIDIG_ENHET)
 
             // Act & assert
             val exception =
@@ -45,11 +41,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal kaste feil om arbeidsfordeling er midlertidig enhet 4863 og NAV-ident er systembruker`() {
             // Arrange
-            val arbeidsfordelingPåBehandling =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingPåBehandling = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.MIDLERTIDIG_ENHET)
 
             // Act & assert
             val exception =
@@ -67,11 +59,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.MIDLERTIDIG_ENHET)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -95,11 +83,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.MIDLERTIDIG_ENHET)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -128,11 +112,7 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
             val enhetNavIdentHarTilgangTil = KontantstøtteEnhet.OSLO
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.MIDLERTIDIG_ENHET)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -160,11 +140,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal kaste feil hvis arbeidsfordeling er Vikafossen 2103 og NAV-ident er null`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
 
             // Act & assert
             val exception =
@@ -181,14 +157,8 @@ class TilpassArbeidsfordelingServiceTest {
         fun `skal returnere Vikafossen 2103 dersom arbeidsfordeling er Vikafossen 2103 og NAV-ident ikke har tilgang til Vikafossen 2103`() {
             // Arrange
             val navIdent = NavIdent("1")
-            val enhetNavIdentHarTilgangTil1 = KontantstøtteEnhet.STEINKJER
-            val enhetNavIdentHarTilgangTil2 = KontantstøtteEnhet.VADSØ
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -218,11 +188,7 @@ class TilpassArbeidsfordelingServiceTest {
             val navIdent = NavIdent("1")
             val enhetNavIdentHarTilgangTil = KontantstøtteEnhet.VIKAFOSSEN
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -249,11 +215,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere enhetId dersom arbeidsfordeling ikke er 2103 eller 4863 og NAV-ident er null`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.STEINKJER.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.STEINKJER.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.STEINKJER)
 
             // Act
             val tilpassetArbeidsfordelingsenhet =
@@ -272,11 +234,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.DRAMMEN.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.DRAMMEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.DRAMMEN)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -334,11 +292,7 @@ class TilpassArbeidsfordelingServiceTest {
 
             val enhetNavIdentHarTilgangTil = KontantstøtteEnhet.OSLO
 
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.STEINKJER.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.STEINKJER.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.STEINKJER)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -367,13 +321,7 @@ class TilpassArbeidsfordelingServiceTest {
             // Arrange
             val navIdent = NavIdent("1")
 
-            val arbeidsfordelingEnhet = KontantstøtteEnhet.OSLO
-
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = arbeidsfordelingEnhet.enhetsnummer,
-                    enhetNavn = arbeidsfordelingEnhet.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.OSLO)
 
             every {
                 mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(
@@ -394,8 +342,8 @@ class TilpassArbeidsfordelingServiceTest {
                 )
 
             // Assert
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(arbeidsfordelingEnhet.enhetsnummer)
-            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(arbeidsfordelingEnhet.enhetsnavn)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetId).isEqualTo(arbeidsfordelingsenhet.enhetId)
+            assertThat(tilpassetArbeidsfordelingsenhet.enhetNavn).isEqualTo(arbeidsfordelingsenhet.enhetNavn)
         }
 
         @Test
@@ -425,7 +373,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere navIdent dersom navIdent har tilgang til arbeidsfordelingsenhet`() {
             // Arrange
-            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet(enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer, enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn)
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
@@ -443,7 +391,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere null dersom navIdent ikke har tilgang til arbeidsfordelingsenhet`() {
             // Arrange
-            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet(enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer, enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn)
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
             val navIdent = NavIdent("1")
 
             every { mockedIntegrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(navIdent = navIdent) } returns
@@ -461,7 +409,7 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere null dersom navIdent er null`() {
             // Arrange
-            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet(enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer, enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn)
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
             val navIdent = null
 
             // Act
@@ -474,16 +422,11 @@ class TilpassArbeidsfordelingServiceTest {
         @Test
         fun `skal returnere null dersom vi er i systemkontekst`() {
             // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = KontantstøtteEnhet.VIKAFOSSEN.enhetsnummer,
-                    enhetNavn = KontantstøtteEnhet.VIKAFOSSEN.enhetsnavn,
-                )
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VIKAFOSSEN)
             val navIdent = NavIdent(SYSTEM_FORKORTELSE)
 
             // Act
-            val tilordnetRessurs =
-                tilpassArbeidsfordelingService.bestemTilordnetRessursPåOppgave(arbeidsfordelingsenhet, navIdent)
+            val tilordnetRessurs = tilpassArbeidsfordelingService.bestemTilordnetRessursPåOppgave(arbeidsfordelingsenhet, navIdent)
 
             // Assert
             assertThat(tilordnetRessurs).isNull()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
@@ -1,0 +1,215 @@
+package no.nav.familie.ks.sak.kjerne.klage
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
+import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import no.nav.familie.ks.sak.common.TestClockProvider
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.TilpassArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.util.UUID
+
+class KlagebehandlingOppretterTest {
+    private val dagensDato = LocalDate.of(2025, 8, 25)
+
+    private val fagsakService = mockk<FagsakService>()
+    private val klageClient = mockk<KlageClient>()
+    private val integrasjonClient = mockk<IntegrasjonClient>()
+    private val tilpassArbeidsfordelingService = mockk<TilpassArbeidsfordelingService>()
+    private val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensDato)
+    private val unleash = mockk<UnleashNextMedContextService>()
+
+    private val klagebehandlingOppretter =
+        KlagebehandlingOppretter(
+            fagsakService,
+            klageClient,
+            integrasjonClient,
+            tilpassArbeidsfordelingService,
+            clockProvider,
+            unleash,
+        )
+
+    @BeforeEach
+    fun setup() {
+        every { unleash.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING) } returns true
+    }
+
+    @Nested
+    inner class OpprettKlage {
+        @Test
+        fun `skal kaste exception hvis klagebehandlingen blir mottatt etter dagens dato`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato.plusDays(1)
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+                }
+            assertThat(exception.message).isEqualTo("Kan ikke opprette klage med krav mottatt frem i tid.")
+        }
+
+        @Test
+        fun `skal kaste exception om man ikke finner en behandlende enhet for aktør`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+
+            every { integrasjonClient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns emptyList()
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+                }
+            assertThat(exception.message).isEqualTo("Fant ingen arbeidsfordelingsenhet for aktør.")
+        }
+
+        @Test
+        fun `skal kaste exception om man ikke finner flere behandlende enheter for aktør`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+
+            every { integrasjonClient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns
+                listOf(
+                    Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.OSLO),
+                    Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VADSØ),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+                }
+            assertThat(exception.message).isEqualTo("Fant flere arbeidsfordelingsenheter for aktør.")
+        }
+
+        @Test
+        fun `skal opprette klage ved å sende inn kun fagsakId som parameter`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.OSLO)
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
+            every { integrasjonClient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+            every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns arbeidsfordelingsenhet
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak.id, dagensDato)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.KONTANTSTØTTE)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.KS)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(arbeidsfordelingsenhet.enhetId)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+
+        @Test
+        fun `skal lage OpprettKlageRequest uten å tilpasse enhetsnummeret fra fagsak aktør`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.OSLO)
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { integrasjonClient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+            every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns arbeidsfordelingsenhet
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.KONTANTSTØTTE)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.KS)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(arbeidsfordelingsenhet.enhetId)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+
+        @Test
+        fun `skal lage OpprettKlageRequest og tilpasse enhetsnummeret fra fagsak aktør basert på tilgangene til saksbehandler`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+            val arbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.OSLO)
+            val tilpassetArbeidsfordelingsenhet = Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VADSØ)
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { integrasjonClient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+            every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns tilpassetArbeidsfordelingsenhet
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.KONTANTSTØTTE)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.KS)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(tilpassetArbeidsfordelingsenhet.enhetId)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+
+        @Test
+        fun `skal lage OpprettKlageRequest hvor behandlendeEnhet er satt til saksbehandlers enhet når toggle er av`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+
+            val klagebehandlingId = UUID.randomUUID()
+
+            val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
+
+            every { unleash.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_AA_FINNE_ENHET_FOR_OPPRETTING_AV_KLAGEBEHANDLING) } returns false
+            every { integrasjonClient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(any()) } returns listOf(KontantstøtteEnhet.OSLO, KontantstøtteEnhet.VIKAFOSSEN)
+            every { klageClient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
+
+            // Act
+            val id = klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+
+            // Assert
+            assertThat(id).isEqualTo(klagebehandlingId)
+            assertThat(opprettKlageRequest.captured.ident).isEqualTo(fagsak.aktør.aktivFødselsnummer())
+            assertThat(opprettKlageRequest.captured.stønadstype).isEqualTo(Stønadstype.KONTANTSTØTTE)
+            assertThat(opprettKlageRequest.captured.eksternFagsakId).isEqualTo(fagsak.id.toString())
+            assertThat(opprettKlageRequest.captured.fagsystem).isEqualTo(Fagsystem.KS)
+            assertThat(opprettKlageRequest.captured.behandlendeEnhet).isEqualTo(KontantstøtteEnhet.OSLO.enhetsnummer)
+            assertThat(opprettKlageRequest.captured.behandlingsårsak).isEqualTo(Klagebehandlingsårsak.ORDINÆR)
+        }
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26038

Når vi velger enhet for opprett klage requesten må vi se på hvilken enhet som tilhører fagsak aktør før vi deretter tilpasser det i forhold til enhetene saksbehandler har tilgang til. 

Endringene er gjemt bak en toggle.

Relatert PR for BA: https://github.com/navikt/familie-ba-sak/pull/5593

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

