### PR TITLE
Porteføljejustering: Fjerner filtrering på behandlesAvApplikasjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/PorteføljejusteringFlyttOppgaveTask.kt
@@ -88,7 +88,6 @@ class PorteføljejusteringFlyttOppgaveTask(
         // av BehandleSak, GodkjenndeVedtak eller BehandleUnderkjentVedtak
         if (
             oppgave.saksreferanse != null &&
-            oppgave.behandlesAvApplikasjon == "familie-ks-sak" &&
             oppgave.oppgavetype in setOf(BehandleSak.value, GodkjenneVedtak.value, BehandleUnderkjentVedtak.value)
         ) {
             try {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/porteføljejustering/StartPorteføljejusteringTask.kt
@@ -47,7 +47,6 @@ class StartPorteføljejusteringTask(
                 .filterNot { it.saksreferanse?.matches("\\d+[A-Z]\\d+".toRegex()) == true } // Filtrere bort infotrygd-oppgaver
                 .filterNot { it.mappeId == null } // Vi skal ikke flytte oppgaver som ikke har mappe id
                 .filter { it.behandlingstype == Behandlingstype.NASJONAL.value }
-                .filter { oppgave -> startPorteføljejusteringTaskDto.behandlesAvApplikasjon?.let { it == oppgave.behandlesAvApplikasjon } ?: true }
 
         logger.info("Fant ${oppgaverSomSkalFlyttes.size} kontantstøtte oppgaver som skal flyttes")
 


### PR DESCRIPTION
### 📮 Favro: [NAV-27181](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-27181)

### 💰 Hva skal gjøres, og hvorfor?
Ingen oppgaver plukkes ut til flytting pga manglende `behandlesAvApplikasjon`-felt på oppgave.

Fjerner filtrering på `behandlesAvApplikasjon` da ingen oppgaver med behandlingstype `NASJONAL` har feltet `behandlesAvApplikasjon` satt.
