### PR TITLE
Blokker bulgarske lev etter jan 2026

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/common/util/Tid.kt
@@ -60,6 +60,8 @@ fun YearMonth.forrigeMåned(): YearMonth = this.minusMonths(1)
 
 fun YearMonth.nesteMåned(): YearMonth = this.plusMonths(1)
 
+fun YearMonth.isSameOrAfter(toCompare: YearMonth): Boolean = this.isAfter(toCompare) || this == toCompare
+
 fun LocalDate.erDagenFør(other: LocalDate?) = other != null && this.plusDays(1).equals(other)
 
 data class Periode(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpService.kt
@@ -1,12 +1,17 @@
 package no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp
 
 import no.nav.familie.ks.sak.common.BehandlingId
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
+import no.nav.familie.ks.sak.common.util.isSameOrAfter
+import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.kjerne.eøs.felles.EøsSkjemaService
 import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
 import no.nav.familie.ks.sak.kjerne.eøs.felles.endringsabonnent.EøsSkjemaEndringAbonnent
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.YearMonth
 
 @Service
 class UtenlandskPeriodebeløpService(
@@ -24,7 +29,11 @@ class UtenlandskPeriodebeløpService(
     fun oppdaterUtenlandskPeriodebeløp(
         behandlingId: BehandlingId,
         utenlandskPeriodebeløp: UtenlandskPeriodebeløp,
-    ) = skjemaService.endreSkjemaer(behandlingId, utenlandskPeriodebeløp)
+    ) {
+        validerUtenlandskPeriodeBeløp(utenlandskPeriodebeløp)
+
+        skjemaService.endreSkjemaer(behandlingId, utenlandskPeriodebeløp)
+    }
 
     fun slettUtenlandskPeriodebeløp(
         utenlandskPeriodebeløpId: Long,
@@ -35,4 +44,22 @@ class UtenlandskPeriodebeløpService(
         fraBehandlingId: BehandlingId,
         tilBehandlingId: BehandlingId,
     ) = skjemaService.kopierOgErstattSkjemaer(fraBehandlingId, tilBehandlingId)
+
+    private fun validerUtenlandskPeriodeBeløp(utenlandskPeriodebeløp: UtenlandskPeriodebeløp) {
+        val fom = utenlandskPeriodebeløp.fom ?: throw FunksjonellFeil("Fra og med dato på utenlandskperiode beløp må være satt")
+        val tom = utenlandskPeriodebeløp.tom ?: TIDENES_ENDE.toYearMonth()
+        val januar2026 = YearMonth.of(2026, 1)
+
+        if (utenlandskPeriodebeløp.valutakode == BULGARSK_LEV &&
+            ((fom.isSameOrAfter(januar2026)) || (tom.isSameOrAfter(januar2026)))
+        ) {
+            throw FunksjonellFeil(
+                "Bulgarske lev er ikke lenger gyldig valuta fra 01.01.26",
+            )
+        }
+    }
+
+    companion object {
+        const val BULGARSK_LEV = "BGN"
+    }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
@@ -143,6 +143,24 @@ internal class UtenlandskPeriodebeløpServiceTest {
     }
 
     @Test
+    fun `Skal kaste funksjonell feil dersom fom ikke er satt`() {
+        val feilmelding =
+            assertThrows<FunksjonellFeil> {
+                utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
+                    BehandlingId(1),
+                    UtenlandskPeriodebeløp(
+                        fom = null,
+                        tom = null,
+                        beløp = 1.0.toBigDecimal(),
+                        valutakode = BULGARSK_LEV,
+                    ),
+                )
+            }
+
+        assertThat(feilmelding.message).isEqualTo("Fra og med dato på utenlandskperiode beløp må være satt")
+    }
+
+    @Test
     fun `Skal kaste funksjonell feil dersom det forsøkes å settes fom fra og med 1 januar 2026 med valutakode BGN`() {
         val feilmelding =
             assertThrows<FunksjonellFeil> {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
@@ -3,12 +3,14 @@ package no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ks.sak.common.BehandlingId
+import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
 import no.nav.familie.ks.sak.data.tilfeldigPerson
 import no.nav.familie.ks.sak.kjerne.eøs.differanseberegning.domene.Intervall
 import no.nav.familie.ks.sak.kjerne.eøs.felles.domene.EøsSkjemaRepository
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.domene.KompetanseRepository
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.mockEøsSkjemaRepository
+import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.UtenlandskPeriodebeløpService.Companion.BULGARSK_LEV
 import no.nav.familie.ks.sak.kjerne.eøs.utenlandskperiodebeløp.domene.UtenlandskPeriodebeløp
 import no.nav.familie.ks.sak.kjerne.eøs.util.KompetanseBuilder
 import no.nav.familie.ks.sak.kjerne.eøs.util.UtenlandskPeriodebeløpBuilder
@@ -19,6 +21,8 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.YearMonth
 
 internal class UtenlandskPeriodebeløpServiceTest {
     private val utenlandskPeriodebeløpRepository: EøsSkjemaRepository<UtenlandskPeriodebeløp> =
@@ -136,5 +140,41 @@ internal class UtenlandskPeriodebeløpServiceTest {
         assertNull(faktiskUtenlandskPeriodebeløp.elementAt(1).intervall)
         assertNull(faktiskUtenlandskPeriodebeløp.elementAt(1).kalkulertMånedligBeløp)
         assertEquals("SE", faktiskUtenlandskPeriodebeløp.elementAt(1).utbetalingsland)
+    }
+
+    @Test
+    fun `Skal kaste funksjonell feil dersom det forsøkes å settes fom fra og med 1 januar 2026 med valutakode BGN`() {
+        val feilmelding =
+            assertThrows<FunksjonellFeil> {
+                utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
+                    BehandlingId(1),
+                    UtenlandskPeriodebeløp(
+                        fom = YearMonth.of(2026, 1),
+                        tom = null,
+                        beløp = 1.0.toBigDecimal(),
+                        valutakode = BULGARSK_LEV,
+                    ),
+                )
+            }
+
+        assertThat(feilmelding.message).isEqualTo("Bulgarske lev er ikke lenger gyldig valuta fra 01.01.26")
+    }
+
+    @Test
+    fun `Skal kaste funksjonell feil dersom det forsøkes å settes tom fra og med 1 januar 2026 med valutakode BGN`() {
+        val feilmelding =
+            assertThrows<FunksjonellFeil> {
+                utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
+                    BehandlingId(1),
+                    UtenlandskPeriodebeløp(
+                        fom = YearMonth.of(2025, 1),
+                        tom = YearMonth.of(2026, 1),
+                        beløp = 1.0.toBigDecimal(),
+                        valutakode = BULGARSK_LEV,
+                    ),
+                )
+            }
+
+        assertThat(feilmelding.message).isEqualTo("Bulgarske lev er ikke lenger gyldig valuta fra 01.01.26")
     }
 }


### PR DESCRIPTION
### 📮 Favro: Nav-27103

### 💰 Hva skal gjøres, og hvorfor?
Vi må legge inn sperre for bruk av bulgarsk lev fra og MED jan 2026.

<img width="821" height="808" alt="Bulgarsk lev blokk" src="https://github.com/user-attachments/assets/d33d2f08-c823-4c8a-bb31-685ce6fc5114" />
