### PR TITLE
Oppgrader til JDK25, kotlin 2.3.0 og Chainguard

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -61,7 +61,7 @@ jobs:
         # queries: security-extended,security-and-quality
 
         with:
-          java-version: "21"
+          java-version: "25"
           distribution: 'temurin'
 
           cache: 'maven'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,7 @@ jobs:
       build-image: true
       push-image: true
       byosbom: target/classes/META-INF/sbom/application.cdx.json
+      java-version: 25
     secrets: inherit
   deploy-dev:
     name: Deploy dev

--- a/.github/workflows/manual-deploy-dev.yaml
+++ b/.github/workflows/manual-deploy-dev.yaml
@@ -20,6 +20,7 @@ jobs:
       build-image: true
       push-image: true
       byosbom: target/classes/META-INF/sbom/application.cdx.json
+      java-version: 25
     secrets: inherit
   deploy-with-new-image:
     name: Deploy with new image

--- a/.github/workflows/manual-deploy-prod.yaml
+++ b/.github/workflows/manual-deploy-prod.yaml
@@ -21,6 +21,7 @@ jobs:
       build-image: true
       push-image: true
       byosbom: target/classes/META-INF/sbom/application.cdx.json
+      java-version: 25
     secrets: inherit
   deploy-with-new-image:
     name: Deploy with new image

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,6 +28,7 @@ jobs:
       with-coverage: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' && true || false }}
       coverage-artifact-name: 'enhetstest'
       coverage-artifact-path: 'target/coverage/enhetstest/jacoco.xml'
+      java-version: 25
     secrets: inherit
 
   integrasjonstest:
@@ -40,6 +41,7 @@ jobs:
       with-coverage: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' && true || false }}
       coverage-artifact-name: 'integrasjonstest'
       coverage-artifact-path: 'target/coverage/integrasjonstest/jacoco.xml'
+      java-version: 25
     secrets: inherit
 
   sonar:
@@ -55,7 +57,7 @@ jobs:
         uses: navikt/familie-baks-gha-workflows/.github/actions/setup-java-maven@main # ratchet:exclude
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          java-version: '21'
+          java-version: '25'
       - name: Last ned enhetstest rapport
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # ratchet:actions/download-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21:nonroot
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 COPY --chown=nonroot:nonroot ./target/familie-ks-sak.jar /app/app.jar
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.7</version> <!-- Skal samsvare med spring-boot-dependencies -->
+        <version>3.5.8</version> <!-- Skal samsvare med spring-boot-dependencies -->
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -29,11 +29,8 @@
         <kotlinx.version>1.10.2</kotlinx.version>
 
         <!-- Spring -->
-        <spring-boot-dependencies.version>3.5.7</spring-boot-dependencies.version> <!-- Skal samsvare med spring-boot-starter-parent -->
+        <spring-boot-dependencies.version>3.5.8</spring-boot-dependencies.version> <!-- Skal samsvare med spring-boot-starter-parent -->
         <springdoc.version>2.8.14</springdoc.version>
-
-        <!-- Http Client - nyeste versjon fra httpclient(5.5.1) skaper problemer med Spring Boot 3.5.7. Issue: HTTPCLIENT-2405. Skal være fikset i 3.5.8, men bør testes -->
-        <httpclient5.version>5.5</httpclient5.version>
 
         <!-- Nav felles -->
         <nav-token-client.version>5.0.39</nav-token-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Java/Kotlin -->
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <kotlin.version>2.3.0</kotlin.version>
         <kotlin.compiler.languageVersion>2.3</kotlin.compiler.languageVersion>
         <kotlin.compiler.apiVersion>2.3</kotlin.compiler.apiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
 
         <!-- Java/Kotlin -->
         <java.version>21</java.version>
-        <kotlin.version>2.2.21</kotlin.version>
-        <kotlin.compiler.languageVersion>2.0</kotlin.compiler.languageVersion>
-        <kotlin.compiler.apiVersion>2.0</kotlin.compiler.apiVersion>
+        <kotlin.version>2.3.0</kotlin.version>
+        <kotlin.compiler.languageVersion>2.3</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>2.3</kotlin.compiler.apiVersion>
         <kotlinx.version>1.10.2</kotlinx.version>
 
         <!-- Spring -->

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
@@ -56,6 +56,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.support.ParameterDeclarations
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -419,7 +420,10 @@ internal class TilbakekrevingServiceTest {
     }
 
     private class TestProvider : ArgumentsProvider {
-        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
+        override fun provideArguments(
+            parameters: ParameterDeclarations,
+            context: ExtensionContext,
+        ): Stream<out Arguments> =
             Stream.of(
                 Arguments.of(Pair(MottakerType.FULLMEKTIG, Vergetype.ANNEN_FULLMEKTIG)),
                 Arguments.of(Pair(MottakerType.VERGE, Vergetype.VERGE_FOR_VOKSEN)),


### PR DESCRIPTION
### 📮 Favro: NAV-26277

### 💰 Hva skal gjøres, og hvorfor?
- **Bump kotlin til 2.3.0**
- **Bump spring boot til 3.5.8**
- **Oppgraderer til LTS JDK25, Chaniguard og kotlin 2.3.0**

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
