### PR TITLE
Ikke assert på MDCConstants.MDC_CALL_ID verdi

### DIFF
--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/JournalførManueltBrevTaskTest.kt
@@ -359,7 +359,7 @@ class JournalførManueltBrevTaskTest {
             assertThat(dto.manueltBrevDto).isEqualTo(manueltBrevDto)
             assertThat(dto.avsenderMottaker).isEqualTo(mottakerInfo.tilAvsenderMottaker())
             assertThat(dto.manuellAdresseInfo).isEqualTo(mottakerInfo.manuellAdresseInfo)
-            assertThat(dto.eksternReferanseId).isEqualTo("${fagsakId}_${behandlingId}_null")
+            assertThat(dto.eksternReferanseId).contains("${fagsakId}_${behandlingId}_")
             assertThat(task.metadata["fagsakId"]).isEqualTo(fagsakId.toString())
             assertThat(task.metadata["behandlingId"]).isEqualTo(behandlingId.toString())
             assertThat(task.metadata["brevmal"]).isEqualTo(manueltBrevDto.brevmal.name)


### PR DESCRIPTION
### 📮 Favro: NAV-27011

### 💰 Hva skal gjøres, og hvorfor?

JournalførManueltBrevTaskTest.skal opprette task 
Denne testen feiler veldig, se f.eks her der den feiler 2 ganger på rad. (se attempt1&attempt2)
https://github.com/navikt/familie-ks-sak/actions/runs/20128543243/job/57766806030

Oppstår fordi man asserter på et felt som settes av ${MDC.get(MDCConstants.MDC_CALL_ID)} som kan variere i bygg.

