### PR TITLE
Korriger brevsignatur for enheter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/KontantstøtteEnhet.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/KontantstøtteEnhet.kt
@@ -7,13 +7,13 @@ enum class KontantstøtteEnhet(
     val enhetsnavn: String,
     val gruppenavn: String,
 ) {
-    VIKAFOSSEN("2103", "NAV Vikafossen", "0000-GA-ENHET_2103"),
-    DRAMMEN("4806", "NAV Familie- og pensjonsytelser Drammen", "0000-GA-ENHET_4806"),
-    VADSØ("4820", "NAV Familie- og pensjonsytelser Vadsø", "0000-GA-ENHET_4820"),
-    OSLO("4833", "NAV Familie- og pensjonsytelser Oslo 1", "0000-GA-ENHET_4833"),
-    STORD("4842", "NAV Familie- og pensjonsytelser Stord", "0000-GA-ENHET_4842"),
-    STEINKJER("4817", "NAV Familie- og pensjonsytelser Steinkjer", "0000-GA-ENHET_4817"),
-    BERGEN("4812", "NAV Familie- og pensjonsytelser Bergen", "0000-GA-ENHET_4812"),
+    VIKAFOSSEN("2103", "Nav Vikafossen", "0000-GA-ENHET_2103"),
+    DRAMMEN("4806", "Nav familie- og pensjonsytelser Drammen", "0000-GA-ENHET_4806"),
+    VADSØ("4820", "Nav familie- og pensjonsytelser Vadsø", "0000-GA-ENHET_4820"),
+    OSLO("4833", "Nav familie- og pensjonsytelser Oslo 1", "0000-GA-ENHET_4833"),
+    STORD("4842", "Nav familie- og pensjonsytelser Stord", "0000-GA-ENHET_4842"),
+    STEINKJER("4817", "Nav familie- og pensjonsytelser Steinkjer", "0000-GA-ENHET_4817"),
+    BERGEN("4812", "Nav familie- og pensjonsytelser Bergen", "0000-GA-ENHET_4812"),
     MIDLERTIDIG_ENHET("4863", "Midlertidig enhet", "0000-GA-ENHET_4863"),
     ;
 


### PR DESCRIPTION
### 📮 Favro: NAV-26981

### 💰 Hva skal gjøres, og hvorfor?
Signatur for enhetene var feil. `NAV` skal skrives med liten `av` og `Familie` skal skrive med liten f 