### PR TITLE
Porteføljejustering: validering ved flytting av oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/MappeIdMapping.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/MappeIdMapping.kt
@@ -4,15 +4,17 @@ import no.nav.familie.ks.sak.common.exception.Feil
 
 private val mappeIdVadsøTilBergen =
     mapOf(
-        100012691L to "100012789",
-        100012692L to "100012790",
-        100012693L to "100012791",
-        100012721L to "100012792",
-        100012695L to "100012765",
+        100012691L to 100012789L,
+        100012692L to 100012790L,
+        100012693L to 100012791L,
+        100012721L to 100012792L,
+        100012695L to 100012765L,
     )
 
 fun hentMappeIdHosBergenSomTilsvarerMappeIVadsø(
-    mappeIdVadsø: Long,
-): String =
-    mappeIdVadsøTilBergen
-        .getOrElse(mappeIdVadsø) { throw Feil("Finner ikke mappe id $mappeIdVadsø i mapping") }
+    mappeIdVadsø: Long?,
+): Long? =
+    mappeIdVadsø?.let {
+        mappeIdVadsøTilBergen
+            .getOrElse(mappeIdVadsø) { throw Feil("Finner ikke mappe id $mappeIdVadsø i mapping") }
+    }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.VADSØ
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.klage.KlageKlient
@@ -51,6 +52,10 @@ class PorteføljejusteringFlyttOppgaveTask(
     override fun doTask(task: Task) {
         val oppgaveId = task.payload.toLong()
         val oppgave = integrasjonKlient.finnOppgaveMedId(oppgaveId)
+        if (oppgave.tildeltEnhetsnr != VADSØ.enhetsnummer) {
+            logger.info("Oppgave med id $oppgaveId er ikke tildelt Vadsø. Avbryter flytting av oppgave.")
+            return
+        }
 
         val nyEnhetId = validerOgHentNyEnhetForOppgave(oppgave) ?: return
         val nyMappeId =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -4,17 +4,17 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype.NASJONAL
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.BehandleSak
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.BehandleUnderkjentVedtak
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.GodkjenneVedtak
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.integrasjon.secureLogger
-import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.BERGEN
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.VADSØ
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ks.sak.kjerne.klage.KlageKlient
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -23,15 +23,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.Properties
-import java.util.UUID
-import kotlin.apply
-import kotlin.collections.firstOrNull
-import kotlin.collections.set
-import kotlin.collections.single
-import kotlin.jvm.java
-import kotlin.let
-import kotlin.text.toLong
-import kotlin.toString
 
 @Service
 @TaskStepBeskrivelse(
@@ -42,8 +33,6 @@ import kotlin.toString
 )
 class PorteføljejusteringFlyttOppgaveTask(
     private val integrasjonKlient: IntegrasjonKlient,
-    private val tilbakekrevingKlient: TilbakekrevingKlient,
-    private val klageKlient: KlageKlient,
     private val behandlingRepository: BehandlingRepository,
     private val personidentService: PersonidentService,
     private val fagsakService: FagsakService,
@@ -69,51 +58,31 @@ class PorteføljejusteringFlyttOppgaveTask(
             return
         }
 
-        val nyMappeId =
-            oppgave.mappeId?.let {
-                hentMappeIdHosBergenSomTilsvarerMappeIVadsø(
-                    it,
-                )
-            }
+        val nyMappeId = hentMappeIdHosBergenSomTilsvarerMappeIVadsø(oppgave.mappeId)
 
-        val skalOppdatereEnhetEllerMappe = nyMappeId != oppgave.mappeId?.toString() || nyEnhetId != oppgave.tildeltEnhetsnr
-
-        if (skalOppdatereEnhetEllerMappe) { // Vi oppdaterer bare hvis det er forskjell på enhet eller mappe. Kaster ikke feil grunnet ønsket om idempotens.
+        // Vi oppdaterer bare hvis det er forskjell på enhet eller mappe. Kaster ikke feil grunnet ønske om idempotens.
+        val skalOppdatereEnhetEllerMappe = nyMappeId != oppgave.mappeId || nyEnhetId != oppgave.tildeltEnhetsnr
+        if (skalOppdatereEnhetEllerMappe) {
             integrasjonKlient.tilordneEnhetOgMappeForOppgave(
                 oppgaveId = oppgaveId,
                 nyEnhet = nyEnhetId,
                 nyMappe = nyMappeId.toString(),
             )
             logger.info(
-                "Oppdatert oppgave med id $oppgaveId." +
-                    "Fra enhet ${oppgave.tildeltEnhetsnr} til ny enhet $nyEnhetId." +
-                    "Fra mappe ${oppgave.mappeId} til ny mappe $nyMappeId ",
+                "Oppdatert oppgave med id $oppgaveId.\n" +
+                    "Fra enhet ${oppgave.tildeltEnhetsnr} til ny enhet $nyEnhetId.\n" +
+                    "Fra mappe ${oppgave.mappeId} til ny mappe $nyMappeId.",
             )
         }
 
-        // Vi går bare videre med oppdatering i fagsystemer hvis typen er av BehandleSak, GodkjenndeVedtak eller BehandleUnderkjentVedtak
-        // og oppgaven har en tilknyttet saksreferanse
-
-        val saksreferanse = oppgave.saksreferanse
-        when {
-            saksreferanse == null -> return
-            oppgave.oppgavetype !in (
-                listOf(
-                    Oppgavetype.BehandleSak.value,
-                    Oppgavetype.GodkjenneVedtak.value,
-                    Oppgavetype.BehandleUnderkjentVedtak.value,
-                )
-            ) -> return
-            oppgave.behandlesAvApplikasjon == "familie-ks-sak" -> {
-                oppdaterÅpenBehandlingIKsSak(oppgave, nyEnhetId)
-            }
-
-            oppgave.behandlesAvApplikasjon == "familie-klage" -> {
-                oppdaterEnhetPåÅpenBehandlingIKlage(oppgaveId, nyEnhetId)
-            }
-            oppgave.behandlesAvApplikasjon == "familie-tilbake" -> {
-                oppdaterEnhetPåÅpenBehandlingITilbakekreving(UUID.fromString(saksreferanse), nyEnhetId)
-            }
+        // Vi oppdaterer bare behandlingen i ks-sak hvis typen er
+        // av BehandleSak, GodkjenndeVedtak eller BehandleUnderkjentVedtak
+        if (
+            oppgave.saksreferanse != null &&
+            oppgave.behandlesAvApplikasjon == "familie-ks-sak" &&
+            oppgave.oppgavetype in setOf(BehandleSak.value, GodkjenneVedtak.value, BehandleUnderkjentVedtak.value)
+        ) {
+            oppdaterÅpenBehandlingIKsSak(oppgave, nyEnhetId)
         }
     }
 
@@ -158,20 +127,6 @@ class PorteføljejusteringFlyttOppgaveTask(
             } ?: throw Feil("Fant ikke åpen behandling på aktør til oppgaveId ${oppgave.id}")
 
         arbeidsfordelingService.oppdaterBehandlendeEnhetPåBehandlingIForbindelseMedPorteføljejustering(åpenBehandlingPåAktør, nyEnhet)
-    }
-
-    private fun oppdaterEnhetPåÅpenBehandlingITilbakekreving(
-        behandlingEksternBrukId: UUID,
-        nyEnhetId: String,
-    ) {
-        tilbakekrevingKlient.oppdaterEnhetPåÅpenBehandling(behandlingEksternBrukId, nyEnhetId)
-    }
-
-    private fun oppdaterEnhetPåÅpenBehandlingIKlage(
-        oppgaveId: Long,
-        nyEnhetId: String,
-    ) {
-        klageKlient.oppdaterEnhetPåÅpenBehandling(oppgaveId, nyEnhetId)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.porteføljejustering
 
 import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype.NASJONAL
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
@@ -54,6 +55,11 @@ class PorteføljejusteringFlyttOppgaveTask(
         val oppgave = integrasjonKlient.finnOppgaveMedId(oppgaveId)
         if (oppgave.tildeltEnhetsnr != VADSØ.enhetsnummer) {
             logger.info("Oppgave med id $oppgaveId er ikke tildelt Vadsø. Avbryter flytting av oppgave.")
+            return
+        }
+
+        if (oppgave.behandlingstype != NASJONAL.toString()) {
+            logger.info("Oppgave med id $oppgaveId har ikke behandlingstype NASJONAL. Avbryter flytting av oppgave.")
             return
         }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -52,8 +52,7 @@ class PorteføljejusteringFlyttOppgaveTask(
         val oppgaveId = task.payload.toLong()
         val oppgave = integrasjonKlient.finnOppgaveMedId(oppgaveId)
 
-        val ident = oppgave.identer?.firstOrNull { it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident ?: throw Feil("Oppgave med id $oppgaveId er ikke tilknyttet en ident.")
-        val nyEnhetId = validerOgHentNyEnhetForOppgave(ident, oppgaveId) ?: return
+        val nyEnhetId = validerOgHentNyEnhetForOppgave(oppgave) ?: return
         val nyMappeId =
             oppgave.mappeId?.let {
                 hentMappeIdHosBergenSomTilsvarerMappeIVadsø(
@@ -103,9 +102,12 @@ class PorteføljejusteringFlyttOppgaveTask(
     }
 
     private fun validerOgHentNyEnhetForOppgave(
-        ident: String,
-        oppgaveId: Long,
+        oppgave: Oppgave,
     ): String? {
+        val ident =
+            oppgave.identer?.firstOrNull { it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident
+                ?: throw Feil("Oppgave med id ${oppgave.id} er ikke tilknyttet en ident.")
+
         val arbeidsfordelingsenheter = integrasjonKlient.hentBehandlendeEnheter(ident)
 
         if (arbeidsfordelingsenheter.isEmpty()) {

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/MappeIdMappingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/MappeIdMappingTest.kt
@@ -18,7 +18,7 @@ class MappeIdMappingTest {
     )
     fun `skal returnere korrekt mappe id for Bergen når mappe id fra Vadsø finnes i mapping`(
         mappeIdVadsø: Long,
-        forventetMappeIdBergen: String,
+        forventetMappeIdBergen: Long,
     ) {
         // Act
         val result = hentMappeIdHosBergenSomTilsvarerMappeIVadsø(mappeIdVadsø)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
@@ -6,6 +6,8 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype.NASJONAL
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
@@ -16,24 +18,23 @@ import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
-import no.nav.familie.ks.sak.integrasjon.tilbakekreving.TilbakekrevingKlient
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.BERGEN
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.DRAMMEN
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.VADSØ
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ks.sak.kjerne.klage.KlageKlient
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import java.util.UUID
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
 
 class PorteføljejusteringFlyttOppgaveTaskTest {
     private val integrasjonKlient: IntegrasjonKlient = mockk()
-    private val tilbakekrevingKlient: TilbakekrevingKlient = mockk()
-    private val klageKlient: KlageKlient = mockk()
     private val behandlingRepository: BehandlingRepository = mockk()
     private val personidentService: PersonidentService = mockk()
     private val fagsakService: FagsakService = mockk()
@@ -42,8 +43,6 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     private val porteføljejusteringFlyttOppgaveTask =
         PorteføljejusteringFlyttOppgaveTask(
             integrasjonKlient = integrasjonKlient,
-            tilbakekrevingKlient = tilbakekrevingKlient,
-            klageKlient = klageKlient,
             behandlingRepository = behandlingRepository,
             personidentService = personidentService,
             fagsakService = fagsakService,
@@ -51,16 +50,59 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         )
 
     @Test
-    fun `Skal kaste feil dersom oppgave ikke er tilknyttet noe folkeregistrert ident`() {
+    fun `Skal ikke flytte dersom oppgave ikke er tildelt Vadsø`() {
         // Arrange
         val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.SAMHANDLERNR),
-                    ),
+                id = 1,
+                tildeltEnhetsnr = BERGEN.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
+            )
+
+        // Act
+        porteføljejusteringFlyttOppgaveTask.doTask(task)
+
+        // Assert
+        verify(exactly = 0) { integrasjonKlient.hentBehandlendeEnheter(any()) }
+        verify(exactly = 0) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(any(), any(), any()) }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Behandlingstype::class, names = ["NASJONAL"], mode = EXCLUDE)
+    fun `Skal ikke flytte dersom oppgave ikke har behandlingstype NASJONAL`(
+        behandlingstype: Behandlingstype,
+    ) {
+        // Arrange
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+
+        every { integrasjonKlient.finnOppgaveMedId(1) } returns
+            Oppgave(
+                id = 1,
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = behandlingstype.toString(),
+            )
+
+        // Act
+        porteføljejusteringFlyttOppgaveTask.doTask(task)
+
+        // Assert
+        verify(exactly = 0) { integrasjonKlient.hentBehandlendeEnheter(any()) }
+        verify(exactly = 0) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(any(), any(), any()) }
+    }
+
+    @Test
+    fun `Skal kaste feil dersom oppgave ikke er tilknyttet en folkeregistrert ident`() {
+        // Arrange
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+
+        every { integrasjonKlient.finnOppgaveMedId(1) } returns
+            Oppgave(
+                id = 1,
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.SAMHANDLERNR)),
             )
 
         // Act && Assert
@@ -68,20 +110,21 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             assertThrows<Feil> {
                 porteføljejusteringFlyttOppgaveTask.doTask(task)
             }
+
         assertThat(exception.message).isEqualTo("Oppgave med id 1 er ikke tilknyttet en ident.")
     }
 
     @Test
-    fun `Skal kaste feil dersom vi ikke får tilbake noen enheter på ident ved kall mot integrasjoner og videre til norg2`() {
+    fun `Skal kaste feil dersom vi ikke får tilbake noen enheter på ident fra norg`() {
         // Arrange
         val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
+                id = 1,
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
         every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns emptyList()
@@ -96,22 +139,22 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     }
 
     @Test
-    fun `Skal kaste feil dersom vi får tilbake flere enn 1 enhet på ident ved kall mot integrasjoner og videre til norg2`() {
+    fun `Skal kaste feil dersom vi får tilbake flere enheter på ident fra norg`() {
         // Arrange
         val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
+                id = 1,
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
         every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
             listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.BERGEN.enhetsnummer, KontantstøtteEnhet.BERGEN.enhetsnavn),
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.DRAMMEN.enhetsnummer, KontantstøtteEnhet.DRAMMEN.enhetsnavn),
+                Arbeidsfordelingsenhet(BERGEN.enhetsnummer, BERGEN.enhetsnavn),
+                Arbeidsfordelingsenhet(DRAMMEN.enhetsnummer, DRAMMEN.enhetsnavn),
             )
 
         // Act && Assert
@@ -124,22 +167,19 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     }
 
     @Test
-    fun `Skal kaste feil dersom vi får tilbake Vadsø som enhet på ident ved kall mot integrasjoner og videre til norg2`() {
+    fun `Skal kaste feil dersom vi får tilbake Vadsø som enhet på ident fra norg`() {
         // Arrange
         val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
+                id = 1,
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
-        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
-            listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.VADSØ.enhetsnummer, KontantstøtteEnhet.VADSØ.enhetsnavn),
-            )
+        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(VADSØ.enhetsnummer, VADSØ.enhetsnavn))
 
         // Act && Assert
         val exception =
@@ -150,71 +190,59 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         assertThat(exception.message).isEqualTo("Oppgave med id 1 tildeles fortsatt Vadsø som enhet")
     }
 
-    @Test
-    fun `Skal stoppe utføringen av task hvis det er midlertidig enhet vi får tilbake ved kall mot integrasjoner og videre til norg2`() {
+    @ParameterizedTest
+    @EnumSource(value = KontantstøtteEnhet::class, names = ["BERGEN", "VADSØ"], mode = EXCLUDE)
+    fun `Skal ikke flytte hvis ny enhet ikke er Bergen`(
+        enhet: KontantstøtteEnhet,
+    ) {
         // Arrange
         val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
-                tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
-                saksreferanse = "referanse",
-                oppgavetype = "BEH_SAK",
+                id = 1,
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
-        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
-            listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnummer, KontantstøtteEnhet.MIDLERTIDIG_ENHET.enhetsnavn),
-            )
+        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(enhet.enhetsnummer, enhet.enhetsnavn))
 
         // Act
         porteføljejusteringFlyttOppgaveTask.doTask(task)
 
         // Assert
         verify(exactly = 0) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(any(), any(), any()) }
-        verify { arbeidsfordelingService wasNot Called }
     }
 
     @Test
-    fun `Skal oppdatere oppgaven med ny enhet og mappe og ikke mer dersom saksreferansen ikke er fylt ut`() {
+    fun `Skal oppdatere oppgaven med ny enhet og mappe, men ikke behandlingen, dersom saksreferansen ikke er fylt ut`() {
         // Arrange
         val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
-                tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
-                saksreferanse = null,
-                oppgavetype = "BEH_SAK",
+                id = 1,
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
                 mappeId = 100012692,
-                behandlesAvApplikasjon = "familie-ks-sak",
             )
 
-        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
-            listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.BERGEN.enhetsnummer, KontantstøtteEnhet.BERGEN.enhetsnavn),
-            )
-
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") } returns mockk()
+        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(BERGEN.enhetsnummer, BERGEN.enhetsnavn))
+        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") } returns mockk()
 
         // Act
         porteføljejusteringFlyttOppgaveTask.doTask(task)
 
         // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") }
