### PR TITLE
NAV-26466: Filtrer bort perioder med tom-dato som er før cut off datoen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
@@ -17,7 +17,7 @@ import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.time.LocalDate
 
-private val cutOffTomDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 9, 1)
+private val cutOffTomDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 10, 1)
 
 data class ManglendeSvalbardmerkingDto(
     val ident: String,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
@@ -11,13 +11,13 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadre
 import no.nav.familie.tidslinje.Periode
 import no.nav.familie.tidslinje.Tidslinje
 import no.nav.familie.tidslinje.beskjærEtter
+import no.nav.familie.tidslinje.isSameOrAfter
 import no.nav.familie.tidslinje.tilTidslinje
-import no.nav.familie.tidslinje.utvidelser.klipp
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.time.LocalDate
 
-private val cutOffDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 9, 1)
+private val cutOffTomDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 9, 1)
 
 data class ManglendeSvalbardmerkingDto(
     val ident: String,
@@ -56,8 +56,8 @@ fun List<Person>?.tilManglendeSvalbardmerkingDto(personResultater: Set<PersonRes
                         !bosattIRiketVilkår.utdypendeVilkårsvurderinger.contains(
                             UtdypendeVilkårsvurdering.BOSATT_PÅ_SVALBARD,
                         )
-                }.klipp(cutOffDatoForVisningAvManglendeMerkinger)
-                .tilPerioderIkkeNull()
+                }.tilPerioderIkkeNull()
+                .filter { it.tom == null || it.tom!!.isSameOrAfter(cutOffTomDatoForVisningAvManglendeMerkinger) }
                 .filter { it.verdi }
                 .map { ManglendeSvalbardmerkingPeriodeDto(fom = it.fom, tom = it.tom) }
 

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -117,8 +117,11 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonEnkel
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.arbeidsforhold.GrArbeidsforhold
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.bostedsadresse.GrBostedsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.dødsfall.Dødsfall
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.opphold.GrOpphold
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.oppholdsadresse.GrOppholdsadresse
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.sivilstand.GrSivilstand
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.statsborgerskap.GrStatsborgerskap
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
@@ -451,6 +454,44 @@ fun lagAndelTilkjentYtelse(
     kildeBehandlingId = behandling.id,
     differanseberegnetPeriodebeløp = differanseberegnetPeriodebeløp,
 )
