### PR TITLE
Legge på isLeader for å kun sende epost fra en pod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.ks.sak.barnehagelister.domene.BarnehagebarnRepository
 import no.nav.familie.ks.sak.barnehagelister.epost.EpostService
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.leader.LeaderClient
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -19,7 +20,10 @@ class BarnehagelisteVarslingService(
 ) {
     @Scheduled(cron = "0 0 6 * * ?")
     @Transactional
-    fun sendVarlingOmBarnehagelisteHverMorgenKl6() {
+    fun sendVarslingOmBarnehagelisteHverMorgenKl6() {
+        if (LeaderClient.isLeader() != true) {
+            return
+        }
         sendVarslingOmNyBarnehagelisteTilEnhet()
     }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26430

Vi sender epost om barnehagelister to ganger, tror det skylder at det er flere pods som kjører scheduled funksjon. Har lagt på en isLeader sjekk, for å kutte det ned til en. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
_Er det noe du er usikker på eller ønsker å diskutere? Beskriv det gjerne her eller kommenter koden det gjelder._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

Fant ingen god måte å teste det på, vil sjekke loggene imorgen om den kjøres 1 eller to ganger.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
