### PR TITLE
Søkers vilkår skal være utgjørende for barn også

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -490,12 +490,12 @@ class BrevPeriodeContext(
                     nasjonalEllerFellesBegrunnelse = begrunnelse,
                 )
 
-                val antallTimerBarnehageplass =
-                    hentAntallTimerBarnehageplassTekst(personerGjeldendeForBegrunnelse)
-
                 val begrunnelseGjelderOpphørFraForrigeBehandling = sanityBegrunnelse.begrunnelseGjelderOpphørFraForrigeBehandling()
 
                 if (relevanteKompetanser.isEmpty() && (begrunnelse.begrunnelseType.erAvslagEllerEøsAvslag() || begrunnelse.begrunnelseType == BegrunnelseType.EØS_OPPHØR)) {
+                    val antallTimerBarnehageplass =
+                        hentAntallTimerBarnehageplassTekst(personerGjeldendeForBegrunnelse)
+
                     val barnIBegrunnelse = personerGjeldendeForBegrunnelse.filter { it.type == PersonType.BARN }
                     val barnasFødselsdagerForAvslagOgOpphør =
                         hentBarnasFødselsdagerForAvslagOgOpphør(
@@ -519,7 +519,7 @@ class BrevPeriodeContext(
                     )
                 } else {
                     relevanteKompetanser.mapNotNull { kompetanse ->
-                        val barnIBegrunnelseOgIKompetanseFødselsdato =
+                        val barnIBegrunnelseOgIKompetanse =
                             kompetanse.barnAktører
                                 .mapNotNull { barnAktør ->
                                     if (gjelderSøker && begrunnelseGjelderOpphørFraForrigeBehandling) {
@@ -527,9 +527,15 @@ class BrevPeriodeContext(
                                     } else {
                                         personerGjeldendeForBegrunnelse
                                     }.find { it.aktør == barnAktør }
-                                }.map { it.fødselsdato }
+                                }
+
+                        val barnIBegrunnelseOgIKompetanseFødselsdato =
+                            barnIBegrunnelseOgIKompetanse.map { it.fødselsdato }
 
                         if (barnIBegrunnelseOgIKompetanseFødselsdato.isNotEmpty()) {
+                            val antallTimerBarnehageplass =
+                                hentAntallTimerBarnehageplassTekst(barnIBegrunnelseOgIKompetanse.toSet())
+
                             EØSBegrunnelseMedKompetanseDto(
                                 vedtakBegrunnelseType = begrunnelse.begrunnelseType,
                                 apiNavn = begrunnelse.sanityApiNavn,
@@ -551,7 +557,10 @@ class BrevPeriodeContext(
                 }
             }
 
-    private fun Tidslinje<UtfyltKompetanse>.finnPeriodeSomAvsluttesRettFørVedtaksperioden() = tilPerioderIkkeNull().singleOrNull { it.avsluttesMånedenFørVedtaksperioden() }
+    private fun Tidslinje<UtfyltKompetanse>.finnPeriodeSomAvsluttesRettFørVedtaksperioden() =
+        tilPerioderIkkeNull().singleOrNull {
+            it.avsluttesMånedenFørVedtaksperioden()
+        }
 
     private fun Periode<UtfyltKompetanse>.avsluttesMånedenFørVedtaksperioden() =
         this.tom != null &&

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -498,6 +498,7 @@ class StepDefinition {
         dataTable: DataTable,
     ) {
         val utvidedeVedtaksperioderMedBegrunnelser = hentUtvidedeVedtaksperioderMedBegrunnelser(behandlingId).sortedBy { it.fom ?: TIDENES_MORGEN }
+
         val relevantUtvidetVedtaksperiode =
             utvidedeVedtaksperioderMedBegrunnelser.find {
                 it.fom == parseNullableDato(periodeFom) && it.tom == parseNullableDato(periodeTom)

--- a/src/test/resources/cucumber/sekundærland/opphør.feature
+++ b/src/test/resources/cucumber/sekundærland/opphør.feature
@@ -60,3 +60,119 @@ Egenskap: Sekundærland - opphør
     Så forvent følgende brevbegrunnelser for behandling 1 i periode 01.11.2023 til -
       | Begrunnelse                    | Type | Barnas fødselsdatoer | Antall barn | Målform | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland | Antall timer barnehageplass |
       | OPPHØR_SELVSTENDIG_RETT_OPPHØR | EØS  | 15.09.22             | 1           | NB      | arbeider         | inaktiv                   | Norge                 | Polen                          | Polen               | 0                           |
+
+  Scenario: Ved opphør grunnet søkers vilkår, skal bare barn med relevante kompetanser trekkes inn
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus |
+      | 1            | 1        |                     | SØKNAD           | EØS                 | AVSLUTTET         |
+      | 2            | 1        | 1                   | SØKNAD           | EØS                 | UTREDES           |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 21.02.1992  |
+      | 1            | 2       | BARN       | 10.01.2022  |
+      | 2            | 1       | SØKER      | 21.02.1992  |
+      | 2            | 2       | BARN       | 10.01.2022  |
+      | 2            | 3       | BARN       | 13.02.2024  |
+
+    Og følgende dagens dato 09.11.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                    | Utdypende vilkår             | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | MEDLEMSKAP                |                              | 21.02.1997 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 1       | LOVLIG_OPPHOLD            |                              | 01.09.2021 | 01.01.2024 | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 1       | BOSATT_I_RIKET            | OMFATTET_AV_NORSK_LOVGIVNING | 01.09.2021 | 01.01.2024 | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER |                              |            |            | IKKE_AKTUELT | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS            |                              | 10.01.2022 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BOR_MED_SØKER             | BARN_BOR_I_EØS_MED_SØKER     | 10.01.2022 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET            | BARN_BOR_I_EØS               | 10.01.2022 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 2       | BARNETS_ALDER             |                              | 10.01.2023 | 10.01.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                    | Utdypende vilkår             | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | MEDLEMSKAP                |                              | 21.02.1997 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 1       | BOSATT_I_RIKET            | OMFATTET_AV_NORSK_LOVGIVNING | 01.09.2021 | 02.07.2025 | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 1       | LOVLIG_OPPHOLD            |                              | 01.09.2021 | 02.07.2025 | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER |                              |            |            | IKKE_AKTUELT | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 2       | BOR_MED_SØKER             | BARN_BOR_I_EØS_MED_SØKER     | 10.01.2022 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET            | BARN_BOR_I_EØS               | 10.01.2022 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS            |                              | 10.01.2022 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER             |                              | 10.01.2023 | 10.01.2024 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+      | 3       | MEDLEMSKAP_ANNEN_FORELDER |                              |            |            | IKKE_AKTUELT | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 3       | BARNEHAGEPLASS            |                              | 13.02.2024 |            | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 3       | BOSATT_I_RIKET            | BARN_BOR_I_EØS               | 13.02.2024 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 3       | BOR_MED_SØKER             | BARN_BOR_I_EØS_MED_SØKER     | 13.02.2024 |            | OPPFYLT      | Nei                  |                      | EØS_FORORDNINGEN | Nei                                   |              |
+      | 3       | BARNETS_ALDER             |                              | 13.02.2025 | 13.10.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+
+    Og følgende endrede utbetalinger
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak              | Prosent | Søknadstidspunkt |
+      | 2       | 1            | 01.02.2023 | 30.06.2023 | ETTERBETALING_3MND | 0       | 18.09.2023       |
+      | 2       | 2            | 01.02.2023 | 30.06.2023 | ETTERBETALING_3MND | 0       | 18.09.2023       |
+
+    Og følgende kompetanser for behandling 1
+      | AktørId | Fra dato   | Til dato   | Resultat              | Søkers aktivitet | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.07.2023 | 31.12.2023 | NORGE_ER_SEKUNDÆRLAND | ARBEIDER         | I_ARBEID                  | NO                    | PL                             | PL                  |
+
+    Og følgende kompetanser for behandling 2
+      | AktørId | Fra dato   | Til dato   | Resultat              | Søkers aktivitet                     | Annen forelders aktivitet | Søkers aktivitetsland | Annen forelders aktivitetsland | Barnets bostedsland |
+      | 2       | 01.07.2023 | 31.12.2023 | NORGE_ER_SEKUNDÆRLAND | ARBEIDER                             | I_ARBEID                  | NO                    | PL                             | PL                  |
+      | 3       | 01.03.2025 | 30.06.2025 | NORGE_ER_SEKUNDÆRLAND | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | I_ARBEID                  | NO                    | PL                             | PL                  |
+
+    Og følgende utenlandske periodebeløp for behandling 1
+      | AktørId | Fra dato   | Til dato   | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 01.07.2023 | 31.12.2023 | 0     | PLN         | MÅNEDLIG  | PL              |
+
+    Og følgende utenlandske periodebeløp for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Valuta kode | Intervall | Utbetalingsland |
+      | 2       | 01.07.2023 | 31.12.2023 | 0     | PLN         | MÅNEDLIG  | PL              |
+      | 3       | 01.03.2025 | 30.06.2025 | 500   | PLN         | MÅNEDLIG  | PL              |
+
+    Og følgende valutakurser for behandling 1
+      | AktørId | Fra dato   | Til dato   | Valutakursdato | Valuta kode | Kurs         |
+      | 2       | 01.07.2023 | 31.12.2023 | 2023-12-29     | PLN         | 2.5902753773 |
+
+    Og følgende valutakurser for behandling 2
+      | AktørId | Fra dato   | Til dato   | Valutakursdato | Valuta kode | Kurs         |
+      | 3       | 01.03.2025 | 30.06.2025 | 2025-02-03     | PLN         | 2.7721689741 |
+      | 2       | 01.07.2023 | 31.12.2023 | 2023-12-29     | PLN         | 2.5902753773 |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.02.2023 | 30.06.2023 | 0     | ORDINÆR_KONTANTSTØTTE | 0       | 7500 | 0                      |                          |
+      | 2       | 01.07.2023 | 31.12.2023 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   | 7500                     |
+      | 3       | 01.03.2025 | 30.06.2025 | 6114  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   | 6114                     |
+    Og når behandlingsresultatet er utledet for behandling 2
+    Så forvent at behandlingsresultatet er INNVILGET_OG_OPPHØRT på behandling 2
+
+    Og vedtaksperioder er laget for behandling 2
+
+    Så forvent følgende vedtaksperioder på behandling 2
+      | Fra dato   | Til dato   | Vedtaksperiodetype | Kommentar |
+      | 01.03.2025 | 30.06.2025 | UTBETALING         |           |
+      | 01.07.2025 |            | OPPHØR             |           |
+
+    Så forvent at følgende begrunnelser er gyldige for behandling 2
+      | Fra dato   | Til dato   | VedtaksperiodeType | Regelverk Gyldige begrunnelser | Gyldige begrunnelser     | Ugyldige begrunnelser |
+      | 01.03.2025 | 30.06.2025 | UTBETALING         |                                | INNVILGET_IKKE_BARNEHAGE |                       |
+      | 01.07.2025 |            | OPPHØR             |                                |                          |                       |
+      | 01.07.2025 |            | OPPHØR             | EØS_FORORDNINGEN               | OPPHØR_EØS_STANDARD      |                       |
+
+    Og når disse begrunnelsene er valgt for behandling 2
+      | Fra dato   | Til dato   | Standardbegrunnelser     | Eøsbegrunnelser     | Fritekster |
+      | 01.03.2025 | 30.06.2025 | INNVILGET_IKKE_BARNEHAGE |                     |            |
+      | 01.07.2025 |            |                          | OPPHØR_EØS_STANDARD |            |
+
+    Så forvent følgende brevbegrunnelser for behandling 2 i periode 01.07.2025 til -
+      | Begrunnelse         | Type | Gjelder søker | Barnas fødselsdatoer | Antall barn | Annen forelders aktivitet | Annen forelders aktivitetsland | Barnets bostedsland | Søkers aktivitet                     | Søkers aktivitetsland | Målform | Antall timer barnehageplass |
+      | OPPHØR_EØS_STANDARD | EØS  |               | 13.02.24             | 1           | I_ARBEID                  | Polen                          | Polen               | MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN | Norge                 |         | 0                           |


### PR DESCRIPTION
### 📮 Favro: NAV-26732

### 💰 Hva skal gjøres, og hvorfor?

Når vi skal flette inn barn ved eøs opphør, så må vi bare hente inn relevante barn.
Det fungerer ikke så bra per i dag, siden det er noen tilfeller der det er vilkårene til søker som fører til opphør, men det er bare et sett av barna som er relevante (ikke alle). Per nå trekker vi inn alle barn hvis vi ikke finner noe relevante barn.

I dette caset så har vi faktisk 1 relevant barn, men siden vi ikke tar hensyn til søkers vilkår, så tror koden at det ikke er noen relevante barn, og derfor trekker inn alle.

Endrer derfor koden som sjekker etter relevante barn til å ta hensyn til søkers vilkår, da søkers vilkår kan føre til opphør for barn.