### PR TITLE
Fiks for konsistensavstemming som timer ut

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,9 @@
         <spring-boot-dependencies.version>3.5.7</spring-boot-dependencies.version> <!-- Skal samsvare med spring-boot-starter-parent -->
         <springdoc.version>2.8.13</springdoc.version>
 
+        <!-- Http Client - nyeste versjon fra httpclient(5.5.1) skaper problemer med Spring Boot 3.5.7. Issue: HTTPCLIENT-2405. Skal være fikset i 3.5.8, men bør testes -->
+        <httpclient5.version>5.5</httpclient5.version>
+
         <!-- Nav felles -->
         <nav-token-client.version>5.0.37</nav-token-client.version>
         <nav-foedselsnummer.version>1.0-SNAPSHOT.6</nav-foedselsnummer.version>
@@ -39,7 +42,7 @@
         <!-- Nav Familie-->
         <prosessering.version>2.20251030085530_74c10e1</prosessering.version>
         <felles-kontrakter.version>3.0_20251030120445_40c2cd0</felles-kontrakter.version>
-        <felles.version>3.20251030143732_d6733bc</felles.version>
+        <felles.version>3.20251105085627_d96d39b</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20251027085135_48de1e7</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.stønadsstatistikk>2.0_20251027085135_48de1e7</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.saksstatistikk>2.0_20251027085135_48de1e7</familie.kontrakter.saksstatistikk>

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ks.sak.api
 
+import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
 import no.nav.familie.eksterne.kontrakter.VedtakDVH
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -314,6 +315,12 @@ class ForvaltningController(
             .replace("\n", System.lineSeparator())
     }
 