+
+fun lagPerson(
+    id: Long = 0,
+    type: PersonType = PersonType.SØKER,
+    fødselsdato: LocalDate = LocalDate.now().minusYears(19),
+    navn: String = PersonType.SØKER.name,
+    kjønn: Kjønn = Kjønn.KVINNE,
+    målform: Målform = Målform.NB,
+    personopplysningGrunnlag: PersonopplysningGrunnlag,
+    aktør: Aktør = randomAktør(),
+    bostedsadresser: (person: Person) -> List<GrBostedsadresse> = { listOf() },
+    oppholdsadresser: (person: Person) -> List<GrOppholdsadresse> = { listOf() },
+    statsborgerskap: (person: Person) -> List<GrStatsborgerskap> = { listOf() },
+    opphold: (person: Person) -> List<GrOpphold> = { listOf() },
+    arbeidsforhold: (person: Person) -> List<GrArbeidsforhold> = { listOf() },
+    sivilstander: (person: Person) -> List<GrSivilstand> = { listOf() },
+    dødsfall: Dødsfall? = null,
+): Person {
+    val person =
+        Person(
+            id = id,
+            type = type,
+            fødselsdato = fødselsdato,
+            navn = navn,
+            kjønn = kjønn,
+            målform = målform,
+            personopplysningGrunnlag = personopplysningGrunnlag,
+            aktør = aktør,
+            dødsfall = dødsfall,
+        )
+    person.bostedsadresser.addAll(bostedsadresser(person))
+    person.oppholdsadresser.addAll(oppholdsadresser(person))
+    person.statsborgerskap.addAll(statsborgerskap(person))
+    person.opphold.addAll(opphold(person))
+    person.arbeidsforhold.addAll(arbeidsforhold(person))
+    person.sivilstander.addAll(sivilstander(person))
+    return person
+}
 
 fun lagPerson(
     personopplysningGrunnlag: PersonopplysningGrunnlag = mockk(relaxed = true),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ks.sak.common.entitet.DatoIntervallEntitet
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonResultat
+import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.lagVilkårsvurdering
 import no.nav.familie.ks.sak.data.no.nav.familie.ks.sak.datagenerator.lagGrMatrikkelOppholdsadresse
@@ -272,125 +273,360 @@ class ManglendeSvalbardmerkingDtoTest {
         }
 
         @Test
-        fun `skal beskjære perioder som begynner før første september 2025 slik at fom er første september 2025`() {
+        fun `skal ikke vise perioder som slutter før første september 2025`() {
             // Arrange
-            val bosattPåSvalbardPeriode = DatoIntervallEntitet(fom = LocalDate.of(2025, 8, 31), tom = null)
+            val behandling = lagBehandling()
+            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
 
             val søker =
-                lagPerson(personType = PersonType.SØKER).also {
-                    it.oppholdsadresser =
-                        mutableListOf(
+                lagPerson(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    type = PersonType.SØKER,
+                    fødselsdato = LocalDate.of(1980, 1, 1),
+                    oppholdsadresser = {
+                        listOf(
                             lagGrVegadresseOppholdsadresse(
                                 kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
-                                periode = bosattPåSvalbardPeriode,
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(1980, 1, 1),
+                                        tom = LocalDate.of(2025, 8, 31),
+                                    ),
+                            ),
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = "0301",
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(2025, 9, 1),
+                                        tom = null,
+                                    ),
                             ),
                         )
-                }
+                    },
+                )
+            personopplysningGrunnlag.personer.add(søker)
 
-            val barn1 =
-                lagPerson(personType = PersonType.BARN).also {
-                    it.oppholdsadresser =
-                        mutableListOf(
-                            lagGrMatrikkelOppholdsadresse(
+            val barn =
+                lagPerson(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    type = PersonType.BARN,
+                    fødselsdato = LocalDate.of(2015, 1, 1),
+                    oppholdsadresser = {
+                        listOf(
+                            lagGrVegadresseOppholdsadresse(
                                 kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
-                                periode = bosattPåSvalbardPeriode,
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(2015, 1, 1),
+                                        tom = LocalDate.of(2025, 8, 31),
+                                    ),
+                            ),
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = "0301",
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(2025, 9, 1),
+                                        tom = null,
+                                    ),
                             ),
                         )
-                }
-
-            val barn2 =
-                lagPerson(personType = PersonType.BARN).also {
-                    it.oppholdsadresser =
-                        mutableListOf(
-                            lagGrUtenlandskOppholdsadresse(
-                                oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
-                                periode = bosattPåSvalbardPeriode,
-                            ),
-                        )
-                }
-
-            val barn3 =
-                lagPerson(personType = PersonType.BARN).also {
-                    it.oppholdsadresser =
-                        mutableListOf(
-                            lagGrUkjentAdresseOppholdsadresse(
-                                oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD,
-                                periode = bosattPåSvalbardPeriode,
-                            ),
-                        )
-                }
-            val behandling = lagBehandling()
+                    },
+                )
+            personopplysningGrunnlag.personer.add(barn)
 
             val vilkårsvurdering =
