### PR TITLE
Hvis en søker bare har avslåtte behandlinger, er det ikke verdi i å utlede endringsresultat

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.ClockProvider
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
-import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat.BehandlingsresultatUtils.skalUtledeSøknadsresultatForBehandling

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.common.ClockProvider
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.behandlingsresultat.BehandlingsresultatUtils.skalUtledeSøknadsresultatForBehandling
@@ -36,6 +37,11 @@ class BehandlingsresultatService(
         val behandling = behandlingService.hentBehandling(behandlingId)
 
         val forrigeBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id)
+        val harTidligereBareBehandlingerSomErAvslått =
+            behandlingService
+                .hentBehandlingerPåFagsak(behandlingId)
+                .filter { it.erAvsluttet() }
+                .all { it.resultat != Behandlingsresultat.AVSLÅTT }
 
         val søknadGrunnlag = søknadGrunnlagService.finnAktiv(behandlingId = behandling.id)
         val søknadDto = søknadGrunnlag?.tilSøknadDto()
@@ -80,7 +86,7 @@ class BehandlingsresultatService(
 
         // 2 ENDRINGER
         val endringsresultat =
-            if (forrigeBehandling != null) {
+            if (forrigeBehandling != null && harTidligereBareBehandlingerSomErAvslått) {
                 val kompetanser = kompetanseService.hentKompetanser(behandlingId = BehandlingId(behandlingId))
                 val forrigeKompetanser = kompetanseService.hentKompetanser(behandlingId = BehandlingId(forrigeBehandling.id))
 
@@ -128,6 +134,7 @@ class BehandlingsresultatService(
                     // alle barna som er krysset av på søknad
                     søknadDto?.barnaMedOpplysninger?.filter { it.erFolkeregistrert && it.inkludertISøknaden }?.map { personidentService.hentAktør(it.ident) } ?: emptyList()
                 }
+
                 BehandlingÅrsak.KLAGE -> personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id).personer.map { it.aktør }
                 else -> emptyList()
             }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -41,7 +41,7 @@ class BehandlingsresultatService(
             behandlingService
                 .hentBehandlingerPåFagsak(behandlingId)
                 .filter { it.erAvsluttet() }
-                .all { it.resultat != Behandlingsresultat.AVSLÅTT }
+                .all { it.resultat == Behandlingsresultat.AVSLÅTT }
 
         val søknadGrunnlag = søknadGrunnlagService.finnAktiv(behandlingId = behandling.id)
         val søknadDto = søknadGrunnlag?.tilSøknadDto()
@@ -86,7 +86,7 @@ class BehandlingsresultatService(
 
         // 2 ENDRINGER
         val endringsresultat =
-            if (forrigeBehandling != null && harTidligereBareBehandlingerSomErAvslått) {
+            if (forrigeBehandling != null && !harTidligereBareBehandlingerSomErAvslått) {
                 val kompetanser = kompetanseService.hentKompetanser(behandlingId = BehandlingId(behandlingId))
                 val forrigeKompetanser = kompetanseService.hentKompetanser(behandlingId = BehandlingId(forrigeBehandling.id))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -113,7 +113,7 @@ class StepDefinition {
 
     /**
      * Mulige felter:
-     * | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingsstatus |
+     * | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingsstatus | Behandlingsresultat |
      */
     @Og("følgende behandlinger")
     fun `følgende behandling`(dataTable: DataTable) {
@@ -579,6 +579,8 @@ class StepDefinition {
                 .filter { behandling -> behandling.fagsak.id == fagsakId && behandling.status == BehandlingStatus.AVSLUTTET }
                 .maxByOrNull { it.id }
         }
+
+        every { behandlingService.hentBehandlingerPåFagsak(any()) } returns behandlinger.values.toList()
 
         val søknadGrunnlagService = mockk<SøknadGrunnlagService>()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/VedtaksperiodeUtil.kt
@@ -92,13 +92,16 @@ fun lagbehandlinger(
         val behandlingKategori =
             parseValgfriEnum<BehandlingKategori>(Domenebegrep.BEHANDLINGSKATEGORI, rad)
                 ?: BehandlingKategori.NASJONAL
+        val behandlingsresultat =
+            parseValgfriEnum<Behandlingsresultat>(Domenebegrep.BEHANDLINGSRESULTAT, rad)
+                ?: Behandlingsresultat.IKKE_VURDERT
         val status = parseValgfriEnum<BehandlingStatus>(Domenebegrep.BEHANDLINGSSTATUS, rad)
 
         val behandling =
             lagBehandling(
                 fagsak = fagsak,
                 opprettetÅrsak = behandlingÅrsak ?: BehandlingÅrsak.SØKNAD,
-                resultat = Behandlingsresultat.IKKE_VURDERT,
+                resultat = behandlingsresultat,
                 kategori = behandlingKategori,
             ).copy(id = behandlingId)
         behandling.apply {

--- a/src/test/resources/cucumber/vedtaksperioder/avslag.feature
+++ b/src/test/resources/cucumber/vedtaksperioder/avslag.feature
@@ -218,3 +218,58 @@ Egenskap: Avslag perioder
     Så forvent følgende brevbegrunnelser for behandling 2 i periode - til -
       | Begrunnelse                                      | Type     | Gjelder søker | Barnas fødselsdatoer | Antall barn | Måned og år begrunnelsen gjelder for | Beløp | Søknadstidspunkt | Antall timer barnehageplass | Gjelder andre forelder | Målform | Måned og år før vedtaksperiode |
       | AVSLAG_DEN_ANDRE_FORELDEREN_IKKE_MEDLEM_I_FEM_ÅR | STANDARD |               | 18.07.24             | 1           |                                      | 0     |                  | 0                           | Ja                     |         |                                |
+
+
+  Scenario: Hvis man tidligere bare har fått rent avslag på søknader, så skal man ikke utlede endringsresultat da det er ingen endringer på eksisterende ytelse
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus | Behandlingsresultat |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         | AVSLÅTT             |
+      | 2            | 1        | 1                   | SØKNAD           | NASJONAL            | UTREDES           |                     |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 04.03.1995  |
+      | 1            | 2       | BARN       | 18.11.2023  |
+      | 2            | 1       | SØKER      | 04.03.1995  |
+      | 2            | 2       | BARN       | 18.11.2023  |
+    Og følgende dagens dato 08.12.2025
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser                     | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | MEDLEMSKAP                   |                  |            |            | IKKE_OPPFYLT | Ja                   | AVSLAG_IKKE_MEDLEM_FOLKETRYGDEN_I_FEM_ÅR | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | BOSATT_I_RIKET               |                  | 11.01.2021 |            | OPPFYLT      | Nei                  |                                          | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                                          | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 18.11.2023 |            | OPPFYLT      | Nei                  |                                          | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 18.11.2023 |            | OPPFYLT      | Nei                  |                                          |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 18.12.2024 | 18.06.2025 | OPPFYLT      | Nei                  |                                          |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser         | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | MEDLEMSKAP                   |                  | 04.03.2000 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | BOSATT_I_RIKET               |                  | 11.01.2021 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_AKTUELT | Nei                  |                              | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 18.11.2023 |            | OPPFYLT      | Nei                  |                              | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 18.11.2023 |            | OPPFYLT      | Nei                  |                              |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 18.12.2024 | 18.06.2025 | OPPFYLT      | Nei                  |                              |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 19.06.2025 |            | IKKE_OPPFYLT | Ja                   | AVSLAG_BARN_OVER_19_MND_0824 |                  | Nei                                   |              |
+
+    Og følgende endrede utbetalinger
+      | AktørId | BehandlingId | Fra dato   | Til dato   | Årsak              | Prosent | Søknadstidspunkt |
+      | 2       | 2            | 01.12.2024 | 30.06.2025 | ETTERBETALING_3MND | 0       | 20.11.2025       |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.12.2024 | 30.06.2025 | 0     | ORDINÆR_KONTANTSTØTTE | 0       | 7500 | 0                      |                          |
+    Og når behandlingsresultatet er utledet for behandling 2
+
+    Så forvent at behandlingsresultatet er AVSLÅTT på behandling 2


### PR DESCRIPTION
### 📮 Favro: NAV-26913
### 💰 Hva skal gjøres, og hvorfor?

Vi bør ikke utlede endringsresultat for fagsak der det bare eksisterer avslåtte behandlinger.
Dette er fordi at fagsaken på det tidspunktet ikke har fått innvilget noe kontantstøtte, og det blir feil å bruke overskriften "Vi har endret kontantstøtten din" ved ny avslag.