+        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") }
         verify { arbeidsfordelingService wasNot Called }
     }
 
     @ParameterizedTest
-    @EnumSource(Oppgavetype::class, names = ["BehandleSak", "GodkjenneVedtak", "BehandleUnderkjentVedtak"], mode = EnumSource.Mode.EXCLUDE)
-    fun `Skal oppdatere oppgaven med ny enhet og mappe og ikke mer dersom saksreferanse er fylt ut, men det er ikke av type behandle sak, godkjenne vedtak eller behandle underkjent vedtak`(
+    @EnumSource(Oppgavetype::class, names = ["BehandleSak", "GodkjenneVedtak", "BehandleUnderkjentVedtak"], mode = EXCLUDE)
+    fun `Skal oppdatere oppgaven med ny enhet og mappe, men ikke behandlingen, dersom saksreferanse er fylt ut, men det er ikke av type behandle sak, godkjenne vedtak eller behandle underkjent vedtak`(
         oppgavetype: Oppgavetype,
     ) {
         // Arrange
@@ -222,159 +250,67 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
-                tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                id = 1,
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
                 saksreferanse = "183421813",
                 oppgavetype = oppgavetype.value,
                 mappeId = 100012692,
                 behandlesAvApplikasjon = "familie-ks-sak",
             )
 
-        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
-            listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.BERGEN.enhetsnummer, KontantstøtteEnhet.BERGEN.enhetsnavn),
-            )
-
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") } returns mockk()
+        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(BERGEN.enhetsnummer, BERGEN.enhetsnavn))
+        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") } returns mockk()
 
         // Act
         porteføljejusteringFlyttOppgaveTask.doTask(task)
 
         // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") }