-                lagVilkårsvurdering(behandling = behandling, lagPersonResultat = { vilkårsvurdering ->
-                    setOf(
-                        lagPersonResultat(
-                            vilkårsvurdering = vilkårsvurdering,
-                            aktør = søker.aktør,
-                            lagVilkårResultater = { personResultat ->
-                                setOf(
-                                    lagBosattIRiketVilkårForPersonResultat(
-                                        personResultat = personResultat,
-                                        behandling = behandling,
-                                        periode = bosattPåSvalbardPeriode,
-                                    ),
-                                )
-                            },
-                        ),
-                        lagPersonResultat(
-                            vilkårsvurdering = vilkårsvurdering,
-                            aktør = barn1.aktør,
-                            lagVilkårResultater = { personResultat ->
-                                setOf(
-                                    lagBosattIRiketVilkårForPersonResultat(
-                                        personResultat = personResultat,
-                                        behandling = behandling,
-                                        periode = bosattPåSvalbardPeriode,
-                                    ),
-                                )
-                            },
-                        ),
-                        lagPersonResultat(
-                            vilkårsvurdering = vilkårsvurdering,
-                            aktør = barn2.aktør,
-                            lagVilkårResultater = { personResultat ->
-                                setOf(
-                                    lagBosattIRiketVilkårForPersonResultat(
-                                        personResultat = personResultat,
-                                        behandling = behandling,
-                                        periode = bosattPåSvalbardPeriode,
-                                    ),
-                                )
-                            },
-                        ),
-                        lagPersonResultat(
-                            vilkårsvurdering = vilkårsvurdering,
-                            aktør = barn3.aktør,
-                            lagVilkårResultater = { personResultat ->
-                                setOf(
-                                    lagBosattIRiketVilkårForPersonResultat(
-                                        personResultat = personResultat,
-                                        behandling = behandling,
-                                        periode = bosattPåSvalbardPeriode,
-                                    ),
-                                )
-                            },
-                        ),
-                    )
-                })
+                lagVilkårsvurdering(
+                    behandling = behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = søker.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(1980, 1, 1),
+                                                    tom = LocalDate.of(2025, 8, 31),
+                                                ),
+                                            utdypendeVilkårsvurderinger = emptyList(),
+                                        ),
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(2025, 9, 1),
+                                                    tom = null,
+                                                ),
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = barn.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(2015, 1, 1),
+                                                    tom = LocalDate.of(2025, 8, 31),
+                                                ),
+                                            utdypendeVilkårsvurderinger = emptyList(),
+                                        ),
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(2025, 9, 1),
+                                                    tom = null,
+                                                ),
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
 
-            val personer = listOf(søker, barn1, barn2, barn3)
+            val personer = listOf(søker, barn)
 
             // Act
-            val manglendeSvalbardmerking =
-                personer.tilManglendeSvalbardmerkingDto(personResultater = vilkårsvurdering.personResultater)
+            val manglendeSvalbardmerking = personer.tilManglendeSvalbardmerkingDto(personResultater = vilkårsvurdering.personResultater)
 
             // Assert
