### PR TITLE
flytt-transactional-til-minste-mulige-scope

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
@@ -61,7 +61,6 @@ class BarnehagebarnService(
 
     fun hentAlleKommuner(): Set<String> = barnehagebarnRepository.hentAlleKommuner()
 
-    @Transactional
     fun finnKommunerSendtInnSisteDøgn(): Set<KommuneEllerBydel> {
         val barnSendtInnSisteDøgn =
             barnehagebarnRepository

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagebarnService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class BarnehagebarnService(
@@ -59,4 +60,13 @@ class BarnehagebarnService(
     }
 
     fun hentAlleKommuner(): Set<String> = barnehagebarnRepository.hentAlleKommuner()
+
+    @Transactional
+    fun finnKommunerSendtInnSisteDøgn(): Set<KommuneEllerBydel> {
+        val barnSendtInnSisteDøgn =
+            barnehagebarnRepository
+                .findAll()
+                .filter { it.endretTidspunkt >= LocalDateTime.now().minusDays(1) }
+        return barnSendtInnSisteDøgn.map { KommuneEllerBydel(it.kommuneNr, it.kommuneNavn) }.toSet()
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingService.kt
@@ -14,12 +14,11 @@ import java.time.LocalDateTime
 
 @Service
 class BarnehagelisteVarslingService(
-    val barnehageBarnRepository: BarnehagebarnRepository,
+    val barnehageBarnService: BarnehagebarnService,
     val epostService: EpostService,
     val geografiService: GeografiHierarkiService,
 ) {
     @Scheduled(cron = "0 0 6 * * ?")
-    @Transactional
     fun sendVarslingOmBarnehagelisteHverMorgenKl6() {
         if (LeaderClient.isLeader() != true) {
             return
@@ -34,7 +33,7 @@ class BarnehagelisteVarslingService(
         logger.info("Sjekker om det er kommet inn barnehagelister ila siste døgn.")
 
         val enhetTilFylkeMap = hentEnhetTilFylkeMap()
-        val kommunerSendtForFørsteGangSisteDøgn = finnKommunerSendtInnSisteDøgn()
+        val kommunerSendtForFørsteGangSisteDøgn = barnehageBarnService.finnKommunerSendtInnSisteDøgn()
         val enheterSomSkalVarslesTilKommuner =
             kommunerSendtForFørsteGangSisteDøgn.groupBy { hentAnsvarligEnhetForKommuneEllerBydel(enhetTilFylkeMap, it.nummer) }
 
@@ -54,15 +53,6 @@ class BarnehagelisteVarslingService(
                     }
                 }
         }
-    }
-
-    // Bruker kommuneNr i stedet for kommunenavn siden det er mindre mulighet for feilskriving
-    private fun finnKommunerSendtInnSisteDøgn(): Set<KommuneEllerBydel> {
-        val barnSendtInnSisteDøgn =
-            barnehageBarnRepository
-                .findAll()
-                .filter { it.endretTidspunkt >= LocalDateTime.now().minusDays(1) }
-        return barnSendtInnSisteDøgn.map { KommuneEllerBydel(it.kommuneNr, it.kommuneNavn) }.toSet()
     }
 
     private fun hentEnhetTilFylkeMap(): Map<String, Set<String>> {
@@ -93,7 +83,7 @@ class BarnehagelisteVarslingService(
     }
 }
 
-private data class KommuneEllerBydel(
+data class KommuneEllerBydel(
     val nummer: String,
     val navn: String,
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingService.kt
@@ -2,15 +2,12 @@ package no.nav.familie.ks.sak.barnehagelister
 
 import com.fasterxml.jackson.core.type.TypeReference
 import no.nav.familie.kontrakter.felles.objectMapper
-import no.nav.familie.ks.sak.barnehagelister.domene.BarnehagebarnRepository
 import no.nav.familie.ks.sak.barnehagelister.epost.EpostService
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.leader.LeaderClient
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 class BarnehagelisteVarslingService(

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingServiceIntegrasjonsTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/barnehagelister/BarnehagelisteVarslingServiceIntegrasjonsTest.kt
@@ -16,12 +16,20 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDateTime
 
 class BarnehagelisteVarslingServiceIntegrasjonsTest(
-    @Autowired private val barnehageBarnRepository: BarnehagebarnRepository,
+    @Autowired private val barnehagebarnRepository: BarnehagebarnRepository,
 ) : OppslagSpringRunnerTest() {
+    private val barnehageBarnService =
+        BarnehagebarnService(
+            barnehagebarnRepository = barnehagebarnRepository,
+            andelTilkjentYtelseRepository = mockk(),
+            fagsakRepository = mockk(),
+            behandlingRepository = mockk(),
+            vilkårsvurderingService = mockk(),
+        )
     private val epostService = mockk<EpostService>()
     private val geografiHierarkiService = mockk<GeografiHierarkiService>()
     private val barnehagelisteVarslingService =
-        BarnehagelisteVarslingService(barnehageBarnRepository, epostService, geografiHierarkiService)
+        BarnehagelisteVarslingService(barnehageBarnService, epostService, geografiHierarkiService)
 
     @BeforeEach
     fun setup() {
@@ -72,7 +80,7 @@ class BarnehagelisteVarslingServiceIntegrasjonsTest(
                 kommuneNr = "0302",
                 kommuneNavn = "Grünerløkka",
             )
-        barnehageBarnRepository.saveAll(
+        barnehagebarnRepository.saveAll(
             listOf(
                 barnehageBarnSendtIGår,
                 barnehageBarnSendtIGårMedSammeKommuneSomIDag,
@@ -110,7 +118,7 @@ class BarnehagelisteVarslingServiceIntegrasjonsTest(
                 kommuneNavn = "Gamle Oslo",
             )
 
-        barnehageBarnRepository.saveAll(
+        barnehagebarnRepository.saveAll(
             listOf(
                 barnehagebarnSendtForMerEnnEttDøgnSiden,
             ),


### PR DESCRIPTION
Flytt metode for å hente kommuner det har blitt sendt inn barn for til service og legg transactional på den metoden i stedet for å wrappe en hel klasse i én transaksjon

### 💰 Hva skal gjøres, og hvorfor?
Etter tips fra Thomas burde Schedeuled og Transactional ikke ligge på samme metode. Ref https://stackoverflow.com/questions/18399006/spring-transactional-scheduled-method-throws-transactionexception

Gir også ikke mening å ha Transactional så høyt oppe når det kun gjøres ett databasekall og man enkelt kan wrappe den metoden i Transactional i stedet.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
