### PR TITLE
Bugfiks ved bruk av all og henting av behandlinger på fagsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -36,11 +36,15 @@ class BehandlingsresultatService(
         val behandling = behandlingService.hentBehandling(behandlingId)
 
         val forrigeBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id)
-        val harTidligereBareBehandlingerSomErAvslått =
+
+        val tidligereAvsluttetBehandlingerIFagsak =
             behandlingService
-                .hentBehandlingerPåFagsak(behandlingId)
+                .hentBehandlingerPåFagsak(behandling.fagsak.id)
                 .filter { it.erAvsluttet() }
-                .all { it.resultat == Behandlingsresultat.AVSLÅTT }
+
+        val harTidligereBareBehandlingerSomErAvslått =
+            tidligereAvsluttetBehandlingerIFagsak.isNotEmpty() &&
+                tidligereAvsluttetBehandlingerIFagsak.all { it.resultat.erAvslått() }
 
         val søknadGrunnlag = søknadGrunnlagService.finnAktiv(behandlingId = behandling.id)
         val søknadDto = søknadGrunnlag?.tilSøknadDto()


### PR DESCRIPTION
### 📮 Favro: Nav-27021

### 💰 Hva skal gjøres, og hvorfor?
To feil med nåværendes kode:

1. I kotlin så defaultes ALL til å være true hvis lista er tomt
2. Man må sende inn fagsakId og ikke behandlingId når man skal hente alle behandlinger tilhørende fagsak.

Det er verdt å merke seg at testene gikk gjennom selvom nr 2 var feil, fordi fagsakid og behandlingId i testene våres pleier å være det samme. Dette bør fikses i etterkant, men det er viktig at denne merges asap.