### PR TITLE
Vi forhindrer endring til vadsø hvis nasjonal sak, steinkjer hvis eøs sak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -136,11 +136,11 @@ class ArbeidsfordelingService(
         when {
             behandling.kategori == BehandlingKategori.EØS &&
                 endreBehandlendeEnhet.enhetId == KontantstøtteEnhet.STEINKJER.enhetsnummer ->
-                throw FunksjonellFeil("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Steinkjer dersom det er en EØS sak.")
+                throw FunksjonellFeil("Fra og med 5. januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Steinkjer dersom det er en EØS sak.")
 
             behandling.kategori == BehandlingKategori.NASJONAL &&
                 endreBehandlendeEnhet.enhetId == KontantstøtteEnhet.VADSØ.enhetsnummer ->
-                throw FunksjonellFeil("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Vadsø dersom det er en Nasjonal sak.")
+                throw FunksjonellFeil("Fra og med 5. januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Vadsø dersom det er en Nasjonal sak.")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ks.sak.integrasjon.oppgave.OppgaveService
@@ -14,6 +15,7 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåB
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.hentArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.tilArbeidsfordelingsenhet
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -99,6 +101,8 @@ class ArbeidsfordelingService(
         behandling: Behandling,
         endreBehandlendeEnhet: EndreBehandlendeEnhetDto,
     ) {
+        validerEndringAvBehandlendeEnhet(behandling, endreBehandlendeEnhet)
+
         val aktivArbeidsfordelingPåBehandling = hentArbeidsfordelingPåBehandling(behandling.id)
 
         val aktivArbeidsfordelingsenhet =
@@ -123,6 +127,21 @@ class ArbeidsfordelingService(
             manuellOppdatering = true,
             begrunnelse = endreBehandlendeEnhet.begrunnelse,
         )
+    }
+
+    private fun validerEndringAvBehandlendeEnhet(
+        behandling: Behandling,
+        endreBehandlendeEnhet: EndreBehandlendeEnhetDto,
+    ) {
+        when {
+            behandling.kategori == BehandlingKategori.EØS &&
+                endreBehandlendeEnhet.enhetId == KontantstøtteEnhet.STEINKJER.enhetsnummer ->
+                throw FunksjonellFeil("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Steinkjer dersom det er en EØS sak.")
+
+            behandling.kategori == BehandlingKategori.NASJONAL &&
+                endreBehandlendeEnhet.enhetId == KontantstøtteEnhet.VADSØ.enhetsnummer ->
+                throw FunksjonellFeil("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Vadsø dersom det er en Nasjonal sak.")
+        }
     }
 
     fun hentArbeidsfordelingsenhet(behandling: Behandling): Arbeidsfordelingsenhet {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
 import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
@@ -20,6 +21,7 @@ import no.nav.familie.ks.sak.integrasjon.oppgave.OppgaveService
 import no.nav.familie.ks.sak.integrasjon.pdl.PersonopplysningerService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -83,58 +85,93 @@ internal class ArbeidsfordelingServiceTest {
         assertThat(finnArbeidsfordelingPåBehandling).isEqualTo(mockedArbeidsfordelingPåBehandling)
     }
 
-    @Test
-    fun `manueltOppdaterBehandlendeEnhet skal kaste exception dersom behandling ikke har tilknyttet arbeidsfordeling`() {
-        val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
-        val endreBehandlendeEnhetDto = EndreBehandlendeEnhetDto("testId", "testBegrunnelse")
+    @Nested
+    inner class ManueltOppdaterBehandlendeEnhet {
+        @Test
+        fun `Skal kaste exception dersom behandling ikke har tilknyttet arbeidsfordeling`() {
+            val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
+            val endreBehandlendeEnhetDto = EndreBehandlendeEnhetDto("testId", "testBegrunnelse")
 
-        every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) } returns null
+            every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) } returns null
 
-        val feil =
-            assertThrows<Feil> {
-                arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(
-                    behandling,
-                    endreBehandlendeEnhetDto,
+            val feil =
+                assertThrows<Feil> {
+                    arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(
+                        behandling,
+                        endreBehandlendeEnhetDto,
+                    )
+                }
+
+            assertThat(feil.message).isEqualTo("Finner ikke tilknyttet arbeidsfordeling på behandling med id ${behandling.id}")
+        }
+
+        @Test
+        fun `Skal kaste funksjonell feil dersom nasjonal behandling forsøkes å settes over til Vadsø`() {
+            val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER, kategori = BehandlingKategori.NASJONAL)
+            val endreBehandlendeEnhetDto = EndreBehandlendeEnhetDto(KontantstøtteEnhet.VADSØ.enhetsnummer, "testBegrunnelse")
+
+            val feil =
+                assertThrows<FunksjonellFeil> {
+                    arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(
+                        behandling,
+                        endreBehandlendeEnhetDto,
+                    )
+                }
+
+            assertThat(feil.message).isEqualTo("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Vadsø dersom det er en Nasjonal sak.")
+        }
+
+        @Test
+        fun `Skal kaste funksjonell feil dersom eøs behandling forsøkes å settes over til Steinkjer`() {
+            val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER, kategori = BehandlingKategori.EØS)
+            val endreBehandlendeEnhetDto = EndreBehandlendeEnhetDto(KontantstøtteEnhet.STEINKJER.enhetsnummer, "testBegrunnelse")
+
+            val feil =
+                assertThrows<FunksjonellFeil> {
+                    arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(
+                        behandling,
+                        endreBehandlendeEnhetDto,
+                    )
+                }
+
+            assertThat(feil.message).isEqualTo("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Steinkjer dersom det er en EØS sak.")
+        }
+
+        @Test
+        fun `Skal kaste lagre ned ny arbeidsfordelingPåBehandling med nye detaljer`() {
+            val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
+            val endreBehandlendeEnhetDto = EndreBehandlendeEnhetDto("testId", "testBegrunnelse")
+            val mockedArbeidsfordelingPåBehandling = mockk<ArbeidsfordelingPåBehandling>(relaxed = true)
+            val mockedArbeidsfordelingPåBehandlingEtterEndring = mockk<ArbeidsfordelingPåBehandling>(relaxed = true)
+
+            every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) } returns mockedArbeidsfordelingPåBehandling
+            every { integrasjonKlient.hentNavKontorEnhet("testId") } returns
+                NavKontorEnhet(
+                    0,
+                    "testNavn",
+                    "testEnhet",
+                    "testStatus",
                 )
