### PR TITLE
NAV-26066: Legger til funksjonalitet for å sjekke om Svalbard-perioder har Svalbard-merking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Nav Familie-->
         <prosessering.version>2.20250825143618_c0302c9</prosessering.version>
-        <felles-kontrakter.version>3.0_20250827085324_488a77e</felles-kontrakter.version>
+        <felles-kontrakter.version>3.0_20250902143555_da31aa4</felles-kontrakter.version>
         <felles.version>3.20250804101327_a0f5fad</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20250826113118_c8aa66d</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.stønadsstatistikk>2.0_20250826113118_c8aa66d</familie.kontrakter.stønadsstatistikk>

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
@@ -52,6 +52,7 @@ data class BehandlingResponsDto(
     val korrigertVedtak: KorrigertVedtakResponsDto?,
     val brevmottakere: List<BrevmottakerDto> = emptyList(),
     val søknadMottattDato: LocalDateTime?,
+    val manglendeSvalbardmerking: List<ManglendeSvalbardmerkingDto>,
 )
 
 data class BehandlingStegTilstandResponsDto(

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
@@ -1,0 +1,76 @@
+package no.nav.familie.ks.sak.api.dto
+
+import no.nav.familie.ks.sak.common.util.tilEtterfølgendePar
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.tilTidslinje
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrOppholdsadresse
+import no.nav.familie.tidslinje.Periode
+import no.nav.familie.tidslinje.Tidslinje
+import no.nav.familie.tidslinje.beskjærEtter
+import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.kombinerMed
+import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import java.time.LocalDate
+
+data class ManglendeSvalbardmerkingDto(
+    val ident: String,
+    val manglendeSvalbardmerkingPerioder: List<ManglendeSvalbardmerkingPeriodeDto>,
+)
+
+data class ManglendeSvalbardmerkingPeriodeDto(
+    val fom: LocalDate?,
+    val tom: LocalDate?,
+)
+
+fun List<Person>?.tilManglendeSvalbardmerkingDto(personResultater: Set<PersonResultat>?): List<ManglendeSvalbardmerkingDto> {
+    if (this == null || personResultater == null) return emptyList()
+
+    val bosattIRiketVilkårTidslinjePerPerson: Map<String, Tidslinje<VilkårResultat>> =
+        personResultater.associate {
+            it.aktør.aktivFødselsnummer() to
+                it.vilkårResultater
+                    .filter { vilkårResultat -> vilkårResultat.vilkårType == Vilkår.BOSATT_I_RIKET && vilkårResultat.periodeFom != null }
+                    .tilTidslinje()
+        }
+    val svalbardOppholdTidslinjerPerPerson: Map<String, Tidslinje<GrOppholdsadresse>> =
+        this.associate { it.aktør.aktivFødselsnummer() to it.oppholdsadresser.tilSvalbardOppholdTidslinje() }
+
+    return bosattIRiketVilkårTidslinjePerPerson.mapNotNull { (fnr, bosattIRiketVilkårTidslinje) ->
+        val svalbardOppholdTidslinje = svalbardOppholdTidslinjerPerPerson[fnr] ?: return@mapNotNull null
+
+        // Svalbard opphold utenfor perioder med bosatt i riket vurderes ikke
+        val beskjærtSvalbardOppholdTidslinje = svalbardOppholdTidslinje.beskjærEtter(bosattIRiketVilkårTidslinje)
+
+        val perioderMedManglendeSvalbardMerking =
+            bosattIRiketVilkårTidslinje
+                .kombinerMed(beskjærtSvalbardOppholdTidslinje) { bosattIRiketVilkår, grOppholdsadresse ->
+                    grOppholdsadresse != null &&
+                        bosattIRiketVilkår != null &&
+                        !bosattIRiketVilkår.utdypendeVilkårsvurderinger.contains(
+                            UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD,
+                        )
+                }.tilPerioderIkkeNull()
+                .filter { it.verdi }
+                .map { ManglendeSvalbardmerkingPeriodeDto(fom = it.fom, tom = it.tom) }
+
+        if (perioderMedManglendeSvalbardMerking.isEmpty()) return@mapNotNull null
+
+        ManglendeSvalbardmerkingDto(fnr, perioderMedManglendeSvalbardMerking)
+    }
+}
+
+fun List<GrOppholdsadresse>.tilSvalbardOppholdTidslinje(): Tidslinje<GrOppholdsadresse> =
+    this
+        .filter { it.erPåSvalbard() }
+        .sortedBy { it.periode?.fom }
+        .tilEtterfølgendePar { grOppholdsadresse, nesteGrOppholdsadresse ->
+            Periode(
+                verdi = grOppholdsadresse,
+                fom = grOppholdsadresse.periode?.fom,
+                tom = grOppholdsadresse.periode?.tom ?: nesteGrOppholdsadresse?.periode?.fom?.minusDays(1),
+            )
+        }.tilTidslinje()

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ks.sak.api.dto.BehandlingStegTilstandResponsDto
 import no.nav.familie.ks.sak.api.dto.BrevmottakerDto
 import no.nav.familie.ks.sak.api.dto.EndretUtbetalingAndelResponsDto
 import no.nav.familie.ks.sak.api.dto.FeilutbetaltValutaDto
+import no.nav.familie.ks.sak.api.dto.ManglendeSvalbardmerkingDto
 import no.nav.familie.ks.sak.api.dto.OvergangsordningAndelDto
 import no.nav.familie.ks.sak.api.dto.PersonResponsDto
 import no.nav.familie.ks.sak.api.dto.PersonerMedAndelerResponsDto
@@ -50,7 +51,7 @@ object BehandlingMapper {
         arbeidsfordelingPåBehandling: ArbeidsfordelingPåBehandling,
         søknadsgrunnlag: SøknadDto?,
         personer: List<PersonResponsDto>,
-        personResultater: List<PersonResultat>?,
+        personResultater: Set<PersonResultat>?,
         personerMedAndelerTilkjentYtelse: List<PersonerMedAndelerResponsDto>,
         utbetalingsperioder: List<UtbetalingsperiodeResponsDto>,
         vedtak: VedtakDto?,
@@ -68,6 +69,7 @@ object BehandlingMapper {
         korrigertEtterbetaling: KorrigertEtterbetaling?,
         korrigertVedtak: KorrigertVedtak?,
         brevmottakere: List<BrevmottakerDto>,
+        manglendeSvalbardmerking: List<ManglendeSvalbardmerkingDto>,
     ) = BehandlingResponsDto(
         behandlingId = behandling.id,
         steg = behandling.steg,
@@ -118,6 +120,7 @@ object BehandlingMapper {
         korrigertEtterbetaling = korrigertEtterbetaling?.tilKorrigertEtterbetalingResponsDto(),
         korrigertVedtak = korrigertVedtak?.tilKorrigertVedtakResponsDto(),
         brevmottakere = brevmottakere,
+        manglendeSvalbardmerking = manglendeSvalbardmerking,
     )
 
     private fun lagArbeidsfordelingRespons(arbeidsfordelingPåBehandling: ArbeidsfordelingPåBehandling) =

--- a/src/main/kotlin/no/nav/familie/ks/sak/common/util/Utils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/util/Utils.kt
@@ -51,3 +51,5 @@ fun hentDokument(dokumentNavn: String): ByteArray {
 
     return dokumentByteArray
 }
+
+fun <T, R> List<T>.tilEtterfølgendePar(transform: (a: T, b: T?) -> R): List<R> = this.windowed(size = 2, step = 1, partialWindows = true) { transform(it[0], it.getOrNull(1)) }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/BehandlingService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.behandling
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
 import no.nav.familie.ks.sak.api.dto.tilFeilutbetaltValutaDto
+import no.nav.familie.ks.sak.api.dto.tilManglendeSvalbardmerkingDto
 import no.nav.familie.ks.sak.api.dto.tilTotrinnskontrollDto
 import no.nav.familie.ks.sak.api.dto.tilUtbetalingsperiodeResponsDto
 import no.nav.familie.ks.sak.api.dto.tilUtvidetVedtaksperiodeMedBegrunnelserDto
@@ -144,7 +145,7 @@ class BehandlingService(
 
         val søknadsgrunnlag = søknadGrunnlagService.finnAktiv(behandlingId)?.tilSøknadDto()
         val personResultater =
-            vilkårsvurderingService.finnAktivVilkårsvurdering(behandlingId)?.personResultater?.toList()
+            vilkårsvurderingService.finnAktivVilkårsvurdering(behandlingId)?.personResultater
 
         val andelerTilkjentYtelse = andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandlingId)
         val personerMedAndelerTilkjentYtelse =
@@ -223,29 +224,32 @@ class BehandlingService(
 
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
 
+        val manglendeSvalbardmerking = personer.tilManglendeSvalbardmerkingDto(personResultater)
+
         return BehandlingMapper.lagBehandlingRespons(
-            behandling,
-            arbeidsfordelingPåBehandling,
-            søknadsgrunnlag,
-            personResponser,
-            personResultater,
-            personerMedAndelerTilkjentYtelse,
-            utbetalingsperioder,
-            vedtak,
-            totrinnskontroll,
-            endreteUtbetalingerMedAndeler,
-            overgangsordningAndeler,
-            endringstidspunkt,
-            tilbakekreving,
-            sisteVedtaksperiodeVisningDato,
-            feilutbetalteValuta,
-            kompetanser,
-            refusjonEøs,
-            utenlandskePeriodebeløp,
-            valutakurser,
-            korrigertEtterbetaling,
-            korrigertVedtak,
-            brevmottakere,
+            behandling = behandling,
+            arbeidsfordelingPåBehandling = arbeidsfordelingPåBehandling,
+            søknadsgrunnlag = søknadsgrunnlag,
+            personer = personResponser,
+            personResultater = personResultater,
+            personerMedAndelerTilkjentYtelse = personerMedAndelerTilkjentYtelse,
+            utbetalingsperioder = utbetalingsperioder,
+            vedtak = vedtak,
+            totrinnskontroll = totrinnskontroll,
+            endretUtbetalingAndeler = endreteUtbetalingerMedAndeler,
+            overgangsordningAndeler = overgangsordningAndeler,
+            endringstidspunkt = endringstidspunkt,
+            tilbakekreving = tilbakekreving,
+            sisteVedtaksperiodeVisningDato = sisteVedtaksperiodeVisningDato,
+            feilutbetalteValuta = feilutbetalteValuta,
+            kompetanser = kompetanser,
+            refusjonEøs = refusjonEøs,
+            utenlandskePeriodebeløp = utenlandskePeriodebeløp,
+            valutakurser = valutakurser,
+            korrigertEtterbetaling = korrigertEtterbetaling,
+            korrigertVedtak = korrigertVedtak,
+            brevmottakere = brevmottakere,
+            manglendeSvalbardmerking = manglendeSvalbardmerking,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrMatrikkeladresseOppholdsadresse.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
 import no.nav.familie.kontrakter.felles.personopplysning.Matrikkeladresse
 import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted.PAA_SVALBARD
+import no.nav.familie.kontrakter.felles.svalbard.erKommunePåSvalbard
 import java.util.Objects
 
 @Entity(name = "GrMatrikkeladresseOppholdsadresse")
@@ -42,6 +43,8 @@ data class GrMatrikkeladresseOppholdsadresse(
         val oppholdAnnetSted = oppholdAnnetSted.takeIf { it == PAA_SVALBARD }?.let { ", $it" } ?: ""
         return postnummer?.let { "$postnummer$poststed$oppholdAnnetSted" } ?: "Ukjent adresse$oppholdAnnetSted"
     }
+
+    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrOppholdsadresse.kt
@@ -53,6 +53,8 @@ abstract class GrOppholdsadresse(
 
     abstract fun tilFrontendString(): String
 
+    abstract fun erPåSvalbard(): Boolean
+
     companion object {
         fun fraOppholdsadresse(
             oppholdsadresse: Oppholdsadresse,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUkjentAdresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUkjentAdresseOppholdsadresse.kt
@@ -12,4 +12,6 @@ class GrUkjentAdresseOppholdsadresse : GrOppholdsadresse() {
     override fun toSecureString(): String = "GrUkjentAdresseOppholdsadresse(${oppholdAnnetSted ?: ""})"
 
     override fun tilFrontendString(): String = "Ukjent adresse${oppholdAnnetSted.takeIf { it == PAA_SVALBARD }?.let { ", $it" } ?: ""}"
+
+    override fun erPåSvalbard(): Boolean = oppholdAnnetSted == PAA_SVALBARD
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUtenlandskAdresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrUtenlandskAdresseOppholdsadresse.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadr
 import jakarta.persistence.Column
 import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted.PAA_SVALBARD
 import no.nav.familie.kontrakter.felles.personopplysning.UtenlandskAdresse
 import no.nav.familie.ks.sak.common.util.storForbokstav
 
@@ -50,6 +51,8 @@ data class GrUtenlandskAdresseOppholdsadresse(
     }
 
     override fun toString(): String = "GrUtenlandskAdresseOppholdsadresse(detaljer skjult)"
+
+    override fun erPåSvalbard(): Boolean = oppholdAnnetSted == PAA_SVALBARD
 
     companion object {
         fun fraUtenlandskAdresse(utenlandskAdresse: UtenlandskAdresse): GrUtenlandskAdresseOppholdsadresse =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrVegadresseOppholdsadresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/domene/oppholdsadresse/GrVegadresseOppholdsadresse.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
 import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted.PAA_SVALBARD
 import no.nav.familie.kontrakter.felles.personopplysning.Vegadresse
+import no.nav.familie.kontrakter.felles.svalbard.erKommunePåSvalbard
 import no.nav.familie.ks.sak.common.util.nullableTilString
 import no.nav.familie.ks.sak.common.util.storForbokstav
 import java.util.Objects
@@ -59,6 +60,8 @@ data class GrVegadresseOppholdsadresse(
             else -> "$adressenavn $husnummer$husbokstav$postnummer$poststed$oppholdAnnetSted"
         }
     }
+
+    override fun erPåSvalbard(): Boolean = (kommunenummer != null && erKommunePåSvalbard(kommunenummer)) || oppholdAnnetSted == PAA_SVALBARD
 
     override fun equals(other: Any?): Boolean {
         if (other == null || javaClass != other.javaClass) {

--- a/src/test/common/no/nav/familie/ks/sak/datagenerator/AdresseGenerator.kt
+++ b/src/test/common/no/nav/familie/ks/sak/datagenerator/AdresseGenerator.kt
@@ -1,0 +1,79 @@
+package no.nav.familie.ks.sak.data.no.nav.familie.ks.sak.datagenerator
+
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted
+import no.nav.familie.ks.sak.common.entitet.DatoIntervallEntitet
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrMatrikkeladresseOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrUkjentAdresseOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrUtenlandskAdresseOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrVegadresseOppholdsadresse
+
+fun lagGrVegadresseOppholdsadresse(
+    matrikkelId: Long? = null,
+    husnummer: String? = null,
+    husbokstav: String? = null,
+    bruksenhetsnummer: String? = null,
+    adressenavn: String? = null,
+    kommunenummer: String? = null,
+    tilleggsnavn: String? = null,
+    postnummer: String? = null,
+    periode: DatoIntervallEntitet? = null,
+    poststed: String? = null,
+) = GrVegadresseOppholdsadresse(
+    matrikkelId = matrikkelId,
+    husnummer = husnummer,
+    husbokstav = husbokstav,
+    bruksenhetsnummer = bruksenhetsnummer,
+    adressenavn = adressenavn,
+    kommunenummer = kommunenummer,
+    tilleggsnavn = tilleggsnavn,
+    postnummer = postnummer,
+    poststed = poststed,
+).also { it.periode = periode }
+
+fun lagGrMatrikkelOppholdsadresse(
+    matrikkelId: Long? = null,
+    bruksenhetsnummer: String? = null,
+    kommunenummer: String? = null,
+    tilleggsnavn: String? = null,
+    postnummer: String? = null,
+    periode: DatoIntervallEntitet? = null,
+    poststed: String? = null,
+) = GrMatrikkeladresseOppholdsadresse(
+    matrikkelId = matrikkelId,
+    bruksenhetsnummer = bruksenhetsnummer,
+    kommunenummer = kommunenummer,
+    tilleggsnavn = tilleggsnavn,
+    postnummer = postnummer,
+    poststed = poststed,
+).also { it.periode = periode }
+
+fun lagGrUtenlandskOppholdsadresse(
+    adressenavnNummer: String? = null,
+    bygningEtasjeLeilighet: String? = null,
+    postboksNummerNavn: String? = null,
+    postkode: String? = null,
+    bySted: String? = null,
+    regionDistriktOmraade: String? = null,
+    landkode: String? = null,
+    periode: DatoIntervallEntitet? = null,
+    oppholdAnnetSted: OppholdAnnetSted? = null,
+) = GrUtenlandskAdresseOppholdsadresse(
+    adressenavnNummer = adressenavnNummer,
+    bygningEtasjeLeilighet = bygningEtasjeLeilighet,
+    postboksNummerNavn = postboksNummerNavn,
+    postkode = postkode,
+    bySted = bySted,
+    regionDistriktOmraade = regionDistriktOmraade,
+    landkode = landkode,
+).also {
+    it.periode = periode
+    it.oppholdAnnetSted = oppholdAnnetSted
+}
+
+fun lagGrUkjentAdresseOppholdsadresse(
+    periode: DatoIntervallEntitet? = null,
+    oppholdAnnetSted: OppholdAnnetSted? = null,
+) = GrUkjentAdresseOppholdsadresse().also {
+    it.periode = periode
+    it.oppholdAnnetSted = oppholdAnnetSted
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
@@ -1,0 +1,391 @@
+package no.nav.familie.ks.sak.api.dto
+
+import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted
+import no.nav.familie.kontrakter.felles.svalbard.SvalbardKommune
+import no.nav.familie.ks.sak.common.entitet.DatoIntervallEntitet
+import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagPerson
+import no.nav.familie.ks.sak.data.lagPersonResultat
+import no.nav.familie.ks.sak.data.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.lagVilkårResultat
+import no.nav.familie.ks.sak.data.lagVilkårsvurdering
+import no.nav.familie.ks.sak.data.no.nav.familie.ks.sak.datagenerator.lagGrMatrikkelOppholdsadresse
+import no.nav.familie.ks.sak.data.no.nav.familie.ks.sak.datagenerator.lagGrUkjentAdresseOppholdsadresse
+import no.nav.familie.ks.sak.data.no.nav.familie.ks.sak.datagenerator.lagGrUtenlandskOppholdsadresse
+import no.nav.familie.ks.sak.data.no.nav.familie.ks.sak.datagenerator.lagGrVegadresseOppholdsadresse
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
+import no.nav.familie.tidslinje.utvidelser.tilPerioder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ManglendeSvalbardmerkingDtoTest {
+    @Nested
+    inner class TilManglendeSvalbardmerkingDto {
+        @Test
+        fun `skal finne alle perioder for alle personer som ikke er markert med 'Bosatt på Svalbard' men har oppholdsadresse på Svalbard`() {
+            // Arrange
+            val bosattPåSvalbardPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 8, 15), tom = null)
+
+            val søker =
+                lagPerson(personType = PersonType.SØKER).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+
+            val barn1 =
+                lagPerson(personType = PersonType.BARN).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrMatrikkelOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+
+            val barn2 =
+                lagPerson(personType = PersonType.BARN).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrUtenlandskOppholdsadresse(
+                                oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+
+            val barn3 =
+                lagPerson(personType = PersonType.BARN).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrUkjentAdresseOppholdsadresse(
+                                oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+            val behandling = lagBehandling()
+            val persongrunnlag =
+                lagTestPersonopplysningGrunnlag(
+                    behandling.id,
+                    søker,
+                    barn1,
+                    barn2,
+                    barn3,
+                )
+            val vilkårsvurdering =
+                lagVilkårsvurdering(behandling = behandling, lagPersonResultat = { vilkårsvurdering ->
+                    setOf(
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = søker.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                    ),
+                                )
+                            },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = barn1.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                    ),
+                                )
+                            },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = barn2.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                    ),
+                                )
+                            },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = barn3.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                    ),
+                                )
+                            },
+                        ),
+                    )
+                })
+
+            val personer = listOf(søker, barn1, barn2, barn3)
+
+            // Act
+            val manglendeSvalbardmerking =
+                personer.tilManglendeSvalbardmerkingDto(personResultater = vilkårsvurdering.personResultater)
+
+            // Assert
+            assertThat(manglendeSvalbardmerking).hasSize(4)
+            assertThat(manglendeSvalbardmerking.all { it.manglendeSvalbardmerkingPerioder.size == 1 }).isTrue
+            val manglendePerioder = manglendeSvalbardmerking.flatMap { it.manglendeSvalbardmerkingPerioder }
+            assertThat(manglendePerioder.all { manglendePeriode -> manglendePeriode.fom == bosattPåSvalbardPeriode.fom && manglendePeriode.tom == bosattPåSvalbardPeriode.tom }).isTrue
+        }
+
+        @Test
+        fun `skal returnere tom liste dersom alle perioder for alle personer med oppholdsadresse på Svalbard har blitt markert med "Bosatt på Svalbard"`() {
+            // Arrange
+            val bosattPåSvalbardPeriode = DatoIntervallEntitet(fom = LocalDate.of(2024, 8, 15), tom = null)
+
+            val søker =
+                lagPerson(personType = PersonType.SØKER).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+
+            val barn1 =
+                lagPerson(personType = PersonType.BARN).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrMatrikkelOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+
+            val barn2 =
+                lagPerson(personType = PersonType.BARN).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrUtenlandskOppholdsadresse(
+                                oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+
+            val barn3 =
+                lagPerson(personType = PersonType.BARN).also {
+                    it.oppholdsadresser =
+                        mutableListOf(
+                            lagGrUkjentAdresseOppholdsadresse(
+                                oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
+                                periode = bosattPåSvalbardPeriode,
+                            ),
+                        )
+                }
+            val behandling = lagBehandling()
+            val persongrunnlag =
+                lagTestPersonopplysningGrunnlag(
+                    behandling.id,
+                    søker,
+                    barn1,
+                    barn2,
+                    barn3,
+                )
+            val vilkårsvurdering =
+                lagVilkårsvurdering(behandling = behandling, lagPersonResultat = { vilkårsvurdering ->
+                    setOf(
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = søker.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                        utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD),
+                                    ),
+                                )
+                            },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = barn1.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                        utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD),
+                                    ),
+                                )
+                            },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = barn2.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                        utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD),
+                                    ),
+                                )
+                            },
+                        ),
+                        lagPersonResultat(
+                            vilkårsvurdering = vilkårsvurdering,
+                            aktør = barn3.aktør,
+                            lagVilkårResultater = { personResultat ->
+                                setOf(
+                                    lagBosattIRiketVilkårForPersonResultat(
+                                        personResultat = personResultat,
+                                        behandling = behandling,
+                                        periode = bosattPåSvalbardPeriode,
+                                        utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD),
+                                    ),
+                                )
+                            },
+                        ),
+                    )
+                })
+
+            val personer = listOf(søker, barn1, barn2, barn3)
+
+            // Act
+            val manglendeSvalbardmerking =
+                personer.tilManglendeSvalbardmerkingDto(personResultater = vilkårsvurdering.personResultater)
+
+            // Assert
+            assertThat(manglendeSvalbardmerking).hasSize(0)
+        }
+
+        private fun lagBosattIRiketVilkårForPersonResultat(
+            personResultat: PersonResultat,
+            behandling: Behandling,
+            periode: DatoIntervallEntitet,
+            utdypendeVilkårsvurderinger: List<UtdypendeVilkårsvurdering> = emptyList(),
+        ): VilkårResultat =
+            lagVilkårResultat(
+                behandlingId = behandling.id,
+                personResultat = personResultat,
+                vilkårType = Vilkår.BOSATT_I_RIKET,
+                resultat = Resultat.OPPFYLT,
+                periodeFom = periode.fom,
+                periodeTom = null,
+                begrunnelse = "",
+                utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
+            )
+    }
+
+    @Nested
+    inner class TilSvalbardOppholdTidslinje {
+        @Test
+        fun `skal lage perioder med tom dato satt til fom dato til neste element dersom tom dato ikke finnes`() {
+            // Arrange
+            val førsteFom = LocalDate.of(2021, 1, 1)
+            val andreFom = LocalDate.of(2022, 5, 5)
+            val tredjeFom = LocalDate.of(2023, 10, 10)
+
+            val grOppholdsadresser =
+                listOf(
+                    lagGrVegadresseOppholdsadresse(
+                        kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                        periode = DatoIntervallEntitet(fom = førsteFom, tom = null),
+                    ),
+                    lagGrMatrikkelOppholdsadresse(
+                        kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                        periode = DatoIntervallEntitet(fom = andreFom, tom = null),
+                    ),
+                    lagGrUtenlandskOppholdsadresse(
+                        oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
+                        periode = DatoIntervallEntitet(fom = tredjeFom, tom = null),
+                    ),
+                )
+
+            // Act
+            val oppholdsadresseTidslinje = grOppholdsadresser.tilSvalbardOppholdTidslinje()
+
+            // Assert
+            val perioder = oppholdsadresseTidslinje.tilPerioder()
+            assertThat(perioder).hasSize(3)
+
+            assertThat(perioder[0].fom).isEqualTo(førsteFom)
+            assertThat(perioder[0].tom).isEqualTo(andreFom.minusDays(1))
+
+            assertThat(perioder[1].fom).isEqualTo(andreFom)
+            assertThat(perioder[1].tom).isEqualTo(tredjeFom.minusDays(1))
+
+            assertThat(perioder[2].fom).isEqualTo(tredjeFom)
+            assertThat(perioder[2].tom).isNull()
+        }
+
+        @Test
+        fun `skal lage perioder med tom dato dersom tom dato finnes`() {
+            // Arrange
+            val førsteFom = LocalDate.of(2021, 1, 1)
+            val førsteTom = LocalDate.of(2022, 5, 4)
+            val andreFom = LocalDate.of(2022, 5, 5)
+            val andreTom = LocalDate.of(2023, 10, 9)
+            val tredjeFom = LocalDate.of(2023, 10, 10)
+
+            val grOppholdsadresser =
+                listOf(
+                    lagGrVegadresseOppholdsadresse(
+                        kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                        periode = DatoIntervallEntitet(fom = førsteFom, tom = førsteTom),
+                    ),
+                    lagGrMatrikkelOppholdsadresse(
+                        kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                        periode = DatoIntervallEntitet(fom = andreFom, tom = andreTom),
+                    ),
+                    lagGrUtenlandskOppholdsadresse(
+                        oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
+                        periode = DatoIntervallEntitet(fom = tredjeFom, tom = null),
+                    ),
+                )
+
+            // Act
+            val oppholdsadresseTidslinje = grOppholdsadresser.tilSvalbardOppholdTidslinje()
+
+            // Assert
+            val perioder = oppholdsadresseTidslinje.tilPerioder()
+            assertThat(perioder).hasSize(3)
+
+            assertThat(perioder[0].fom).isEqualTo(førsteFom)
+            assertThat(perioder[0].tom).isEqualTo(førsteTom)
+
+            assertThat(perioder[1].fom).isEqualTo(andreFom)
+            assertThat(perioder[1].tom).isEqualTo(andreTom)
+
+            assertThat(perioder[2].fom).isEqualTo(tredjeFom)
+            assertThat(perioder[2].tom).isNull()
+        }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/util/UtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/util/UtilsTest.kt
@@ -1,8 +1,11 @@
 package no.nav.familie.ks.sak.common.util
 
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import kotlin.collections.get
 
 internal class UtilsTest {
     @Test
@@ -21,4 +24,19 @@ internal class UtilsTest {
 
     @Test
     fun `Navn i uppercase med mellomrom og bindestrek blir formatert korrekt`() = assertEquals("Hense-Ravnen Hopp", "HENSE-RAVNEN HOPP".storForbokstavIAlleNavn())
+
+    @Nested
+    inner class TilEtterfølgendePar {
+        @Test
+        fun `skal plukke ut to og to etterfølgende elementer inkludert det siste elementet`() {
+            val liste = listOf(1, 2, 3, 4, 5)
+            val par = liste.tilEtterfølgendePar { a, b -> a to b }
+            assertThat(par).hasSize(5)
+            assertThat(par[0]).isEqualTo(Pair(1, 2))
+            assertThat(par[1]).isEqualTo(Pair(2, 3))
+            assertThat(par[2]).isEqualTo(Pair(3, 4))
+            assertThat(par[3]).isEqualTo(Pair(4, 5))
+            assertThat(par[4]).isEqualTo(Pair(5, null))
+        }
+    }
 }


### PR DESCRIPTION
Favro: [NAV-26066](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26066)

### 💰 Hva skal gjøres, og hvorfor?
Vi ønsker å kunne varsle saksbehandler om vilkår-perioder som ikke er markert med "Bosatt på Svalbard" for personer som har opphold på Svalbard i samme periode. For å få til dette utvides `RestUtvidetBehandling` med feltet `manglendeSvalbardmerking` som er en liste over alle personer og perioder som potensielt mangler Svalbard-merking.

`manglendeSvalbardmerking` utledes ut i fra en persons oppholdsadresser og bosatt i riket vilkår.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta en gjennomgang om ønskelig