+        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") }
         verify { arbeidsfordelingService wasNot Called }
     }
 
     @ParameterizedTest
     @EnumSource(Oppgavetype::class, names = ["BehandleSak", "GodkjenneVedtak", "BehandleUnderkjentVedtak"], mode = EnumSource.Mode.INCLUDE)
-    fun `Skal oppdatere oppgaven med ny enhet og mappe, og oppdatere behandlingen i ks-sak dersom behandlesAvApplikasjon er familie-ks-sak og oppgavetype er av type behandle sak, godkjenne vedtak eller behandle underkjent vedtak`(
+    fun `Skal oppdatere oppgaven og behandlingen i ks-sak`(
         oppgavetype: Oppgavetype,
     ) {
         // Arrange
         val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val aktørPåOppgave = randomAktør()
+        val behandling = lagBehandling()
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
-                tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                id = 1,
+                identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
+                tildeltEnhetsnr = VADSØ.enhetsnummer,
+                behandlingstype = NASJONAL.toString(),
                 saksreferanse = "183421813",
                 oppgavetype = oppgavetype.value,
                 mappeId = 100012692,
                 behandlesAvApplikasjon = "familie-ks-sak",
                 aktoerId = "1",
             )
-        val aktørPåOppgave = randomAktør()
 
-        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
-            listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.BERGEN.enhetsnummer, KontantstøtteEnhet.BERGEN.enhetsnavn),
-            )
-
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") } returns mockk()
-
+        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(BERGEN.enhetsnummer, BERGEN.enhetsnavn))
+        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") } returns mockk()
         every { personidentService.hentAktør("1") } returns aktørPåOppgave
         every { fagsakService.hentFagsakForPerson(aktørPåOppgave) } returns lagFagsak()
