### PR TITLE
Legg til mangler i porteføljejusteringtask

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -42,6 +42,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.Vilkårsvu
 import no.nav.familie.ks.sak.kjerne.personident.PatchMergetIdentDto
 import no.nav.familie.ks.sak.kjerne.personident.PatchMergetIdentTask
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ks.sak.kjerne.porteføljejustering.RelevanteApplikasjonerForPorteføljejustering
 import no.nav.familie.ks.sak.kjerne.porteføljejustering.StartPorteføljejusteringTask
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
@@ -438,6 +439,7 @@ class ForvaltningController(
     fun opprettTaskerForFlyttingAvVadsøOppgaver(
         @RequestParam("antallFlytteTasks") antallFlytteTasks: Int? = null,
         @RequestParam("dryRun") dryRun: Boolean = true,
+        @RequestParam("behandlesAvApplikasjon") behandlesAvApplikasjon: RelevanteApplikasjonerForPorteføljejustering? = null,
     ): ResponseEntity<String> {
         tilgangService.validerTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
@@ -448,7 +450,7 @@ class ForvaltningController(
             return ResponseEntity.ok("Toggle for porteføljejustering er skrudd av")
         }
 
-        taskService.save(StartPorteføljejusteringTask.opprettTask(antallFlytteTasks, dryRun = dryRun))
+        taskService.save(StartPorteføljejusteringTask.opprettTask(antallFlytteTasks, behandlesAvApplikasjon, dryRun = dryRun))
 
         return ResponseEntity.ok("Opprettet task for flytting av Steinkjer oppgaver")
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlient.kt
@@ -590,7 +590,7 @@ class IntegrasjonKlient(
     fun tilordneEnhetOgMappeForOppgave(
         oppgaveId: Long,
         nyEnhet: String,
-        nyMappe: String?,
+        nyMappe: Long?,
     ): OppgaveResponse {
         val baseUri = URI.create("$integrasjonUri/oppgave/$oppgaveId/enhet/$nyEnhet")
         val uri =

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveDto.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.ks.sak.kjerne.porteføljejustering
+
+data class PorteføljejusteringFlyttOppgaveDto(
+    val oppgaveId: Long,
+    val originalEnhet: String,
+    val originalMappeId: Long? = null,
+)

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -66,7 +66,7 @@ class PorteføljejusteringFlyttOppgaveTask(
             integrasjonKlient.tilordneEnhetOgMappeForOppgave(
                 oppgaveId = oppgaveId,
                 nyEnhet = nyEnhetId,
-                nyMappe = nyMappeId.toString(),
+                nyMappe = nyMappeId,
             )
             logger.info(
                 "Oppdatert oppgave med id $oppgaveId.\n" +

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -52,7 +52,7 @@ class PorteføljejusteringFlyttOppgaveTask(
             return
         }
 
-        if (oppgave.behandlingstype != NASJONAL.toString()) {
+        if (oppgave.behandlingstype != NASJONAL.value) {
             logger.info("Oppgave med id $oppgaveId har ikke behandlingstype NASJONAL. Avbryter flytting av oppgave.")
             task.metadata["status"] = "Oppgave har ikke behandlingstype ${oppgave.behandlingstype}"
             return

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ks.sak.kjerne.porteføljejustering
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.opentelemetry.instrumentation.annotations.WithSpan
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype.NASJONAL
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -40,9 +42,11 @@ class PorteføljejusteringFlyttOppgaveTask(
 ) : AsyncTaskStep {
     @WithSpan
     override fun doTask(task: Task) {
-        val oppgaveId = task.payload.toLong()
+        val porteføljejusteringFlyttOppgaveDto = objectMapper.readValue<PorteføljejusteringFlyttOppgaveDto>(task.payload)
+        val oppgaveId = porteføljejusteringFlyttOppgaveDto.oppgaveId
+
         val oppgave = integrasjonKlient.finnOppgaveMedId(oppgaveId)
-        if (oppgave.tildeltEnhetsnr != VADSØ.enhetsnummer) {
+        if (oppgave.tildeltEnhetsnr !in setOf(VADSØ.enhetsnummer, BERGEN.enhetsnummer)) {
             logger.info("Oppgave med id $oppgaveId er ikke tildelt Vadsø. Avbryter flytting av oppgave.")
             return
         }
@@ -82,7 +86,21 @@ class PorteføljejusteringFlyttOppgaveTask(
             oppgave.behandlesAvApplikasjon == "familie-ks-sak" &&
             oppgave.oppgavetype in setOf(BehandleSak.value, GodkjenneVedtak.value, BehandleUnderkjentVedtak.value)
         ) {
-            oppdaterÅpenBehandlingIKsSak(oppgave, nyEnhetId)
+            try {
+                oppdaterÅpenBehandlingIKsSak(oppgave, nyEnhetId)
+            } catch (e: Exception) {
+                integrasjonKlient.tilordneEnhetOgMappeForOppgave(
+                    oppgaveId = oppgaveId,
+                    nyEnhet = porteføljejusteringFlyttOppgaveDto.originalEnhet,
+                    nyMappe = porteføljejusteringFlyttOppgaveDto.originalMappeId,
+                )
+                logger.info(
+                    "Ruller oppdatert oppgave tilbake med id ${porteføljejusteringFlyttOppgaveDto.oppgaveId}.\n" +
+                        "Fra enhet $nyEnhetId til original enhet ${porteføljejusteringFlyttOppgaveDto.originalEnhet}.\n" +
+                        "Fra mappe $nyMappeId til original mappe ${porteføljejusteringFlyttOppgaveDto.originalMappeId}.",
+                )
+                throw e
+            }
         }
     }
 
@@ -135,12 +153,19 @@ class PorteføljejusteringFlyttOppgaveTask(
 
         fun opprettTask(
             oppgaveId: Long,
-            enhetId: String?,
-            mappeId: String?,
+            enhetId: String,
+            mappeId: Long?,
         ): Task =
             Task(
                 type = TASK_STEP_TYPE,
-                payload = oppgaveId.toString(),
+                payload =
+                    objectMapper.writeValueAsString(
+                        PorteføljejusteringFlyttOppgaveDto(
+                            oppgaveId = oppgaveId,
+                            originalEnhet = enhetId,
+                            originalMappeId = mappeId,
+                        ),
+                    ),
                 properties =
                     Properties().apply {
                         this["oppgaveId"] = oppgaveId.toString()

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTask.kt
@@ -15,13 +15,6 @@ import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import kotlin.collections.filterNot
-import kotlin.collections.forEach
-import kotlin.collections.take
-import kotlin.jvm.java
-import kotlin.let
-import kotlin.text.matches
-import kotlin.text.toRegex
 
 @Service
 @TaskStepBeskrivelse(
@@ -54,6 +47,7 @@ class StartPorteføljejusteringTask(
                 .filterNot { it.saksreferanse?.matches("\\d+[A-Z]\\d+".toRegex()) == true } // Filtrere bort infotrygd-oppgaver
                 .filterNot { it.mappeId == null } // Vi skal ikke flytte oppgaver som ikke har mappe id
                 .filter { it.behandlingstype == Behandlingstype.NASJONAL.value }
+                .filter { oppgave -> startPorteføljejusteringTaskDto.behandlesAvApplikasjon?.let { it == oppgave.behandlesAvApplikasjon } ?: true }
 
         logger.info("Fant ${oppgaverSomSkalFlyttes.size} kontantstøtte oppgaver som skal flyttes")
 
@@ -86,11 +80,20 @@ class StartPorteføljejusteringTask(
 
         fun opprettTask(
             antallTasks: Int? = null,
+            behandlesAvApplikasjon: RelevanteApplikasjonerForPorteføljejustering? = null,
             dryRun: Boolean = true,
         ): Task =
             Task(
                 type = TASK_STEP_TYPE,
-                payload = objectMapper.writeValueAsString(StartPorteføljejusteringTaskDto(antallTasks, dryRun)),
+                payload = objectMapper.writeValueAsString(StartPorteføljejusteringTaskDto(antallTasks, behandlesAvApplikasjon?.applikasjonsnavn, dryRun)),
             )
     }
+}
+
+enum class RelevanteApplikasjonerForPorteføljejustering(
+    val applikasjonsnavn: String,
+) {
+    FAMILIE_KS_SAK("familie-ks-sak"),
+    FAMILIE_KLAGE("familie-klage"),
+    FAMILIE_TILBAKE("familie-tilbake"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTask.kt
@@ -62,8 +62,8 @@ class StartPorteføljejusteringTask(
                         taskService.save(
                             PorteføljejusteringFlyttOppgaveTask.opprettTask(
                                 oppgaveId = it,
-                                enhetId = oppgave.tildeltEnhetsnr,
-                                mappeId = oppgave.mappeId?.toString(),
+                                enhetId = oppgave.tildeltEnhetsnr!!,
+                                mappeId = oppgave.mappeId,
                             ),
                         )
                         opprettedeTasks++

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskDto.kt
@@ -2,5 +2,6 @@ package no.nav.familie.ks.sak.kjerne.porteføljejustering
 
 data class StartPorteføljejusteringTaskDto(
     val antallTasks: Int? = null,
+    val behandlesAvApplikasjon: String? = null,
     val dryRun: Boolean = true,
 )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,15 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      familie-klage-clientcredentials:
+        resource-url: ${FAMILIE_KLAGE_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: ${FAMILIE_KLAGE_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 spring:
   lifecycle:

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
@@ -230,13 +230,13 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             )
 
         every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(BERGEN.enhetsnummer, BERGEN.enhetsnavn))
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") } returns mockk()
+        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, 100012790) } returns mockk()
 
         // Act
         porteføljejusteringFlyttOppgaveTask.doTask(task)
 
         // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") }
+        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, 100012790) }
         verify { arbeidsfordelingService wasNot Called }
     }
 
@@ -261,13 +261,13 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             )
 
         every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(BERGEN.enhetsnummer, BERGEN.enhetsnavn))
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") } returns mockk()
+        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, 100012790) } returns mockk()
 
         // Act
         porteføljejusteringFlyttOppgaveTask.doTask(task)
 
         // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") }
+        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, 100012790) }
         verify { arbeidsfordelingService wasNot Called }
     }
 
@@ -295,7 +295,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             )
 
         every { integrasjonKlient.hentBehandlendeEnheter("1234") } returns listOf(Arbeidsfordelingsenhet(BERGEN.enhetsnummer, BERGEN.enhetsnavn))
-        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") } returns mockk()
+        every { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, 100012790) } returns mockk()
         every { personidentService.hentAktør("1") } returns aktørPåOppgave
         every { fagsakService.hentFagsakForPerson(aktørPåOppgave) } returns lagFagsak()
         every { behandlingRepository.findByFagsakAndAktivAndOpen(any()) } returns behandling
@@ -305,7 +305,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         porteføljejusteringFlyttOppgaveTask.doTask(task)
 
         // Assert
-        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, "100012790") }
+        verify(exactly = 1) { integrasjonKlient.tilordneEnhetOgMappeForOppgave(1, BERGEN.enhetsnummer, 100012790) }
         verify(exactly = 1) { personidentService.hentAktør("1") }
         verify(exactly = 1) { fagsakService.hentFagsakForPerson(aktørPåOppgave) }
         verify(exactly = 1) { behandlingRepository.findByFagsakAndAktivAndOpen(any()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.BERGEN
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.DRAMMEN
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.STORD
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.VADSØ
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
@@ -50,14 +51,14 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         )
 
     @Test
-    fun `Skal ikke flytte dersom oppgave ikke er tildelt Vadsø`() {
+    fun `Skal ikke flytte dersom oppgave ikke er tildelt Vadsø eller Bergen`() {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
                 id = 1,
-                tildeltEnhetsnr = BERGEN.enhetsnummer,
+                tildeltEnhetsnr = STORD.enhetsnummer,
                 behandlingstype = NASJONAL.toString(),
             )
 
@@ -75,7 +76,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         behandlingstype: Behandlingstype,
     ) {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -95,7 +96,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     @Test
     fun `Skal kaste feil dersom oppgave ikke er tilknyttet en folkeregistrert ident`() {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -117,7 +118,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     @Test
     fun `Skal kaste feil dersom vi ikke får tilbake noen enheter på ident fra norg`() {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -141,7 +142,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     @Test
     fun `Skal kaste feil dersom vi får tilbake flere enheter på ident fra norg`() {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -169,7 +170,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     @Test
     fun `Skal kaste feil dersom vi får tilbake Vadsø som enhet på ident fra norg`() {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -196,7 +197,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         enhet: KontantstøtteEnhet,
     ) {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -218,7 +219,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
     @Test
     fun `Skal oppdatere oppgaven med ny enhet og mappe, men ikke behandlingen, dersom saksreferansen ikke er fylt ut`() {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -246,7 +247,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         oppgavetype: Oppgavetype,
     ) {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
 
         every { integrasjonKlient.finnOppgaveMedId(1) } returns
             Oppgave(
@@ -277,7 +278,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
         oppgavetype: Oppgavetype,
     ) {
         // Arrange
-        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", "1")
+        val task = PorteføljejusteringFlyttOppgaveTask.opprettTask(1, "1", 1)
         val aktørPåOppgave = randomAktør()
         val behandling = lagBehandling()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTaskTest.kt
@@ -59,7 +59,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             Oppgave(
                 id = 1,
                 tildeltEnhetsnr = STORD.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
             )
 
         // Act
@@ -102,7 +102,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             Oppgave(
                 id = 1,
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.SAMHANDLERNR)),
             )
 
@@ -124,7 +124,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             Oppgave(
                 id = 1,
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
@@ -148,7 +148,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             Oppgave(
                 id = 1,
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
@@ -176,7 +176,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             Oppgave(
                 id = 1,
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
@@ -203,7 +203,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
             Oppgave(
                 id = 1,
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
             )
 
@@ -226,7 +226,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
                 id = 1,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 mappeId = 100012692,
             )
 
@@ -254,7 +254,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
                 id = 1,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 saksreferanse = "183421813",
                 oppgavetype = oppgavetype.value,
                 mappeId = 100012692,
@@ -287,7 +287,7 @@ class PorteføljejusteringFlyttOppgaveTaskTest {
                 id = 1,
                 identer = listOf(OppgaveIdentV2("1234", IdentGruppe.FOLKEREGISTERIDENT)),
                 tildeltEnhetsnr = VADSØ.enhetsnummer,
-                behandlingstype = NASJONAL.toString(),
+                behandlingstype = NASJONAL.value,
                 saksreferanse = "183421813",
                 oppgavetype = oppgavetype.value,
                 mappeId = 100012692,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTaskTest.kt
@@ -5,12 +5,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
-import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
+import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet.VADSØ
 import no.nav.familie.prosessering.internal.TaskService
 import org.junit.jupiter.api.Test
 
@@ -26,15 +27,15 @@ class StartPorteføljejusteringTaskTest {
         val finnOppgaveRequestForKonVadsø =
             FinnOppgaveRequest(
                 tema = Tema.KON,
-                enhet = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                enhet = VADSØ.enhetsnummer,
             )
         every { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) } returns
             FinnOppgaveResponseDto(
                 antallTreffTotalt = 2,
                 oppgaver =
                     listOf(
-                        Oppgave(id = 1, tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
-                        Oppgave(id = 2, tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
+                        Oppgave(id = 1, tildeltEnhetsnr = VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
+                        Oppgave(id = 2, tildeltEnhetsnr = VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
                     ),
             )
 
@@ -48,10 +49,20 @@ class StartPorteføljejusteringTaskTest {
         // Assert
         verify(exactly = 1) { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) }
         verify(exactly = 1) {
-            taskService.save(match { task -> task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE && task.payload == "1" })
+            taskService.save(
+                match { task ->
+                    task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE &&
+                        task.payload == objectMapper.writeValueAsString(PorteføljejusteringFlyttOppgaveDto(1, VADSØ.enhetsnummer, 50))
+                },
+            )
         }
         verify(exactly = 1) {
-            taskService.save(match { task -> task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE && task.payload == "2" })
+            taskService.save(
+                match { task ->
+                    task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE &&
+                        task.payload == objectMapper.writeValueAsString(PorteføljejusteringFlyttOppgaveDto(2, VADSØ.enhetsnummer, 50))
+                },
+            )
         }
     }
 
@@ -61,15 +72,15 @@ class StartPorteføljejusteringTaskTest {
         val finnOppgaveRequestForKonVadsø =
             FinnOppgaveRequest(
                 tema = Tema.KON,
-                enhet = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                enhet = VADSØ.enhetsnummer,
             )
         every { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) } returns
             FinnOppgaveResponseDto(
                 antallTreffTotalt = 2,
                 oppgaver =
                     listOf(
-                        Oppgave(id = 1, tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
-                        Oppgave(id = 2, tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
+                        Oppgave(id = 1, tildeltEnhetsnr = VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
+                        Oppgave(id = 2, tildeltEnhetsnr = VADSØ.enhetsnummer, mappeId = 50, behandlingstype = Behandlingstype.NASJONAL.value),
                     ),
             )
 
@@ -96,7 +107,7 @@ class StartPorteføljejusteringTaskTest {
         val finnOppgaveRequestForKonVadsø =
             FinnOppgaveRequest(
                 tema = Tema.KON,
-                enhet = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                enhet = VADSØ.enhetsnummer,
             )
         every { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) } returns
             FinnOppgaveResponseDto(
@@ -105,12 +116,12 @@ class StartPorteføljejusteringTaskTest {
                     listOf(
                         Oppgave(
                             id = 1,
-                            tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                            tildeltEnhetsnr = VADSØ.enhetsnummer,
                             mappeId = 50,
                             saksreferanse = "12B34",
                             behandlingstype = Behandlingstype.NASJONAL.value,
                         ),
-                        Oppgave(id = 2, tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer, mappeId = 50, saksreferanse = "IT01", behandlingstype = Behandlingstype.NASJONAL.value),
+                        Oppgave(id = 2, tildeltEnhetsnr = VADSØ.enhetsnummer, mappeId = 50, saksreferanse = "IT01", behandlingstype = Behandlingstype.NASJONAL.value),
                     ),
             )
 
@@ -123,8 +134,22 @@ class StartPorteføljejusteringTaskTest {
 
         // Assert
         verify(exactly = 1) { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) }
-        verify(exactly = 0) { taskService.save(match { task -> task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE && task.payload == "1" }) }
-        verify(exactly = 1) { taskService.save(match { task -> task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE && task.payload == "2" }) }
+        verify(exactly = 0) {
+            taskService.save(
+                match { task ->
+                    task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE &&
+                        task.payload == objectMapper.writeValueAsString(PorteføljejusteringFlyttOppgaveDto(1, VADSØ.enhetsnummer, 50))
+                },
+            )
+        }
+        verify(exactly = 1) {
+            taskService.save(
+                match { task ->
+                    task.type == PorteføljejusteringFlyttOppgaveTask.TASK_STEP_TYPE &&
+                        task.payload == objectMapper.writeValueAsString(PorteføljejusteringFlyttOppgaveDto(2, VADSØ.enhetsnummer, 50))
+                },
+            )
+        }
     }
 
     @Test
@@ -133,7 +158,7 @@ class StartPorteføljejusteringTaskTest {
         val finnOppgaveRequestForKonVadsø =
             FinnOppgaveRequest(
                 tema = Tema.KON,
-                enhet = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                enhet = VADSØ.enhetsnummer,
             )
         every { integrasjonKlient.hentOppgaver(finnOppgaveRequestForKonVadsø) } returns
             FinnOppgaveResponseDto(
@@ -142,7 +167,7 @@ class StartPorteføljejusteringTaskTest {
                     listOf(
                         Oppgave(
                             id = 1,
-                            tildeltEnhetsnr = KontantstøtteEnhet.VADSØ.enhetsnummer,
+                            tildeltEnhetsnr = VADSØ.enhetsnummer,
                             mappeId = null,
                             saksreferanse = "12345",
                         ),


### PR DESCRIPTION
### 📮 Favro: NAV-27106

### 💰 Hva skal gjøres, og hvorfor?
Småfiks etter testing
- Fjerner konvertering av `null` til string før det legges til som query parameter
- Legger til mulighet for å filtrere oppgaver som skal flyttes på `behandlesAvApplikasjon`
- Legger til client credentials klient for klage