-            assertThat(manglendeSvalbardmerking).hasSize(4)
-            assertThat(manglendeSvalbardmerking).allSatisfy {
+            assertThat(manglendeSvalbardmerking).isEmpty()
+        }
+
+        @Test
+        fun `skal vise perioder som har fom dato før første september 2025 hvor tom dato er null`() {
+            // Arrange
+            val behandling = lagBehandling()
+            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+
+            val søker =
+                lagPerson(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    type = PersonType.SØKER,
+                    fødselsdato = LocalDate.of(1980, 1, 1),
+                    oppholdsadresser = {
+                        listOf(
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(1980, 1, 1),
+                                        tom = null,
+                                    ),
+                            ),
+                        )
+                    },
+                )
+            personopplysningGrunnlag.personer.add(søker)
+
+            val barn =
+                lagPerson(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    type = PersonType.BARN,
+                    fødselsdato = LocalDate.of(2015, 1, 1),
+                    oppholdsadresser = {
+                        listOf(
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(2015, 1, 1),
+                                        tom = null,
+                                    ),
+                            ),
+                        )
+                    },
+                )
+            personopplysningGrunnlag.personer.add(barn)
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = søker.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(1980, 1, 1),
+                                                    tom = null,
+                                                ),
+                                            utdypendeVilkårsvurderinger = emptyList(),
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = barn.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(2015, 1, 1),
+                                                    tom = null,
+                                                ),
+                                            utdypendeVilkårsvurderinger = emptyList(),
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            val personer = listOf(søker, barn)
+
+            // Act
+            val manglendeSvalbardmerking = personer.tilManglendeSvalbardmerkingDto(personResultater = vilkårsvurdering.personResultater)
+
+            // Assert
+            assertThat(manglendeSvalbardmerking).hasSize(2)
+            assertThat(manglendeSvalbardmerking).anySatisfy {
+                assertThat(it.ident).isEqualTo(søker.aktør.aktivFødselsnummer())
                 assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
-                assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(2025, 9, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(1980, 1, 1))
                 assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isNull()
+            }
+            assertThat(manglendeSvalbardmerking).anySatisfy {
+                assertThat(it.ident).isEqualTo(barn.aktør.aktivFødselsnummer())
+                assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(2015, 1, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isNull()
+            }
+        }
+
+        @Test
+        fun `skal vise perioder som har tom dato lik første september 2025`() {
+            // Arrange
+            val behandling = lagBehandling()
+            val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+
+            val søker =
+                lagPerson(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    type = PersonType.SØKER,
+                    fødselsdato = LocalDate.of(1980, 1, 1),
+                    oppholdsadresser = {
+                        listOf(
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(1980, 1, 1),
+                                        tom = LocalDate.of(2025, 9, 1),
+                                    ),
+                            ),
+                        )
+                    },
+                )
+            personopplysningGrunnlag.personer.add(søker)
+
+            val barn =
+                lagPerson(
+                    personopplysningGrunnlag = personopplysningGrunnlag,
+                    type = PersonType.BARN,
+                    fødselsdato = LocalDate.of(2015, 1, 1),
+                    oppholdsadresser = {
+                        listOf(
+                            lagGrVegadresseOppholdsadresse(
+                                kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
+                                periode =
+                                    DatoIntervallEntitet(
+                                        fom = LocalDate.of(2015, 1, 1),
+                                        tom = LocalDate.of(2025, 9, 1),
+                                    ),
+                            ),
+                        )
+                    },
+                )
+            personopplysningGrunnlag.personer.add(barn)
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = søker.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(1980, 1, 1),
+                                                    tom = LocalDate.of(2025, 9, 1),
+                                                ),
+                                            utdypendeVilkårsvurderinger = emptyList(),
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                vilkårsvurdering = it,
+                                aktør = barn.aktør,
+                                lagVilkårResultater = { personResultat ->
+                                    setOf(
+                                        lagBosattIRiketVilkårForPersonResultat(
+                                            personResultat = personResultat,
+                                            behandling = behandling,
+                                            periode =
+                                                DatoIntervallEntitet(
+                                                    fom = LocalDate.of(2015, 1, 1),
+                                                    tom = LocalDate.of(2025, 9, 1),
+                                                ),
+                                            utdypendeVilkårsvurderinger = emptyList(),
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            val personer = listOf(søker, barn)
+
+            // Act
+            val manglendeSvalbardmerking = personer.tilManglendeSvalbardmerkingDto(personResultater = vilkårsvurdering.personResultater)
+
+            // Assert
+            assertThat(manglendeSvalbardmerking).hasSize(2)
+            assertThat(manglendeSvalbardmerking).anySatisfy {
+                assertThat(it.ident).isEqualTo(søker.aktør.aktivFødselsnummer())
+                assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(1980, 1, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 9, 1))
+            }
+            assertThat(manglendeSvalbardmerking).anySatisfy {
+                assertThat(it.ident).isEqualTo(barn.aktør.aktivFødselsnummer())
+                assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(2015, 1, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 9, 1))
             }
         }
 
@@ -406,7 +642,7 @@ class ManglendeSvalbardmerkingDtoTest {
                 vilkårType = Vilkår.BOSATT_I_RIKET,
                 resultat = Resultat.OPPFYLT,
                 periodeFom = periode.fom,
-                periodeTom = null,
+                periodeTom = periode.tom,
                 begrunnelse = "",
                 utdypendeVilkårsvurderinger = utdypendeVilkårsvurderinger,
             )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
@@ -273,7 +273,7 @@ class ManglendeSvalbardmerkingDtoTest {
         }
 
         @Test
