### PR TITLE
NAV-26466: Filtrer bort urelevante manglende perioder for svalbard merking

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
@@ -12,9 +12,12 @@ import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.beskjærEtter
 import no.nav.familie.tidslinje.tilTidslinje
+import no.nav.familie.tidslinje.utvidelser.klipp
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.time.LocalDate
+
+private val cutOffDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 9, 1)
 
 data class ManglendeSvalbardmerkingDto(
     val ident: String,
@@ -53,7 +56,8 @@ fun List<Person>?.tilManglendeSvalbardmerkingDto(personResultater: Set<PersonRes
                         !bosattIRiketVilkår.utdypendeVilkårsvurderinger.contains(
                             UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD,
                         )
-                }.tilPerioderIkkeNull()
+                }.klipp(cutOffDatoForVisningAvManglendeMerkinger)
+                .tilPerioderIkkeNull()
                 .filter { it.verdi }
                 .map { ManglendeSvalbardmerkingPeriodeDto(fom = it.fom, tom = it.tom) }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26466

Ønsker å vise kun perioder som har en fom dato som er fra og med 01.09.2025. Om det ikke finnes en fom dato så sjekker vi om tom datoen er lik eller senere 01.09.2025, men burde vel i teorien ikke skje pga. periodesplitter.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