-
-        val behandling = lagBehandling()
         every { behandlingRepository.findByFagsakAndAktivAndOpen(any()) } returns behandling
-
-        every { arbeidsfordelingService.oppdaterBehandlendeEnhetPåBehandlingIForbindelseMedPorteføljejustering(behandling, KontantstøtteEnhet.BERGEN.enhetsnummer) } just Runs
+        every { arbeidsfordelingService.oppdaterBehandlendeEnhetPåBehandlingIForbindelseMedPorteføljejustering(behandling, BERGEN.enhetsnummer) } just Runs
 
         // Act
         porteføljejusteringFlyttOppgaveTask.doTask(task)
 
         // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") }
+        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") }
         verify(exactly = 1) { personidentService.hentAktør("1") }
         verify(exactly = 1) { fagsakService.hentFagsakForPerson(aktørPåOppgave) }
         verify(exactly = 1) { behandlingRepository.findByFagsakAndAktivAndOpen(any()) }
         verify(exactly = 1) {
-            arbeidsfordelingService.oppdaterBehandlendeEnhetPåBehandlingIForbindelseMedPorteføljejustering(behandling, KontantstøtteEnhet.BERGEN.enhetsnummer)
+            arbeidsfordelingService.oppdaterBehandlendeEnhetPåBehandlingIForbindelseMedPorteføljejustering(behandling, BERGEN.enhetsnummer)
         }
