### PR TITLE
Legg til nasjonal rett differanseberegning kompetent land

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
         <prosessering.version>2.20251103090009_f7d38c7</prosessering.version>
         <felles-kontrakter.version>3.0_20251106145307_0419786</felles-kontrakter.version>
         <felles.version>3.20251105152539_b03ed80</felles.version>
-        <eksterne-kontrakter-bisys.version>2.0_20251027085135_48de1e7</eksterne-kontrakter-bisys.version>
-        <familie.kontrakter.stønadsstatistikk>2.0_20251027085135_48de1e7</familie.kontrakter.stønadsstatistikk>
-        <familie.kontrakter.saksstatistikk>2.0_20251027085135_48de1e7</familie.kontrakter.saksstatistikk>
+        <eksterne-kontrakter-bisys.version>2.0_20251207221645_82d9e1d</eksterne-kontrakter-bisys.version>
+        <familie.kontrakter.stønadsstatistikk>2.0_20251207221645_82d9e1d</familie.kontrakter.stønadsstatistikk>
+        <familie.kontrakter.saksstatistikk>2.0_20251207221645_82d9e1d</familie.kontrakter.saksstatistikk>
         <utbetalingsgenerator.version>1.0_20250922101633_e4c1c4d</utbetalingsgenerator.version>
 
         <!-- Database -->

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -97,9 +97,7 @@ data class Kompetanse(
             this.resultat != null &&
             this.barnAktører.isNotEmpty()
 
-    fun erNorgeSekundærland() =
-        this.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND || this.resultat == KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING
-
+    fun erNorgeSekundærland() = this.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND || this.resultat == KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING
 
     companion object {
         val blankKompetanse = Kompetanse(fom = null, tom = null, barnAktører = emptySet())

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -97,6 +97,10 @@ data class Kompetanse(
             this.resultat != null &&
             this.barnAktører.isNotEmpty()
 
+    fun erNorgeSekundærland() =
+        this.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND || this.resultat == KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING
+
+
     companion object {
         val blankKompetanse = Kompetanse(fom = null, tom = null, barnAktører = emptySet())
     }
@@ -192,5 +196,3 @@ fun List<UtfyltKompetanse>.tilTidslinje() =
                 verdi = it,
             )
         }.tilTidslinje()
-
-fun Kompetanse.erNorgeSekundærLand() = this.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND || this.resultat == KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -120,7 +120,6 @@ enum class KompetanseAktivitet(
 
     MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN(true, true),
     MOTTAR_PENSJON(true, true),
-    NASJONAL_RETT_DIFFERANSEBEREGNING(true, true),
     INAKTIV(true, true),
 
     I_ARBEID(false, true),
@@ -133,6 +132,9 @@ enum class KompetanseResultat {
     NORGE_ER_PRIMÆRLAND,
     NORGE_ER_SEKUNDÆRLAND,
     TO_PRIMÆRLAND,
+
+    // Dette defineres også som at Norge er sekundærland
+    NASJONAL_RETT_DIFFERANSEBEREGNING,
 }
 
 sealed interface IKompetanse {
@@ -190,3 +192,5 @@ fun List<UtfyltKompetanse>.tilTidslinje() =
                 verdi = it,
             )
         }.tilTidslinje()
+
+fun Kompetanse.erNorgeSekundærLand() = this.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND || this.resultat == KompetanseResultat.NASJONAL_RETT_DIFFERANSEBEREGNING

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.medBehandlingId
 import no.nav.familie.ks.sak.kjerne.eøs.felles.endringsabonnent.EøsSkjemaEndringAbonnent
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
+import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.erNorgeSekundærLand
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.tidslinje.Tidslinje
@@ -80,9 +81,14 @@ internal fun tilpassUtenlandskePeriodebeløpTilKompetanser(
                 kompetanse == null -> null
                 upb == null || upb.utbetalingsland != kompetanse.annenForeldersAktivitetsland ->
                     UtenlandskPeriodebeløp.NULL.copy(utbetalingsland = kompetanse.annenForeldersAktivitetsland)
+
                 else -> upb
             }
         }.tilSkjemaer()
 }
 
-fun Map<Aktør, Tidslinje<Kompetanse>>.filtrerSekundærland() = this.mapValues { (_, tidslinje) -> tidslinje.filtrer { it?.resultat == KompetanseResultat.NORGE_ER_SEKUNDÆRLAND } }
+fun Map<Aktør, Tidslinje<Kompetanse>>.filtrerSekundærland() = this.mapValues { (_, tidslinje) ->
+    tidslinje.filtrer {
+        it?.erNorgeSekundærLand() == true
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
@@ -8,8 +8,6 @@ import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
 import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.medBehandlingId
 import no.nav.familie.ks.sak.kjerne.eøs.felles.endringsabonnent.EøsSkjemaEndringAbonnent
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.Kompetanse
-import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseResultat
-import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.erNorgeSekundærLand
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.tidslinje.Tidslinje
@@ -90,6 +88,6 @@ internal fun tilpassUtenlandskePeriodebeløpTilKompetanser(
 fun Map<Aktør, Tidslinje<Kompetanse>>.filtrerSekundærland() =
     this.mapValues { (_, tidslinje) ->
         tidslinje.filtrer {
-            it?.erNorgeSekundærLand() == true
+            it?.erNorgeSekundærland() == true
         }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserService.kt
@@ -87,8 +87,9 @@ internal fun tilpassUtenlandskePeriodebeløpTilKompetanser(
         }.tilSkjemaer()
 }
 
-fun Map<Aktør, Tidslinje<Kompetanse>>.filtrerSekundærland() = this.mapValues { (_, tidslinje) ->
-    tidslinje.filtrer {
-        it?.erNorgeSekundærLand() == true
+fun Map<Aktør, Tidslinje<Kompetanse>>.filtrerSekundærland() =
+    this.mapValues { (_, tidslinje) ->
+        tidslinje.filtrer {
+            it?.erNorgeSekundærLand() == true
+        }
     }
-}


### PR DESCRIPTION
### 📮 Favro: NAV-26831

### 💰 Hva skal gjøres, og hvorfor?

Favrokortet var tidligere feil, og påsto at nasjonal rett differanse beregning skulle legges til som en annen forelders aktivitet i kompetanse. Dette er feil, og i henhold til bestillingen fra team nasjonalt fagansvarlige skal den legges til som kompetent land.

Den har derfor blitt lagt inn som kompetanseresultat her, og den skal oppføre seg helt som sekundærland valget.
Eneste forskjellen er at man får annerledes begrunnelser i vedtak siden.
<img width="1198" height="750" alt="Screenshot 2025-12-04 at 22 38 46" src="https://github.com/user-attachments/assets/03fcf6dc-7b36-4c8e-9457-57b49bdb2507" />
