### PR TITLE
Lagre oppholdsadresse i personopplysningsgrunnlag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Nav Familie-->
         <prosessering.version>2.20250825143618_c0302c9</prosessering.version>
-        <felles-kontrakter.version>3.0_20250826121939_ee97111</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250827085324_488a77e</felles-kontrakter.version>
         <felles.version>3.20250804101327_a0f5fad</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250826113118_c8aa66d</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.stønadsstatistikk>2.0_20250826113118_c8aa66d</familie.kontrakter.stønadsstatistikk>

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
@@ -85,6 +85,7 @@ data class RegisterHistorikkResponsDto(
     val oppholdstillatelse: List<RegisteropplysningResponsDto>? = emptyList(),
     val statsborgerskap: List<RegisteropplysningResponsDto>? = emptyList(),
     val bostedsadresse: List<RegisteropplysningResponsDto>? = emptyList(),
+    val oppholdsadresse: List<RegisteropplysningResponsDto>? = emptyList(),
     val dødsboadresse: List<RegisteropplysningResponsDto>? = emptyList(),
 )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/RegisterHistorikkMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/RegisterHistorikkMapper.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.dødsfall.Dødsfall
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.opphold.GrOpphold
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrOppholdsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.sivilstand.GrSivilstand
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.statsborgerskap.GrStatsborgerskap
 
@@ -30,6 +31,7 @@ object RegisterHistorikkMapper {
             hentetTidspunkt = person.personopplysningGrunnlag.opprettetTidspunkt,
             oppholdstillatelse = person.opphold.map { lagRegisterOpplysningDto(it) },
             bostedsadresse = person.bostedsadresser.map { lagRegisterOpplysningDto(it) },
+            oppholdsadresse = person.oppholdsadresser.map { lagRegisterOpplysningDto(it) },
             sivilstand = person.sivilstander.map { lagRegisterOpplysningDto(it) },
         )
     }