-    }
-
-    @ParameterizedTest
-    @EnumSource(Oppgavetype::class, names = ["BehandleSak", "GodkjenneVedtak", "BehandleUnderkjentVedtak"], mode = EnumSource.Mode.INCLUDE)
-    fun `Skal oppdatere oppgaven med ny enhet og mappe, og oppdatere behandlingen i klage dersom behandlesAvApplikasjon er familie-klage og oppgavetype er av type behandle sak, godkjenne vedtak eller behandle underkjent vedtak`(
-        oppgavetype: Oppgavetype,
-    ) {
-        // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
-        val oppgaveId = 1L
-
-        every { integrasjonKlient.finnOppgaveMedId(1) } returns
-            Oppgave(
-                id = oppgaveId,
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
-                tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
-                saksreferanse = "183421813",
-                oppgavetype = oppgavetype.value,
-                mappeId = 100012692,
-                behandlesAvApplikasjon = "familie-klage",
-                aktoerId = "1",
-            )
-
-        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
-            listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.BERGEN.enhetsnummer, KontantstøtteEnhet.BERGEN.enhetsnavn),
-            )
-
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") } returns mockk()
-        every { klageKlient.oppdaterEnhetPåÅpenBehandling(oppgaveId, "4812") } returns "TODO"
-
-        // Act
-        porteføljejusteringFlyttOppgaveTask.doTask(task)
-
-        // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") }
-        verify(exactly = 1) { klageKlient.oppdaterEnhetPåÅpenBehandling(oppgaveId, KontantstøtteEnhet.BERGEN.enhetsnummer) }
-    }
-
-    @ParameterizedTest
-    @EnumSource(Oppgavetype::class, names = ["BehandleSak", "GodkjenneVedtak", "BehandleUnderkjentVedtak"], mode = EnumSource.Mode.INCLUDE)
-    fun `Skal oppdatere oppgaven med ny enhet og mappe, og oppdatere behandlingen i klage dersom behandlesAvApplikasjon er familie-tilbake og oppgavetype er av type behandle sak, godkjenne vedtak eller behandle underkjent vedtak`(
-        oppgavetype: Oppgavetype,
-    ) {
-        // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
-        val behandlingEksternBrukId = UUID.randomUUID()
-
-        every { integrasjonKlient.finnOppgaveMedId(1) } returns
-            Oppgave(
-                identer =
-                    listOf(
-                        OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT),
-                    ),
-                tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
-                saksreferanse = behandlingEksternBrukId.toString(),
-                oppgavetype = oppgavetype.value,
-                mappeId = 100012692,
-                behandlesAvApplikasjon = "familie-tilbake",
-                aktoerId = "1",
-            )
-
-        every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns
-            listOf(
-                Arbeidsfordelingsenhet(KontantstøtteEnhet.BERGEN.enhetsnummer, KontantstøtteEnhet.BERGEN.enhetsnavn),
-            )
-
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") } returns mockk()
-        every { tilbakekrevingKlient.oppdaterEnhetPåÅpenBehandling(behandlingEksternBrukId, "4812") } returns "TODO"
-
-        // Act
-        porteføljejusteringFlyttOppgaveTask.doTask(task)
-
-        // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, KontantstøtteEnhet.BERGEN.enhetsnummer, "100012790") }
-        verify(exactly = 1) { tilbakekrevingKlient.oppdaterEnhetPåÅpenBehandling(behandlingEksternBrukId, KontantstøtteEnhet.BERGEN.enhetsnummer) }
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-27117

### 💰 Hva skal gjøres, og hvorfor?
Vi ønsker å begrense hvilke oppgaver som skal flyttes:
- Hopper over oppgave dersom tildelt enhet ikke er Vadsø
- Hopper over oppgave dersom behandlingstype ikke er `NASJONAL`. (Dette ekskluderer EØS, tilbakekreving og klage)
- Hopper over oppgave dersom ny enhet ikke er Bergen

Rydder også opp litt og fjerner overflødig kode, nå som oppgaver for tilbakekreving og klage ikke skal flyttes

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.