### PR TITLE
Hent arbeidsfordeling basert på behandlingstype

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
@@ -5,17 +5,13 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.api.dto.MinimalFagsakResponsDto
-import no.nav.familie.ks.sak.api.dto.leggTilEnhet
-import no.nav.familie.ks.sak.api.dto.utvidManueltBrevDtoMedEnhetOgMottaker
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.config.BehandlerRolle
-import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
 import no.nav.familie.ks.sak.kjerne.brev.BrevService
 import no.nav.familie.ks.sak.kjerne.brev.GenererBrevService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
-import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.sikkerhet.AuditLoggerEvent
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
@@ -40,8 +36,6 @@ class BrevController(
     private val tilgangService: TilgangService,
     private val behandlingService: BehandlingService,
     private val vedtakService: VedtakService,
-    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
-    private val arbeidsfordelingService: ArbeidsfordelingService,
     private val fagsakService: FagsakService,
 ) {
     @PostMapping(path = ["/forhaandsvis-brev/{behandlingId}"])
@@ -62,7 +56,7 @@ class BrevController(
 
         return brevService
             .hentForhåndsvisningAvBrev(
-                manueltBrevDto = manueltBrevDto.utvidManueltBrevDtoMedEnhetOgMottaker(behandlingId, personopplysningGrunnlagService, arbeidsfordelingService),
+                manueltBrevDto = brevService.utvidManueltBrevDtoMedEnhetOgMottaker(behandlingId, manueltBrevDto),
             ).let { Ressurs.success(it) }
     }
 
@@ -84,7 +78,7 @@ class BrevController(
 
         return brevService
             .hentForhåndsvisningAvBrev(
-                manueltBrevDto = manueltBrevDto.leggTilEnhet(arbeidsfordelingService),
+                manueltBrevDto = brevService.leggTilEnhet(manueltBrevDto),
             ).let { Ressurs.success(it) }
     }
 
@@ -102,7 +96,7 @@ class BrevController(
         val fagsak = fagsakService.hentFagsak(fagsakId)
 
         brevService.sendBrev(
-            manueltBrevDto = manueltBrevDto.leggTilEnhet(arbeidsfordelingService),
+            manueltBrevDto = brevService.leggTilEnhet(manueltBrevDto),
             fagsak = fagsak,
         )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
@@ -78,7 +78,7 @@ class BrevController(
 
         return brevService
             .hentForhåndsvisningAvBrev(
-                manueltBrevDto = brevService.leggTilEnhet(manueltBrevDto),
+                manueltBrevDto = brevService.leggTilEnhet(fagsakId, manueltBrevDto),
             ).let { Ressurs.success(it) }
     }
 
@@ -96,7 +96,7 @@ class BrevController(
         val fagsak = fagsakService.hentFagsak(fagsakId)
 
         brevService.sendBrev(
-            manueltBrevDto = brevService.leggTilEnhet(manueltBrevDto),
+            manueltBrevDto = brevService.leggTilEnhet(fagsak.id, manueltBrevDto),
             fagsak = fagsak,
         )
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManueltBrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManueltBrevDto.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.slåSammen
 import no.nav.familie.ks.sak.common.util.tilKortString
-import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.BrevDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.Brevmal
@@ -28,7 +27,6 @@ import no.nav.familie.ks.sak.kjerne.brev.domene.maler.UtbetalingEtterKAVedtakBre
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.VarselbrevMedÅrsakerDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.VarselbrevMedÅrsakerOgBarnDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.flettefelt
-import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import java.time.LocalDate
 
@@ -297,40 +295,6 @@ fun ManueltBrevDto.tilBrev(saksbehandlerNavn: String): BrevDto =
             throw Feil("Kan ikke mappe fra manuel brevrequest til ${this.brevmal}.")
         }
     }
-
-fun ManueltBrevDto.utvidManueltBrevDtoMedEnhetOgMottaker(
-    behandlingId: Long,
-    personopplysningGrunnlagService: PersonopplysningGrunnlagService,
-    arbeidsfordelingService: ArbeidsfordelingService,
-): ManueltBrevDto {
-    val mottakerPerson = personopplysningGrunnlagService.hentSøker(behandlingId)
-    val arbeidsfordelingPåBehandling = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId)
-
-    return this.copy(
-        enhet =
-            Enhet(
-                enhetNavn = arbeidsfordelingPåBehandling.behandlendeEnhetNavn,
-                enhetId = arbeidsfordelingPåBehandling.behandlendeEnhetId,
-            ),
-        mottakerMålform = mottakerPerson?.målform ?: mottakerMålform,
-        mottakerNavn = mottakerPerson?.navn ?: mottakerNavn,
-    )
-}
-
-fun ManueltBrevDto.leggTilEnhet(arbeidsfordelingService: ArbeidsfordelingService): ManueltBrevDto {
-    val arbeidsfordelingsenhet =
-        arbeidsfordelingService.hentArbeidsfordelingsenhetPåIdenter(
-            søkerIdent = mottakerIdent,
-            barnIdenter = barnIBrev,
-        )
-    return this.copy(
-        enhet =
-            Enhet(
-                enhetNavn = arbeidsfordelingsenhet.enhetNavn,
-                enhetId = arbeidsfordelingsenhet.enhetId,
-            ),
-    )
-}
 
 private fun List<LocalDate>?.tilFormaterteFødselsdager() =
     slåSammen(

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -12,4 +12,5 @@ enum class FeatureToggle(
     // Ikke operasjonelle
     KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
     PORTEFØLJEJUSTERING("familie-ks-sak.portefoljejustering"),
+    HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE("familie-ks-sak.hent-arbeidsfordeling-med-behandlingstype"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.kjerne.arbeidsfordeling
 
 import jakarta.transaction.Transactional
 import no.nav.familie.kontrakter.felles.NavIdent
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.ks.sak.api.dto.EndreBehandlendeEnhetDto
 import no.nav.familie.ks.sak.common.exception.Feil
@@ -157,13 +158,14 @@ class ArbeidsfordelingService(
 
         val identMedStrengeste = finnPersonMedStrengesteAdressebeskyttelse(personer)
 
-        return integrasjonKlient.hentBehandlendeEnheter(identMedStrengeste ?: søker.first).singleOrNull()
+        return integrasjonKlient.hentBehandlendeEnheter(identMedStrengeste ?: søker.first, behandling.kategori.tilOppgavebehandlingType()).singleOrNull()
             ?: throw Feil(message = "Fant flere eller ingen enheter på behandling.")
     }
 
     fun hentArbeidsfordelingsenhetPåIdenter(
         søkerIdent: String,
         barnIdenter: List<String>,
+        behandlingstype: Behandlingstype?,
     ): Arbeidsfordelingsenhet {
         val identerLagtSammen = barnIdenter + søkerIdent
 
@@ -174,7 +176,7 @@ class ArbeidsfordelingService(
 
         val identMedStrengeste = finnPersonMedStrengesteAdressebeskyttelse(identTilAdresseBeskyttelseGraderingMap)
 
-        return integrasjonKlient.hentBehandlendeEnheter(identMedStrengeste ?: søkerIdent).singleOrNull()
+        return integrasjonKlient.hentBehandlendeEnheter(identMedStrengeste ?: søkerIdent, behandlingstype).singleOrNull()
             ?: throw Feil(message = "Fant flere eller ingen enheter på behandling.")
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
@@ -60,7 +60,7 @@ class BrevService(
         sendBrev(behandling.fagsak, behandlingId, manueltBrevDtoMedMottakerData)
     }
 
-    private fun utvidManueltBrevDtoMedEnhetOgMottaker(
+    fun utvidManueltBrevDtoMedEnhetOgMottaker(
         behandlingId: Long,
         manueltBrevDto: ManueltBrevDto,
     ): ManueltBrevDto {
@@ -75,6 +75,22 @@ class BrevService(
                 ),
             mottakerMålform = mottakerPerson?.målform ?: manueltBrevDto.mottakerMålform,
             mottakerNavn = mottakerPerson?.navn ?: manueltBrevDto.mottakerNavn,
+        )
+    }
+
+    fun leggTilEnhet(manueltBrevDto: ManueltBrevDto): ManueltBrevDto {
+        val arbeidsfordelingsenhet =
+            arbeidsfordelingService.hentArbeidsfordelingsenhetPåIdenter(
+                søkerIdent = manueltBrevDto.mottakerIdent,
+                barnIdenter = manueltBrevDto.barnIBrev,
+                behandlingstype = null,
+            )
+        return manueltBrevDto.copy(
+            enhet =
+                Enhet(
+                    enhetNavn = arbeidsfordelingsenhet.enhetNavn,
+                    enhetId = arbeidsfordelingsenhet.enhetId,
+                ),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
@@ -1,16 +1,21 @@
 package no.nav.familie.ks.sak.kjerne.brev
 
 import no.nav.familie.http.client.RessursException
+import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.ks.sak.api.dto.ManuellAdresseInfo
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.integrasjon.distribuering.DistribuerDødsfallBrevPåFagsakTask
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ks.sak.integrasjon.logger
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.SettBehandlingPåVentService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
@@ -25,6 +30,7 @@ import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.kjerne.logg.LoggService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -36,13 +42,15 @@ class BrevService(
     private val taskService: TaskRepositoryWrapper,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
-    private val vilkårsvurderingService: VilkårsvurderingService,
+    private val `vilkårsvurderingService`: VilkårsvurderingService,
     private val behandlingRepository: BehandlingRepository,
-    private val settBehandlingPåVentService: SettBehandlingPåVentService,
+    private val `settBehandlingPåVentService`: SettBehandlingPåVentService,
     private val genererBrevService: GenererBrevService,
     private val brevmottakerService: BrevmottakerService,
     private val validerBrevmottakerService: ValiderBrevmottakerService,
     private val saksbehandlerContext: SaksbehandlerContext,
+    private val featureToggleService: FeatureToggleService,
+    private val behandlingService: BehandlingService,
 ) {
     fun hentForhåndsvisningAvBrev(
         manueltBrevDto: ManueltBrevDto,
@@ -78,13 +86,36 @@ class BrevService(
         )
     }
 
-    fun leggTilEnhet(manueltBrevDto: ManueltBrevDto): ManueltBrevDto {
+    fun leggTilEnhet(
+        fagsakId: Long,
+        manueltBrevDto: ManueltBrevDto,
+    ): ManueltBrevDto {
         val arbeidsfordelingsenhet =
-            arbeidsfordelingService.hentArbeidsfordelingsenhetPåIdenter(
-                søkerIdent = manueltBrevDto.mottakerIdent,
-                barnIdenter = manueltBrevDto.barnIBrev,
-                behandlingstype = null,
-            )
+            if (featureToggleService.isEnabled(FeatureToggle.HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE)) {
+                val enheterSomNavIdentHarTilgangTil = integrasjonKlient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(SikkerhetContext.hentSaksbehandler()))
+                if (enheterSomNavIdentHarTilgangTil.size == 1) {
+                    Arbeidsfordelingsenhet(
+                        enhetId = enheterSomNavIdentHarTilgangTil.first().enhetsnummer,
+                        enhetNavn = enheterSomNavIdentHarTilgangTil.first().enhetsnavn,
+                    )
+                } else {
+                    val sisteVedtatteBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId)
+
+                    arbeidsfordelingService
+                        .hentArbeidsfordelingsenhetPåIdenter(
+                            søkerIdent = manueltBrevDto.mottakerIdent,
+                            barnIdenter = manueltBrevDto.barnIBrev,
+                            behandlingstype = sisteVedtatteBehandling?.kategori?.tilOppgavebehandlingType(),
+                        )
+                }
+            } else {
+                arbeidsfordelingService
+                    .hentArbeidsfordelingsenhetPåIdenter(
+                        søkerIdent = manueltBrevDto.mottakerIdent,
+                        barnIdenter = manueltBrevDto.barnIBrev,
+                        behandlingstype = null,
+                    )
+            }
         return manueltBrevDto.copy(
             enhet =
                 Enhet(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretter.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.TilpassArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.Fagsak
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
@@ -25,6 +26,7 @@ class KlagebehandlingOppretter(
     private val integrasjonKlient: IntegrasjonKlient,
     private val tilpassArbeidsfordelingService: TilpassArbeidsfordelingService,
     private val clockProvider: ClockProvider,
+    private val behandlingService: BehandlingService,
 ) {
     private val logger = LoggerFactory.getLogger(KlagebehandlingOppretter::class.java)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -48,7 +50,13 @@ class KlagebehandlingOppretter(
         val fødselsnummer = fagsak.aktør.aktivFødselsnummer()
         val navIdent = NavIdent(SikkerhetContext.hentSaksbehandler())
 
-        val arbeidsfordelingsenheter = integrasjonKlient.hentBehandlendeEnheter(fødselsnummer)
+        val sisteVedtatteBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsak.id)
+
+        val arbeidsfordelingsenheter =
+            integrasjonKlient.hentBehandlendeEnheter(
+                ident = fødselsnummer,
+                behandlingstype = sisteVedtatteBehandling?.kategori?.tilOppgavebehandlingType(),
+            )
 
         if (arbeidsfordelingsenheter.isEmpty()) {
             logger.error("Fant ingen arbeidsfordelingsenheter for aktør. Se SecureLogs for detaljer.")

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -198,7 +198,7 @@ internal class ArbeidsfordelingServiceTest {
                     .findByBehandlingAndAktiv(behandling.id)
             } returns lagPersonopplysningGrunnlag(søkerPersonIdent = søker.aktør.aktivFødselsnummer())
 
-            every { integrasjonKlient.hentBehandlendeEnheter(søker.aktør.aktivFødselsnummer()) } returns
+            every { integrasjonKlient.hentBehandlendeEnheter(søker.aktør.aktivFødselsnummer(), any()) } returns
                 listOf(
                     arbeidsfordelingsenhet,
                 )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
@@ -10,9 +10,9 @@ import io.mockk.verify
 import no.nav.familie.ks.sak.api.dto.Bruker
 import no.nav.familie.ks.sak.api.dto.FullmektigEllerVerge
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
-import no.nav.familie.ks.sak.api.dto.utvidManueltBrevDtoMedEnhetOgMottaker
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagBrevmottakerDto
@@ -23,6 +23,7 @@ import no.nav.familie.ks.sak.data.lagVilkårsvurderingMedSøkersVilkår
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.SettBehandlingPåVentService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
@@ -65,6 +66,8 @@ class BrevServiceTest {
             ),
         )
     private val saksbehandlerContext = mockk<SaksbehandlerContext>(relaxed = true)
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val behandlingService = mockk<BehandlingService>()
 
     private val brevService =
         BrevService(
@@ -80,6 +83,8 @@ class BrevServiceTest {
             brevmottakerService = brevmottakerService,
             validerBrevmottakerService = validerBrevmottakerService,
             saksbehandlerContext = saksbehandlerContext,
+            featureToggleService = featureToggleService,
+            behandlingService = behandlingService,
         )
 
     private val søker = randomAktør()
@@ -124,10 +129,9 @@ class BrevServiceTest {
             val forhåndsvisning =
                 brevService
                     .hentForhåndsvisningAvBrev(
-                        manueltBrevDto.utvidManueltBrevDtoMedEnhetOgMottaker(
+                        brevService.utvidManueltBrevDtoMedEnhetOgMottaker(
                             behandling.id,
-                            personopplysningGrunnlagService,
-                            arbeidsfordelingService,
+                            manueltBrevDto,
                         ),
                     )
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
@@ -10,13 +10,16 @@ import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import no.nav.familie.ks.sak.common.TestClockProvider
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
+import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.KontantstøtteEnhet
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.TilpassArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.fagsak.FagsakService
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -31,6 +34,7 @@ class KlagebehandlingOppretterTest {
     private val integrasjonKlient = mockk<IntegrasjonKlient>()
     private val tilpassArbeidsfordelingService = mockk<TilpassArbeidsfordelingService>()
     private val clockProvider = TestClockProvider.lagClockProviderMedFastTidspunkt(dagensDato)
+    private val behandlingService = mockk<BehandlingService>()
 
     private val klagebehandlingOppretter =
         KlagebehandlingOppretter(
@@ -39,7 +43,13 @@ class KlagebehandlingOppretterTest {
             integrasjonKlient,
             tilpassArbeidsfordelingService,
             clockProvider,
+            behandlingService,
         )
+
+    @BeforeEach
+    fun setup() {
+        every { behandlingService.hentSisteBehandlingSomErVedtatt(any()) } returns lagBehandling()
+    }
 
     @Nested
     inner class OpprettKlage {
@@ -63,7 +73,7 @@ class KlagebehandlingOppretterTest {
             val fagsak = lagFagsak()
             val klageMottattDato = dagensDato
 
-            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns emptyList()
+            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer(), any()) } returns emptyList()
 
             // Act & assert
             val exception =
@@ -79,7 +89,7 @@ class KlagebehandlingOppretterTest {
             val fagsak = lagFagsak()
             val klageMottattDato = dagensDato
 
-            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns
+            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer(), any()) } returns
                 listOf(
                     Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.OSLO),
                     Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.VADSØ),
@@ -103,7 +113,7 @@ class KlagebehandlingOppretterTest {
             val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
 
             every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
-            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer(), any()) } returns listOf(arbeidsfordelingsenhet)
             every { klageKlient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
             every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns arbeidsfordelingsenhet
 
@@ -130,7 +140,7 @@ class KlagebehandlingOppretterTest {
 
             val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
 
-            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer(), any()) } returns listOf(arbeidsfordelingsenhet)
             every { klageKlient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
             every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns arbeidsfordelingsenhet
 
@@ -158,7 +168,7 @@ class KlagebehandlingOppretterTest {
 
             val opprettKlageRequest = slot<OpprettKlagebehandlingRequest>()
 
-            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer()) } returns listOf(arbeidsfordelingsenhet)
+            every { integrasjonKlient.hentBehandlendeEnheter(fagsak.aktør.aktivFødselsnummer(), any()) } returns listOf(arbeidsfordelingsenhet)
             every { klageKlient.opprettKlage(capture(opprettKlageRequest)) } returns klagebehandlingId
             every { tilpassArbeidsfordelingService.tilpassArbeidsfordelingsenhetTilSaksbehandler(arbeidsfordelingsenhet, any()) } returns tilpassetArbeidsfordelingsenhet
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/fake/FakeIntegrasjonKlient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/fake/FakeIntegrasjonKlient.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.fake
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.mockk
 import no.nav.familie.kontrakter.felles.NavIdent
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
@@ -17,6 +18,7 @@ import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkSpråk
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -41,7 +43,7 @@ import java.util.UUID
 
 class FakeIntegrasjonKlient(
     restOperations: RestOperations,
-) : IntegrasjonKlient(URI("integrasjoner-url"), restOperations) {
+) : IntegrasjonKlient(URI("integrasjoner-url"), restOperations, mockk(relaxed = true)) {
     private val egenansatt = mutableSetOf<String>()
     private val behandlendeEnhetForIdent = mutableMapOf<String, List<Arbeidsfordelingsenhet>>()
     private val journalførteDokumenter = mutableListOf<ArkiverDokumentRequest>()
@@ -121,7 +123,10 @@ class FakeIntegrasjonKlient(
         )
     }
 
-    override fun hentBehandlendeEnheter(ident: String): List<Arbeidsfordelingsenhet> =
+    override fun hentBehandlendeEnheter(
+        ident: String,
+        behandlingstype: Behandlingstype?,
+    ): List<Arbeidsfordelingsenhet> =
         behandlendeEnhetForIdent[ident] ?: listOf(
             Arbeidsfordelingsenhet.opprettFra(KontantstøtteEnhet.OSLO),
         )


### PR DESCRIPTION
### 📮 Favro: NAV-27118

### 💰 Hva skal gjøres, og hvorfor?
Legger til mulighet for å sende med `behandlingstype` som parameter for å hente arbeidsfordeling for ident.

- I kontekst av en behandling brukes `Behandling::kategori`
- For manuelle brev sendt på fagsaken som ikke er koblet til en behandling velges arbeidsfordeling med prioritering:
  1. Enheten til saksbehandler, hvis saksbehandler kun har tilgang til én enhet
  2. Arbeidsfordeling for søkers ident med kategori fra siste vedtatte behandling
  3. Arbeidsfordeling for søkers ident uten behandlingstype, hvis det ikke finnes en siste vedtatt behandling
- For klager hentes arbeidsfordeling med behandlingstype basert på siste vedtatte behandling

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.