### PR TITLE
Svalbardsmerking skal ikke skape splitt i vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiode/UtbetalingsperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiode/UtbetalingsperiodeUtil.kt
@@ -165,20 +165,19 @@ private fun List<AndelTilkjentYtelseMedEndreteUtbetalinger>.tilTidslinje(): Tids
 data class SplittkriterierForVilkår(
     val vilkårType: Vilkår,
     val resultat: Resultat,
-    val periodeFom: LocalDate?,
-    val periodeTom: LocalDate?,
-    val erEksplisittAvslagPåSøknad: Boolean?,
+    val erEksplisittAvslagPåSøknad: Boolean,
     val regelverk: Regelverk?,
     val utdypendeVilkårsvurderinger: Set<UtdypendeVilkårsvurdering>,
 ) {
     constructor(vilkårResultat: VilkårResultat) : this(
         vilkårType = vilkårResultat.vilkårType,
         resultat = vilkårResultat.resultat,
-        periodeFom = vilkårResultat.periodeFom,
-        periodeTom = vilkårResultat.periodeTom,
-        erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad,
+        erEksplisittAvslagPåSøknad = vilkårResultat.erEksplisittAvslagPåSøknad ?: false,
         regelverk = vilkårResultat.vurderesEtter,
-        utdypendeVilkårsvurderinger = vilkårResultat.utdypendeVilkårsvurderinger.toSet(),
+        utdypendeVilkårsvurderinger =
+            vilkårResultat.utdypendeVilkårsvurderinger
+                .filter { it != UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD }
+                .toSet(),
     )
 }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.forrigebehandling
 
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilTidslinje
@@ -64,8 +65,11 @@ object EndringIVilkårsvurderingUtil {
             nåværendeVilkårTidslinje.kombinerMed(tidligereVilkårTidslinje) { nåværende, forrige ->
                 if (nåværende == null || forrige == null) return@kombinerMed false
 
-                val erEndringerIUtdypendeVilkårsvurdering =
-                    nåværende.utdypendeVilkårsvurderinger.toSet() != forrige.utdypendeVilkårsvurderinger.toSet()
+                val nåværendeUtdypendeVilkårsvurderingUtenBosattPåSvalbard = nåværende.utdypendeVilkårsvurderinger.filter { it != UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD }.toSet()
+                val forrigeUtdypendeVilkårsvurderingUtenBosattPåSvalbard = forrige.utdypendeVilkårsvurderinger.filter { it != UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD }.toSet()
+
+                val erEndringerIUtdypendeVilkårsvurdering = nåværendeUtdypendeVilkårsvurderingUtenBosattPåSvalbard != forrigeUtdypendeVilkårsvurderingUtenBosattPåSvalbard
+
                 val erEndringerIRegelverk = nåværende.vurderesEtter != forrige.vurderesEtter
                 val erVilkårSomErSplittetOpp = nåværende.periodeFom != forrige.periodeFom
 

--- a/src/test/resources/cucumber/vilkår/svalbard.feature
+++ b/src/test/resources/cucumber/vilkår/svalbard.feature
@@ -1,0 +1,49 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Svalbard
+
+  Bakgrunn:
+    Gitt følgende fagsaker
+      | FagsakId |  | 1 |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 15.06.1994  |
+      | 1            | 2       | BARN       | 23.02.2024  |
+
+  Scenario: Ved splitt i vilkår grunnet bosatt på svalbard merkingen så skal ikke vedtaksperiodene splittes
+
+    Og følgende dagens dato 01.09.2025
+
+    Og følgende vilkårresultater for behandling 1
+
+      | AktørId | Vilkår                                  | Utdypende vilkår   | Fra dato   | Til dato   | Resultat | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET                          |                    | 15.06.1994 | 02.07.2025 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                              |                    | 15.06.1994 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | BOSATT_I_RIKET                          | BOSATT_PÅ_SVALBARD | 03.07.2025 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER,BOR_MED_SØKER |                    | 23.02.2024 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS                          |                    | 23.02.2024 |            | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET                          |                    | 23.02.2024 | 02.07.2025 | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNETS_ALDER                           |                    | 23.02.2025 | 23.10.2025 | OPPFYLT  | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET                          | BOSATT_PÅ_SVALBARD | 03.07.2025 |            | OPPFYLT  | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+    Og andeler er beregnet for behandling 1
+    Så forvent følgende andeler tilkjent ytelse for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.03.2025 | 30.09.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+
+    Og når behandlingsresultatet er utledet for behandling 1
+
+    Så forvent at behandlingsresultatet er INNVILGET_OG_OPPHØRT på behandling 1
+
+    Og vedtaksperioder er laget for behandling 1
+
+    Så forvent følgende vedtaksperioder på behandling 1
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.03.2025 | 30.09.2025 | UTBETALING         |           |
+      | 01.10.2025 |            | OPPHØR             |           |


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26104

Vi endrer på når det skal lages egen vedtaksperiode grunnet endring i vilkårsvurdering:

- Når FOM endrer på seg, lager vi ikke egen vedtaksperiode med mindre det kommer med endringer i andeler
- Når TOM endrer på seg, lager vi ikke egen vedtaksperiode med mindre det kommer med endringer i andeler
- Når man legger/fjerner svalbardsmerking så lager vi ikke egen vedtaksperiode med mindre det kommer endringer i andeler