### PR TITLE
Sletter toggles

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -10,7 +10,6 @@ enum class FeatureToggle(
     KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER("familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"),
 
     // Ikke operasjonelle
-    KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK("familie-ks-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak"),
     SKAL_HÅNDTERE_FALSK_IDENTITET("familie-ks-sak.skal-handtere-falsk-identitet"),
     HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE("familie-ks-sak.hent-arbeidsfordeling-med-behandlingstype"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingService.kt
@@ -10,8 +10,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.integrasjon.oppgave.OpprettOppgaveTask
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -49,19 +47,10 @@ class OpprettBehandlingService(
     private val taskService: TaskRepositoryWrapper,
     private val stegService: StegService,
     private val behandlingMetrikker: BehandlingMetrikker,
-    private val featureToggleService: FeatureToggleService,
     private val eksternBehandlingRelasjonService: EksternBehandlingRelasjonService,
 ) {
     @Transactional
     fun opprettBehandling(opprettBehandlingRequest: OpprettBehandlingDto): Behandling {
-        if (opprettBehandlingRequest.behandlingÅrsak == BehandlingÅrsak.IVERKSETTE_KA_VEDTAK &&
-            !featureToggleService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK)
-        ) {
-            throw FunksjonellFeil(
-                melding = "Kan ikke opprette behandling med årsak Iverksette KA-vedtak.",
-            )
-        }
-
         val aktør = personidentService.hentAktør(opprettBehandlingRequest.søkersIdent)
         val fagsak =
             fagsakRepository.finnFagsakForAktør(aktør)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/OpprettBehandlingServiceTest.kt
@@ -11,8 +11,6 @@ import no.nav.familie.ks.sak.api.dto.OpprettBehandlingDto
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagNyEksternBehandlingRelasjon
@@ -52,7 +50,6 @@ class OpprettBehandlingServiceTest {
     private val behandlingRepository = mockk<BehandlingRepository>()
     private val taskService = mockk<TaskRepositoryWrapper>()
     private val behandlingMetrikker = mockk<BehandlingMetrikker>()
-    private val featureToggleService = mockk<FeatureToggleService>()
     private val eksternBehandlingRelasjonService = mockk<EksternBehandlingRelasjonService>()
 
     private val opprettBehandlingService =
@@ -66,7 +63,6 @@ class OpprettBehandlingServiceTest {
             taskService = taskService,
             stegService = stegService,
             behandlingMetrikker = behandlingMetrikker,
-            featureToggleService = featureToggleService,
             eksternBehandlingRelasjonService = eksternBehandlingRelasjonService,
         )
 
@@ -323,26 +319,6 @@ class OpprettBehandlingServiceTest {
                     opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
                 }
             assertThat(exception.message).isEqualTo("Kan ikke opprette revurdering på $fagsak uten noen andre behandlinger som er vedtatt.")
-        }
-
-        @Test
-        fun `skal kaste feil dersom behandlingsårsak er IVERKSETTE_KA_VEDTAK og toggle ikke er skrudd på`() {
-            // Arrange
-            val opprettBehandlingDto =
-                OpprettBehandlingDto(
-                    søkersIdent = søkersIdent,
-                    behandlingType = BehandlingType.REVURDERING,
-                    behandlingÅrsak = BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
-                )
-
-            every { featureToggleService.isEnabled(FeatureToggle.KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK) } returns false
-
-            // Act & assert
-            val exception =
-                assertThrows<FunksjonellFeil> {
-                    opprettBehandlingService.opprettBehandling(opprettBehandlingDto)
-                }
-            assertThat(exception.melding).isEqualTo("Kan ikke opprette behandling med årsak Iverksette KA-vedtak.")
         }
 
         @Test


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Sletter toggle som har vært på i prod en stund

Slettede toggles:
- `KAN_OPPRETTE_REVURDERING_MED_ÅRSAK_IVERKSETTE_KA_VEDTAK` har vært på i prod lenge