-        fun `skal ikke vise perioder som slutter før første september 2025`() {
+        fun `skal ikke vise perioder som slutter før første oktober 2025`() {
             // Arrange
             val behandling = lagBehandling()
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
@@ -290,14 +290,14 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(1980, 1, 1),
-                                        tom = LocalDate.of(2025, 8, 31),
+                                        tom = LocalDate.of(2025, 9, 30),
                                     ),
                             ),
                             lagGrVegadresseOppholdsadresse(
                                 kommunenummer = "0301",
                                 periode =
                                     DatoIntervallEntitet(
-                                        fom = LocalDate.of(2025, 9, 1),
+                                        fom = LocalDate.of(2025, 10, 1),
                                         tom = null,
                                     ),
                             ),
@@ -318,14 +318,14 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(2015, 1, 1),
-                                        tom = LocalDate.of(2025, 8, 31),
+                                        tom = LocalDate.of(2025, 9, 30),
                                     ),
                             ),
                             lagGrVegadresseOppholdsadresse(
                                 kommunenummer = "0301",
                                 periode =
                                     DatoIntervallEntitet(
-                                        fom = LocalDate.of(2025, 9, 1),
+                                        fom = LocalDate.of(2025, 10, 1),
                                         tom = null,
                                     ),
                             ),
@@ -350,7 +350,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(1980, 1, 1),
-                                                    tom = LocalDate.of(2025, 8, 31),
+                                                    tom = LocalDate.of(2025, 9, 30),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -359,7 +359,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             behandling = behandling,
                                             periode =
                                                 DatoIntervallEntitet(
-                                                    fom = LocalDate.of(2025, 9, 1),
+                                                    fom = LocalDate.of(2025, 10, 1),
                                                     tom = null,
                                                 ),
                                         ),
@@ -377,7 +377,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(2015, 1, 1),
-                                                    tom = LocalDate.of(2025, 8, 31),
+                                                    tom = LocalDate.of(2025, 9, 30),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -386,7 +386,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             behandling = behandling,
                                             periode =
                                                 DatoIntervallEntitet(
-                                                    fom = LocalDate.of(2025, 9, 1),
+                                                    fom = LocalDate.of(2025, 10, 1),
                                                     tom = null,
                                                 ),
                                         ),
@@ -407,7 +407,7 @@ class ManglendeSvalbardmerkingDtoTest {
         }
 
         @Test
-        fun `skal vise perioder som har fom dato før første september 2025 hvor tom dato er null`() {
+        fun `skal vise perioder som har fom dato før første oktober 2025 hvor tom dato er null`() {
             // Arrange
             val behandling = lagBehandling()
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
@@ -519,7 +519,7 @@ class ManglendeSvalbardmerkingDtoTest {
         }
 
         @Test
-        fun `skal vise perioder som har tom dato lik første september 2025`() {
+        fun `skal vise perioder som har tom dato lik første oktober 2025`() {
             // Arrange
             val behandling = lagBehandling()
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
@@ -536,7 +536,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(1980, 1, 1),
-                                        tom = LocalDate.of(2025, 9, 1),
+                                        tom = LocalDate.of(2025, 10, 1),
                                     ),
                             ),
                         )
@@ -556,7 +556,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(2015, 1, 1),
-                                        tom = LocalDate.of(2025, 9, 1),
+                                        tom = LocalDate.of(2025, 10, 1),
                                     ),
                             ),
                         )
@@ -580,7 +580,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(1980, 1, 1),
-                                                    tom = LocalDate.of(2025, 9, 1),
+                                                    tom = LocalDate.of(2025, 10, 1),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -598,7 +598,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(2015, 1, 1),
-                                                    tom = LocalDate.of(2025, 9, 1),
+                                                    tom = LocalDate.of(2025, 10, 1),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -620,13 +620,13 @@ class ManglendeSvalbardmerkingDtoTest {
                 assertThat(it.ident).isEqualTo(søker.aktør.aktivFødselsnummer())
                 assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
                 assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(1980, 1, 1))
-                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 9, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 10, 1))
             }
             assertThat(manglendeSvalbardmerking).anySatisfy {
                 assertThat(it.ident).isEqualTo(barn.aktør.aktivFødselsnummer())
                 assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
                 assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(2015, 1, 1))
-                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 9, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 10, 1))
             }
         }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro:  https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26466

Ønsker nå å kun vise perioder som ikke har en tom dato som er før 01.10.2025.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