+    @Operation(
+        summary = "Endepunkt for å teste trege http kall",
+        description =
+            "Dette endepunktet kaller et endepunkt som vil sove x antall sekunder i familie-oppdrag",
+    )
+    @Deprecated("Kan slettes når spring er fikset med httpclient5")
     @PostMapping(path = ["/testTregtEndepunktOppdrag"])
     fun sov(
         @RequestParam sekunder: Long,
@@ -323,9 +330,9 @@ class ForvaltningController(
         repeat(antallGanger.toInt()) { i ->
             try {
                 avstemmingKlient.sov(sekunder)
-                logger.info("Run #${i + 1}: OK")
+                logger.info("testTregtEndepunktOppdrag kjørte ok #${i + 1}")
             } catch (e: Exception) {
-                logger.error("Run #${i + 1}: FAILED", e)
+                logger.error("testTregtEndepunktOppdrag feilet #${i + 1}", e)
                 result = "FAILED"
             }
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ks.sak.config.SpringProfile
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ks.sak.integrasjon.ecb.ECBService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
+import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.internal.TestVerktøyService
 import no.nav.familie.ks.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ks.sak.kjerne.avstemming.GrensesnittavstemmingTask
@@ -87,6 +88,7 @@ class ForvaltningController(
     private val autovedtakService: AutovedtakService,
     private val barnehagebarnService: BarnehagebarnService,
     private val barnehagelisteVarslingService: BarnehagelisteVarslingService,
+    private val oppdragKlient: OppdragKlient,
 ) {
     private val logger = LoggerFactory.getLogger(ForvaltningController::class.java)
 
@@ -310,6 +312,24 @@ class ForvaltningController(
         return testVerktøyService
             .hentBrevTest(behandlingId)
             .replace("\n", System.lineSeparator())
+    }
+
+    @PostMapping(path = ["/testTregtEndepunktOppdrag"])
+    fun sov(
+        @RequestParam sekunder: Long,
+        @RequestParam antallGanger: Long,
+    ): String {
+        var result = "OK"
+        repeat(antallGanger.toInt()) { i ->
+            try {
+                oppdragKlient.sov(sekunder)
+                logger.info("Run #${i + 1}: OK")
+            } catch (e: Exception) {
+                logger.error("Run #${i + 1}: FAILED", e)
+                result = "FAILED"
+            }
+        }
+        return result
     }
 
     @PostMapping("/opprettAutovedtakBehandlingPaaFagsak")

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -27,7 +27,7 @@ import no.nav.familie.ks.sak.config.SpringProfile
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ks.sak.integrasjon.ecb.ECBService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient
-import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
+import no.nav.familie.ks.sak.integrasjon.oppdrag.AvstemmingKlient
 import no.nav.familie.ks.sak.internal.TestVerktøyService
 import no.nav.familie.ks.sak.kjerne.autovedtak.AutovedtakService
 import no.nav.familie.ks.sak.kjerne.avstemming.GrensesnittavstemmingTask
@@ -88,7 +88,7 @@ class ForvaltningController(
     private val autovedtakService: AutovedtakService,
     private val barnehagebarnService: BarnehagebarnService,
     private val barnehagelisteVarslingService: BarnehagelisteVarslingService,
-    private val oppdragKlient: OppdragKlient,
+    private val avstemmingKlient: AvstemmingKlient,
 ) {
     private val logger = LoggerFactory.getLogger(ForvaltningController::class.java)
 
@@ -322,7 +322,7 @@ class ForvaltningController(
         var result = "OK"
         repeat(antallGanger.toInt()) { i ->
             try {
-                oppdragKlient.sov(sekunder)
+                avstemmingKlient.sov(sekunder)
                 logger.info("Run #${i + 1}: OK")
             } catch (e: Exception) {
                 logger.error("Run #${i + 1}: FAILED", e)

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
@@ -133,7 +133,7 @@ class ApplicationConfig {
         bearerTokenClientInterceptor: BearerTokenClientInterceptor,
     ): RestOperations =
         RestTemplateBuilder()
-            .connectTimeout(Duration.of(2, ChronoUnit.SECONDS))
+            .connectTimeout(Duration.of(30, ChronoUnit.SECONDS))
             .readTimeout(Duration.of(30, ChronoUnit.SECONDS))
             .additionalMessageConverters(listOf(MappingJackson2HttpMessageConverter(objectMapper)) + RestTemplate().messageConverters)
             .additionalInterceptors(
@@ -148,7 +148,7 @@ class ApplicationConfig {
         bearerTokenClientCredentialsClientInterceptor: BearerTokenClientCredentialsClientInterceptor,
     ): RestOperations =
         RestTemplateBuilder()
-            .connectTimeout(Duration.of(2, ChronoUnit.SECONDS))
+            .connectTimeout(Duration.of(30, ChronoUnit.SECONDS))
             .readTimeout(Duration.of(30, ChronoUnit.SECONDS))
             .additionalMessageConverters(listOf(MappingJackson2HttpMessageConverter(objectMapper)) + RestTemplate().messageConverters)
             .additionalInterceptors(

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
@@ -3,6 +3,9 @@ package no.nav.familie.ks.sak.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.familie.http.client.RetryOAuth2HttpClient
 import no.nav.familie.http.config.RestTemplateAzure
+import no.nav.familie.http.interceptor.BearerTokenClientInterceptor
+import no.nav.familie.http.interceptor.ConsumerIdClientInterceptor
+import no.nav.familie.http.interceptor.MdcValuesPropagatingClientInterceptor
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
@@ -119,6 +122,23 @@ class ApplicationConfig {
                 emptyList()
             }
     }
+
+    @Bean("jwtBearer")
+    fun restTemplateJwtBearer(
+        consumerIdClientInterceptor: ConsumerIdClientInterceptor,
+        bearerTokenClientInterceptor: BearerTokenClientInterceptor,
+    ): RestOperations =
+        RestTemplateBuilder()
+            .readTimeout(Duration.ofMinutes(2))
+            .connectTimeout(Duration.ofMinutes(2))
+            .interceptors(
+                consumerIdClientInterceptor,
+                bearerTokenClientInterceptor,
+                MdcValuesPropagatingClientInterceptor(),
+            ).additionalMessageConverters(
+                ByteArrayHttpMessageConverter(),
+                MappingJackson2HttpMessageConverter(objectMapper),
+            ).build()
 
     companion object {
         private val log = LoggerFactory.getLogger(ApplicationConfig::class.java)

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
@@ -170,9 +170,6 @@ class ApplicationConfig {
                 consumerIdClientInterceptor,
                 bearerTokenClientInterceptor,
                 MdcValuesPropagatingClientInterceptor(),
-            ).additionalMessageConverters(
-                ByteArrayHttpMessageConverter(),
-                MappingJackson2HttpMessageConverter(objectMapper),
             ).build()
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt
@@ -52,7 +52,7 @@ import java.net.URI
 @Component
 class IntegrasjonClient(
     @Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: URI,
-    @Qualifier("azure") restOperations: RestOperations,
+    @Qualifier("jwtBearer") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "integrasjon") {
     val tilgangPersonUri =
         UriComponentsBuilder

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/infotrygd/InfotrygdReplikaClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/infotrygd/InfotrygdReplikaClient.kt
@@ -16,7 +16,7 @@ import java.time.YearMonth
 @Component
 class InfotrygdReplikaClient(
     @Value("\${FAMILIE_KS_INFOTRYGD_API_URL}") private val familieKsInfotrygdUri: URI,
-    @Qualifier("azure") restOperations: RestOperations,
+    @Qualifier("jwtBearer") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "familie-ks-infotrygd") {
     fun hentKontantstøttePerioderFraInfotrygd(identer: List<String>): InnsynResponse {
         val requestURI =

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/AvstemmingKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/AvstemmingKlient.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.ks.sak.integrasjon.oppdrag
+
+import no.nav.familie.http.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestOperations
+
+@Service
+class AvstemmingKlient(
+    @Value("\${FAMILIE_OPPDRAG_API_URL}")
+    private val familieOppdragUri: String,
+    @Qualifier("jwtBearerLongTimeout") restOperations: RestOperations,
+) : AbstractRestClient(restOperations, "økonomi_kontantstøtte")

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/AvstemmingKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/AvstemmingKlient.kt
@@ -1,14 +1,142 @@
 package no.nav.familie.ks.sak.integrasjon.oppdrag
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.felles.oppdrag.GrensesnittavstemmingRequest
+import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingRequestV2
+import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
+import no.nav.familie.ks.sak.integrasjon.kallEksternTjenesteRessurs
+import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.FAGSYSTEM
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
+import java.net.URI
+import java.time.LocalDateTime
+import java.util.UUID
 
 @Service
 class AvstemmingKlient(
     @Value("\${FAMILIE_OPPDRAG_API_URL}")
     private val familieOppdragUri: String,
     @Qualifier("jwtBearerLongTimeout") restOperations: RestOperations,
-) : AbstractRestClient(restOperations, "økonomi_kontantstøtte")
+) : AbstractRestClient(restOperations, "økonomi_kontantstøtte") {
+    fun sendGrensesnittavstemmingTilOppdrag(
+        fom: LocalDateTime,
+        tom: LocalDateTime,
+        avstemmingId: UUID?,
+    ): String {
+        val uri = URI.create("$familieOppdragUri/grensesnittavstemming")
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Gjør grensesnittavstemming mot oppdrag",
+        ) {
+            postForEntity(
+                uri = uri,
+                payload =
+                    GrensesnittavstemmingRequest(
+                        fagsystem = FAGSYSTEM,
+                        fra = fom,
+                        til = tom,
+                        avstemmingId = avstemmingId,
+                    ),
+            )
+        }
+    }
+
+    fun konsistensavstemOppdragStart(
+        avstemmingsdato: LocalDateTime,
+        transaksjonsId: UUID,
+    ): String {
+        val uri =
+            URI.create(
+                "$familieOppdragUri/v2/konsistensavstemming" +
+                    "?sendStartmelding=true&sendAvsluttmelding=false&transaksjonsId=$transaksjonsId",
+            )
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Start konsistensavstemming mot oppdrag i batch",
+        ) {
+            postForEntity(
+                uri = uri,
+                KonsistensavstemmingRequestV2(
+                    fagsystem = FAGSYSTEM,
+                    avstemmingstidspunkt = avstemmingsdato,
+                    perioderForBehandlinger = emptyList(),
+                ),
+            )
+        }
+    }
+
+    fun konsistensavstemOppdragData(
+        avstemmingsdato: LocalDateTime,
+        perioderTilAvstemming: List<PerioderForBehandling>,
+        transaksjonsId: UUID,
+    ): String {
+        val uri =
+            URI.create(
+                "$familieOppdragUri/v2/konsistensavstemming" +
+                    "?sendStartmelding=false&sendAvsluttmelding=false&transaksjonsId=$transaksjonsId",
+            )
+
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Konsistenstavstemmer chunk mot oppdrag",
+        ) {
+            postForEntity(
+                uri = uri,
+                KonsistensavstemmingRequestV2(
+                    fagsystem = FAGSYSTEM,
+                    avstemmingstidspunkt = avstemmingsdato,
+                    perioderForBehandlinger = perioderTilAvstemming,
+                ),
+            )
+        }
+    }
+
+    fun konsistensavstemOppdragAvslutt(
+        avstemmingsdato: LocalDateTime,
+        transaksjonsId: UUID,
+    ): String {
+        val uri =
+            URI.create(
+                "$familieOppdragUri/v2/konsistensavstemming" +
+                    "?sendStartmelding=false&sendAvsluttmelding=true&transaksjonsId=$transaksjonsId",
+            )
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "Avslutt konsistensavstemming mot oppdrag",
+        ) {
+            postForEntity(
+                uri = uri,
+                KonsistensavstemmingRequestV2(
+                    fagsystem = FAGSYSTEM,
+                    avstemmingstidspunkt = avstemmingsdato,
+                    perioderForBehandlinger = emptyList(),
+                ),
+            )
+        }
+    }
+
+    fun sov(
+        sovAntallSekunder: Long,
+    ): String {
+        val uri =
+            URI.create(
+                "$familieOppdragUri/timeout-test?sekunder=$sovAntallSekunder",
+            )
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "sov",
+        ) {
+            getForEntity(
+                uri = uri,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 class OppdragKlient(
     @Value("\${FAMILIE_OPPDRAG_API_URL}")
     private val familieOppdragUri: String,
-    @Qualifier("azure") restOperations: RestOperations,
+    @Qualifier("jwtBearer") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "økonomi_kontantstøtte") {
     fun iverksettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag): String {
         val uri = URI.create("$familieOppdragUri/oppdrag")
@@ -173,6 +173,24 @@ class OppdragKlient(
                     avstemmingstidspunkt = avstemmingsdato,
                     perioderForBehandlinger = emptyList(),
                 ),
+            )
+        }
+    }
+
+    fun sov(
+        sovAntallSekunder: Long,
+    ): String {
+        val uri =
+            URI.create(
+                "$familieOppdragUri/timeout-test?sekunder=$sovAntallSekunder",
+            )
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag",
+            uri = uri,
+            formål = "sov",
+        ) {
+            getForEntity(
+                uri = uri,
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 class OppdragKlient(
     @Value("\${FAMILIE_OPPDRAG_API_URL}")
     private val familieOppdragUri: String,
-    @Qualifier("jwtBearerLongTimeout") restOperations: RestOperations,
+    @Qualifier("jwtBearer") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "økonomi_kontantstøtte") {
     fun iverksettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag): String {
         val uri = URI.create("$familieOppdragUri/oppdrag")

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -1,11 +1,8 @@
 package no.nav.familie.ks.sak.integrasjon.oppdrag
 
 import no.nav.familie.http.client.AbstractRestClient
-import no.nav.familie.kontrakter.felles.oppdrag.GrensesnittavstemmingRequest
-import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingRequestV2
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
-import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonClient.Companion.RETRY_BACKOFF_5000MS
@@ -17,8 +14,6 @@ import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
 import java.net.URI
-import java.time.LocalDateTime
-import java.util.UUID
 
 @Service
 class OppdragKlient(
@@ -73,126 +68,6 @@ class OppdragKlient(
             uri = uri,
             formål = "Hent utbetalingsoppdrag for fagsaker",
         ) { postForEntity(uri = uri, payload = fagsakIder) }
-    }
-
-    fun sendGrensesnittavstemmingTilOppdrag(
-        fom: LocalDateTime,
-        tom: LocalDateTime,
-        avstemmingId: UUID?,
-    ): String {
-        val uri = URI.create("$familieOppdragUri/grensesnittavstemming")
-        return kallEksternTjenesteRessurs(
-            tjeneste = "familie-oppdrag",
-            uri = uri,
-            formål = "Gjør grensesnittavstemming mot oppdrag",
-        ) {
-            postForEntity(
-                uri = uri,
-                payload =
-                    GrensesnittavstemmingRequest(
-                        fagsystem = FAGSYSTEM,
-                        fra = fom,
-                        til = tom,
-                        avstemmingId = avstemmingId,
-                    ),
-            )
-        }
-    }
-
-    fun konsistensavstemOppdragStart(
-        avstemmingsdato: LocalDateTime,
-        transaksjonsId: UUID,
-    ): String {
-        val uri =
-            URI.create(
-                "$familieOppdragUri/v2/konsistensavstemming" +
-                    "?sendStartmelding=true&sendAvsluttmelding=false&transaksjonsId=$transaksjonsId",
-            )
-
-        return kallEksternTjenesteRessurs(
-            tjeneste = "familie-oppdrag",
-            uri = uri,
-            formål = "Start konsistensavstemming mot oppdrag i batch",
-        ) {
-            postForEntity(
-                uri = uri,
-                KonsistensavstemmingRequestV2(
-                    fagsystem = FAGSYSTEM,
-                    avstemmingstidspunkt = avstemmingsdato,
-                    perioderForBehandlinger = emptyList(),
-                ),
-            )
-        }
-    }
-
-    fun konsistensavstemOppdragData(
-        avstemmingsdato: LocalDateTime,
-        perioderTilAvstemming: List<PerioderForBehandling>,
-        transaksjonsId: UUID,
-    ): String {
-        val uri =
-            URI.create(
-                "$familieOppdragUri/v2/konsistensavstemming" +
-                    "?sendStartmelding=false&sendAvsluttmelding=false&transaksjonsId=$transaksjonsId",
-            )
-
-        return kallEksternTjenesteRessurs(
-            tjeneste = "familie-oppdrag",
-            uri = uri,
-            formål = "Konsistenstavstemmer chunk mot oppdrag",
-        ) {
-            postForEntity(
-                uri = uri,
-                KonsistensavstemmingRequestV2(
-                    fagsystem = FAGSYSTEM,
-                    avstemmingstidspunkt = avstemmingsdato,
-                    perioderForBehandlinger = perioderTilAvstemming,
-                ),
-            )
-        }
-    }
-
-    fun konsistensavstemOppdragAvslutt(
-        avstemmingsdato: LocalDateTime,
-        transaksjonsId: UUID,
-    ): String {
-        val uri =
-            URI.create(
-                "$familieOppdragUri/v2/konsistensavstemming" +
-                    "?sendStartmelding=false&sendAvsluttmelding=true&transaksjonsId=$transaksjonsId",
-            )
-        return kallEksternTjenesteRessurs(
-            tjeneste = "familie-oppdrag",
-            uri = uri,
-            formål = "Avslutt konsistensavstemming mot oppdrag",
-        ) {
-            postForEntity(
-                uri = uri,
-                KonsistensavstemmingRequestV2(
-                    fagsystem = FAGSYSTEM,
-                    avstemmingstidspunkt = avstemmingsdato,
-                    perioderForBehandlinger = emptyList(),
-                ),
-            )
-        }
-    }
-
-    fun sov(
-        sovAntallSekunder: Long,
-    ): String {
-        val uri =
-            URI.create(
-                "$familieOppdragUri/timeout-test?sekunder=$sovAntallSekunder",
-            )
-        return kallEksternTjenesteRessurs(
-            tjeneste = "familie-oppdrag",
-            uri = uri,
-            formål = "sov",
-        ) {
-            getForEntity(
-                uri = uri,
-            )
-        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlient.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 class OppdragKlient(
     @Value("\${FAMILIE_OPPDRAG_API_URL}")
     private val familieOppdragUri: String,
-    @Qualifier("jwtBearer") restOperations: RestOperations,
+    @Qualifier("jwtBearerLongTimeout") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "økonomi_kontantstøtte") {
     fun iverksettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag): String {
         val uri = URI.create("$familieOppdragUri/oppdrag")

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlClient.kt
@@ -38,7 +38,7 @@ import java.net.URI
 @Service
 class PdlClient(
     pdlConfig: PdlConfig,
-    @Qualifier("azureClientCredential") val restTemplate: RestOperations,
+    @Qualifier("jwtBearerClientCredential") val restTemplate: RestOperations,
 ) : AbstractPingableRestClient(restTemplate, "pdl.personinfo") {
     private val pdlUri = pdlConfig.pdlUri
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilbakekreving/TilbakekrevingKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilbakekreving/TilbakekrevingKlient.kt
@@ -23,7 +23,7 @@ import java.net.URI
 @Service
 class TilbakekrevingKlient(
     @Value("\${FAMILIE_TILBAKE_API_URL}") private val familieTilbakeUri: URI,
-    @Qualifier("azure") restOperations: RestOperations,
+    @Qualifier("jwtBearer") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "tilbakreving") {
     fun harÅpenTilbakekrevingsbehandling(fagsakId: Long): Boolean {
         val uri = URI.create("$familieTilbakeUri/fagsystem/${Fagsystem.KONT}/fagsak/$fagsakId/finnesApenBehandling/v1")

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingService.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ks.sak.kjerne.avstemming
 
 import no.nav.familie.kontrakter.felles.oppdrag.PerioderForBehandling
 import no.nav.familie.ks.sak.common.exception.Feil
-import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
+import no.nav.familie.ks.sak.integrasjon.oppdrag.AvstemmingKlient
 import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
@@ -14,7 +14,7 @@ import java.util.UUID
 
 @Service
 class AvstemmingService(
-    private val oppdragKlient: OppdragKlient,
+    private val avstemmingKlient: AvstemmingKlient,
     private val behandlingService: BehandlingService,
     private val beregningService: BeregningService,
 ) {
@@ -23,7 +23,7 @@ class AvstemmingService(
         tom: LocalDateTime,
         avstemmingId: UUID?,
     ) {
-        oppdragKlient.sendGrensesnittavstemmingTilOppdrag(fom = fom, tom = tom, avstemmingId = avstemmingId)
+        avstemmingKlient.sendGrensesnittavstemmingTilOppdrag(fom = fom, tom = tom, avstemmingId = avstemmingId)
     }
 
     fun sendKonsistensavstemmingStartMelding(
@@ -31,7 +31,7 @@ class AvstemmingService(
         transaksjonsId: UUID,
     ) {
         logger.info("Utfører Konsistensavstemming: Sender start melding for transaksjonsId $transaksjonsId")
-        oppdragKlient.konsistensavstemOppdragStart(avstemmingstidspunkt, transaksjonsId)
+        avstemmingKlient.konsistensavstemOppdragStart(avstemmingstidspunkt, transaksjonsId)
     }
 
     fun sendKonsistensavstemmingData(
@@ -40,7 +40,7 @@ class AvstemmingService(
         transaksjonsId: UUID,
     ) {
         logger.info("Utfører Konsistensavstemming: Sender perioder for transaksjonsId $transaksjonsId")
-        oppdragKlient.konsistensavstemOppdragData(avstemmingstidspunkt, perioderTilAvstemming, transaksjonsId)
+        avstemmingKlient.konsistensavstemOppdragData(avstemmingstidspunkt, perioderTilAvstemming, transaksjonsId)
     }
 
     fun sendKonsistensavstemmingAvsluttMelding(
@@ -48,7 +48,7 @@ class AvstemmingService(
         transaksjonsId: UUID,
     ) {
         logger.info("Utfører Konsistensavstemming: Sender avslutt melding for transaksjonsId $transaksjonsId")
-        oppdragKlient.konsistensavstemOppdragAvslutt(avstemmingstidspunkt, transaksjonsId)
+        avstemmingKlient.konsistensavstemOppdragAvslutt(avstemmingstidspunkt, transaksjonsId)
     }
 
     fun hentDataForKonsistensavstemming(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageClient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlageClient.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 @Component
 class KlageClient(
-    @Qualifier("azure") restOperations: RestOperations,
+    @Qualifier("jwtBearer") restOperations: RestOperations,
     @Value("\${FAMILIE_KLAGE_URL}") private val familieKlageUri: URI,
 ) : AbstractRestClient(restOperations, "integrasjon") {
     fun opprettKlage(opprettKlagebehandlingRequest: OpprettKlagebehandlingRequest): UUID {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingServiceTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
-import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
+import no.nav.familie.ks.sak.integrasjon.oppdrag.AvstemmingKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
@@ -15,13 +15,13 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.LocalDateTime
 
 internal class AvstemmingServiceTest {
-    private val oppdragKlient = mockk<OppdragKlient>()
+    private val avstemmingKlient = mockk<AvstemmingKlient>()
     private val behandlingService = mockk<BehandlingService>()
     private val beregningService = mockk<BeregningService>()
 
     private val avstemmingService =
         AvstemmingService(
-            oppdragKlient = oppdragKlient,
+            avstemmingKlient = avstemmingKlient,
             behandlingService = behandlingService,
             beregningService = beregningService,
         )

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,5 +7,5 @@
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
 
-    <logger name="no" level="DEBUG"/>
+    <logger name="no" level="INFO"/>
 </configuration>


### PR DESCRIPTION
### 📮 Favro: NAV-26693

### 💰 Hva skal gjøres, og hvorfor?
En feil i Spring boot gjør at connection timeout ikke funker så bra med siste httpclient5. Ser ut til å fikses i spring boot 3.5.8
https://github.com/spring-projects/spring-boot/issues/47940
[issues.apache.org/jira/browse/HTTPCLIENT-2405](https://issues.apache.org/jira/browse/HTTPCLIENT-2405)

Så vi nedgraderer httpclient5 til den som funker med spring boot.

Som en backup-løsning så har man også gått bort fra restTemplate-profilene i familie-felles, med timeout satt lengre tid. I tilfelle noen merger ned feil versjon av httpclient5 for tidlig
azure -> jwtBearer
azureClientCredentials -> jwtBearerClientCredentials

Har også flyttet alle avstemmingsklientkallene til egen profil som har lengre timeout enn de andre, siden de potensielt kan ta lang tid. Disse bruker jwtBearerLongTimeout

Det er også ett nytt endepunkt i forvalter som man kan bruke for å teste når 3.5.8 kommer


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

Testet i miljø så godt det lar seg gjøre.
