### PR TITLE
Send med fjernMappeFraOppgave = false i kall for å endre enhet og mappe

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlient.kt
@@ -598,6 +598,7 @@ class IntegrasjonKlient(
                 .fromUri(baseUri)
                 .queryParam("nullstillTilordnetRessurs", true)
                 .queryParam("mappeId", nyMappe)
+                .queryParam("fjernMappeFraOppgave", false)
                 .build()
                 .toUri()
 


### PR DESCRIPTION
### 📮 Favro: NAV-27106

### 💰 Hva skal gjøres, og hvorfor?
Feltet `fjernMappeFraOppgave` er påkrevd i endepunkt i integrasjoner.
Setter det til `false` for alle kall for porteføljejustering