### PR TITLE
Fjern deprekert variabel fra deploy: APIKEY

### DIFF
--- a/.github/workflows/deploy-kafka-manager.yaml
+++ b/.github/workflows/deploy-kafka-manager.yaml
@@ -3,6 +3,10 @@ name: Deploy familie-baks-kafka-manager
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -12,12 +16,10 @@ jobs:
       - name: Deploy familie-baks-kafka-manager til dev
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/kafka-manager/familie-baks-kafka-manager-dev.yaml
       - name: Deploy familie-baks-kafka-manager til prod
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/kafka-manager/familie-baks-kafka-manager-prod.yaml

--- a/.github/workflows/deploy-unleash-api-token.yaml
+++ b/.github/workflows/deploy-unleash-api-token.yaml
@@ -3,6 +3,10 @@ name: Deploy unleash api-token for dev og prod
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy-dev:
     runs-on: ubuntu-latest
@@ -12,7 +16,6 @@ jobs:
       - name: deploy unleash api-token to dev
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/unleash/unleash-apitoken-dev.yaml
   deploy-prod:
@@ -23,6 +26,5 @@ jobs:
       - name: deploy unleash api-token to prod
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/unleash/unleash-apitoken-prod.yaml

--- a/.github/workflows/manual-deploy-kafka-aiven.yaml
+++ b/.github/workflows/manual-deploy-kafka-aiven.yaml
@@ -3,6 +3,10 @@ name: Deploy kafka topics
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -13,62 +17,53 @@ jobs:
       - name: Deploy dvh-vedtak-topic til dev
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/kafka/dvh-vedtak-topic-dev.yaml
       - name: Deploy dvh-vedtak-topic til prod
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/kafka/dvh-vedtak-topic-prod.yaml
 
       - name: Deploy dvh-sakstatistikk-behandling-topic til dev
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/kafka/dvh-sakstatistikk-behandling-topic-dev.yaml
       - name: Deploy dvh-sakstatistikk-behandling-topic til prod
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/kafka/dvh-sakstatistikk-behandling-topic-prod.yaml
+
       - name: Deploy dvh-sakstatistikk-siste-tilstand-behandling-topic til dev
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/kafka/dvh-sakstatistikk-siste-tilstand-behandling-topic-dev.yaml
       - name: Deploy dvh-sakstatistikk-siste-tilstand-behandling-topic til prod
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/kafka/dvh-sakstatistikk-siste-tilstand-behandling-topic-prod.yaml
 
       - name: Deploy dvh-sakstatistikk-sak-topic til dev
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/kafka/dvh-sakstatistikk-sak-topic-dev.yaml
       - name: Deploy dvh-sakstatistikk-sak-topic til prod
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/kafka/dvh-sakstatistikk-sak-topic-prod.yaml
       - name: Deploy barnehagelister topic til dev
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/kafka/barnehagelister-topic-dev.yaml
       - name: Deploy barnehagelister topic til prod
         uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/kafka/barnehagelister-topic-prod.yaml

--- a/.nais/kafka-manager/familie-baks-kafka-manager-dev.yaml
+++ b/.nais/kafka-manager/familie-baks-kafka-manager-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: teamfamilie
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2024.10.25-13.23-52ea038 # See https://github.com/navikt/kafka-manager/actions
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2026.01.08-11.18-235a0f4 # See https://github.com/navikt/kafka-manager/actions
   port: 8080
   ingresses:
     - https://familie-baks-kafka-manager.intern.dev.nav.no

--- a/.nais/kafka-manager/familie-baks-kafka-manager-prod.yaml
+++ b/.nais/kafka-manager/familie-baks-kafka-manager-prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: teamfamilie
 spec:
-  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2024.10.25-13.23-52ea038 # See https://github.com/navikt/kafka-manager/actions
+  image: europe-north1-docker.pkg.dev/nais-management-233d/poao/kafka-manager:2026.01.08-11.18-235a0f4 # See https://github.com/navikt/kafka-manager/actions
   port: 8080
   ingresses:
     - https://familie-baks-kafka-manager.intern.nav.no


### PR DESCRIPTION
### 📮 Favro: NAV-24832

### 💰 Hva skal gjøres, og hvorfor?
Apper som bruker APIKEY vil potensielt feile på et tidspunkt feile når den løper ut (`Error: fatal: PermissionDenied: failed authentication`). Nais har for lenge siden deprekert APIKEY og støtter "nøkkelfri" deploy.

Tråd: https://nav-it.slack.com/archives/C01DE3M9YBV/p1702893023861639

Bonus fra sidelinjen: Oppdaterer kafka-manager image.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