-            }
+            every {
+                mockedArbeidsfordelingPåBehandling.copy(
+                    0,
+                    0,
+                    "testId",
+                    "testNavn",
+                    true,
+                )
+            } returns mockedArbeidsfordelingPåBehandlingEtterEndring
+            every {
+                arbeidsfordelingPåBehandlingRepository.save(mockedArbeidsfordelingPåBehandlingEtterEndring)
+            } returns mockedArbeidsfordelingPåBehandlingEtterEndring
 
-        assertThat(feil.message).isEqualTo("Finner ikke tilknyttet arbeidsfordeling på behandling med id ${behandling.id}")
-    }
+            arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(behandling, endreBehandlendeEnhetDto)
 
-    @Test
-    fun `manueltOppdaterBehandlendeEnhet skal kaste lagre ned ny arbeidsfordelingPåBehandling med nye detaljer`() {
-        val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.ÅRLIG_KONTROLL)
-        val endreBehandlendeEnhetDto = EndreBehandlendeEnhetDto("testId", "testBegrunnelse")
-        val mockedArbeidsfordelingPåBehandling = mockk<ArbeidsfordelingPåBehandling>(relaxed = true)
-        val mockedArbeidsfordelingPåBehandlingEtterEndring = mockk<ArbeidsfordelingPåBehandling>(relaxed = true)
-
-        every { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) } returns mockedArbeidsfordelingPåBehandling
-        every { integrasjonKlient.hentNavKontorEnhet("testId") } returns
-            NavKontorEnhet(
-                0,
-                "testNavn",
-                "testEnhet",
-                "testStatus",
-            )
-        every {
-            mockedArbeidsfordelingPåBehandling.copy(
-                0,
-                0,
-                "testId",
-                "testNavn",
-                true,
-            )
-        } returns mockedArbeidsfordelingPåBehandlingEtterEndring
-        every {
-            arbeidsfordelingPåBehandlingRepository.save(mockedArbeidsfordelingPåBehandlingEtterEndring)
-        } returns mockedArbeidsfordelingPåBehandlingEtterEndring
-
-        arbeidsfordelingService.manueltOppdaterBehandlendeEnhet(behandling, endreBehandlendeEnhetDto)
-
-        verify(exactly = 1) { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) }
-        verify(exactly = 1) { integrasjonKlient.hentNavKontorEnhet("testId") }
-        verify(exactly = 1) { mockedArbeidsfordelingPåBehandling.copy(0, 0, "testId", "testNavn", true) }
-        verify(exactly = 1) { arbeidsfordelingPåBehandlingRepository.save(mockedArbeidsfordelingPåBehandlingEtterEndring) }
+            verify(exactly = 1) { arbeidsfordelingPåBehandlingRepository.finnArbeidsfordelingPåBehandling(behandling.id) }
+            verify(exactly = 1) { integrasjonKlient.hentNavKontorEnhet("testId") }
+            verify(exactly = 1) { mockedArbeidsfordelingPåBehandling.copy(0, 0, "testId", "testNavn", true) }
+            verify(exactly = 1) { arbeidsfordelingPåBehandlingRepository.save(mockedArbeidsfordelingPåBehandlingEtterEndring) }
+        }
     }
 
     @Nested

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -118,7 +118,7 @@ internal class ArbeidsfordelingServiceTest {
                     )
                 }
 
-            assertThat(feil.message).isEqualTo("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Vadsø dersom det er en Nasjonal sak.")
+            assertThat(feil.message).isEqualTo("Fra og med 5. januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Vadsø dersom det er en Nasjonal sak.")
         }
 
         @Test
@@ -134,7 +134,7 @@ internal class ArbeidsfordelingServiceTest {
                     )
                 }
 
-            assertThat(feil.message).isEqualTo("Fra og med 5 Januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Steinkjer dersom det er en EØS sak.")
+            assertThat(feil.message).isEqualTo("Fra og med 5. januar 2026 er det ikke lenger å mulig å endre behandlende enhet til Steinkjer dersom det er en EØS sak.")
         }
 
         @Test


### PR DESCRIPTION
### 📮 Favro: NAV-27087

### 💰 Hva skal gjøres, og hvorfor?
Vi kaster funksjonell feil hvis

- Det forsøkes å sette Vadsø som behandlende enhet når behandlingkategori er Nasjonal
- Det forsøkes å sette Steinkjer som behandlende enhet når behandlingkategori er EØS