### PR TITLE
NAV-26605: Endrer dato fra 01.10.2025 til 30.09.2025 da man får innvilget tillegg for perioder som slutter den 30.09.2025

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDto.kt
@@ -17,7 +17,7 @@ import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
 import java.time.LocalDate
 
-private val cutOffTomDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 10, 1)
+private val cutOffTomDatoForVisningAvManglendeMerkinger = LocalDate.of(2025, 9, 30)
 
 data class ManglendeSvalbardmerkingDto(
     val ident: String,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManglendeSvalbardmerkingDtoTest.kt
@@ -273,7 +273,7 @@ class ManglendeSvalbardmerkingDtoTest {
         }
 
         @Test
-        fun `skal ikke vise perioder som slutter før første oktober 2025`() {
+        fun `skal ikke vise perioder som slutter før 30 september 2025`() {
             // Arrange
             val behandling = lagBehandling()
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
@@ -290,14 +290,14 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(1980, 1, 1),
-                                        tom = LocalDate.of(2025, 9, 30),
+                                        tom = LocalDate.of(2025, 9, 29),
                                     ),
                             ),
                             lagGrVegadresseOppholdsadresse(
                                 kommunenummer = "0301",
                                 periode =
                                     DatoIntervallEntitet(
-                                        fom = LocalDate.of(2025, 10, 1),
+                                        fom = LocalDate.of(2025, 9, 30),
                                         tom = null,
                                     ),
                             ),
@@ -318,14 +318,14 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(2015, 1, 1),
-                                        tom = LocalDate.of(2025, 9, 30),
+                                        tom = LocalDate.of(2025, 9, 29),
                                     ),
                             ),
                             lagGrVegadresseOppholdsadresse(
                                 kommunenummer = "0301",
                                 periode =
                                     DatoIntervallEntitet(
-                                        fom = LocalDate.of(2025, 10, 1),
+                                        fom = LocalDate.of(2025, 9, 30),
                                         tom = null,
                                     ),
                             ),
@@ -350,7 +350,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(1980, 1, 1),
-                                                    tom = LocalDate.of(2025, 9, 30),
+                                                    tom = LocalDate.of(2025, 9, 29),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -359,7 +359,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             behandling = behandling,
                                             periode =
                                                 DatoIntervallEntitet(
-                                                    fom = LocalDate.of(2025, 10, 1),
+                                                    fom = LocalDate.of(2025, 9, 30),
                                                     tom = null,
                                                 ),
                                         ),
@@ -377,7 +377,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(2015, 1, 1),
-                                                    tom = LocalDate.of(2025, 9, 30),
+                                                    tom = LocalDate.of(2025, 9, 29),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -386,7 +386,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             behandling = behandling,
                                             periode =
                                                 DatoIntervallEntitet(
-                                                    fom = LocalDate.of(2025, 10, 1),
+                                                    fom = LocalDate.of(2025, 9, 30),
                                                     tom = null,
                                                 ),
                                         ),
@@ -407,7 +407,7 @@ class ManglendeSvalbardmerkingDtoTest {
         }
 
         @Test
-        fun `skal vise perioder som har fom dato før første oktober 2025 hvor tom dato er null`() {
+        fun `skal vise perioder som har fom dato før 30 september 2025 hvor tom dato er null`() {
             // Arrange
             val behandling = lagBehandling()
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
@@ -436,14 +436,14 @@ class ManglendeSvalbardmerkingDtoTest {
                 lagPerson(
                     personopplysningGrunnlag = personopplysningGrunnlag,
                     type = PersonType.BARN,
-                    fødselsdato = LocalDate.of(2015, 1, 1),
+                    fødselsdato = LocalDate.of(2025, 9, 29),
                     oppholdsadresser = {
                         listOf(
                             lagGrVegadresseOppholdsadresse(
                                 kommunenummer = SvalbardKommune.SVALBARD.kommunenummer,
                                 periode =
                                     DatoIntervallEntitet(
-                                        fom = LocalDate.of(2015, 1, 1),
+                                        fom = LocalDate.of(2025, 9, 29),
                                         tom = null,
                                     ),
                             ),
@@ -485,7 +485,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             behandling = behandling,
                                             periode =
                                                 DatoIntervallEntitet(
-                                                    fom = LocalDate.of(2015, 1, 1),
+                                                    fom = LocalDate.of(2025, 9, 29),
                                                     tom = null,
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
@@ -513,13 +513,13 @@ class ManglendeSvalbardmerkingDtoTest {
             assertThat(manglendeSvalbardmerking).anySatisfy {
                 assertThat(it.ident).isEqualTo(barn.aktør.aktivFødselsnummer())
                 assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
-                assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(2015, 1, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(2025, 9, 29))
                 assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isNull()
             }
         }
 
         @Test
-        fun `skal vise perioder som har tom dato lik første oktober 2025`() {
+        fun `skal vise perioder som har tom dato lik 30 september 2025`() {
             // Arrange
             val behandling = lagBehandling()
             val personopplysningGrunnlag = lagPersonopplysningGrunnlag(behandlingId = behandling.id)
@@ -536,7 +536,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(1980, 1, 1),
-                                        tom = LocalDate.of(2025, 10, 1),
+                                        tom = LocalDate.of(2025, 9, 30),
                                     ),
                             ),
                         )
@@ -556,7 +556,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                 periode =
                                     DatoIntervallEntitet(
                                         fom = LocalDate.of(2015, 1, 1),
-                                        tom = LocalDate.of(2025, 10, 1),
+                                        tom = LocalDate.of(2025, 9, 30),
                                     ),
                             ),
                         )
@@ -580,7 +580,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(1980, 1, 1),
-                                                    tom = LocalDate.of(2025, 10, 1),
+                                                    tom = LocalDate.of(2025, 9, 30),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -598,7 +598,7 @@ class ManglendeSvalbardmerkingDtoTest {
                                             periode =
                                                 DatoIntervallEntitet(
                                                     fom = LocalDate.of(2015, 1, 1),
-                                                    tom = LocalDate.of(2025, 10, 1),
+                                                    tom = LocalDate.of(2025, 9, 30),
                                                 ),
                                             utdypendeVilkårsvurderinger = emptyList(),
                                         ),
@@ -620,13 +620,13 @@ class ManglendeSvalbardmerkingDtoTest {
                 assertThat(it.ident).isEqualTo(søker.aktør.aktivFødselsnummer())
                 assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
                 assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(1980, 1, 1))
-                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 10, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 9, 30))
             }
             assertThat(manglendeSvalbardmerking).anySatisfy {
                 assertThat(it.ident).isEqualTo(barn.aktør.aktivFødselsnummer())
                 assertThat(it.manglendeSvalbardmerkingPerioder).hasSize(1)
                 assertThat(it.manglendeSvalbardmerkingPerioder.first().fom).isEqualTo(LocalDate.of(2015, 1, 1))
-                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 10, 1))
+                assertThat(it.manglendeSvalbardmerkingPerioder.first().tom).isEqualTo(LocalDate.of(2025, 9, 30))
             }
         }
 


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26605

Ønsker å vise varsler for perioder som har en tom dato på eller etter 30.09.2025 da man kan få innvilget tillegget for perioder som slutter på denne datoen. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer. I så fall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
