### PR TITLE
Flytter kode fra PorteføljejusteringService inn i StartPorteføljejusteringTask

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -42,7 +42,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.Vilkårsvu
 import no.nav.familie.ks.sak.kjerne.personident.PatchMergetIdentDto
 import no.nav.familie.ks.sak.kjerne.personident.PatchMergetIdentTask
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
-import no.nav.familie.ks.sak.kjerne.porteføljejustering.PorteføljejusteringService
+import no.nav.familie.ks.sak.kjerne.porteføljejustering.StartPorteføljejusteringTask
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
 import no.nav.familie.ks.sak.statistikk.saksstatistikk.SakStatistikkService
@@ -93,7 +93,6 @@ class ForvaltningController(
     private val barnehagebarnService: BarnehagebarnService,
     private val barnehagelisteVarslingService: BarnehagelisteVarslingService,
     private val avstemmingKlient: AvstemmingKlient,
-    private val porteføljejusteringService: PorteføljejusteringService,
     private val featureToggleService: FeatureToggleService,
 ) {
     private val logger = LoggerFactory.getLogger(ForvaltningController::class.java)
@@ -449,8 +448,8 @@ class ForvaltningController(
             return ResponseEntity.ok("Toggle for porteføljejustering er skrudd av")
         }
 
-        val (antallOppgaverTotalt, antallFlytteTasksOpprettet) = porteføljejusteringService.lagTaskForOverføringAvOppgaverFraVadsø(antallFlytteTasks, dryRun)
+        taskService.save(StartPorteføljejusteringTask.opprettTask(antallFlytteTasks, dryRun = dryRun))
 
-        return ResponseEntity.ok("Antall oppgaver totalt:$antallOppgaverTotalt, Antall tasks opprettet for flytting:$antallFlytteTasksOpprettet")
+        return ResponseEntity.ok("Opprettet task for flytting av Steinkjer oppgaver")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskDto.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.ks.sak.kjerne.porteføljejustering
+
+data class StartPorteføljejusteringTaskDto(
+    val antallTasks: Int? = null,
+    val dryRun: Boolean = true,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskTest.kt
@@ -14,11 +14,11 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
 import no.nav.familie.prosessering.internal.TaskService
 import org.junit.jupiter.api.Test
 
-class PorteføljejusteringServiceTest {
+class StartPorteføljejusteringTaskTest {
     private val integrasjonKlient: IntegrasjonKlient = mockk()
     private val taskService: TaskService = mockk()
 
-    private val porteføljejusteringService = PorteføljejusteringService(integrasjonKlient, taskService)
+    private val startPorteføljejusteringTask = StartPorteføljejusteringTask(integrasjonKlient, taskService)
 
     @Test
     fun `Skal hente kontantstøtte oppgaver hos enhet Vadsø og opprette task på flytting av enhet`() {
@@ -40,8 +40,10 @@ class PorteføljejusteringServiceTest {
 
         every { taskService.save(any()) } returns mockk()
 
+        val task = StartPorteføljejusteringTask.opprettTask(dryRun = false)
+
         // Act
-        porteføljejusteringService.lagTaskForOverføringAvOppgaverFraVadsø(dryRun = false)
+        startPorteføljejusteringTask.doTask(task)
 
         // Assert
         verify(exactly = 1) { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) }
@@ -73,8 +75,10 @@ class PorteføljejusteringServiceTest {
 
         every { taskService.save(any()) } returns mockk()
 
+        val task = StartPorteføljejusteringTask.opprettTask(dryRun = true)
+
         // Act
-        porteføljejusteringService.lagTaskForOverføringAvOppgaverFraVadsø(dryRun = true)
+        startPorteføljejusteringTask.doTask(task)
 
         // Assert
         verify(exactly = 1) { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) }
@@ -112,8 +116,10 @@ class PorteføljejusteringServiceTest {
 
         every { taskService.save(any()) } returns mockk()
 
+        val task = StartPorteføljejusteringTask.opprettTask(dryRun = false)
+
         // Act
-        porteføljejusteringService.lagTaskForOverføringAvOppgaverFraVadsø(dryRun = false)
+        startPorteføljejusteringTask.doTask(task)
 
         // Assert
         verify(exactly = 1) { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) }
@@ -145,8 +151,10 @@ class PorteføljejusteringServiceTest {
 
         every { taskService.save(any()) } returns mockk()
 
+        val task = StartPorteføljejusteringTask.opprettTask(dryRun = false)
+
         // Act
-        porteføljejusteringService.lagTaskForOverføringAvOppgaverFraVadsø(dryRun = false)
+        startPorteføljejusteringTask.doTask(task)
 
         // Assert
         verify(exactly = 1) { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) }


### PR DESCRIPTION
### 📮 Favro: [NAV-27121](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-27121)

### 💰 Hva skal gjøres, og hvorfor?
Vi får ikke hentet oppgaver for Vadsø med personlige brukere i prod og må sørge for at spørring kjøres av systembruker. Flytter derfor spørring og opprettelse av flytte-tasks inn i egen task `StartPorteføljejusteringTask`.

Sletter også `PorteføljejusteringService` og renamer `PorteføljejusteringServiceTest` -> `StartPorteføljejusteringTaskTest` og justererer testene.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.
