### PR TITLE
Bug i barnehagelister

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -10,11 +10,13 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
     fun findAllByIdent(ident: String): List<Barnehagebarn>
 
     @Query(
-        """
+        """    
     WITH input AS (
-    --Vi referer til disse variablene flere ganger så da må de legges inn slik
-        SELECT CAST(:ident AS TEXT) AS ident_param, CAST(:kommuneNavn AS TEXT) AS kommunenavn_param
-),     
+        -- Referer til disse variablene flere ganger så de må legges inn slik
+        SELECT 
+        CAST(:ident AS TEXT) as ident_param,
+        CAST (:kommuneNavn AS TEXT) as kommunenavn_param
+    ),
     siste_iverksatte_behandling_i_løpende_fagsak AS (
     -- Finn nyeste iverksatte behandling med utbetaling for løpende og ikke-arkivert fagsak for barn
     SELECT f.id AS fagsakid, MAX(b.aktivert_tid) AS aktivert_tid
@@ -23,7 +25,8 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
              JOIN behandling b ON aty.fk_behandling_id = b.id
              JOIN fagsak f ON b.fk_fagsak_id = f.id
              JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
-    WHERE (input.ident_param IS NULL OR p.foedselsnummer = input.ident_param)
+             CROSS JOIN input i
+    WHERE (i.ident_param IS NULL OR p.foedselsnummer = i.ident_param)
       AND p.aktiv = true
       AND f.status = 'LØPENDE'
       AND f.arkivert = false
@@ -32,7 +35,7 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
 ),
 lopende_andel_i_siste_iverksatte_behandling AS (
     -- Sjekker om barnet har en løpende andel i siste iverksatte behandling 
-    SELECT p.foedselsnummer, aty.stonad_tom + interval '1 month' >= current_date AS lopende_andel
+    SELECT p.foedselsnummer, aty.stonad_tom + interval '1 month - 1 day' >= current_date AS lopende_andel
     FROM personident p
              JOIN andel_tilkjent_ytelse aty ON p.fk_aktoer_id = aty.fk_aktoer_id
              JOIN behandling b ON aty.fk_behandling_id = b.id
@@ -40,7 +43,8 @@ lopende_andel_i_siste_iverksatte_behandling AS (
              JOIN siste_iverksatte_behandling_i_løpende_fagsak iblf
                   ON f.id = iblf.fagsakid
                   AND b.aktivert_tid = iblf.aktivert_tid
-    WHERE (input.ident_param IS NULL OR p.foedselsnummer = input.ident_param)
+    CROSS JOIN input i
+    WHERE (i.ident_param IS NULL OR p.foedselsnummer = i.ident_param)
       AND p.aktiv = true
 ),
 avvik_antall_timer_vilkar_resultat_og_barnehagebarn AS (
@@ -74,10 +78,10 @@ barnehagebarn_visning AS (
                        ON bb.ident = lab.foedselsnummer
              LEFT JOIN avvik_antall_timer_vilkar_resultat_og_barnehagebarn atv
                        ON bb.id = atv.barnehagebarn_id
-             CROSS JOIN input
+    CROSS JOIN input i
     WHERE (NOT :kunLøpendeAndeler OR lab.lopende_andel = true)
-      AND (input.ident_param IS NULL OR bb.ident = input.ident_param)
-      AND (input.kommunenavn_param IS NULL OR bb.kommune_navn ILIKE input.kommunenavn_param)
+      AND (i.ident_param IS NULL OR bb.ident = i.ident_param)
+      AND (i.kommunenavn_param IS NULL OR bb.kommune_navn ILIKE i.kommunenavn_param)
     GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype,
              bb.kommune_navn, bb.kommune_nr, atv.avvik
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -15,11 +15,13 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
         -- Referer til disse variablene flere ganger så de må legges inn slik
         SELECT 
         CAST(:ident AS TEXT) as ident_param,
-        CAST (:kommuneNavn AS TEXT) as kommunenavn_param
+        CAST(:kommuneNavn AS TEXT) as kommunenavn_param
     ),
     siste_iverksatte_behandling_i_løpende_fagsak AS (
     -- Finn nyeste iverksatte behandling med utbetaling for løpende og ikke-arkivert fagsak for barn
-    SELECT f.id AS fagsakid, MAX(b.aktivert_tid) AS aktivert_tid
+    SELECT 
+        f.id AS fagsakid, 
+        MAX(b.aktivert_tid) AS aktivert_tid
     FROM personident p
              JOIN andel_tilkjent_ytelse aty ON p.fk_aktoer_id = aty.fk_aktoer_id
              JOIN behandling b ON aty.fk_behandling_id = b.id
@@ -35,7 +37,9 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
 ),
 lopende_andel_i_siste_iverksatte_behandling AS (
     -- Sjekker om barnet har en løpende andel i siste iverksatte behandling 
-    SELECT p.foedselsnummer, aty.stonad_tom + interval '1 month - 1 day' >= current_date AS lopende_andel
+    SELECT 
+        p.foedselsnummer, 
+        aty.stonad_tom + interval '1 month - 1 day' >= current_date AS lopende_andel -- stonad_tom blir satt til første dag i mnd, men vi ønsker å ha med hele måneden i filtreringen
     FROM personident p
              JOIN andel_tilkjent_ytelse aty ON p.fk_aktoer_id = aty.fk_aktoer_id
              JOIN behandling b ON aty.fk_behandling_id = b.id
@@ -48,9 +52,10 @@ lopende_andel_i_siste_iverksatte_behandling AS (
       AND p.aktiv = true
 ),
 avvik_antall_timer_vilkar_resultat_og_barnehagebarn AS (
-    SELECT bb.id as barnehagebarn_id,
+    SELECT 
+        bb.id as barnehagebarn_id,
            CASE
-               WHEN bb.antall_timer_i_barnehage < 33
+               WHEN bb.antall_timer_i_barnehage < 33 -- minst 33 timer barnehageplass regnes som fulltidsplass
                    THEN vr.antall_timer != bb.antall_timer_i_barnehage
                ELSE vr.antall_timer <= 33
            END as avvik

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -56,7 +56,8 @@ avvik_antall_timer_vilkar_resultat_og_barnehagebarn AS (
 ),
 input_params AS (
     --Vi referer til disse variablene to ganger så da må de legges inn slik
-    SELECT :ident AS ident_param, :kommuneNavn AS kommunenavn_param
+    SELECT 
+    CAST(:ident AS TEXT) AS ident_param, CAST(:kommuneNavn AS TEXT) AS kommunenavn_param
 ),
 barnehagebarn_visning AS (
     --Må trekkes ut til egen CTE for at sortering for pageables skal fungere på felter som ikke ligger i barnehagebarn fra før

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/domene/BarnehagebarnRepository.kt
@@ -11,50 +11,77 @@ interface BarnehagebarnRepository : JpaRepository<Barnehagebarn, UUID> { // , Jp
 
     @Query(
         """
-WITH lopende_andel_i_aktiv_behandling_for_ident
-         AS (SELECT p.foedselsnummer, aty.stonad_tom >= current_date as lopende_andel
-             FROM andel_tilkjent_ytelse aty
-                      JOIN behandling b ON aty.fk_behandling_id = b.id
-                      JOIN personident p ON aty.fk_aktoer_id = p.fk_aktoer_id
-             WHERE p.aktiv
-               AND b.aktiv),
-     avvik_antall_timer_vilkar_resultat_og_barnehagebarn
-         AS (SELECT bb.id                                          as barnehagebarn_id,
-                    CASE
-                        WHEN bb.antall_timer_i_barnehage < 33 THEN vr.antall_timer != bb.antall_timer_i_barnehage
-                        ELSE vr.antall_timer <= 33
-                    END as avvik
-             FROM barnehagebarn bb
-                      JOIN personident p ON bb.ident = p.foedselsnummer and p.aktiv
-                      JOIN person_resultat pr ON pr.fk_aktoer_id = p.fk_aktoer_id
-                      JOIN vilkar_resultat vr
-                           ON pr.id = vr.fk_person_resultat_id
-                               AND vr.vilkar = 'BARNEHAGEPLASS'
-                               AND bb.fom = vr.periode_fom::date),
-     vars
-         as (select :ident as ident_param, :kommuneNavn as kommunenavn_param), --Vi referer til disse variablene to ganger så da må de legges inn slik
-     barnehagebarn_visning as (SELECT bb.ident, --Må trekkes ut til egen CTE for at sortering for pageables skal fungere på felter som ikke ligger i barnehagebarn fra før
-                                      bb.fom,
-                                      bb.tom,
-                                      bb.antall_timer_i_barnehage as antallTimerBarnehage,
-                                      bb.endringstype,
-                                      bb.kommune_navn             as kommuneNavn,
-                                      bb.kommune_nr               as kommuneNr,
-                                      MAX(bb.endret_tid)          as endretTid,
-                                      atv.avvik
-                               FROM Barnehagebarn bb
-                                        LEFT JOIN lopende_andel_i_aktiv_behandling_for_ident ila
-                                                  ON bb.ident = ila.foedselsnummer
-                                        LEFT JOIN avvik_antall_timer_vilkar_resultat_og_barnehagebarn atv
-                                                  on bb.id = atv.barnehagebarn_id
-                                        CROSS JOIN vars
-                               WHERE (NOT :kunLøpendeAndeler OR ila.lopende_andel = true)
-                                 AND (vars.ident_param IS NULL OR bb.ident = vars.ident_param)
-                                 AND (vars.kommunenavn_param IS NULL OR bb.kommune_navn ILIKE vars.kommunenavn_param)
-                               GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype,
-                                        bb.kommune_navn, bb.kommune_nr,
-                                        atv.avvik)
-select ident,
+    WITH siste_iverksatte_behandling_i_løpende_fagsak AS (
+    -- Finn nyeste iverksatte behandling med utbetaling for løpende og ikke-arkivert fagsak for barn
+    SELECT f.id AS fagsakid, MAX(b.aktivert_tid) AS aktivert_tid
+    FROM personident p
+             JOIN andel_tilkjent_ytelse aty ON p.fk_aktoer_id = aty.fk_aktoer_id
+             JOIN behandling b ON aty.fk_behandling_id = b.id
+             JOIN fagsak f ON b.fk_fagsak_id = f.id
+             JOIN tilkjent_ytelse ty ON b.id = ty.fk_behandling_id
+    WHERE (:ident IS NULL OR p.foedselsnummer = :ident)
+      AND p.aktiv = true
+      AND f.status = 'LØPENDE'
+      AND f.arkivert = false
+      AND ty.utbetalingsoppdrag IS NOT NULL
+    GROUP BY f.id
+),
+lopende_andel_i_siste_iverksatte_behandling AS (
+    -- Sjekker om barnet har en løpende andel i siste iverksatte behandling 
+    SELECT p.foedselsnummer, aty.stonad_tom + interval '1 month' >= current_date AS lopende_andel
+    FROM personident p
+             JOIN andel_tilkjent_ytelse aty ON p.fk_aktoer_id = aty.fk_aktoer_id
+             JOIN behandling b ON aty.fk_behandling_id = b.id
+             JOIN fagsak f ON b.fk_fagsak_id = f.id
+             JOIN siste_iverksatte_behandling_i_løpende_fagsak sibilf
+                  ON f.id = sibilf.fagsakid
+                  AND b.aktivert_tid = sibilf.aktivert_tid
+    WHERE (:ident IS NULL OR p.foedselsnummer = :ident)
+      AND p.aktiv = true
+),
+avvik_antall_timer_vilkar_resultat_og_barnehagebarn AS (
+    SELECT bb.id as barnehagebarn_id,
+           CASE
+               WHEN bb.antall_timer_i_barnehage < 33
+                   THEN vr.antall_timer != bb.antall_timer_i_barnehage
+               ELSE vr.antall_timer <= 33
+           END as avvik
+    FROM barnehagebarn bb
+             JOIN personident p ON bb.ident = p.foedselsnummer AND p.aktiv
+             JOIN person_resultat pr ON pr.fk_aktoer_id = p.fk_aktoer_id
+             JOIN vilkar_resultat vr
+                  ON pr.id = vr.fk_person_resultat_id
+                      AND vr.vilkar = 'BARNEHAGEPLASS'
+                      AND bb.fom = vr.periode_fom::date
+),
+input_params AS (
+    --Vi referer til disse variablene to ganger så da må de legges inn slik
+    SELECT :ident AS ident_param, :kommuneNavn AS kommunenavn_param
+),
+barnehagebarn_visning AS (
+    --Må trekkes ut til egen CTE for at sortering for pageables skal fungere på felter som ikke ligger i barnehagebarn fra før
+    SELECT bb.ident,
+           bb.fom,
+           bb.tom,
+           bb.antall_timer_i_barnehage AS antallTimerBarnehage,
+           bb.endringstype,
+           bb.kommune_navn AS kommuneNavn,
+           bb.kommune_nr AS kommuneNr,
+           MAX(bb.endret_tid) AS endretTid,
+           atv.avvik
+    FROM barnehagebarn bb
+             LEFT JOIN lopende_andel_i_siste_iverksatte_behandling laisib
+                       ON bb.ident = laisib.foedselsnummer
+             LEFT JOIN avvik_antall_timer_vilkar_resultat_og_barnehagebarn atv
+                       ON bb.id = atv.barnehagebarn_id
+             CROSS JOIN input_params
+    WHERE (NOT :kunLøpendeAndeler OR laisib.lopende_andel = true)
+      AND (input_params.ident_param IS NULL OR bb.ident = input_params.ident_param)
+      AND (input_params.kommunenavn_param IS NULL OR bb.kommune_navn ILIKE input_params.kommunenavn_param)
+    GROUP BY bb.ident, bb.fom, bb.tom, bb.antall_timer_i_barnehage, bb.endringstype,
+             bb.kommune_navn, bb.kommune_nr, atv.avvik
+)
+SELECT ident,
        fom,
        tom,
        antallTimerBarnehage,
@@ -63,8 +90,8 @@ select ident,
        kommuneNr,
        endretTid,
        avvik
-from barnehagebarn_visning;
-""",
+FROM barnehagebarn_visning;     
+ """,
         nativeQuery = true,
     )
     fun finnBarnehagebarn(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
@@ -252,4 +252,28 @@ class BarnehagebarnServiceHentBarnIntegrasjonsTest(
 
         assertThat(barnehagebarn.map { it.ident }).containsExactly("34567890123")
     }
+
+    @Test
+    @Sql(
+        scripts = ["/barnehagelister/barnehagebarn-lopende-andel-i-ikke-aktiv-behandling.sql"],
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+    )
+    fun `hentBarnehageBarn henter barn med løpende andel i behandling som ikke er aktiv`() {
+        // Arrange
+        val params =
+            BarnehagebarnRequestParams(
+                ident = null,
+                kommuneNavn = null,
+                kunLøpendeAndel = true,
+            )
+
+        // Act
+        val barnehagebarn =
+            barnehagebarnService.hentBarnehagebarnForVisning(barnehagebarnRequestParams = params).content
+
+        // Assert
+        assertThat(barnehagebarn.size).`as`("Forventet 1 barn, fikk ${barnehagebarn.size}").isEqualTo(1)
+
+        assertThat(barnehagebarn.map { it.ident }).containsExactly("34567890123")
+    }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnServiceHentBarnIntegrasjonsTest.kt
@@ -228,4 +228,28 @@ class BarnehagebarnServiceHentBarnIntegrasjonsTest(
             .isEqualTo("23456789012")
         assertThat(barnehagebarnSide2.last().ident).`as`("Barn som ble endret nyligst:").isEqualTo("12345678901")
     }
+
+    @Test
+    @Sql(
+        scripts = ["/barnehagelister/barnehagebarn-19mnd-lopende-andel.sql"],
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+    )
+    fun `hentBarnehageBarn henter barn som fyller 19 mnd i inneværende mnd med løpende andel`() {
+        // Arrange
+        val params =
+            BarnehagebarnRequestParams(
+                ident = null,
+                kommuneNavn = null,
+                kunLøpendeAndel = true,
+            )
+
+        // Act
+        val barnehagebarn =
+            barnehagebarnService.hentBarnehagebarnForVisning(barnehagebarnRequestParams = params).content
+
+        // Assert
+        assertThat(barnehagebarn.size).`as`("Forventet 1 barn, fikk ${barnehagebarn.size}").isEqualTo(1)
+
+        assertThat(barnehagebarn.map { it.ident }).containsExactly("34567890123")
+    }
 }

--- a/src/test/resources/barnehagelister/barnehagebarn-19mnd-lopende-andel.sql
+++ b/src/test/resources/barnehagelister/barnehagebarn-19mnd-lopende-andel.sql
@@ -1,0 +1,42 @@
+TRUNCATE TABLE aktoer, personident, po_person, gr_personopplysninger, behandling, fagsak, tilkjent_ytelse, andel_tilkjent_ytelse, person_resultat, vilkar_resultat, barnehagebarn CASCADE;
+
+-- Barn
+INSERT INTO aktoer(aktoer_id) VALUES ('3456');
+
+-- Søker
+INSERT INTO aktoer(aktoer_id) VALUES ('9988');
+
+INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('34567890123', '3456', true);
+INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('99887766554', '9988', true);
+
+INSERT INTO fagsak(id, fk_aktoer_id, status, arkivert) VALUES (10, '9988', 'LØPENDE', false);
+
+INSERT INTO behandling(id, fk_fagsak_id, behandling_type, aktivert_tid, aktiv, kategori, opprettet_aarsak)
+VALUES (10, 10, 'FØRSTEGANGSBEHANDLING', NOW(), true, 'NASJONAL', 'SØKNAD');
+
+INSERT INTO gr_personopplysninger(id, fk_behandling_id) VALUES (10, 10);
+
+INSERT INTO po_person(id, fk_gr_personopplysninger_id, type, fk_aktoer_id ) VALUES (10, 10, 'BARN', '3456');
+INSERT INTO po_person(id, fk_gr_personopplysninger_id, type, fk_aktoer_id ) VALUES (11, 10, 'SØKER', '9988');
+
+INSERT INTO vilkaarsvurdering(id, fk_behandling_id) VALUES (10, 10);
+
+INSERT INTO person_resultat(id, fk_aktoer_id, fk_vilkaarsvurdering_id) VALUES (10, '3456', 10);
+
+INSERT INTO vilkar_resultat(id, vilkar, periode_fom, periode_tom, resultat, fk_person_resultat_id, fk_behandling_id, antall_timer)
+VALUES (10, 'BARNEHAGEPLASS', CURRENT_DATE - INTERVAL '1 month', CURRENT_DATE, 'OPPFYLT', 10, 10, 30);
+
+INSERT INTO tilkjent_ytelse(id, fk_behandling_id, opprettet_dato, utbetalingsoppdrag) VALUES (10, 10, CURRENT_TIMESTAMP, '{}');
+
+INSERT INTO andel_tilkjent_ytelse(id, fk_behandling_id, tilkjent_ytelse_id, fk_aktoer_id, kalkulert_utbetalingsbelop,stonad_fom, stonad_tom, type, sats, prosent
+) VALUES (10, 10, 10, '3456', 100,CURRENT_TIMESTAMP - INTERVAL '3 month', DATE_TRUNC('month', CURRENT_DATE), 'ORDINÆR_KONTANTSTØTTE', 100, 100);
+
+-- Barnehagebarn
+INSERT INTO barnehagebarn(
+    id, ident, fom, tom, antall_timer_i_barnehage, kommune_navn, kommune_nr, arkiv_referanse, endret_tid
+) VALUES (
+             'c7de9709-7817-4f3e-a822-5d4ca49a6914', '34567890123',
+             CURRENT_DATE - INTERVAL '1 month',
+             CURRENT_DATE + INTERVAL '1 month',
+             30, 'Oslo', '1', '5555', CURRENT_TIMESTAMP
+         );

--- a/src/test/resources/barnehagelister/barnehagebarn-lopende-andel-i-ikke-aktiv-behandling.sql
+++ b/src/test/resources/barnehagelister/barnehagebarn-lopende-andel-i-ikke-aktiv-behandling.sql
@@ -1,0 +1,42 @@
+TRUNCATE TABLE aktoer, personident, po_person, gr_personopplysninger, behandling, fagsak, tilkjent_ytelse, andel_tilkjent_ytelse, person_resultat, vilkar_resultat, barnehagebarn CASCADE;
+
+-- Barn
+INSERT INTO aktoer(aktoer_id) VALUES ('1234');
+
+-- Søker
+INSERT INTO aktoer(aktoer_id) VALUES ('9988');
+
+INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('34567890123', '1234', true);
+INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('99887766554', '9988', true);
+
+INSERT INTO fagsak(id, fk_aktoer_id, status, arkivert) VALUES (10, '9988', 'LØPENDE', false);
+
+INSERT INTO behandling(id, fk_fagsak_id, behandling_type, aktivert_tid, aktiv, kategori, opprettet_aarsak)
+VALUES (10, 10, 'FØRSTEGANGSBEHANDLING', NOW(), false, 'NASJONAL', 'SØKNAD');
+
+INSERT INTO gr_personopplysninger(id, fk_behandling_id) VALUES (10, 10);
+
+INSERT INTO po_person(id, fk_gr_personopplysninger_id, type, fk_aktoer_id ) VALUES (10, 10, 'BARN', '1234');
+INSERT INTO po_person(id, fk_gr_personopplysninger_id, type, fk_aktoer_id ) VALUES (11, 10, 'SØKER', '9988');
+
+INSERT INTO vilkaarsvurdering(id, fk_behandling_id) VALUES (10, 10);
+
+INSERT INTO person_resultat(id, fk_aktoer_id, fk_vilkaarsvurdering_id) VALUES (10, '1234', 10);
+
+INSERT INTO vilkar_resultat(id, vilkar, periode_fom, periode_tom, resultat, fk_person_resultat_id, fk_behandling_id, antall_timer)
+VALUES (10, 'BARNEHAGEPLASS', CURRENT_DATE - INTERVAL '1 month', CURRENT_DATE, 'OPPFYLT', 10, 10, 30);
+
+INSERT INTO tilkjent_ytelse(id, fk_behandling_id, opprettet_dato, utbetalingsoppdrag) VALUES (10, 10, CURRENT_TIMESTAMP, '{}');
+
+INSERT INTO andel_tilkjent_ytelse(id, fk_behandling_id, tilkjent_ytelse_id, fk_aktoer_id, kalkulert_utbetalingsbelop,stonad_fom, stonad_tom, type, sats, prosent
+) VALUES (10, 10, 10, '1234', 100,CURRENT_TIMESTAMP - INTERVAL '3 month', DATE_TRUNC('month', CURRENT_DATE), 'ORDINÆR_KONTANTSTØTTE', 100, 100);
+
+-- Barnehagebarn
+INSERT INTO barnehagebarn(
+    id, ident, fom, tom, antall_timer_i_barnehage, kommune_navn, kommune_nr, arkiv_referanse, endret_tid
+) VALUES (
+             'c7de9709-7817-4f3e-a822-5d4ca49a6914', '34567890123',
+             CURRENT_DATE - INTERVAL '1 month',
+             CURRENT_DATE + INTERVAL '1 month',
+             30, 'Oslo', '1', '5555', CURRENT_TIMESTAMP
+         );

--- a/src/test/resources/barnehagelister/barnehagebarn-med-løpende-andeler.sql
+++ b/src/test/resources/barnehagelister/barnehagebarn-med-løpende-andeler.sql
@@ -11,7 +11,7 @@ INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('123456789
 INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('23456789012', '2345', true);
 INSERT INTO personident (foedselsnummer, fk_aktoer_id, aktiv) VALUES ('90123456789', '9876', true);
 
-INSERT INTO fagsak(id, fk_aktoer_id) VALUES (1, '9876');
+INSERT INTO fagsak(id, fk_aktoer_id, status, arkivert) VALUES (1, '9876', 'LØPENDE', false);
 
 INSERT INTO behandling(id, fk_fagsak_id, behandling_type, aktivert_tid, aktiv, kategori, opprettet_aarsak) VALUES (1, 1, 'FØRSTEGANGSBEHANDLING', NOW(), true, 'NASJONAL', 'SØKNAD');
 
@@ -29,7 +29,7 @@ INSERT INTO person_resultat(id, fk_aktoer_id, fk_vilkaarsvurdering_id) VALUES (2
 INSERT INTO vilkar_resultat(id, vilkar, periode_fom, periode_tom, resultat, fk_person_resultat_id, fk_behandling_id, antall_timer) VALUES (1, 'BARNEHAGEPLASS', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '2 months', 'OPPFYLT', 1, 1, 30);
 INSERT INTO vilkar_resultat(id, vilkar, periode_fom, periode_tom, resultat, fk_person_resultat_id, fk_behandling_id, antall_timer) VALUES (2, 'BARNEHAGEPLASS', CURRENT_TIMESTAMP - INTERVAL '3 months', CURRENT_TIMESTAMP - INTERVAL '1 months', 'OPPFYLT', 2, 1, 30);
 
-INSERT INTO tilkjent_ytelse(id, fk_behandling_id, opprettet_dato) VALUES (1, 1, CURRENT_TIMESTAMP);
+INSERT INTO tilkjent_ytelse(id, fk_behandling_id, opprettet_dato, utbetalingsoppdrag) VALUES (1, 1, CURRENT_TIMESTAMP, '{}');
 
 INSERT INTO andel_tilkjent_ytelse(id, fk_behandling_id, tilkjent_ytelse_id, fk_aktoer_id, kalkulert_utbetalingsbelop, stonad_fom, stonad_tom, type, sats, prosent) VALUES (1, 1, 1, '1234', 100, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '2 months', 'ORDINÆR_KONTANTSTØTTE', 100, 100);
 INSERT INTO andel_tilkjent_ytelse(id, fk_behandling_id, tilkjent_ytelse_id, fk_aktoer_id, kalkulert_utbetalingsbelop, stonad_fom, stonad_tom, type, sats, prosent) VALUES (2, 1, 1, '2345', 100, CURRENT_TIMESTAMP - INTERVAL '3 months', CURRENT_TIMESTAMP - INTERVAL '1 months', 'ORDINÆR_KONTANTSTØTTE', 100, 100);


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26158)

### 💰 Hva skal gjøres, og hvorfor?
Endrer filtrering for barn med løpende utbetalinger i barnehagelister. Tidligere ble det filtrert på aktiv behandling, men ved opprettelse av f.eks. revurdering ble ikke behandlingen med løpende utbetaling fanget opp, og barnet falt ut av filtreringen "kun løpende utbetalinger". Spørringen er nå endret til å filtrere på siste iverksatte behandling i løpende og ikke-arkivert fagsak med utbetalingsoppdrag.

For å finne ut om barnet har løpende andeler, sjekkes om det finnes stonad_tom >= dagens dato i andel tilkjent ytelse. Siden stonad_tom blir satt til første dag i måneden, er det lagt til èn måned i sjekken slik at SB kan gå gjennom listen for inneværende måned.
 
### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