@@ -56,6 +58,13 @@ object RegisterHistorikkMapper {
             fom = bostedsAdresse.periode?.fom,
             tom = bostedsAdresse.periode?.tom,
             verdi = bostedsAdresse.tilFrontendString(),
+        )
+
+    private fun lagRegisterOpplysningDto(oppholdsadresse: GrOppholdsadresse) =
+        RegisteropplysningResponsDto(
+            fom = oppholdsadresse.periode?.fom,
+            tom = oppholdsadresse.periode?.tom,
+            verdi = oppholdsadresse.tilFrontendString(),
         )
 
     private fun lagRegisterOpplysningDto(

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlUtil.kt
@@ -81,6 +81,7 @@ fun tilPersonInfo(
         forelderBarnRelasjonerMaskert = maskertForelderBarnRelasjoner,
         adressebeskyttelseGradering = pdlPersonData.adressebeskyttelse.firstOrNull()?.gradering,
         bostedsadresser = pdlPersonData.bostedsadresse,
+        oppholdsadresser = pdlPersonData.oppholdsadresse,
         statsborgerskap = pdlPersonData.statsborgerskap,
         opphold = pdlPersonData.opphold,
         sivilstander = pdlPersonData.sivilstand,

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlPersonInfo.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlPersonInfo.kt
@@ -11,6 +11,7 @@ import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.KJOENN
 import no.nav.familie.kontrakter.felles.personopplysning.Opphold
+import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Sivilstand
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
@@ -26,6 +27,7 @@ data class PdlPersonInfo(
     val forelderBarnRelasjonerMaskert: Set<ForelderBarnRelasjonInfoMaskert> = emptySet(),
     val adressebeskyttelseGradering: ADRESSEBESKYTTELSEGRADERING? = null,
     val bostedsadresser: List<Bostedsadresse> = emptyList(),
+    val oppholdsadresser: List<Oppholdsadresse> = emptyList(),
     val sivilstander: List<Sivilstand> = emptyList(),
     val opphold: List<Opphold>? = emptyList(),
     val statsborgerskap: List<Statsborgerskap>? = emptyList(),

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlResponser.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/domene/PdlResponser.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.ForelderBarnRelasjon
 import no.nav.familie.kontrakter.felles.personopplysning.KJOENN
 import no.nav.familie.kontrakter.felles.personopplysning.Opphold
+import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
 import no.nav.familie.kontrakter.felles.personopplysning.Sivilstand
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
 import no.nav.familie.ks.sak.common.exception.Feil
@@ -120,6 +121,7 @@ data class PdlPersonData(
     val adressebeskyttelse: List<Adressebeskyttelse> = emptyList(),
     val sivilstand: List<Sivilstand> = emptyList(),
     val bostedsadresse: List<Bostedsadresse>,
+    val oppholdsadresse: List<Oppholdsadresse> = emptyList(),
     val opphold: List<Opphold> = emptyList(),
     val statsborgerskap: List<Statsborgerskap> = emptyList(),
     val doedsfall: List<Doedsfall> = emptyList(),

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Personopplys
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.dødsfall.Dødsfall
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.opphold.GrOpphold
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrOppholdsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.sivilstand.GrSivilstand
 import org.springframework.stereotype.Service
 
@@ -47,6 +48,10 @@ class PersonService(
                 personinfo.bostedsadresser
                     .filtrerUtKunNorskeBostedsadresser()
                     .map { GrBostedsadresse.fraBostedsadresse(it, person) }
+                    .toMutableList()
+            person.oppholdsadresser =
+                personinfo.oppholdsadresser
+                    .map { GrOppholdsadresse.fraOppholdsadresse(it, person) }
                     .toMutableList()
             person.sivilstander = personinfo.sivilstander.map { GrSivilstand.fraSivilstand(it, person) }.toMutableList()
             person.dødsfall =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/Person.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/Person.kt
@@ -25,6 +25,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.arbeidsforho
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.dødsfall.Dødsfall
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.opphold.GrOpphold
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrOppholdsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.sivilstand.GrSivilstand
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.statsborgerskap.GrStatsborgerskap
 import org.hibernate.annotations.Fetch
@@ -65,6 +66,9 @@ data class Person(
     // Workaround før Hibernatebug https://hibernate.atlassian.net/browse/HHH-1718
     @Fetch(value = FetchMode.SUBSELECT)
     var bostedsadresser: MutableList<GrBostedsadresse> = mutableListOf(),
+    @OneToMany(mappedBy = "person", cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
+    var oppholdsadresser: MutableList<GrOppholdsadresse> = mutableListOf(),
     @OneToMany(mappedBy = "person", cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
     // Workaround før Hibernatebug https://hibernate.atlassian.net/browse/HHH-1718
     @Fetch(value = FetchMode.SUBSELECT)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrBostedsadresse.kt
@@ -50,9 +50,9 @@ abstract class GrBostedsadresse(
             person: Person,
         ): GrBostedsadresse {
             val mappetAdresse =
-                bostedsadresse.vegadresse?.let { GrVegadresse.fraVegadresse(it) }
-                    ?: bostedsadresse.matrikkeladresse?.let { GrMatrikkeladresse.fraMatrikkeladresse(it) }
-                    ?: bostedsadresse.ukjentBosted?.let { GrUkjentBosted.fraUkjentBosted(it) }
+                bostedsadresse.vegadresse?.let { GrVegadresseBostedsadresse.fraVegadresse(it) }
+                    ?: bostedsadresse.matrikkeladresse?.let { GrMatrikkeladresseBostedsadresse.fraMatrikkeladresse(it) }
+                    ?: bostedsadresse.ukjentBosted?.let { GrUkjentBostedBostedsadresse.fraUkjentBosted(it) }
                     ?: throw Feil("Vegadresse, matrikkeladresse og ukjent bosted har verdi null ved mapping fra bostedadresse")
 
             return mappetAdresse.also {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrMatrikkeladresseBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrMatrikkeladresseBostedsadresse.kt
@@ -6,9 +6,9 @@ import jakarta.persistence.Entity
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
 import java.util.Objects
 
-@Entity(name = "GrMatrikkeladresse")
+@Entity(name = "GrMatrikkeladresseBostedsadresse")
 @DiscriminatorValue("Matrikkeladresse")
-data class GrMatrikkeladresse(
+data class GrMatrikkeladresseBostedsadresse(
     @Column(name = "matrikkel_id")
     val matrikkelId: Long?,
     @Column(name = "bruksenhetsnummer")
@@ -21,11 +21,11 @@ data class GrMatrikkeladresse(
     val kommunenummer: String?,
 ) : GrBostedsadresse() {
     override fun toSecureString(): String =
-        """MatrikkeladresseDao(matrikkelId=$matrikkelId,bruksenhetsnummer=$bruksenhetsnummer,
+        """GrMatrikkeladresseBostedsadresse(matrikkelId=$matrikkelId,bruksenhetsnummer=$bruksenhetsnummer,
             tilleggsnavn=$tilleggsnavn, postnummer=$postnummer,kommunenummer=$kommunenummer
         """.trimMargin()
 
-    override fun toString(): String = "Matrikkeladresse(detaljer skjult)"
+    override fun toString(): String = "GrMatrikkeladresseBostedsadresse(detaljer skjult)"
 
     override fun tilFrontendString() = """Matrikkel $matrikkelId, bruksenhet $bruksenhetsnummer, postnummer $postnummer""".trimMargin()
 
@@ -33,7 +33,7 @@ data class GrMatrikkeladresse(
         if (other == null || javaClass != other.javaClass) {
             return false
         }
-        val otherMatrikkeladresse = other as GrMatrikkeladresse
+        val otherMatrikkeladresse = other as GrMatrikkeladresseBostedsadresse
         return this === other ||
             matrikkelId != null &&
             matrikkelId == otherMatrikkeladresse.matrikkelId &&
@@ -43,8 +43,8 @@ data class GrMatrikkeladresse(
     override fun hashCode(): Int = Objects.hash(matrikkelId)
 
     companion object {
-        fun fraMatrikkeladresse(matrikkeladresse: Matrikkeladresse): GrMatrikkeladresse =
-            GrMatrikkeladresse(
+        fun fraMatrikkeladresse(matrikkeladresse: Matrikkeladresse): GrMatrikkeladresseBostedsadresse =
+            GrMatrikkeladresseBostedsadresse(
                 matrikkelId = matrikkeladresse.matrikkelId,
                 bruksenhetsnummer = matrikkeladresse.bruksenhetsnummer,
                 tilleggsnavn = matrikkeladresse.tilleggsnavn,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrUkjentBostedBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrUkjentBostedBostedsadresse.kt
@@ -5,19 +5,19 @@ import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
 import no.nav.familie.kontrakter.felles.personopplysning.UkjentBosted
 
-@Entity(name = "GrUkjentBosted")
+@Entity(name = "GrUkjentBostedBostedsadresse")
 @DiscriminatorValue("ukjentBosted")
-data class GrUkjentBosted(
+data class GrUkjentBostedBostedsadresse(
     @Column(name = "bostedskommune")
     val bostedskommune: String,
 ) : GrBostedsadresse() {
-    override fun toSecureString(): String = """UkjentadresseDao(bostedskommune=$bostedskommune""".trimMargin()
+    override fun toSecureString(): String = """GrUkjentBostedBostedsadresse(bostedskommune=$bostedskommune""".trimMargin()
 
     override fun tilFrontendString() = """Ukjent adresse, kommune $bostedskommune""".trimMargin()
 
-    override fun toString(): String = "UkjentBostedAdresse(detaljer skjult)"
+    override fun toString(): String = "GrUkjentBostedBostedsadresse(detaljer skjult)"
 
     companion object {
-        fun fraUkjentBosted(ukjentBosted: UkjentBosted): GrUkjentBosted = GrUkjentBosted(bostedskommune = ukjentBosted.bostedskommune)
+        fun fraUkjentBosted(ukjentBosted: UkjentBosted): GrUkjentBostedBostedsadresse = GrUkjentBostedBostedsadresse(bostedskommune = ukjentBosted.bostedskommune)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrVegadresseBostedsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/bostedsadresse/GrVegadresseBostedsadresse.kt
@@ -8,9 +8,9 @@ import no.nav.familie.ks.sak.common.util.nullableTilString
 import no.nav.familie.ks.sak.common.util.storForbokstav
 import java.util.Objects
 
-@Entity(name = "GrVegadresse")
+@Entity(name = "GrVegadresseBostedsadresse")
 @DiscriminatorValue("Vegadresse")
-data class GrVegadresse(
+data class GrVegadresseBostedsadresse(
     @Column(name = "matrikkel_id")
     val matrikkelId: Long?,
     @Column(name = "husnummer")
@@ -29,12 +29,12 @@ data class GrVegadresse(
     val postnummer: String?,
 ) : GrBostedsadresse() {
     override fun toSecureString(): String =
-        """VegadresseDao(husnummer=$husnummer,husbokstav=$husbokstav,matrikkelId=$matrikkelId,
+        """GrVegadresseBostedsadresse(husnummer=$husnummer,husbokstav=$husbokstav,matrikkelId=$matrikkelId,
                 |bruksenhetsnummer=$bruksenhetsnummer,adressenavn=$adressenavn,kommunenummer=$kommunenummer,
                 |tilleggsnavn=$tilleggsnavn,postnummer=$postnummer
         """.trimMargin()
 
-    override fun toString(): String = "Vegadresse(detaljer skjult)"
+    override fun toString(): String = "GrVegadresseBostedsadresse(detaljer skjult)"
 
     override fun tilFrontendString() =
         """${adressenavn.nullableTilString().storForbokstav()} 
@@ -44,7 +44,7 @@ data class GrVegadresse(
         if (other == null || javaClass != other.javaClass) {
             return false
         }
-        val otherVegadresse = other as GrVegadresse
+        val otherVegadresse = other as GrVegadresseBostedsadresse
 
         return this === other ||
             (
@@ -64,8 +64,8 @@ data class GrVegadresse(
     override fun hashCode(): Int = Objects.hash(matrikkelId)
 
     companion object {
-        fun fraVegadresse(vegadresse: Vegadresse): GrVegadresse =
-            GrVegadresse(
+        fun fraVegadresse(vegadresse: Vegadresse): GrVegadresseBostedsadresse =
+            GrVegadresseBostedsadresse(
                 matrikkelId = vegadresse.matrikkelId,
                 husnummer = vegadresse.husnummer,
                 husbokstav = vegadresse.husbokstav,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
@@ -1,0 +1,65 @@
+package no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted.PAA_SVALBARD
+import java.util.Objects
+
+@Entity(name = "GrMatrikkeladresseOppholdsadresse")
+@DiscriminatorValue("Matrikkeladresse")
+data class GrMatrikkeladresseOppholdsadresse(
+    @Column(name = "matrikkel_id")
+    val matrikkelId: Long?,
+    @Column(name = "bruksenhetsnummer")
+    val bruksenhetsnummer: String?,
+    @Column(name = "tilleggsnavn")
+    val tilleggsnavn: String?,
+    @Column(name = "postnummer")
+    val postnummer: String?,
+    @Column(name = "kommunenummer")
+    val kommunenummer: String?,
+) : GrOppholdsadresse() {
+    override fun toSecureString(): String =
+        "GrMatrikkeladresseOppholdsadresse(" +
+            "matrikkelId=$matrikkelId, " +
+            "bruksenhetsnummer=$bruksenhetsnummer, " +
+            "tilleggsnavn=$tilleggsnavn, " +
+            "postnummer=$postnummer, " +
+            "kommunenummer=$kommunenummer, " +
+            "oppholdAnnetSted=$oppholdAnnetSted" +
+            ")"
+
+    override fun toString(): String = "GrMatrikkeladresseOppholdsadresse(detaljer skjult)"
+
+    override fun tilFrontendString(): String {
+        val postnummer = postnummer?.let { "Postnummer $postnummer" }
+        val oppholdAnnetSted = oppholdAnnetSted.takeIf { it == PAA_SVALBARD }?.let { ", $it" } ?: ""
+        return postnummer?.let { "$postnummer$oppholdAnnetSted" } ?: "Ukjent adresse$oppholdAnnetSted"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || javaClass != other.javaClass) {
+            return false
+        }
+        val otherMatrikkeladresse = other as GrMatrikkeladresseOppholdsadresse
+        return this === other ||
+            matrikkelId != null &&
+            matrikkelId == otherMatrikkeladresse.matrikkelId &&
+            bruksenhetsnummer == otherMatrikkeladresse.bruksenhetsnummer
+    }
+
+    override fun hashCode(): Int = Objects.hash(matrikkelId)
+
+    companion object {
+        fun fraMatrikkeladresse(matrikkeladresse: Matrikkeladresse): GrMatrikkeladresseOppholdsadresse =
+            GrMatrikkeladresseOppholdsadresse(
+                matrikkelId = matrikkeladresse.matrikkelId,
+                bruksenhetsnummer = matrikkeladresse.bruksenhetsnummer.takeUnless { it.isNullOrBlank() },
+                tilleggsnavn = matrikkeladresse.tilleggsnavn.takeUnless { it.isNullOrBlank() },
+                postnummer = matrikkeladresse.postnummer.takeUnless { it.isNullOrBlank() },
+                kommunenummer = matrikkeladresse.kommunenummer.takeUnless { it.isNullOrBlank() },
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrOppholdsadresse.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorColumn
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted
+import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
+import no.nav.familie.ks.sak.common.entitet.BaseEntitet
+import no.nav.familie.ks.sak.common.entitet.DatoIntervallEntitet
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrMatrikkeladresseOppholdsadresse.Companion.fraMatrikkeladresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrUtenlandskAdresseOppholdsadresse.Companion.fraUtenlandskAdresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrVegadresseOppholdsadresse.Companion.fraVegadresse
+
+@Entity(name = "GrOppholdsadresse")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+@Table(name = "PO_OPPHOLDSADRESSE")
+abstract class GrOppholdsadresse(
+    // Alle attributter må være open ellers kastes feil ved oppstart.
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "po_oppholdsadresse_seq_generator")
+    @SequenceGenerator(
+        name = "po_oppholdsadresse_seq_generator",
+        sequenceName = "po_oppholdsadresse_seq",
+        allocationSize = 50,
+    )
+    open val id: Long = 0,
+    @Embedded
+    open var periode: DatoIntervallEntitet? = null,
+    @JsonIgnore
+    @ManyToOne
+    @JoinColumn(name = "fk_po_person_id")
+    open var person: Person? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "opphold_annet_sted")
+    open var oppholdAnnetSted: OppholdAnnetSted? = null,
+) : BaseEntitet() {
+    abstract fun toSecureString(): String
+
+    abstract fun tilFrontendString(): String
+
+    companion object {
+        fun fraOppholdsadresse(
+            oppholdsadresse: Oppholdsadresse,
+            person: Person,
+        ): GrOppholdsadresse =
+            (
+                oppholdsadresse.vegadresse?.let { fraVegadresse(it) }
+                    ?: oppholdsadresse.matrikkeladresse?.let { fraMatrikkeladresse(it) }
+                    ?: oppholdsadresse.utenlandskAdresse?.let { fraUtenlandskAdresse(it) }
+                    ?: GrUkjentAdresseOppholdsadresse()
+            ).also {
+                it.person = person
+                it.periode = DatoIntervallEntitet(oppholdsadresse.gyldigFraOgMed, oppholdsadresse.gyldigTilOgMed)
+                it.oppholdAnnetSted = OppholdAnnetSted.parse(oppholdsadresse.oppholdAnnetSted)
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUkjentAdresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUkjentAdresseOppholdsadresse.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse
+
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted.PAA_SVALBARD
+
+@Entity(name = "GrUkjentAdresseOppholdsadresse")
+@DiscriminatorValue("UkjentAdresse")
+class GrUkjentAdresseOppholdsadresse : GrOppholdsadresse() {
+    override fun toString(): String = "GrUkjentAdresseOppholdsadresse(detaljer skjult)"
+
+    override fun toSecureString(): String = "GrUkjentAdresseOppholdsadresse(${oppholdAnnetSted ?: ""})"
+
+    override fun tilFrontendString(): String = "Ukjent adresse${oppholdAnnetSted.takeIf { it == PAA_SVALBARD }?.let { ", $it" } ?: ""}"
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUtenlandskAdresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUtenlandskAdresseOppholdsadresse.kt
@@ -1,0 +1,66 @@
+package no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import no.nav.familie.kontrakter.felles.personopplysning.UtenlandskAdresse
+import no.nav.familie.ks.sak.common.util.storForbokstav
+
+@Entity(name = "GrUtenlandskAdresseOppholdsadresse")
+@DiscriminatorValue("UtenlandskAdresse")
+data class GrUtenlandskAdresseOppholdsadresse(
+    @Column(name = "adressenavn")
+    val adressenavnNummer: String?,
+    @Column(name = "husnummer")
+    val bygningEtasjeLeilighet: String?,
+    @Column(name = "postboks")
+    val postboksNummerNavn: String?,
+    @Column(name = "postnummer")
+    val postkode: String?,
+    @Column(name = "by_sted")
+    val bySted: String?,
+    @Column(name = "region")
+    val regionDistriktOmraade: String?,
+    @Column(name = "landkode")
+    val landkode: String?,
+) : GrOppholdsadresse() {
+    override fun toSecureString(): String =
+        "GrUtenlandskAdresseOppholdsadresse(" +
+            "adressenavnNummer=$adressenavnNummer, " +
+            "bygningEtasjeLeilighet=$bygningEtasjeLeilighet, " +
+            "postboksNummerNavn=$postboksNummerNavn, " +
+            "postkode=$postkode, " +
+            "bySted=$bySted, " +
+            "regionDistriktOmraade=$regionDistriktOmraade, " +
+            "landkode=$landkode, " +
+            "oppholdAnnetSted=$oppholdAnnetSted" +
+            ")"
+
+    override fun tilFrontendString(): String {
+        val adressenavnNummer = adressenavnNummer?.storForbokstav()
+        val bygningEtasjeLeilighet = bygningEtasjeLeilighet?.let { ", $it" } ?: ""
+        val postboks = postboksNummerNavn?.let { ", $it" } ?: ""
+        val postkode = postkode?.let { ", $it" } ?: ""
+        val bySted = bySted?.let { ", $it" } ?: ""
+        val regionDistriktOmraade = regionDistriktOmraade?.let { ", $it" } ?: ""
+        val landkode = landkode?.let { ", $it" } ?: ""
+        return adressenavnNummer?.let {
+            "$adressenavnNummer$bygningEtasjeLeilighet$postboks$postkode$bySted$regionDistriktOmraade$landkode"
+        } ?: "Ukjent utenlandsk adresse$landkode"
+    }
+
+    override fun toString(): String = "GrUtenlandskAdresseOppholdsadresse(detaljer skjult)"
+
+    companion object {
+        fun fraUtenlandskAdresse(utenlandskAdresse: UtenlandskAdresse): GrUtenlandskAdresseOppholdsadresse =
+            GrUtenlandskAdresseOppholdsadresse(
+                utenlandskAdresse.adressenavnNummer.takeUnless { it.isNullOrBlank() },
+                utenlandskAdresse.bygningEtasjeLeilighet.takeUnless { it.isNullOrBlank() },
+                utenlandskAdresse.postboksNummerNavn.takeUnless { it.isNullOrBlank() },
+                utenlandskAdresse.postkode.takeUnless { it.isNullOrBlank() },
+                utenlandskAdresse.bySted.takeUnless { it.isNullOrBlank() },
+                utenlandskAdresse.regionDistriktOmraade.takeUnless { it.isNullOrBlank() },
+                utenlandskAdresse.landkode,
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrVegadresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrVegadresseOppholdsadresse.kt
@@ -1,0 +1,95 @@
+package no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted.PAA_SVALBARD
+import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
+import no.nav.familie.ks.sak.common.util.nullableTilString
+import no.nav.familie.ks.sak.common.util.storForbokstav
+import java.util.Objects
+
+@Entity(name = "GrVegadresseOppholdsadresse")
+@DiscriminatorValue("Vegadresse")
+data class GrVegadresseOppholdsadresse(
+    @Column(name = "matrikkel_id")
+    val matrikkelId: Long?,
+    @Column(name = "husnummer")
+    val husnummer: String?,
+    @Column(name = "husbokstav")
+    val husbokstav: String?,
+    @Column(name = "bruksenhetsnummer")
+    val bruksenhetsnummer: String?,
+    @Column(name = "adressenavn")
+    val adressenavn: String?,
+    @Column(name = "kommunenummer")
+    val kommunenummer: String?,
+    @Column(name = "tilleggsnavn")
+    val tilleggsnavn: String?,
+    @Column(name = "postnummer")
+    val postnummer: String?,
+) : GrOppholdsadresse() {
+    override fun toSecureString(): String =
+        "GrVegadresseOppholdsadresse(" +
+            "husnummer=$husnummer, " +
+            "husbokstav=$husbokstav, " +
+            "matrikkelId=$matrikkelId, " +
+            "bruksenhetsnummer=$bruksenhetsnummer, " +
+            "adressenavn=$adressenavn, " +
+            "kommunenummer=$kommunenummer, " +
+            "tilleggsnavn=$tilleggsnavn, " +
+            "postnummer=$postnummer, " +
+            "oppholdAnnetSted=$oppholdAnnetSted" +
+            ")"
+
+    override fun toString(): String = "GrVegadresseOppholdsadresse(detaljer skjult)"
+
+    override fun tilFrontendString(): String {
+        val adressenavn = adressenavn?.storForbokstav()
+        val husnummer = husnummer.nullableTilString()
+        val husbokstav = husbokstav.nullableTilString()
+        val postnummer = postnummer?.let { ", $it" } ?: ""
+        val oppholdAnnetSted = oppholdAnnetSted.takeIf { it == PAA_SVALBARD }?.let { ", $it" } ?: ""
+        return when (adressenavn) {
+            null -> "Ukjent adresse$oppholdAnnetSted"
+            else -> "$adressenavn $husnummer$husbokstav$postnummer$oppholdAnnetSted"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || javaClass != other.javaClass) {
+            return false
+        }
+        val otherVegadresse = other as GrVegadresseOppholdsadresse
+
+        return this === other ||
+            (
+                (matrikkelId != null && matrikkelId == otherVegadresse.matrikkelId) ||
+                    (
+                        (matrikkelId == null && otherVegadresse.matrikkelId == null) &&
+                            postnummer != null &&
+                            !(adressenavn == null && husnummer == null && husbokstav == null) &&
+                            (adressenavn == otherVegadresse.adressenavn) &&
+                            (husnummer == otherVegadresse.husnummer) &&
+                            (husbokstav == otherVegadresse.husbokstav) &&
+                            (postnummer == otherVegadresse.postnummer)
+                    )
+            )
+    }
+
+    override fun hashCode(): Int = Objects.hash(matrikkelId)
+
+    companion object {
+        fun fraVegadresse(vegadresse: Vegadresse): GrVegadresseOppholdsadresse =
+            GrVegadresseOppholdsadresse(
+                matrikkelId = vegadresse.matrikkelId,
+                husnummer = vegadresse.husnummer.takeUnless { it.isNullOrBlank() },
+                husbokstav = vegadresse.husbokstav.takeUnless { it.isNullOrBlank() },
+                bruksenhetsnummer = vegadresse.bruksenhetsnummer.takeUnless { it.isNullOrBlank() },
+                adressenavn = vegadresse.adressenavn.takeUnless { it.isNullOrBlank() },
+                kommunenummer = vegadresse.kommunenummer.takeUnless { it.isNullOrBlank() },
+                tilleggsnavn = vegadresse.tilleggsnavn.takeUnless { it.isNullOrBlank() },
+                postnummer = vegadresse.postnummer.takeUnless { it.isNullOrBlank() },
+            )
+    }
+}

--- a/src/main/resources/db/migration/V41__opprett_oppholdsadresse_tabell.sql
+++ b/src/main/resources/db/migration/V41__opprett_oppholdsadresse_tabell.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS PO_OPPHOLDSADRESSE
+(
+    id                 BIGINT                                 NOT NULL PRIMARY KEY,
+    type               VARCHAR                                NOT NULL,
+    fom                DATE,
+    tom                DATE,
+    fk_po_person_id    BIGINT REFERENCES PO_PERSON (id) ON DELETE CASCADE,
+    opphold_annet_sted VARCHAR,
+
+    matrikkel_id       BIGINT,
+    husnummer          VARCHAR,
+    husbokstav         VARCHAR,
+    bruksenhetsnummer  VARCHAR,
+    adressenavn        VARCHAR,
+    kommunenummer      VARCHAR,
+    tilleggsnavn       VARCHAR,
+    postnummer         VARCHAR,
+
+    postboks           VARCHAR,
+    by_sted            VARCHAR,
+    region             VARCHAR,
+    landkode           VARCHAR,
+
+    opprettet_av       VARCHAR      DEFAULT 'VL'              NOT NULL,
+    opprettet_tid      TIMESTAMP(3) DEFAULT current_timestamp NOT NULL,
+    endret_av          VARCHAR,
+    endret_tid         TIMESTAMP(3),
+    versjon            BIGINT       DEFAULT 0                 NOT NULL
+);
+
+CREATE SEQUENCE po_oppholdsadresse_seq INCREMENT BY 50 START WITH 1000000 NO CYCLE;
+
+CREATE INDEX po_oppholdsadresse_person_id_idx ON PO_OPPHOLDSADRESSE (fk_po_person_id);

--- a/src/main/resources/pdl/graphql.config.yml
+++ b/src/main/resources/pdl/graphql.config.yml
@@ -1,0 +1,8 @@
+schema: pdl-api-schema.graphql
+extensions:
+  endpoints:
+    PDL GraphQL Endpoint:
+      url: https://pdl-api.dev.adeo.no/graphql
+      headers:
+        user-agent: familie-ks-sak
+      introspect: false

--- a/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
+++ b/src/main/resources/pdl/hentperson-med-relasjoner-og-registerinformasjon.graphql
@@ -46,6 +46,37 @@ query($ident: ID!) {person: hentPerson(ident: $ident) {
             bostedskommune
         }
     }
+    oppholdsadresse(historikk: true) {
+        gyldigFraOgMed
+        gyldigTilOgMed
+        oppholdAnnetSted
+        vegadresse {
+            matrikkelId
+            husnummer
+            husbokstav
+            bruksenhetsnummer
+            adressenavn
+            kommunenummer
+            tilleggsnavn
+            postnummer
+        }
+        matrikkeladresse {
+            matrikkelId
+            bruksenhetsnummer
+            tilleggsnavn
+            postnummer
+            kommunenummer
+        }
+        utenlandskAdresse {
+            adressenavnNummer
+            bygningEtasjeLeilighet
+            postboksNummerNavn
+            postkode
+            bySted
+            regionDistriktOmraade
+            landkode
+        }
+    }
     sivilstand(historikk: true) {
         gyldigFraOgMed
         type

--- a/src/main/resources/pdl/pdl-api-schema.graphql
+++ b/src/main/resources/pdl/pdl-api-schema.graphql
@@ -1,0 +1,945 @@
+# This file was generated. Do not edit manually.
+
+schema {
+    query: Query
+}
+
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
+
+"Indicates an Input Object is a OneOf Input Object."
+directive @oneOf on INPUT_OBJECT
+
+type AdresseCompletionResult {
+    addressFound: CompletionAdresse
+    suggestions: [String!]!
+}
+
+type AdresseSearchHit {
+    matrikkeladresse: MatrikkeladresseResult
+    score: Float
+    vegadresse: VegadresseResult
+}
+
+type AdresseSearchResult {
+    hits: [AdresseSearchHit!]!
+    pageNumber: Int
+    totalHits: Int
+    totalPages: Int
+}
+
+type Adressebeskyttelse {
+    folkeregistermetadata: Folkeregistermetadata
+    gradering: AdressebeskyttelseGradering!
+    metadata: Metadata!
+}
+
+type Bostedsadresse {
+    angittFlyttedato: Date
+    coAdressenavn: String
+    folkeregistermetadata: Folkeregistermetadata
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+    matrikkeladresse: Matrikkeladresse
+    metadata: Metadata!
+    ukjentBosted: UkjentBosted
+    utenlandskAdresse: UtenlandskAdresse
+    vegadresse: Vegadresse
+}
+
+type CompletionAdresse {
+    matrikkeladresse: MatrikkeladresseResult
+    vegadresse: VegadresseResult
+}
+
+type DeltBosted {
+    coAdressenavn: String
+    folkeregistermetadata: Folkeregistermetadata!
+    matrikkeladresse: Matrikkeladresse
+    metadata: Metadata!
+    sluttdatoForKontrakt: Date
+    startdatoForKontrakt: Date!
+    ukjentBosted: UkjentBosted
+    utenlandskAdresse: UtenlandskAdresse
+    vegadresse: Vegadresse
+}
+
+type DoedfoedtBarn {
+    dato: Date
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+type Doedsfall {
+    doedsdato: Date
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+" Endring som har blitt utført på opplysningen. F.eks: Opprett -> Korriger -> Korriger"
+type Endring {
+    hendelseId: String!
+    """
+
+    Opphavet til informasjonen. I NAV blir dette satt i forbindelse med registrering (f.eks: Sykehuskassan).
+    Fra Folkeregisteret får vi opphaven til dems opplysning, altså NAV, UDI, Politiet, Skatteetaten o.l.. Fra Folkeregisteret kan det også være tekniske navn som: DSF_MIGRERING, m.m..
+    """
+    kilde: String!
+    " Tidspunktet for registrering."
+    registrert: DateTime!
+    " Hvem endringen har blitt utført av, ofte saksbehandler (f.eks Z990200), men kan også være system (f.eks srvXXXX). Denne blir satt til \"Folkeregisteret\" for det vi får fra dem."
+    registrertAv: String!
+    " Hvilke system endringen har kommet fra (f.eks srvXXX). Denne blir satt til \"FREG\" for det vi får fra Folkeregisteret."
+    systemkilde: String!
+    " Hvilke type endring som har blitt utført."
+    type: Endringstype!
+}
+
+type FalskIdentitet {
+    erFalsk: Boolean!
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+    rettIdentitetErUkjent: Boolean
+    rettIdentitetVedIdentifikasjonsnummer: String
+    rettIdentitetVedOpplysninger: FalskIdentitetIdentifiserendeInformasjon
+}
+
+type FalskIdentitetIdentifiserendeInformasjon {
+    foedselsdato: Date
+    kjoenn: KjoennType
+    personnavn: Personnavn!
+    statsborgerskap: [String!]!
+}
+
+type Foedested {
+    foedekommune: String
+    foedeland: String
+    foedested: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Foedsel {
+    foedekommune: String
+    foedeland: String
+    foedested: String
+    foedselsaar: Int
+    foedselsdato: Date
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Foedselsdato {
+    foedselsaar: Int
+    foedselsdato: Date
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Folkeregisteridentifikator {
+    folkeregistermetadata: Folkeregistermetadata!
+    identifikasjonsnummer: String!
+    metadata: Metadata!
+    status: String!
+    type: String!
+}
+
+type Folkeregistermetadata {
+    aarsak: String
+    ajourholdstidspunkt: DateTime
+    gyldighetstidspunkt: DateTime
+    kilde: String
+    opphoerstidspunkt: DateTime
+    sekvens: Int
+}
+
+type Folkeregisterpersonstatus {
+    folkeregistermetadata: Folkeregistermetadata!
+    forenkletStatus: String!
+    metadata: Metadata!
+    status: String!
+}
+
+type ForelderBarnRelasjon {
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+    minRolleForPerson: ForelderBarnRelasjonRolle
+    relatertPersonUtenFolkeregisteridentifikator: RelatertBiPerson
+    relatertPersonsIdent: String
+    relatertPersonsRolle: ForelderBarnRelasjonRolle!
+}
+
+type Foreldreansvar {
+    ansvar: String
+    ansvarlig: String
+    ansvarligUtenIdentifikator: RelatertBiPerson
+    ansvarssubjekt: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type GeografiskTilknytning {
+    gtBydel: String
+    gtKommune: String
+    gtLand: String
+    gtType: GtType!
+    regel: String!
+}
+
+type HentIdenterBolkResult {
+    code: String!
+    ident: String!
+    identer: [IdentInformasjon!]
+}
+
+type HentPersonBolkResult {
+    code: String!
+    ident: String!
+    person: Person
+}
+
+type IdentInformasjon {
+    gruppe: IdentGruppe!
+    historisk: Boolean!
+    ident: String!
+}
+
+type IdentifiserendeInformasjon {
+    foedselsdato: Date
+    kjoenn: String
+    navn: Personnavn
+    statsborgerskap: [String!]
+}
+
+type Identitetsgrunnlag {
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+    status: Identitetsgrunnlagsstatus!
+}
+
+type Identliste {
+    identer: [IdentInformasjon!]!
+}
+
+type InnflyttingTilNorge {
+    folkeregistermetadata: Folkeregistermetadata
+    fraflyttingsland: String
+    fraflyttingsstedIUtlandet: String
+    metadata: Metadata!
+}
+
+type KartverketAdresse {
+    id: Long!
+    matrikkeladresse: KartverketMatrikkeladresse
+    vegadresse: KartverketVegadresse
+}
+
+type KartverketBydel {
+    bydelsnavn: String
+    bydelsnummer: String
+}
+
+type KartverketFylke {
+    navn: String
+    nummer: String
+}
+
+type KartverketGrunnkrets {
+    grunnkretsnavn: String
+    grunnkretsnummer: String
+}
+
+type KartverketKommune {
+    fylke: KartverketFylke
+    navn: String
+    nummer: String
+}
+
+type KartverketMatrikkeladresse {
+    adressetilleggsnavn: String
+    bydel: KartverketBydel
+    grunnkrets: KartverketGrunnkrets
+    kortnavn: String
+    matrikkelnummer: KartverketMatrikkelnummer
+    postnummeromraade: KartverketPostnummeromraade
+    representasjonspunkt: KartverketRepresentasjonspunkt
+    undernummer: Int
+}
+
+type KartverketMatrikkelnummer {
+    bruksnummer: Int
+    festenummer: Int
+    gaardsnummer: Int
+    kommunenummer: String
+    seksjonsnummer: Int
+}
+
+type KartverketPostnummeromraade {
+    postnummer: String
+    poststed: String
+}
+
+type KartverketRepresentasjonspunkt {
+    posisjonskvalitet: Int
+    x: Float
+    y: Float
+    z: Float
+}
+
+type KartverketVeg {
+    adressekode: Int
+    adressenavn: String
+    kommune: KartverketKommune
+    kortnavn: String
+    stedsnummer: String
+}
+
+type KartverketVegadresse {
+    adressetilleggsnavn: String
+    bokstav: String
+    bydel: KartverketBydel
+    grunnkrets: KartverketGrunnkrets
+    kortnavn: String
+    nummer: Int
+    postnummeromraade: KartverketPostnummeromraade
+    representasjonspunkt: KartverketRepresentasjonspunkt
+    veg: KartverketVeg
+}
+
+type Kjoenn {
+    folkeregistermetadata: Folkeregistermetadata
+    kjoenn: KjoennType
+    metadata: Metadata!
+}
+
+type Kontaktadresse {
+    coAdressenavn: String
+    folkeregistermetadata: Folkeregistermetadata
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+    metadata: Metadata!
+    postadresseIFrittFormat: PostadresseIFrittFormat
+    postboksadresse: Postboksadresse
+    type: KontaktadresseType!
+    utenlandskAdresse: UtenlandskAdresse
+    utenlandskAdresseIFrittFormat: UtenlandskAdresseIFrittFormat
+    vegadresse: Vegadresse
+}
+
+type KontaktinformasjonForDoedsbo {
+    adresse: KontaktinformasjonForDoedsboAdresse!
+    advokatSomKontakt: KontaktinformasjonForDoedsboAdvokatSomKontakt
+    attestutstedelsesdato: Date!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+    organisasjonSomKontakt: KontaktinformasjonForDoedsboOrganisasjonSomKontakt
+    personSomKontakt: KontaktinformasjonForDoedsboPersonSomKontakt
+    skifteform: KontaktinformasjonForDoedsboSkifteform!
+}
+
+type KontaktinformasjonForDoedsboAdresse {
+    adresselinje1: String!
+    adresselinje2: String
+    landkode: String
+    postnummer: String!
+    poststedsnavn: String!
+}
+
+type KontaktinformasjonForDoedsboAdvokatSomKontakt {
+    organisasjonsnavn: String
+    organisasjonsnummer: String
+    personnavn: Personnavn!
+}
+
+type KontaktinformasjonForDoedsboOrganisasjonSomKontakt {
+    kontaktperson: Personnavn
+    organisasjonsnavn: String!
+    organisasjonsnummer: String
+}
+
+type KontaktinformasjonForDoedsboPersonSomKontakt {
+    foedselsdato: Date
+    identifikasjonsnummer: String
+    personnavn: Personnavn
+}
+
+type Koordinater {
+    kvalitet: Int
+    x: Float
+    y: Float
+    z: Float
+}
+
+type Matrikkeladresse {
+    bruksenhetsnummer: String
+    kommunenummer: String
+    koordinater: Koordinater
+    matrikkelId: Long
+    postnummer: String
+    tilleggsnavn: String
+}
+
+type MatrikkeladresseResult {
+    bruksnummer: String
+    gaardsnummer: String
+    kommunenummer: String
+    matrikkelId: String
+    postnummer: String
+    poststed: String
+    tilleggsnavn: String
+}
+
+type Metadata {
+    """
+
+    En liste over alle endringer som har blitt utført over tid.
+    Vær obs på at denne kan endre seg og man burde takle at det finnes flere korrigeringer i listen, så dersom man ønsker å kun vise den siste, så må man selv filtrere ut dette.
+    Det kan også ved svært få tilfeller skje at opprett blir fjernet. F.eks ved splitt tilfeller av identer. Dette skal skje i svært få tilfeller. Dersom man ønsker å presentere opprettet tidspunktet, så blir det tidspunktet på den første endringen.
+    """
+    endringer: [Endring!]!
+    """
+
+    Feltet betegner hvorvidt dette er en funksjonelt historisk opplysning, for eksempel en tidligere fraflyttet adresse eller et foreldreansvar som er utløpt fordi barnet har fylt 18 år.
+    I de fleste tilfeller kan dette utledes ved å se på de andre feltene i opplysningen. Dette er imidlertid ikke alltid tilfellet, blant annet for foreldreansvar.
+    Feltet bør brukes av konsumenter som henter informasjon fra GraphQL med historikk, men som også trenger å utlede gjeldende informasjon.
+    """
+    historisk: Boolean!
+    " Master refererer til hvem som eier opplysningen, f.eks så har PDL en kopi av Folkeregisteret, da vil master være FREG og eventuelle endringer på dette må gå via Folkeregisteret (API mot dem eller andre rutiner)."
+    master: String!
+    """
+
+    I PDL så får alle forekomster av en opplysning en ID som representerer dens unike forekomst.
+    F.eks, så vil en Opprett ha ID X, korriger ID Y (der hvor den spesifiserer at den korrigerer X).
+    Dersom en opplysning ikke er lagret i PDL, så vil denne verdien ikke være utfylt.
+    """
+    opplysningsId: String
+}
+
+type Navn {
+    etternavn: String!
+    folkeregistermetadata: Folkeregistermetadata
+    forkortetNavn: String @deprecated(reason: "No longer supported")
+    fornavn: String!
+    gyldigFraOgMed: Date
+    mellomnavn: String
+    metadata: Metadata!
+    originaltNavn: OriginaltNavn
+}
+
+type Navspersonidentifikator {
+    identifikasjonsnummer: String!
+    metadata: Metadata!
+}
+
+type Opphold {
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+    oppholdFra: Date
+    oppholdTil: Date
+    type: Oppholdstillatelse!
+}
+
+type Oppholdsadresse {
+    coAdressenavn: String
+    folkeregistermetadata: Folkeregistermetadata
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+    matrikkeladresse: Matrikkeladresse
+    metadata: Metadata!
+    oppholdAnnetSted: String
+    utenlandskAdresse: UtenlandskAdresse
+    vegadresse: Vegadresse
+}
+
+type OriginaltNavn {
+    etternavn: String
+    fornavn: String
+    mellomnavn: String
+}
+
+type Person {
+    adressebeskyttelse(historikk: Boolean = false): [Adressebeskyttelse!]!
+    bostedsadresse(historikk: Boolean = false): [Bostedsadresse!]!
+    deltBosted(historikk: Boolean = false): [DeltBosted!]!
+    doedfoedtBarn: [DoedfoedtBarn!]!
+    doedsfall: [Doedsfall!]!
+    falskIdentitet: FalskIdentitet
+    foedested: [Foedested!]!
+    foedsel: [Foedsel!]! @deprecated(reason: "Erstattet av foedselsdato & foedested")
+    foedselsdato: [Foedselsdato!]!
+    folkeregisteridentifikator(historikk: Boolean = false): [Folkeregisteridentifikator!]!
+    folkeregisterpersonstatus(historikk: Boolean = false): [Folkeregisterpersonstatus!]!
+    forelderBarnRelasjon: [ForelderBarnRelasjon!]!
+    foreldreansvar(historikk: Boolean = false): [Foreldreansvar!]!
+    identitetsgrunnlag(historikk: Boolean = false): [Identitetsgrunnlag!]!
+    innflyttingTilNorge: [InnflyttingTilNorge!]!
+    kjoenn(historikk: Boolean = false): [Kjoenn!]!
+    kontaktadresse(historikk: Boolean = false): [Kontaktadresse!]!
+    kontaktinformasjonForDoedsbo(historikk: Boolean = false): [KontaktinformasjonForDoedsbo!]!
+    navn(historikk: Boolean = false): [Navn!]!
+    navspersonidentifikator(historikk: Boolean = false): [Navspersonidentifikator!]!
+    opphold(historikk: Boolean = false): [Opphold!]!
+    oppholdsadresse(historikk: Boolean = false): [Oppholdsadresse!]!
+    rettsligHandleevne(historikk: Boolean = false): [RettsligHandleevne!]!
+    sikkerhetstiltak: [Sikkerhetstiltak!]!
+    sivilstand(historikk: Boolean = false): [Sivilstand!]!
+    statsborgerskap(historikk: Boolean = false): [Statsborgerskap!]!
+    telefonnummer(historikk: Boolean = false): [Telefonnummer!]!
+    tilrettelagtKommunikasjon: [TilrettelagtKommunikasjon!]!
+    utenlandskIdentifikasjonsnummer(historikk: Boolean = false): [UtenlandskIdentifikasjonsnummer!]!
+    utflyttingFraNorge: [UtflyttingFraNorge!]!
+    vergemaalEllerFremtidsfullmakt(historikk: Boolean = false): [VergemaalEllerFremtidsfullmakt!]!
+}
+
+type PersonSearchHighlight {
+    " Forteller hvorvidt opplysningen som ga treff er markert som historisk."
+    historisk: Boolean
+    """
+
+    liste med feltene og verdiene som ga treff.
+    Merk at for fritekst søk så vil disse kunne referere til hjelpe felter som ikke er synelig i resultatene.
+    """
+    matches: [SearchMatch]
+    """
+
+    Navn/Sti til opplysningen som ga treff. Merk at dette ikke er feltet som ga treff men opplysningen.
+    F.eks. hvis du søker på person.navn.fornavn så vil opplysingen være person.navn.
+    """
+    opplysning: String
+    """
+
+    Gitt att opplysningen som ga treff har en opplysningsId så vil den returneres her.
+    alle søk under person skal ha opplysningsId, men søk i identer vil kunne returnere treff uten opplysningsId.
+    """
+    opplysningsId: String
+}
+
+type PersonSearchHit {
+    " Infromasjon om hva som ga treff i søke resultatet."
+    highlights: [PersonSearchHighlight]
+    " forespurte data"
+    identer(historikk: Boolean = false): [IdentInformasjon!]!
+    " forespurte data"
+    person: Person
+    " Poengsummen elasticsearch  har gitt dette resultatet (brukt til feilsøking, og tuning av søk)"
+    score: Float
+}
+
+type PersonSearchResult {
+    " treff liste"
+    hits: [PersonSearchHit!]!
+    " Side nummer for siden som vises"
+    pageNumber: Int
+    " Totalt antall treff (øvre grense er satt til 10 000)"
+    totalHits: Int
+    " Totalt antall sider"
+    totalPages: Int
+}
+
+type Personnavn {
+    etternavn: String!
+    fornavn: String!
+    mellomnavn: String
+}
+
+type PostadresseIFrittFormat {
+    adresselinje1: String
+    adresselinje2: String
+    adresselinje3: String
+    postnummer: String
+}
+
+type Postboksadresse {
+    postboks: String!
+    postbokseier: String
+    postnummer: String
+}
+
+type Query {
+    forslagAdresse(parameters: CompletionParameters): AdresseCompletionResult
+    hentAdresse(matrikkelId: ID!): KartverketAdresse
+    hentGeografiskTilknytning(ident: ID!): GeografiskTilknytning
+    hentGeografiskTilknytningBolk(identer: [ID!]!): [hentGeografiskTilknytningBolkResult!]!
+    hentIdenter(grupper: [IdentGruppe!], historikk: Boolean = false, ident: ID!): Identliste
+    hentIdenterBolk(grupper: [IdentGruppe!], historikk: Boolean = false, identer: [ID!]!): [HentIdenterBolkResult!]!
+    hentPerson(ident: ID!): Person
+    hentPersonBolk(identer: [ID!]!): [HentPersonBolkResult!]!
+    sokAdresse(criteria: [Criterion], paging: Paging): AdresseSearchResult
+    sokPerson(criteria: [Criterion], paging: Paging): PersonSearchResult
+}
+
+type RelatertBiPerson {
+    foedselsdato: Date
+    kjoenn: KjoennType
+    navn: Personnavn
+    statsborgerskap: String
+}
+
+type RettsligHandleevne {
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+    rettsligHandleevneomfang: String
+}
+
+type SearchMatch {
+    " feltnavn med sti til feltet so ga treff."
+    field: String!
+    " Verdien som ga treff"
+    fragments: [String]
+    type: String
+}
+
+type Sikkerhetstiltak {
+    beskrivelse: String!
+    gyldigFraOgMed: Date!
+    gyldigTilOgMed: Date!
+    kontaktperson: SikkerhetstiltakKontaktperson
+    metadata: Metadata!
+    tiltakstype: String!
+}
+
+type SikkerhetstiltakKontaktperson {
+    enhet: String!
+    personident: String!
+}
+
+type Sivilstand {
+    bekreftelsesdato: Date
+    folkeregistermetadata: Folkeregistermetadata
+    gyldigFraOgMed: Date
+    metadata: Metadata!
+    relatertVedSivilstand: String
+    type: Sivilstandstype!
+}
+
+type Statsborgerskap {
+    bekreftelsesdato: Date
+    folkeregistermetadata: Folkeregistermetadata
+    gyldigFraOgMed: Date
+    gyldigTilOgMed: Date
+    land: String!
+    metadata: Metadata!
+}
+
+type Telefonnummer {
+    landskode: String!
+    metadata: Metadata!
+    nummer: String!
+    prioritet: Int!
+}
+
+type TilrettelagtKommunikasjon {
+    metadata: Metadata!
+    talespraaktolk: Tolk
+    tegnspraaktolk: Tolk
+}
+
+type Tjenesteomraade {
+    tjenesteoppgave: String
+    tjenestevirksomhet: String
+}
+
+type Tolk {
+    spraak: String
+}
+
+type UkjentBosted {
+    bostedskommune: String
+}
+
+type UtenlandskAdresse {
+    adressenavnNummer: String
+    bySted: String
+    bygningEtasjeLeilighet: String
+    landkode: String!
+    postboksNummerNavn: String
+    postkode: String
+    regionDistriktOmraade: String
+}
+
+type UtenlandskAdresseIFrittFormat {
+    adresselinje1: String
+    adresselinje2: String
+    adresselinje3: String
+    byEllerStedsnavn: String
+    landkode: String!
+    postkode: String
+}
+
+type UtenlandskIdentifikasjonsnummer {
+    folkeregistermetadata: Folkeregistermetadata
+    identifikasjonsnummer: String!
+    metadata: Metadata!
+    opphoert: Boolean!
+    utstederland: String!
+}
+
+type UtflyttingFraNorge {
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+    tilflyttingsland: String
+    tilflyttingsstedIUtlandet: String
+    utflyttingsdato: Date
+}
+
+type Vegadresse {
+    adressenavn: String
+    bruksenhetsnummer: String
+    bydelsnummer: String
+    husbokstav: String
+    husnummer: String
+    kommunenummer: String
+    koordinater: Koordinater
+    matrikkelId: Long
+    postnummer: String
+    tilleggsnavn: String
+}
+
+type VegadresseResult {
+    adressekode: String
+    adressenavn: String
+    bydelsnavn: String
+    bydelsnummer: String
+    fylkesnavn: String
+    fylkesnummer: String
+    husbokstav: String
+    husnummer: Int
+    kommunenavn: String
+    kommunenummer: String
+    matrikkelId: String
+    postnummer: String
+    poststed: String
+    tilleggsnavn: String
+}
+
+type VergeEllerFullmektig {
+    identifiserendeInformasjon: IdentifiserendeInformasjon
+    motpartsPersonident: String
+    navn: Personnavn @deprecated(reason: "Erstattes av navn iidentifiserendeInformasjon")
+    omfang: String
+    omfangetErInnenPersonligOmraade: Boolean
+    tjenesteomraade: [Tjenesteomraade!]
+}
+
+type VergemaalEllerFremtidsfullmakt {
+    embete: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+    type: String
+    vergeEllerFullmektig: VergeEllerFullmektig!
+}
+
+type hentGeografiskTilknytningBolkResult {
+    code: String!
+    geografiskTilknytning: GeografiskTilknytning
+    ident: String!
+}
+
+enum AdressebeskyttelseGradering {
+    FORTROLIG
+    STRENGT_FORTROLIG
+    STRENGT_FORTROLIG_UTLAND
+    UGRADERT
+}
+
+enum Direction {
+    ASC
+    DESC
+}
+
+enum Endringstype {
+    KORRIGER
+    OPPHOER
+    OPPRETT
+}
+
+enum Familierelasjonsrolle {
+    BARN
+    FAR
+    MEDMOR
+    MOR
+}
+
+enum ForelderBarnRelasjonRolle {
+    BARN
+    FAR
+    MEDMOR
+    MOR
+}
+
+enum GtType {
+    BYDEL
+    KOMMUNE
+    UDEFINERT
+    UTLAND
+}
+
+enum IdentGruppe {
+    AKTORID
+    FOLKEREGISTERIDENT
+    NPID
+}
+
+enum Identitetsgrunnlagsstatus {
+    IKKE_KONTROLLERT
+    INGEN_STATUS
+    KONTROLLERT
+}
+
+enum KjoennType {
+    KVINNE
+    MANN
+    UKJENT
+}
+
+enum KontaktadresseType {
+    Innland
+    Utland
+}
+
+enum KontaktinformasjonForDoedsboSkifteform {
+    ANNET
+    OFFENTLIG
+}
+
+enum Oppholdstillatelse {
+    MIDLERTIDIG
+    OPPLYSNING_MANGLER
+    PERMANENT
+}
+
+enum Sivilstandstype {
+    ENKE_ELLER_ENKEMANN
+    GIFT
+    GJENLEVENDE_PARTNER
+    REGISTRERT_PARTNER
+    SEPARERT
+    SEPARERT_PARTNER
+    SKILT
+    SKILT_PARTNER
+    UGIFT
+    UOPPGITT
+}
+
+"Format: YYYY-MM-DD (ISO-8601), example: 2017-11-24"
+scalar Date
+
+"Format: YYYY-MM-DDTHH:mm:SS (ISO-8601), example: 2011-12-03T10:15:30"
+scalar DateTime
+
+"A 64-bit signed integer"
+scalar Long
+
+input CompletionFieldValue {
+    fieldName: String!
+    fieldValue: String
+}
+
+input CompletionParameters {
+    completionField: String!
+    fieldValues: [CompletionFieldValue]!
+    maxSuggestions: Int
+}
+
+input Criterion {
+    and: [Criterion]
+    " Feltnavn inkludert sti til ønsket felt (Eksempel: person.navn.fornavn)"
+    fieldName: String
+    not: [Criterion]
+    or: [Criterion]
+    """
+
+    Søk i historiske data
+    true = søker kun i historiske data.
+    false = søker kun i gjeldende data.
+    null = søke i både historiske og gjeldende data.
+    """
+    searchHistorical: Boolean
+    searchRule: SearchRule
+}
+
+input Paging {
+    " Hvilken side i resultatsettet man ønsker vist."
+    pageNumber: Int = 1
+    " antall treff per side (maks 100)"
+    resultsPerPage: Int = 10
+    """
+
+    Liste over felter man ønsker resultatene sortert etter
+    Standard er "score". Score er poengsummen Elasticsearch tildeler hvert resultat.
+    """
+    sortBy: [SearchSorting]
+}
+
+input SearchRule {
+    " Brukes til søke etter datoer som kommer etter opgitt dato."
+    after: String
+    " Brukes til søke etter datoer som kommer før opgitt dato."
+    before: String
+    " Boost brukes til å gi ett søkekriterie høyere eller lavere vektlegging en de andre søke kriteriene."
+    boost: Float
+    " [Flag] Kan brukes til å overstyre standard oppførsellen for søk i felter (standard er case insensitive)"
+    caseSensitive: Boolean @deprecated(reason: "Denne funksjonen ble lite brukt og er deprecated, dette flagget vil ikke lenger ha noe effekt og vil bli fjernet i fremtiden")
+    " Gir treff når opgitt felt inneholder en eller flere ord fra input verdien."
+    contains: String
+    " [Flag] Brukes til å deaktivere fonetisk søk feltene som har dette som standard (Navn)"
+    disablePhonetic: Boolean
+    " Begrenser treff til kun de hvor felt har input verdi"
+    equals: String
+    " Sjekker om feltet finnes / at det ikke har en null verdi."
+    exists: Boolean
+    """
+
+    Søk fra og med (se fromExcluding for bare fra men ikke med)
+    kan benyttes på tall og dato
+    """
+    from: String
+    """
+
+    Søk fra men ikke med oppgitt verdi
+    kan benyttes på tall og dato
+    """
+    fromExcluding: String
+    " Søk som gir treff også for små variasjoner i skrivemåte"
+    fuzzy: String
+    " Brukes til å søke i tall og finner verdier som er størren en input verdi."
+    greaterThan: String
+    " Brukes til å søke i tall og finner verdier som er mindre en input verdi."
+    lessThan: String
+    " Filtrerer bort treff hvor felt inneholder input verdi"
+    notEquals: String
+    " Søk som gir tilfeldig poengsum til hvert treff (kun ment til generering av testdata)"
+    random: Float
+    " Regex søk for spesielle situasjoner (Dette er en treg opprasjon og bør ikke brukes)"
+    regex: String
+    " Gir treff når opgitt feltstarter med opgitt verdi."
+    startsWith: String
+    """
+
+    Søk til og med (se toExcluding for bare til men ikke med)
+    kan benyttes på tall og dato
+    """
+    to: String
+    """
+
+    Søk til men ikke med oppgitt verdi
+    kan benyttes på tall og dato
+    """
+    toExcluding: String
+    " Bruk \"?\" som wildcard for enkelt tegn, og \"*\" som wildcard for 0 eller flere tegn."
+    wildcard: String
+}
+
+input SearchSorting {
+    direction: Direction!
+    " Feltnavn ikludert sti til ønsket felt (eksepmel: person.navn.fornavn)"
+    fieldName: String!
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/oppholdsadresse/OppholdsadresseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/oppholdsadresse/OppholdsadresseTest.kt
@@ -1,0 +1,578 @@
+package no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.oppholdsadresse
+
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted.PAA_SVALBARD
+import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
+import no.nav.familie.kontrakter.felles.personopplysning.UtenlandskAdresse
+import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrMatrikkeladresseOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrUkjentAdresseOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrUtenlandskAdresseOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrVegadresseOppholdsadresse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
+import java.time.LocalDate
+
+class OppholdsadresseTest {
+    private val person1 = mockk<Person>()
+    private val fom = LocalDate.of(2024, 1, 1)
+    private val tom = LocalDate.of(2024, 12, 31)
+    private val vegadresse =
+        Vegadresse(
+            matrikkelId = 12345L,
+            husnummer = "10",
+            husbokstav = "A",
+            bruksenhetsnummer = "H101",
+            adressenavn = "Testgata",
+            kommunenummer = "0301",
+            tilleggsnavn = "Bak butikken",
+            postnummer = "0123",
+        )
+
+    private val matrikkeladresse =
+        Matrikkeladresse(
+            matrikkelId = 67890L,
+            bruksenhetsnummer = "H202",
+            tilleggsnavn = "Ved skogen",
+            postnummer = "1234",
+            kommunenummer = "0219",
+        )
+
+    private val utenlandskAdresse =
+        UtenlandskAdresse(
+            adressenavnNummer = "123 Foreign St",
+            bygningEtasjeLeilighet = "Apt 4B",
+            postboksNummerNavn = "PO Box 567",
+            postkode = "10001",
+            bySted = "New York",
+            regionDistriktOmraade = "NY",
+            landkode = "USA",
+        )
+
+    private val oppholdsadresse = Oppholdsadresse(gyldigFraOgMed = fom, gyldigTilOgMed = tom)
+
+    @Nested
+    inner class FraOppholdsadresse {
+        @ParameterizedTest
+        @EnumSource(OppholdAnnetSted::class)
+        fun `skal håndtere enum name og enum kode for oppholdAnnetSted`(
+            oppholdAnnetSted: OppholdAnnetSted,
+        ) {
+            oppholdsadresse.copy(oppholdAnnetSted = oppholdAnnetSted.name).also {
+                val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(it, person1)
+                assertOppholdsadresse(grOppholdsadresse, forventetOppholdAnnetSted = oppholdAnnetSted)
+            }
+
+            oppholdsadresse.copy(oppholdAnnetSted = oppholdAnnetSted.kode).also {
+                val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(it, person1)
+                assertOppholdsadresse(grOppholdsadresse, forventetOppholdAnnetSted = oppholdAnnetSted)
+            }
+        }
+
+        @Test
+        fun `fraOppholdsadresse skal returnere GrVegadresse når oppholdsadresse har vegadresse`() {
+            // Arrange
+            val oppholdsadresse = oppholdsadresse.copy(vegadresse = vegadresse)
+
+            // Act
+            val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresse, person1)
+
+            // Assert
+            assertThat(grOppholdsadresse).isInstanceOf(GrVegadresseOppholdsadresse::class.java)
+
+            val grVegadresse = grOppholdsadresse as GrVegadresseOppholdsadresse
+            assertOppholdsadresse(grVegadresse)
+            assertVegadresse(grVegadresse)
+        }
+
+        @Test
+        fun `fraOppholdsadresse skal returnere GrMatrikkeladresse når oppholdsadresse har matrikkeladresse`() {
+            // Arrange
+            val oppholdsadresse = oppholdsadresse.copy(matrikkeladresse = matrikkeladresse)
+
+            // Act
+            val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresse, person1)
+
+            // Assert
+            assertThat(grOppholdsadresse).isInstanceOf(GrMatrikkeladresseOppholdsadresse::class.java)
+
+            val grMatrikkeladresse = grOppholdsadresse as GrMatrikkeladresseOppholdsadresse
+            assertOppholdsadresse(grMatrikkeladresse)
+            assertMatrikkeladresse(grMatrikkeladresse)
+        }
+
+        @Test
+        fun `fraOppholdsadresse skal returnere GrUtenlandskAdresse når oppholdsadresse har utenlandskAdresse`() {
+            // Arrange
+            val oppholdsadresse = oppholdsadresse.copy(utenlandskAdresse = utenlandskAdresse)
+
+            // Act
+            val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresse, person1)
+
+            // Assert
+            assertThat(grOppholdsadresse).isInstanceOf(GrUtenlandskAdresseOppholdsadresse::class.java)
+
+            val grUtenlandskAdresse = grOppholdsadresse as GrUtenlandskAdresseOppholdsadresse
+            assertOppholdsadresse(grUtenlandskAdresse)
+            assertUtenlandskAdresse(grUtenlandskAdresse)
+        }
+
+        @Test
+        fun `fraOppholdsadresse skal returnere GrUkjentAdresse når oppholdsadresse ikke har noen adressetyper`() {
+            // Arrange
+            val oppholdsadresse = oppholdsadresse
+
+            // Act
+            val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresse, person1)
+
+            // Assert
+            assertThat(grOppholdsadresse).isInstanceOf(GrUkjentAdresseOppholdsadresse::class.java)
+            assertOppholdsadresse(grOppholdsadresse)
+        }
+
+        @Test
+        fun `fraOppholdsadresse skal håndtere null verdier for gyldigFraOgMed og gyldigTilOgMed`() {
+            // Arrange
+            val oppholdsadresse = oppholdsadresse.copy(gyldigFraOgMed = null, gyldigTilOgMed = null)
+
+            // Act
+            val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresse, person1)
+
+            // Assert
+            assertOppholdsadresse(grOppholdsadresse, forventetFom = null, forventetTom = null)
+        }
+
+        @Test
+        fun `fraOppholdsadresse skal håndtere ukjent oppholdAnnetSted verdi`() {
+            // Arrange
+            val oppholdsadresse = oppholdsadresse.copy(oppholdAnnetSted = "ukjentVerdi")
+
+            // Act
+            val grOppholdsadresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresse, person1)
+
+            // Assert
+            assertThat(grOppholdsadresse.oppholdAnnetSted).isNull()
+        }
+
+        @Test
+        fun `fraOppholdsadresse skal prioritere vegadresse over matrikkeladresse over utenlandsk adresse`() {
+            // Arrange
+            val oppholdsadresseMedUtenlandskAdresse =
+                oppholdsadresse.copy(utenlandskAdresse = utenlandskAdresse)
+
+            val oppholdsadresseMedMatrikkelOgUtenlandskAdresse =
+                oppholdsadresse.copy(matrikkeladresse = matrikkeladresse, utenlandskAdresse = utenlandskAdresse)
+
+            val oppholdsadresseMedVegMatrikkelOgUtenlandskAdresse =
+                oppholdsadresse.copy(vegadresse = vegadresse, matrikkeladresse = matrikkeladresse, utenlandskAdresse = utenlandskAdresse)
+
+            // Act
+            val grUtenlandskAdresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresseMedUtenlandskAdresse, person1)
+            val grMatrikkeladresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresseMedMatrikkelOgUtenlandskAdresse, person1)
+            val grVegadresse = GrOppholdsadresse.fraOppholdsadresse(oppholdsadresseMedVegMatrikkelOgUtenlandskAdresse, person1)
+
+            // Assert
+            assertThat(grUtenlandskAdresse).isInstanceOf(GrUtenlandskAdresseOppholdsadresse::class.java)
+            assertThat(grMatrikkeladresse).isInstanceOf(GrMatrikkeladresseOppholdsadresse::class.java)
+            assertThat(grVegadresse).isInstanceOf(GrVegadresseOppholdsadresse::class.java)
+        }
+    }
+
+    private val grVegadresse =
+        GrOppholdsadresse.fraOppholdsadresse(
+            oppholdsadresse = oppholdsadresse.copy(vegadresse = vegadresse),
+            person = person1,
+        ) as GrVegadresseOppholdsadresse
+
+    private val grMatrikkeladresse =
+        GrOppholdsadresse.fraOppholdsadresse(
+            oppholdsadresse = oppholdsadresse.copy(matrikkeladresse = matrikkeladresse),
+            person = person1,
+        ) as GrMatrikkeladresseOppholdsadresse
+
+    private val grUtenlandskAdresse =
+        GrOppholdsadresse.fraOppholdsadresse(
+            oppholdsadresse = oppholdsadresse.copy(utenlandskAdresse = utenlandskAdresse),
+            person = person1,
+        ) as GrUtenlandskAdresseOppholdsadresse
+
+    @Nested
+    inner class ToString {
+        @Test
+        fun `GrUkjentAdresse toString skal returnere riktig format`() {
+            // Arrange
+            val ukjentAdresse = GrUkjentAdresseOppholdsadresse()
+
+            // Act
+            val result = ukjentAdresse.toString()
+
+            // Assert
+            assertThat(result).isEqualTo("GrUkjentAdresseOppholdsadresse(detaljer skjult)")
+        }
+
+        @Test
+        fun `GrVegadresse toString skal returnere riktig format`() {
+            // Arrange
+            val vegadresse = grVegadresse
+
+            // Act
+            val result = vegadresse.toString()
+
+            // Assert
+            assertThat(result).isEqualTo("GrVegadresseOppholdsadresse(detaljer skjult)")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse toString skal returnere riktig format`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse
+
+            // Act
+            val result = matrikkeladresse.toString()
+
+            // Assert
+            assertThat(result).isEqualTo("GrMatrikkeladresseOppholdsadresse(detaljer skjult)")
+        }
+
+        @Test
+        fun `GrUtenlandskAdresse toString skal returnere riktig format`() {
+            // Arrange
+            val utenlandskAdresse = grUtenlandskAdresse
+
+            // Act
+            val result = utenlandskAdresse.toString()
+            // Assert
+            assertThat(result).isEqualTo("GrUtenlandskAdresseOppholdsadresse(detaljer skjult)")
+        }
+    }
+
+    @Nested
+    inner class ToSecureString {
+        @Test
+        fun `GrUkjentAdresse toSecureString skal returnere riktig format`() {
+            // Arrange
+            val ukjentAdresse = GrUkjentAdresseOppholdsadresse().apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = ukjentAdresse.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo("GrUkjentAdresseOppholdsadresse(Svalbard)")
+        }
+
+        @Test
+        fun `GrUkjentAdresse toSecureString uten oppholdAnnetSted skal returnere riktig format`() {
+            // Arrange
+            val ukjentAdresse = GrUkjentAdresseOppholdsadresse()
+
+            // Act
+            val result = ukjentAdresse.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo("GrUkjentAdresseOppholdsadresse()")
+        }
+
+        @Test
+        fun `GrVegadresse toSecureString skal returnere riktig format`() {
+            // Arrange
+            val vegadresse = grVegadresse.copy().apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = vegadresse.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo(
+                "GrVegadresseOppholdsadresse(husnummer=10, husbokstav=A, matrikkelId=12345, " +
+                    "bruksenhetsnummer=H101, adressenavn=Testgata, kommunenummer=0301, " +
+                    "tilleggsnavn=Bak butikken, postnummer=0123, oppholdAnnetSted=Svalbard)",
+            )
+        }
+
+        @Test
+        fun `GrMatrikkeladresse toSecureString skal returnere riktig format`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse.copy().apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = matrikkeladresse.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo(
+                "GrMatrikkeladresseOppholdsadresse(matrikkelId=67890, bruksenhetsnummer=H202, " +
+                    "tilleggsnavn=Ved skogen, postnummer=1234, " +
+                    "kommunenummer=0219, oppholdAnnetSted=Svalbard)",
+            )
+        }
+
+        @Test
+        fun `GrUtenlandskAdresse toSecureString skal returnere riktig format`() {
+            // Arrange
+            val utenlandskAdresse = grUtenlandskAdresse.copy().apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = utenlandskAdresse.toSecureString()
+
+            // Assert
+            assertThat(result).isEqualTo(
+                "GrUtenlandskAdresseOppholdsadresse(adressenavnNummer=123 Foreign St, " +
+                    "bygningEtasjeLeilighet=Apt 4B, postboksNummerNavn=PO Box 567, " +
+                    "postkode=10001, bySted=New York, regionDistriktOmraade=NY, " +
+                    "landkode=USA, oppholdAnnetSted=Svalbard)",
+            )
+        }
+    }
+
+    @Nested
+    inner class TilFrontendString {
+        @Test
+        fun `GrUkjentAdresse tilFrontendString uten oppholdAnnetSted skal returnere 'Ukjent adresse'`() {
+            // Arrange
+            val ukjentAdresse = GrUkjentAdresseOppholdsadresse()
+
+            // Act
+            val result = ukjentAdresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse")
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = OppholdAnnetSted::class, names = ["PAA_SVALBARD"], mode = EXCLUDE)
+        fun `GrUkjentAdresse tilFrontendString med oppholdAnnetSted annet enn Svalbard skal ikke inkludere det`(
+            opphold: OppholdAnnetSted,
+        ) {
+            // Arrange
+            val ukjentAdresse = GrUkjentAdresseOppholdsadresse().apply { oppholdAnnetSted = opphold }
+
+            // Act
+            val result = ukjentAdresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse")
+        }
+
+        @Test
+        fun `GrUkjentAdresse tilFrontendString med oppholdAnnetSted Svalbard skal inkludere det`() {
+            // Arrange
+            val ukjentAdresse = GrUkjentAdresseOppholdsadresse().apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = ukjentAdresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse, Svalbard")
+        }
+
+        @Test
+        fun `GrVegadresse tilFrontendString uten adressenavn eller oppholdAnnetSted`() {
+            // Arrange
+            val vegadresse = grVegadresse.copy(adressenavn = null)
+
+            // Act
+            val result = vegadresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse")
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = OppholdAnnetSted::class, names = ["PAA_SVALBARD"], mode = EXCLUDE)
+        fun `GrVegadresse tilFrontendString uten adressenavn med oppholdAnnetSted annet enn Svalbard skal ikke inkludere det`(
+            opphold: OppholdAnnetSted,
+        ) {
+            // Arrange
+            val vegadresse = grVegadresse.copy(adressenavn = null).apply { oppholdAnnetSted = opphold }
+
+            // Act
+            val result = vegadresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse")
+        }
+
+        @Test
+        fun `GrVegadresse tilFrontendString uten adressenavn med oppholdAnnetSted Svalbard skal inkludere det`() {
+            // Arrange
+            val vegadresse = grVegadresse.copy(adressenavn = null).apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = vegadresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse, Svalbard")
+        }
+
+        @Test
+        fun `GrVegadresse tilFrontendString med komplett adresse og oppholdAnnetSted Svalbard skal returnere formatert streng`() {
+            // Arrange
+            val vegadresse = grVegadresse.copy().apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = vegadresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Testgata 10A, 0123, Svalbard")
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = OppholdAnnetSted::class, names = ["PAA_SVALBARD"], mode = EXCLUDE)
+        fun `GrVegadresse tilFrontendString med komplett adresse og oppholdAnnetSted annet enn Svalbard skal returnere formatert streng`(
+            opphold: OppholdAnnetSted,
+        ) {
+            // Arrange
+            val vegadresse = grVegadresse.copy().apply { oppholdAnnetSted = opphold }
+
+            // Act
+            val result = vegadresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Testgata 10A, 0123")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse tilFrontendString med postnummer skal returnere formatert streng`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse
+
+            // Act
+            val result = matrikkeladresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Postnummer 1234")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse tilFrontendString med postnummer og oppholdAnnetSted Svalbard skal returnere formatert streng`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse.copy().apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = matrikkeladresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Postnummer 1234, Svalbard")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse tilFrontendString uten postnummer eller oppholdAnnetSted skal returnere 'Ukjent adresse'`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse.copy(postnummer = null)
+
+            // Act
+            val result = matrikkeladresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse")
+        }
+
+        @Test
+        fun `GrMatrikkeladresse tilFrontendString uten postnummer med oppholdAnnetSted Svalbard skal returnere formatert streng`() {
+            // Arrange
+            val matrikkeladresse = grMatrikkeladresse.copy(postnummer = null).apply { oppholdAnnetSted = PAA_SVALBARD }
+
+            // Act
+            val result = matrikkeladresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent adresse, Svalbard")
+        }
+
+        @Test
+        fun `GrUtenlandskAdresse tilFrontendString med komplett adresse skal returnere formatert streng`() {
+            // Arrange
+            val utenlandskAdresse = grUtenlandskAdresse
+
+            // Act
+            val result = utenlandskAdresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("123 foreign st, Apt 4B, PO Box 567, 10001, New York, NY, USA")
+        }
+
+        @Test
+        fun `GrUtenlandskAdresse tilFrontendString uten adressenavnNummer skal returnere formatert streng`() {
+            // Arrange
+            val utenlandskAdresse = grUtenlandskAdresse.copy(adressenavnNummer = null)
+
+            // Act
+            val result = utenlandskAdresse.tilFrontendString()
+
+            // Assert
+            assertThat(result).isEqualTo("Ukjent utenlandsk adresse, USA")
+        }
+    }
+
+    fun assertOppholdsadresse(
+        grOppholdsadresse: GrOppholdsadresse,
+        forventetPerson: Person = person1,
+        forventetFom: LocalDate? = fom,
+        forventetTom: LocalDate? = tom,
+        forventetOppholdAnnetSted: OppholdAnnetSted? = null,
+    ) {
+        assertThat(grOppholdsadresse.person).isEqualTo(forventetPerson)
+        assertThat(grOppholdsadresse.periode?.fom).isEqualTo(forventetFom)
+        assertThat(grOppholdsadresse.periode?.tom).isEqualTo(forventetTom)
+        assertThat(grOppholdsadresse.oppholdAnnetSted).isEqualTo(forventetOppholdAnnetSted)
+    }
+
+    fun assertVegadresse(
+        grVegadresse: GrVegadresseOppholdsadresse,
+        forventetMatrikkelId: Long? = vegadresse.matrikkelId,
+        forventetHusnummer: String? = vegadresse.husnummer,
+        forventetHusbokstav: String? = vegadresse.husbokstav,
+        forventetBruksenhetsnummer: String? = vegadresse.bruksenhetsnummer,
+        forventetAdressename: String? = vegadresse.adressenavn,
+        forventetKommunenummer: String? = vegadresse.kommunenummer,
+        forventetTilleggsnavn: String? = vegadresse.tilleggsnavn,
+        forventetPostnummer: String? = vegadresse.postnummer,
+    ) {
+        assertThat(grVegadresse.matrikkelId).isEqualTo(forventetMatrikkelId)
+        assertThat(grVegadresse.husnummer).isEqualTo(forventetHusnummer)
+        assertThat(grVegadresse.husbokstav).isEqualTo(forventetHusbokstav)
+        assertThat(grVegadresse.bruksenhetsnummer).isEqualTo(forventetBruksenhetsnummer)
+        assertThat(grVegadresse.adressenavn).isEqualTo(forventetAdressename)
+        assertThat(grVegadresse.kommunenummer).isEqualTo(forventetKommunenummer)
+        assertThat(grVegadresse.tilleggsnavn).isEqualTo(forventetTilleggsnavn)
+        assertThat(grVegadresse.postnummer).isEqualTo(forventetPostnummer)
+    }
+
+    fun assertMatrikkeladresse(
+        grMatrikkeladresse: GrMatrikkeladresseOppholdsadresse,
+        forventetMatrikkelId: Long? = matrikkeladresse.matrikkelId,
+        forventetBruksenhetsnummer: String? = matrikkeladresse.bruksenhetsnummer,
+        forventetTilleggsnavn: String? = matrikkeladresse.tilleggsnavn,
+        forventetPostnummer: String? = matrikkeladresse.postnummer,
+        forventetKommunenummer: String? = matrikkeladresse.kommunenummer,
+    ) {
+        assertThat(grMatrikkeladresse.matrikkelId).isEqualTo(forventetMatrikkelId)
+        assertThat(grMatrikkeladresse.bruksenhetsnummer).isEqualTo(forventetBruksenhetsnummer)
+        assertThat(grMatrikkeladresse.tilleggsnavn).isEqualTo(forventetTilleggsnavn)
+        assertThat(grMatrikkeladresse.postnummer).isEqualTo(forventetPostnummer)
+        assertThat(grMatrikkeladresse.kommunenummer).isEqualTo(forventetKommunenummer)
+    }
+
+    fun assertUtenlandskAdresse(
+        grUtenlandskAdresse: GrUtenlandskAdresseOppholdsadresse,
+        forventetAdressenavnNummer: String? = grUtenlandskAdresse.adressenavnNummer,
+        forventetBygningEtasjeLeilighet: String? = grUtenlandskAdresse.bygningEtasjeLeilighet,
+        forventetPostkode: String? = grUtenlandskAdresse.postkode,
+        forventetBySted: String? = grUtenlandskAdresse.bySted,
+        forventetRegionDistriktOmraade: String? = grUtenlandskAdresse.regionDistriktOmraade,
+        forventetLandkode: String? = grUtenlandskAdresse.landkode,
+    ) {
+        assertThat(grUtenlandskAdresse.adressenavnNummer).isEqualTo(forventetAdressenavnNummer)
+        assertThat(grUtenlandskAdresse.bygningEtasjeLeilighet).isEqualTo(forventetBygningEtasjeLeilighet)
+        assertThat(grUtenlandskAdresse.postkode).isEqualTo(forventetPostkode)
+        assertThat(grUtenlandskAdresse.bySted).isEqualTo(forventetBySted)
+        assertThat(grUtenlandskAdresse.regionDistriktOmraade).isEqualTo(forventetRegionDistriktOmraade)
+        assertThat(grUtenlandskAdresse.landkode).isEqualTo(forventetLandkode)
+    }
+}


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Favro: NAV-26037

Samme som i [ba-sak](https://github.com/navikt/familie-ba-sak/pull/5601)

Legger til støtte for oppholdsadresser, med full integrasjon fra PDL til domenemodeller og database. Oppholdsadresser blir mappet, lagret og eksponert i REST-responser.

Endringer:
* Støtte for oppholdsadresse i REST-modeller, domenemodeller og PDL-klient.
* Ny entitetshierarki for oppholdsadresse (GrOppholdsadresse m/ veg-, matrikkel-, utenlandsk- og ukjent adresse).
* Oppdatert Person-entitet til å inkludere oppholdsadresser.
* Omdøpt eksisterende bostedsadresse-entiteter for tydeligere skille.
* Utvidet parsing og mapping for eksterne adressetyper.
* Ryddet kode og lagt logikk i dedikert pakke.