### PR TITLE
Vi sender med saksbehandler signatur til manuell brev dto slik at vi får brukt signaturen til SB som trigget lagring av task

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
@@ -39,6 +39,7 @@ import no.nav.familie.ks.sak.kjerne.brev.mottaker.ValiderBrevmottakerService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -60,6 +61,7 @@ class BrevService(
     private val brevmottakerService: BrevmottakerService,
     private val validerBrevmottakerService: ValiderBrevmottakerService,
     private val featureToggleService: FeatureToggleService,
+    private val saksbehandlerContext: SaksbehandlerContext,
 ) {
     fun hentForhåndsvisningAvBrev(
         manueltBrevDto: ManueltBrevDto,
@@ -108,7 +110,7 @@ class BrevService(
         validerManuelleBrevmottakere(behandlingId, fagsak, manueltBrevDto)
 
         val behandling = behandlingId?.let { behandlingRepository.hentBehandling(behandlingId) }
-        val generertBrev = genererBrevService.genererManueltBrev(manueltBrevDto, false)
+        val generertBrev = genererBrevService.genererManueltBrev(manueltBrevDto)
 
         val førsteside =
             if (manueltBrevDto.brevmal.skalGenerereForside()) {
@@ -251,6 +253,7 @@ class BrevService(
                     fagsakId = fagsak.id,
                     manueltBrevDto = manueltBrevDto,
                     mottakerInfo = mottaker,
+                    saksbehandlerSignaturTilBrev = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev(),
                 ),
             )
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -74,9 +74,10 @@ class GenererBrevService(
     fun genererManueltBrev(
         manueltBrevRequest: ManueltBrevDto,
         erForhåndsvisning: Boolean = false,
+        saksbehandlerSignaturTilBrev: String? = null, // Gjøres til non-nullable når man fjerner feature toggle
     ): ByteArray {
         try {
-            val brev = manueltBrevRequest.tilBrev(saksbehandlerContext.hentSaksbehandlerSignaturTilBrev())
+            val brev = manueltBrevRequest.tilBrev(saksbehandlerSignaturTilBrev ?: saksbehandlerContext.hentSaksbehandlerSignaturTilBrev())
             return brevKlient.genererBrev(
                 målform = manueltBrevRequest.mottakerMålform.tilSanityFormat(),
                 brev = brev,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevDto.kt
@@ -11,4 +11,5 @@ data class JournalførManueltBrevDto(
     val avsenderMottaker: AvsenderMottaker?,
     val manuellAdresseInfo: ManuellAdresseInfo?,
     val eksternReferanseId: String,
+    val saksbehandlerSignaturTilBrev: String,
 )

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevTask.kt
@@ -47,7 +47,14 @@ class JournalførManueltBrevTask(
 
         val fagsak = fagsakService.hentFagsak(dto.fagsakId)
         val behandling = dto.behandlingId?.let { behandlingId -> behandlingService.hentBehandling(behandlingId) }
-        val generertBrev = genererBrevService.genererManueltBrev(dto.manueltBrevDto, false)
+        val saksbehandlerSignaturTilBrev = dto.saksbehandlerSignaturTilBrev
+
+        val generertBrev =
+            genererBrevService.genererManueltBrev(
+                manueltBrevRequest = dto.manueltBrevDto,
+                erForhåndsvisning = false,
+                saksbehandlerSignaturTilBrev = saksbehandlerSignaturTilBrev,
+            )
 
         val førsteside =
             if (dto.manueltBrevDto.brevmal.skalGenerereForside()) {
@@ -124,6 +131,7 @@ class JournalførManueltBrevTask(
             fagsakId: Long,
             manueltBrevDto: ManueltBrevDto,
             mottakerInfo: MottakerInfo,
+            saksbehandlerSignaturTilBrev: String,
         ): Task {
             val dto =
                 JournalførManueltBrevDto(
@@ -138,6 +146,7 @@ class JournalførManueltBrevTask(
                             behandlingId,
                             mottakerInfo is FullmektigEllerVerge,
                         ),
+                    saksbehandlerSignaturTilBrev = saksbehandlerSignaturTilBrev,
                 )
 
             val properties =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
@@ -44,6 +44,7 @@ import no.nav.familie.ks.sak.kjerne.brev.mottaker.ValiderBrevmottakerService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
 import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -76,6 +77,7 @@ class BrevServiceTest {
             ),
         )
     private val featureToggleService = mockk<FeatureToggleService>()
+    private val saksbehandlerContext = mockk<SaksbehandlerContext>(relaxed = true)
 
     private val brevService =
         BrevService(
@@ -93,6 +95,7 @@ class BrevServiceTest {
             brevmottakerService = brevmottakerService,
             validerBrevmottakerService = validerBrevmottakerService,
             featureToggleService = featureToggleService,
+            saksbehandlerContext = saksbehandlerContext,
         )
 
     private val søker = randomAktør()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevTaskTest.kt
@@ -68,7 +68,12 @@ class JournalførManueltBrevTaskTest {
 
             every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
             every { behandlingService.hentBehandling(behandling.id) } returns behandling
-            every { genererBrevService.genererManueltBrev(manueltBrevDto, false) } returns brev
+            every {
+                genererBrevService.genererManueltBrev(
+                    manueltBrevRequest = manueltBrevDto,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
+                )
+            } returns brev
             every {
                 utgåendeJournalføringService.journalførDokument(
                     any(),
@@ -91,6 +96,7 @@ class JournalførManueltBrevTaskTest {
                     fagsakId = fagsak.id,
                     manueltBrevDto = manueltBrevDto,
                     mottakerInfo = mottakerInfo,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
                 )
 
             // Act
@@ -98,7 +104,12 @@ class JournalførManueltBrevTaskTest {
 
             // Assert
             verify(exactly = 1) { fagsakService.hentFagsak(fagsak.id) }
-            verify(exactly = 1) { genererBrevService.genererManueltBrev(manueltBrevDto, false) }
+            verify(exactly = 1) {
+                genererBrevService.genererManueltBrev(
+                    manueltBrevRequest = manueltBrevDto,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
+                )
+            }
             verify(exactly = 1) {
                 utgåendeJournalføringService.journalførDokument(
                     fnr = eq(fagsak.aktør.aktivFødselsnummer()),
@@ -155,7 +166,12 @@ class JournalførManueltBrevTaskTest {
 
             every { fagsakService.hentFagsak(fagsakId) } returns fagsak
             every { behandlingService.hentBehandling(behandlingId) } returns behandling
-            every { genererBrevService.genererManueltBrev(manueltBrevDto, false) } returns brev
+            every {
+                genererBrevService.genererManueltBrev(
+                    manueltBrevRequest = manueltBrevDto,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
+                )
+            } returns brev
             every {
                 utgåendeJournalføringService.journalførDokument(
                     any(),
@@ -178,6 +194,7 @@ class JournalførManueltBrevTaskTest {
                     fagsakId = fagsakId,
                     manueltBrevDto = manueltBrevDto,
                     mottakerInfo = mottakerInfo,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
                 )
 
             // Act
@@ -185,7 +202,12 @@ class JournalførManueltBrevTaskTest {
 
             // Assert
             verify(exactly = 1) { fagsakService.hentFagsak(fagsakId) }
-            verify(exactly = 1) { genererBrevService.genererManueltBrev(manueltBrevDto, false) }
+            verify(exactly = 1) {
+                genererBrevService.genererManueltBrev(
+                    manueltBrevRequest = manueltBrevDto,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
+                )
+            }
             verify(exactly = 1) {
                 utgåendeJournalføringService.journalførDokument(
                     fnr = eq(fagsak.aktør.aktivFødselsnummer()),
@@ -241,7 +263,7 @@ class JournalførManueltBrevTaskTest {
 
             val taskSlot = slot<Task>()
             every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
-            every { genererBrevService.genererManueltBrev(manueltBrevDto, false) } returns brev
+            every { genererBrevService.genererManueltBrev(manueltBrevDto, false, "Olaf Test") } returns brev
             every {
                 utgåendeJournalføringService.journalførDokument(
                     any(),
@@ -263,6 +285,7 @@ class JournalførManueltBrevTaskTest {
                     fagsakId = fagsak.id,
                     manueltBrevDto = manueltBrevDto,
                     mottakerInfo = mottakerInfo,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
                 )
 
             // Act
@@ -270,7 +293,7 @@ class JournalførManueltBrevTaskTest {
 
             // Assert
             verify(exactly = 1) { fagsakService.hentFagsak(fagsak.id) }
-            verify(exactly = 1) { genererBrevService.genererManueltBrev(manueltBrevDto, false) }
+            verify(exactly = 1) { genererBrevService.genererManueltBrev(manueltBrevDto, false, "Olaf Test") }
             verify(exactly = 1) {
                 utgåendeJournalføringService.journalførDokument(
                     fnr = eq(fagsak.aktør.aktivFødselsnummer()),
@@ -324,6 +347,7 @@ class JournalførManueltBrevTaskTest {
                     fagsakId = fagsakId,
                     manueltBrevDto = manueltBrevDto,
                     mottakerInfo = mottakerInfo,
+                    saksbehandlerSignaturTilBrev = "Olaf Test",
                 )
 
             // Assert


### PR DESCRIPTION
### 📮 Favro: NAV-26876

### 💰 Hva skal gjøres, og hvorfor?
Tidligere har man gått over til å sende manuelle brev asynkront.
Dette skjer gjennom JournalførManueltBrevTask som ble opprettet.

Denne tasken kalte videre på 
`dokumentGenereringService.genererManueltBrev` som igjen gjør dette:
```
            val brev: Brev =
                manueltBrevRequest.tilBrev(
                    mottakerIdent,
                    navnTilBrevHeader,
                    saksbehandlerContext.hentSaksbehandlerSignaturTilBrev(),
                ) { kodeverkService.hentLandkoderISO2() }
```

Problemet er at `saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()` returnerer noe forskjellig, avhengig av om kallet startet fra et endepunkt eller en task. Fra et endepunkt så hadde man hentet inn saksbehandler sitt signatur, men fra en task så blir signaturen satt til Vedtaksløsning Barnetrygd f.eks.

For å løse opp i dette har jeg endret det slik at man lagrer ned signaturen i det tasken blir opprettet (når man har tilgang på saksbehandler sin context).