### PR TITLE
NAV-26756: Fjerner begrunnelser som ikke lenger er i bruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelseUtils.kt
@@ -14,7 +14,7 @@ private val logger = LoggerFactory.getLogger(NasjonalEllerFellesBegrunnelse::cla
 fun IBegrunnelse.tilSanityBegrunnelse(sanityBegrunnelser: List<SanityBegrunnelse>): SanityBegrunnelse? {
     val sanityBegrunnelse = sanityBegrunnelser.find { it.apiNavn == this.sanityApiNavn }
     if (sanityBegrunnelse == null) {
-        logger.warn("Finner ikke begrunnelse med apinavn '${this.sanityApiNavn}' på '${this.sanityApiNavn}' i Sanity")
+        logger.warn("Finner ikke begrunnelse med apinavn '${this.sanityApiNavn}' i Sanity")
     }
     return sanityBegrunnelse
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/NasjonalEllerFellesBegrunnelse.kt
@@ -115,10 +115,6 @@ enum class NasjonalEllerFellesBegrunnelse : IBegrunnelse {
         override val begrunnelseType = BegrunnelseType.INNVILGET
         override val sanityApiNavn = "innvilgetErklaringOmMotregning"
     },
-    INNVILGET_13_MND_SAMME_MÅNED_SOM_BARNEHAGEPLASS_0824 {
-        override val begrunnelseType = BegrunnelseType.INNVILGET
-        override val sanityApiNavn = "innvilget13MndSammeMaanedSomBarnehageplass0824"
-    },
     INNVILGET_PÅ_GRUNN_AV_LOVENDRING_2024 {
         override val begrunnelseType = BegrunnelseType.INNVILGET
         override val sanityApiNavn = "innvilgetInnvilgetPaaGrunnAvLovendring"
@@ -692,11 +688,6 @@ enum class NasjonalEllerFellesBegrunnelse : IBegrunnelse {
 
     INNVILGET_MÅNEDEN_BARNET_ER_13_MÅNEDER_0824 {
         override val sanityApiNavn = "innvilgetMaanedenBarneter13Maaneder0824"
-        override val begrunnelseType = BegrunnelseType.INNVILGET
-    },
-
-    INNVILGET_MÅNEDEN_BARNET_SLUTTET_I_BARNEHAGE_0824 {
-        override val sanityApiNavn = "innvilgetMaanedenBarnetSluttetIBarnehage0824"
         override val begrunnelseType = BegrunnelseType.INNVILGET
     },
 


### PR DESCRIPTION
### 📮 Favro: [NAV-26756](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26756)

### 💰 Hva skal gjøres, og hvorfor?
* Fjerner støtte for 2 begrunnelser som er markert som "Ikke i bruk" i Sanity da disse skaper støy i loggene med masse warnings hver gang vi henter sanity-begrunnelser. (Avklart med Anna)
* Justerer loggmelding ved manglende sanity-begrunnelse.
