### PR TITLE
NAV-26885: Sender med erAnnenForelderOmfattetAvNorskLovgivning til familie-brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContext.kt
@@ -125,7 +125,6 @@ class BrevPeriodeContext(
         val barnIPeriode: List<Person> =
             when (utvidetVedtaksperiodeMedBegrunnelser.type) {
                 Vedtaksperiodetype.UTBETALING -> finnBarnIUtbetalingPeriode(identerIBegrunnelene)
-
                 Vedtaksperiodetype.OPPHØR -> emptyList()
                 Vedtaksperiodetype.AVSLAG -> emptyList()
                 Vedtaksperiodetype.FORTSATT_INNVILGET -> barnMedUtbetaling + barnMedNullutbetaling
@@ -169,16 +168,25 @@ class BrevPeriodeContext(
         barnMedUtbetaling: List<Person>,
         utbetalingsbeløp: Int,
     ) = when (utvidetVedtaksperiodeMedBegrunnelser.type) {
-        Vedtaksperiodetype.FORTSATT_INNVILGET -> BrevPeriodeType.FORTSATT_INNVILGET
-        Vedtaksperiodetype.UTBETALING ->
+        Vedtaksperiodetype.FORTSATT_INNVILGET -> {
+            BrevPeriodeType.FORTSATT_INNVILGET
+        }
+
+        Vedtaksperiodetype.UTBETALING -> {
             when {
                 utbetalingsbeløp == 0 -> BrevPeriodeType.INNVILGELSE_INGEN_UTBETALING
                 barnMedUtbetaling.isEmpty() -> BrevPeriodeType.INNVILGELSE_KUN_UTBETALING_PÅ_SØKER
                 else -> BrevPeriodeType.INNVILGELSE
             }
+        }
 
-        Vedtaksperiodetype.AVSLAG -> if (fom != null) BrevPeriodeType.AVSLAG else BrevPeriodeType.AVSLAG_UTEN_PERIODE
-        Vedtaksperiodetype.OPPHØR -> BrevPeriodeType.OPPHOR
+        Vedtaksperiodetype.AVSLAG -> {
+            if (fom != null) BrevPeriodeType.AVSLAG else BrevPeriodeType.AVSLAG_UTEN_PERIODE
+        }
+
+        Vedtaksperiodetype.OPPHØR -> {
+            BrevPeriodeType.OPPHOR
+        }
     }
 
     fun finnBarnIUtbetalingPeriode(identerIBegrunnelene: List<String>): List<Person> {
@@ -201,10 +209,13 @@ class BrevPeriodeContext(
         begrunnelse: IBegrunnelse,
     ): List<LocalDate> =
         when {
-            begrunnelse == NasjonalEllerFellesBegrunnelse.AVSLAG_UREGISTRERT_BARN ->
+            begrunnelse == NasjonalEllerFellesBegrunnelse.AVSLAG_UREGISTRERT_BARN -> {
                 uregistrerteBarn.mapNotNull { it.fødselsdato }
+            }
 
-            else -> hentBarnSomSkalIBegrunnelse(gjelderSøker, personerMedVilkårEllerOvergangsordningSomPasserBegrunnelse, begrunnelse).map { it.fødselsdato }
+            else -> {
+                hentBarnSomSkalIBegrunnelse(gjelderSøker, personerMedVilkårEllerOvergangsordningSomPasserBegrunnelse, begrunnelse).map { it.fødselsdato }
+            }
         }
 
     fun hentBarnSomSkalIBegrunnelse(
@@ -226,9 +237,10 @@ class BrevPeriodeContext(
                 }
             }
 
-            else ->
+            else -> {
                 personerMedVilkårEllerOvergangsordningSomPasserBegrunnelse
                     .filter { it.type == PersonType.BARN }
+            }
         }
 
     fun hentAntallBarnForBegrunnelse(
@@ -384,34 +396,40 @@ class BrevPeriodeContext(
         begrunnelse: IBegrunnelse,
         sanityBegrunnelse: SanityBegrunnelse,
     ) = when (begrunnelse.begrunnelseType) {
-        BegrunnelseType.ETTER_ENDRET_UTBETALING -> begrunnelserForPeriodeContext.hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse)
+        BegrunnelseType.ETTER_ENDRET_UTBETALING -> {
+            begrunnelserForPeriodeContext.hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse)
+        }
 
         BegrunnelseType.FORTSATT_INNVILGET -> {
             hentRelevantePersonerForFortsattInnvilget()
         }
 
-        else ->
+        else -> {
             begrunnelserForPeriodeContext.hentPersonerSomPasserMedBegrunnelseOgPeriode(
                 begrunnelse = begrunnelse,
                 sanityBegrunnelse = sanityBegrunnelse,
             )
+        }
     }
 
     private fun hentRelevantePersonerForEøsBegrunnelse(
         begrunnelse: IBegrunnelse,
         sanityBegrunnelse: SanityBegrunnelse,
     ) = when (begrunnelse.begrunnelseType) {
-        BegrunnelseType.ETTER_ENDRET_UTBETALING -> begrunnelserForPeriodeContext.hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse)
+        BegrunnelseType.ETTER_ENDRET_UTBETALING -> {
+            begrunnelserForPeriodeContext.hentPersonerMedEndretUtbetalingerSomPasserMedVedtaksperiode(sanityBegrunnelse)
+        }
 
         BegrunnelseType.FORTSATT_INNVILGET -> {
             hentRelevantePersonerForFortsattInnvilget()
         }
 
-        else ->
+        else -> {
             begrunnelserForPeriodeContext.hentPersonerSomPasserForKompetanseIPeriode(
                 begrunnelse = begrunnelse,
                 sanityBegrunnelse = sanityBegrunnelse,
             )
+        }
     }
 
     private fun hentRelevantePersonerForFortsattInnvilget(): Set<Person> {
@@ -549,6 +567,7 @@ class BrevPeriodeContext(
                                 antallBarn = hentAntallBarnForBegrunnelse(barnasFødselsdatoer = barnIBegrunnelseOgIKompetanseFødselsdato, begrunnelse = begrunnelse),
                                 maalform = personopplysningGrunnlag.søker.målform.tilSanityFormat(),
                                 antallTimerBarnehageplass = antallTimerBarnehageplass,
+                                erAnnenForelderOmfattetAvNorskLovgivning = kompetanse.erAnnenForelderOmfattetAvNorskLovgivning,
                             )
                         } else {
                             null
@@ -595,9 +614,12 @@ class BrevPeriodeContext(
         val månedenFørFom = vedtaksperiodeFom.minusMonths(1).tilMånedÅr()
 
         return when (vedtaksperiodeType) {
-            Vedtaksperiodetype.AVSLAG ->
+            Vedtaksperiodetype.AVSLAG -> {
                 when {
-                    vedtaksperiodeFom == TIDENES_MORGEN && vedtaksperiodeTom == TIDENES_ENDE -> ""
+                    vedtaksperiodeFom == TIDENES_MORGEN && vedtaksperiodeTom == TIDENES_ENDE -> {
+                        ""
+                    }
+
                     vedtaksperiodeTom == TIDENES_ENDE -> {
                         val vilkårMedEksplisitteAvslag = vilkårResultaterForRelevantePersoner.filter { it.erEksplisittAvslagPåSøknad == true }
                         val avslagsperiodeStarterMånedEtterVilkår =
@@ -612,8 +634,11 @@ class BrevPeriodeContext(
                         }
                     }
 
-                    else -> "${vedtaksperiodeFom.tilMånedÅr()} til ${vedtaksperiodeTom.tilMånedÅr()}"
+                    else -> {
+                        "${vedtaksperiodeFom.tilMånedÅr()} til ${vedtaksperiodeTom.tilMånedÅr()}"
+                    }
                 }
+            }
 
             Vedtaksperiodetype.OPPHØR -> {
                 val opphørGrunnetFulltidsBarnehageplassAugust2024 =
@@ -778,5 +803,7 @@ private fun NasjonalEllerFellesBegrunnelse.hentRelevanteEndringsperioderForBegru
             }
         }
 
-        else -> emptyList()
+        else -> {
+            emptyList()
+        }
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseDto.kt
@@ -8,27 +8,37 @@ sealed class BegrunnelseDto(
 ) : Comparable<BegrunnelseDto> {
     override fun compareTo(other: BegrunnelseDto): Int =
         when (this) {
-            is FritekstBegrunnelseDto -> Int.MAX_VALUE
-            is BegrunnelseDtoMedData ->
+            is FritekstBegrunnelseDto -> {
+                Int.MAX_VALUE
+            }
+
+            is BegrunnelseDtoMedData -> {
                 when (other) {
-                    is FritekstBegrunnelseDto -> this.vedtakBegrunnelseType.sorteringsrekkefølge
-                    is BegrunnelseDtoMedData ->
+                    is FritekstBegrunnelseDto -> {
+                        this.vedtakBegrunnelseType.sorteringsrekkefølge
+                    }
+
+                    is BegrunnelseDtoMedData -> {
                         when (this.sanityBegrunnelseType) {
-                            SanityBegrunnelseType.STANDARD ->
+                            SanityBegrunnelseType.STANDARD -> {
                                 if (other.sanityBegrunnelseType == SanityBegrunnelseType.STANDARD) {
                                     this.vedtakBegrunnelseType.sorteringsrekkefølge - other.vedtakBegrunnelseType.sorteringsrekkefølge
                                 } else {
                                     -Int.MAX_VALUE
                                 }
+                            }
 
-                            else ->
+                            else -> {
                                 if (other.sanityBegrunnelseType == SanityBegrunnelseType.STANDARD) {
                                     Int.MAX_VALUE
                                 } else {
                                     this.vedtakBegrunnelseType.sorteringsrekkefølge - other.vedtakBegrunnelseType.sorteringsrekkefølge
                                 }
+                            }
                         }
+                    }
                 }
+            }
         }
 }
 
@@ -95,6 +105,7 @@ data class EØSBegrunnelseMedKompetanseDto(
     val sokersAktivitet: KompetanseAktivitet,
     val sokersAktivitetsland: String?,
     val antallTimerBarnehageplass: String,
+    val erAnnenForelderOmfattetAvNorskLovgivning: Boolean,
 ) : EØSBegrunnelseDto(
         type = BrevBegrunnelseType.EØS_BEGRUNNELSE,
         apiNavn = apiNavn,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/domene/Kompetanse.kt
@@ -161,6 +161,7 @@ data class UtfyltKompetanse(
     val søkersAktivitetsland: String,
     val barnetsBostedsland: String,
     val resultat: KompetanseResultat,
+    val erAnnenForelderOmfattetAvNorskLovgivning: Boolean,
 ) : IKompetanse
 
 fun Kompetanse.tilIKompetanse(): IKompetanse =
@@ -177,6 +178,7 @@ fun Kompetanse.tilIKompetanse(): IKompetanse =
             søkersAktivitetsland = this.søkersAktivitetsland!!,
             barnetsBostedsland = this.barnetsBostedsland!!,
             resultat = this.resultat!!,
+            erAnnenForelderOmfattetAvNorskLovgivning = this.erAnnenForelderOmfattetAvNorskLovgivning!!,
         )
     } else {
         TomKompetanse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/domeneparser/VedtaksperiodeMedBegrunnelserParser.kt
@@ -79,6 +79,7 @@ object VedtaksperiodeMedBegrunnelserParser {
         ANNEN_FORELDERS_AKTIVITETSLAND("Annen forelders aktivitetsland"),
         BARNETS_BOSTEDSLAND("Barnets bostedsland"),
         RESULTAT("Resultat"),
+        ER_ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING("Annen forelder omfattet av norsk lovgivning"),
     }
 
     enum class DomenebegrepValutakurs(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/BrevbegrunnelseUtil.kt
@@ -116,6 +116,12 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseDto {
             rad,
         )
 
+    val erAnnenForelderOmfattetAvNorskLovgivning =
+        parseValgfriBoolean(
+            VedtaksperiodeMedBegrunnelserParser.DomenebegrepKompetanse.ER_ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING,
+            rad,
+        ) ?: false
+
     val begrunnelse =
         parseEnum<EØSBegrunnelse>(
             BrevPeriodeParser.DomenebegrepBrevBegrunnelse.BEGRUNNELSE,
@@ -155,6 +161,7 @@ fun parseEøsBegrunnelse(rad: Tabellrad): EØSBegrunnelseDto {
             sokersAktivitetsland = søkersAktivitetsland,
             sanityBegrunnelseType = SanityBegrunnelseType.STANDARD,
             antallTimerBarnehageplass = antallTimerBarnehageplass,
+            erAnnenForelderOmfattetAvNorskLovgivning = erAnnenForelderOmfattetAvNorskLovgivning,
         )
     } else {
         EØSBegrunnelseUtenKompetanseDto(


### PR DESCRIPTION
### 📮 Favro: [NAV-26885](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26885)

### 💰 Hva skal gjøres, og hvorfor?
Ved selvstendig rett (`erAnnenForelderOmfattetAvNorskLovgivning = true`) switches aktivitetsvalgene for søker og annen forelder. I `familie-brev` har vi en custom håndtering av selvstendig rett, men denne er ikke tatt i bruk av ks-sak da vi ikke sender med informasjonen om selvstendig rett til `familie-brev`

Sørger her for å sende med `erAnnenForelderOmfattetAvNorskLovgivning` til `familie-brev`

> En del av endringene er ktlint. Reelle endringene er i `EØSBegrunnelseMedKompetanseDto` og `UtfyltKompetanse`.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

Jeg har ikke skrevet tester fordi: Ingen logikk-endringer
