### PR TITLE
Kopier over vilkårsvurdering fra aktiv vilkårsvurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/RegistrereSøknadSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/RegistrereSøknadSteg.kt
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class RegistrereSøknadSteg(
     private val søknadGrunnlagService: SøknadGrunnlagService,
-    private val infotrygdReplikaKlient: InfotrygdReplikaKlient,
     private val loggService: LoggService,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val behandlingService: BehandlingService,
@@ -46,7 +45,7 @@ class RegistrereSøknadSteg(
         val aktivSøknadGrunnlag = søknadGrunnlagService.finnAktiv(behandlingId)
         val aktivSøknadGrunnlagFinnes = aktivSøknadGrunnlag != null
 
-        if (aktivSøknadGrunnlagFinnes && aktivSøknadGrunnlag!!.søknad == registrerSøknadDto.søknad.writeValueAsString()) {
+        if (aktivSøknadGrunnlagFinnes && aktivSøknadGrunnlag.søknad == registrerSøknadDto.søknad.writeValueAsString()) {
             logger.info("Det finnes allerede en identisk søknad, ingen endringer blir utført.")
             return
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.integrasjon.secureLogger
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonValidator
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.PersonResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Regelverk
@@ -46,8 +47,7 @@ class VilkårsvurderingService(
         val aktivVilkårsvurdering = finnAktivVilkårsvurdering(behandling.id)
         val vilkårsvurderingFraForrigeBehandling = forrigeBehandlingSomErVedtatt?.let { hentAktivVilkårsvurderingForBehandling(forrigeBehandlingSomErVedtatt.id) }
 
-        val personopplysningGrunnlag =
-            personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
+        val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
 
         val adopsjonerIBehandling = adopsjonService.hentAlleAdopsjonerForBehandling(BehandlingId(behandling.id))
 
@@ -69,6 +69,10 @@ class VilkårsvurderingService(
             initiellVilkårsvurdering.personResultater
                 .single { it.erSøkersResultater() }
                 .leggTilBlankAnnenVurdering(AnnenVurderingType.OPPLYSNINGSPLIKT)
+        }
+
+        if (behandling.opprettetÅrsak == BehandlingÅrsak.SØKNAD && aktivVilkårsvurdering != null) {
+            initiellVilkårsvurdering.kopierVilkårResultaterFraForrigeVilkårsvurdering(aktivVilkårsvurdering)
         }
 
         initiellVilkårsvurdering.oppdaterMedDødsdatoer(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -389,6 +389,23 @@ fun Vilkårsvurdering.kopierResultaterFraForrigeBehandling(
     }
 }
 
+fun Vilkårsvurdering.kopierVilkårResultaterFraForrigeVilkårsvurdering(
+    forrigeVilkårsvurdering: Vilkårsvurdering,
+) {
+    personResultater.forEach { initieltPersonResultat ->
+        val personResultatForrigeVilkårsvurdering =
+            forrigeVilkårsvurdering.personResultater.find {
+                it.aktør == initieltPersonResultat.aktør
+            }
+
+        if (personResultatForrigeVilkårsvurdering?.vilkårResultater.isNullOrEmpty()) return@forEach
+
+        val kopierteVilkårResultat = personResultatForrigeVilkårsvurdering.vilkårResultater.map { it.kopier(initieltPersonResultat) }
+
+        initieltPersonResultat.setSortedVilkårResultater(kopierteVilkårResultat.toSet())
+    }
+}
+
 private fun PersonResultat.overskrivMedVilkårResultaterFraForrigeBehandling(
     vilkårResultaterFraForrigeBehandling: Collection<VilkårResultat>,
 ): List<VilkårResultat> {

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -1118,6 +1118,7 @@ fun lagVilkårsvurderingOppfylt(
     skalOppretteEøsSpesifikkeVilkår: Boolean = false,
     periodeFom: LocalDate? = null,
     periodeTom: LocalDate? = null,
+    begrunnelse: String = "",
 ): Vilkårsvurdering {
     val vilkårsvurdering =
         Vilkårsvurdering(
@@ -1152,7 +1153,7 @@ fun lagVilkårsvurderingOppfylt(
                                     },
                                 vilkårType = it,
                                 resultat = Resultat.OPPFYLT,
-                                begrunnelse = "",
+                                begrunnelse = begrunnelse,
                                 behandlingId = vilkårsvurdering.behandling.id,
                                 utdypendeVilkårsvurderinger = emptyList(),
                                 erEksplisittAvslagPåSøknad = erEksplisittAvslagPåSøknad,
@@ -1327,6 +1328,7 @@ fun lagVilkårsvurdering(
     søkerPeriodeFom: LocalDate? = LocalDate.now().minusMonths(1),
     søkerPeriodeTom: LocalDate? = LocalDate.now().plusYears(2),
     medAndreVurderinger: Boolean = true,
+    begrunnelse: String = "",
 ): Vilkårsvurdering {
     val vilkårsvurdering =
         Vilkårsvurdering(
@@ -1346,7 +1348,7 @@ fun lagVilkårsvurdering(
                 resultat = resultat,
                 periodeFom = søkerPeriodeFom,
                 periodeTom = søkerPeriodeTom,
-                begrunnelse = "",
+                begrunnelse = begrunnelse,
             ),
             VilkårResultat(
                 behandlingId = behandling.id,
@@ -1355,7 +1357,7 @@ fun lagVilkårsvurdering(
                 resultat = resultat,
                 periodeFom = søkerPeriodeFom,
                 periodeTom = søkerPeriodeTom,
-                begrunnelse = "",
+                begrunnelse = begrunnelse,
             ),
         ),
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårResultat
+import no.nav.familie.ks.sak.data.lagVilkårsvurdering
 import no.nav.familie.ks.sak.data.lagVilkårsvurderingOppfylt
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
@@ -16,206 +17,348 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Res
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
-import org.hamcrest.MatcherAssert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import org.hamcrest.CoreMatchers.`is` as Is
 
 class OppdaterVilkårsvurderingTest {
-    @Test
-    fun `kopierResultaterFraForrigeBehandling skal legge til nytt vilkår`() {
-        val søkerPersonIdent = randomFnr()
-        val barnPersonIdent = randomFnr()
-        val persongrunnlag =
-            lagPersonopplysningGrunnlag(
-                søkerPersonIdent = søkerPersonIdent,
-                barnasIdenter = listOf(barnPersonIdent),
+    @Nested
+    inner class KopierResultaterFraForrigeBehandlingTest {
+        @Test
+        fun `Skal legge til nytt vilkår`() {
+            val søkerPersonIdent = randomFnr()
+            val barnPersonIdent = randomFnr()
+            val persongrunnlag =
+                lagPersonopplysningGrunnlag(
+                    søkerPersonIdent = søkerPersonIdent,
+                    barnasIdenter = listOf(barnPersonIdent),
+                )
+            val vilkårsvurderingForrigeBehandling =
+                lagVilkårsvurderingOppfylt(
+                    personer = listOf(persongrunnlag.søker, persongrunnlag.barna.single()),
+                )
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = mockk(relaxed = true),
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlag,
+                    adopsjonerIBehandling = emptyList(),
+                )
+
+            initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
+                vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
             )
-        val vilkårsvurderingForrigeBehandling =
-            lagVilkårsvurderingOppfylt(
-                personer = listOf(persongrunnlag.søker, persongrunnlag.barna.single()),
-            )
-        val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(
-                behandling = mockk(relaxed = true),
-                forrigeVilkårsvurdering = null,
-                personopplysningGrunnlag = persongrunnlag,
-                adopsjonerIBehandling = emptyList(),
-            )
 
-        initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
-            vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-        )
+            val søkerVilkårResultater =
+                initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == søkerPersonIdent }.vilkårResultater
 
-        val søkerVilkårResultater =
-            initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == søkerPersonIdent }.vilkårResultater
+            val barnVilkårResultater =
+                initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
 
-        val barnVilkårResultater =
-            initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
+            Assertions.assertEquals(2, søkerVilkårResultater.size)
+            Assertions.assertEquals(5, barnVilkårResultater.size)
 
-        Assertions.assertEquals(2, søkerVilkårResultater.size)
-        Assertions.assertEquals(5, barnVilkårResultater.size)
+            Vilkår.hentVilkårFor(persongrunnlag.søker.type).forEach { vilkår ->
+                Assertions.assertEquals(
+                    Resultat.OPPFYLT,
+                    søkerVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
+                )
+            }
 
-        Vilkår.hentVilkårFor(persongrunnlag.søker.type).forEach { vilkår ->
-            Assertions.assertEquals(
-                Resultat.OPPFYLT,
-                søkerVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
-            )
+            Vilkår.hentVilkårFor(persongrunnlag.barna.single().type).forEach { vilkår ->
+                Assertions.assertEquals(
+                    Resultat.OPPFYLT,
+                    barnVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
+                )
+            }
         }
 
-        Vilkår.hentVilkårFor(persongrunnlag.barna.single().type).forEach { vilkår ->
-            Assertions.assertEquals(
-                Resultat.OPPFYLT,
-                barnVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
+        @Test
+        fun `Skal legge til person på vilkårsvurdering`() {
+            val søkerPersonIdent = randomFnr()
+            val persongrunnlag1 =
+                lagPersonopplysningGrunnlag(
+                    søkerPersonIdent = søkerPersonIdent,
+                )
+            val vilkårsvurderingForrigeBehandling = lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag1.søker))
+
+            val barnPersonIdent = randomFnr()
+            val persongrunnlag2 =
+                lagPersonopplysningGrunnlag(
+                    søkerPersonIdent = søkerPersonIdent,
+                    barnasIdenter = listOf(barnPersonIdent),
+                )
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = mockk(relaxed = true),
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlag2,
+                    adopsjonerIBehandling = emptyList(),
+                )
+
+            initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
+                vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
             )
+
+            val søkerVilkårResultater =
+                initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == søkerPersonIdent }.vilkårResultater
+
+            val barnVilkårResultater =
+                initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
+
+            Assertions.assertEquals(2, initiellVilkårsvurdering.personResultater.size)
+
+            Vilkår.hentVilkårFor(persongrunnlag2.søker.type).forEach { vilkår ->
+                Assertions.assertEquals(
+                    Resultat.OPPFYLT,
+                    søkerVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
+                )
+            }
+
+            val initiellVilkårsvurderingUendret =
+                genererInitiellVilkårsvurdering(
+                    behandling = mockk(relaxed = true),
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlag2,
+                    adopsjonerIBehandling = emptyList(),
+                )
+            val barnVilkårResultaterUendret =
+                initiellVilkårsvurderingUendret.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
+
+            Vilkår.hentVilkårFor(persongrunnlag2.barna.single().type).forEach { vilkår ->
+                Assertions.assertEquals(
+                    barnVilkårResultaterUendret.find { it.vilkårType == vilkår }?.resultat,
+                    barnVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
+                )
+            }
         }
-    }
 
-    @Test
-    fun `kopierResultaterFraForrigeBehandling skal legge til person på vilkårsvurdering`() {
-        val søkerPersonIdent = randomFnr()
-        val persongrunnlag1 =
-            lagPersonopplysningGrunnlag(
-                søkerPersonIdent = søkerPersonIdent,
+        @Test
+        fun `Skal fjerne person på vilkårsvurdering`() {
+            val persongrunnlagRevurdering =
+                lagPersonopplysningGrunnlag(
+                    søkerPersonIdent = randomFnr(),
+                )
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = mockk(relaxed = true),
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlagRevurdering,
+                    adopsjonerIBehandling = emptyList(),
+                )
+
+            val persongrunnlagForrigeBehandling =
+                lagPersonopplysningGrunnlag(
+                    søkerPersonIdent = randomFnr(),
+                    barnasIdenter = listOf(randomFnr()),
+                )
+            val vilkårsvurderingForrigeBehandling =
+                lagVilkårsvurderingOppfylt(
+                    personer =
+                        listOf(
+                            persongrunnlagForrigeBehandling.søker,
+                            persongrunnlagForrigeBehandling.barna.single(),
+                        ),
+                )
+
+            initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
+                vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
             )
-        val vilkårsvurderingForrigeBehandling = lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag1.søker))
-
-        val barnPersonIdent = randomFnr()
-        val persongrunnlag2 =
-            lagPersonopplysningGrunnlag(
-                søkerPersonIdent = søkerPersonIdent,
-                barnasIdenter = listOf(barnPersonIdent),
-            )
-        val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(
-                behandling = mockk(relaxed = true),
-                forrigeVilkårsvurdering = null,
-                personopplysningGrunnlag = persongrunnlag2,
-                adopsjonerIBehandling = emptyList(),
-            )
-
-        initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
-            vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-        )
-
-        val søkerVilkårResultater =
-            initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == søkerPersonIdent }.vilkårResultater
-
-        val barnVilkårResultater =
-            initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
-
-        Assertions.assertEquals(2, initiellVilkårsvurdering.personResultater.size)
-
-        Vilkår.hentVilkårFor(persongrunnlag2.søker.type).forEach { vilkår ->
-            Assertions.assertEquals(
-                Resultat.OPPFYLT,
-                søkerVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
-            )
+            Assertions.assertEquals(1, initiellVilkårsvurdering.personResultater.size)
         }
 
-        val initiellVilkårsvurderingUendret =
-            genererInitiellVilkårsvurdering(
-                behandling = mockk(relaxed = true),
-                forrigeVilkårsvurdering = null,
-                personopplysningGrunnlag = persongrunnlag2,
-                adopsjonerIBehandling = emptyList(),
-            )
-        val barnVilkårResultaterUendret =
-            initiellVilkårsvurderingUendret.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
+        @Test
+        fun `Skal ha med tomt vilkår på person hvis vilkåret ble avslått forrige behandling`() {
+            val søkerFnr = randomFnr()
+            val nyBehandling = lagBehandling(type = BehandlingType.REVURDERING)
+            val forrigeBehandling = lagBehandling()
 
-        Vilkår.hentVilkårFor(persongrunnlag2.barna.single().type).forEach { vilkår ->
-            Assertions.assertEquals(
-                barnVilkårResultaterUendret.find { it.vilkårType == vilkår }?.resultat,
-                barnVilkårResultater.find { it.vilkårType == vilkår }?.resultat,
-            )
-        }
-    }
-
-    @Test
-    fun `kopierResultaterFraForrigeBehandling skal fjerne person på vilkårsvurdering`() {
-        val persongrunnlagRevurdering =
-            lagPersonopplysningGrunnlag(
-                søkerPersonIdent = randomFnr(),
-            )
-        val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(
-                behandling = mockk(relaxed = true),
-                forrigeVilkårsvurdering = null,
-                personopplysningGrunnlag = persongrunnlagRevurdering,
-                adopsjonerIBehandling = emptyList(),
-            )
-
-        val persongrunnlagForrigeBehandling =
-            lagPersonopplysningGrunnlag(
-                søkerPersonIdent = randomFnr(),
-                barnasIdenter = listOf(randomFnr()),
-            )
-        val vilkårsvurderingForrigeBehandling =
-            lagVilkårsvurderingOppfylt(
-                personer =
-                    listOf(
-                        persongrunnlagForrigeBehandling.søker,
-                        persongrunnlagForrigeBehandling.barna.single(),
+            val persongrunnlag =
+                lagPersonopplysningGrunnlag(
+                    behandlingId = nyBehandling.id,
+                    søkerPersonIdent = søkerFnr,
+                )
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = nyBehandling,
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlag,
+                    adopsjonerIBehandling = emptyList(),
+                )
+            val vilkårsvurderingForrigeBehandling = Vilkårsvurdering(behandling = forrigeBehandling)
+            val personResultat =
+                PersonResultat(
+                    vilkårsvurdering = vilkårsvurderingForrigeBehandling,
+                    aktør = persongrunnlag.søker.aktør,
+                )
+            val bosattIRiketVilkårResultater =
+                setOf(
+                    lagVilkårResultat(
+                        vilkårType = Vilkår.BOSATT_I_RIKET,
+                        personResultat = personResultat,
+                        resultat = Resultat.IKKE_OPPFYLT,
+                        periodeFom = LocalDate.now().minusYears(2),
+                        periodeTom = LocalDate.now().minusYears(1),
                     ),
+                )
+            personResultat.setSortedVilkårResultater(bosattIRiketVilkårResultater)
+            vilkårsvurderingForrigeBehandling.personResultater = setOf(personResultat)
+
+            initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
+                vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
             )
 
-        initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
-            vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-        )
-        Assertions.assertEquals(1, initiellVilkårsvurdering.personResultater.size)
+            val nyInitBosattIRiketVilkår =
+                initiellVilkårsvurdering.personResultater
+                    .find { it.aktør.aktivFødselsnummer() == søkerFnr }
+                    ?.vilkårResultater
+                    ?.filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
+                    ?: emptyList()
+
+            Assertions.assertTrue(nyInitBosattIRiketVilkår.isNotEmpty())
+            Assertions.assertTrue(nyInitBosattIRiketVilkår.single().resultat == Resultat.IKKE_VURDERT)
+        }
     }
 
-    @Test
-    fun `kopierResultaterFraForrigeBehandling skal ha med tomt vilkår på person hvis vilkåret ble avslått forrige behandling`() {
-        val søkerFnr = randomFnr()
-        val nyBehandling = lagBehandling(type = BehandlingType.REVURDERING)
-        val forrigeBehandling = lagBehandling()
+    @Nested
+    inner class GenererInitiellVilkårsvurderingTest {
+        @Test
+        fun `Skal generere eøs spesifikke vilkår dersom det er en behandling med kategori EØS`() {
+            val søkerFnr = randomFnr()
+            val nyBehandling = lagBehandling(kategori = BehandlingKategori.EØS)
 
-        val persongrunnlag =
-            lagPersonopplysningGrunnlag(
-                behandlingId = nyBehandling.id,
-                søkerPersonIdent = søkerFnr,
-            )
-        val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(
-                behandling = nyBehandling,
-                forrigeVilkårsvurdering = null,
-                personopplysningGrunnlag = persongrunnlag,
-                adopsjonerIBehandling = emptyList(),
-            )
-        val vilkårsvurderingForrigeBehandling = Vilkårsvurdering(behandling = forrigeBehandling)
-        val personResultat =
-            PersonResultat(
-                vilkårsvurdering = vilkårsvurderingForrigeBehandling,
-                aktør = persongrunnlag.søker.aktør,
-            )
-        val bosattIRiketVilkårResultater =
-            setOf(
-                lagVilkårResultat(
-                    vilkårType = Vilkår.BOSATT_I_RIKET,
-                    personResultat = personResultat,
+            val persongrunnlag =
+                lagPersonopplysningGrunnlag(
+                    behandlingId = nyBehandling.id,
+                    søkerPersonIdent = søkerFnr,
+                )
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = nyBehandling,
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlag,
+                    adopsjonerIBehandling = emptyList(),
+                )
+
+            val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
+
+            assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering).isTrue()
+        }
+
+        @Test
+        fun `Skal generere eøs spesifikke vilkår dersom forrige behandling hadde eøs spesifikke vilkår selvom kategori nå er nasjonal`() {
+            val søkerFnr = randomFnr()
+            val nyBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
+
+            val persongrunnlag =
+                lagPersonopplysningGrunnlag(
+                    behandlingId = nyBehandling.id,
+                    søkerPersonIdent = søkerFnr,
+                )
+
+            val forrigeVilkårsvurdering = lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag.søker), skalOppretteEøsSpesifikkeVilkår = true)
+
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = nyBehandling,
+                    forrigeVilkårsvurdering = forrigeVilkårsvurdering,
+                    personopplysningGrunnlag = persongrunnlag,
+                    adopsjonerIBehandling = emptyList(),
+                )
+
+            val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
+
+            assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering).isTrue()
+        }
+
+        @Test
+        fun `Skal generere ikke eøs spesifikke vilkår dersom det er en behandling med kategori NASJONAL`() {
+            val søkerFnr = randomFnr()
+            val nyBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
+
+            val persongrunnlag =
+                lagPersonopplysningGrunnlag(
+                    behandlingId = nyBehandling.id,
+                    søkerPersonIdent = søkerFnr,
+                )
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = nyBehandling,
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlag,
+                    adopsjonerIBehandling = emptyList(),
+                )
+
+            val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
+
+            assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering).isFalse()
+        }
+    }
+
+    @Nested
+    inner class KopierVilkårResultaterFraForrigeVilkårsvurderingTest {
+        @Test
+        fun `Skal kopiere vilkårene til eksisterende personer fra forrige vilkårsvurdering`() {
+            val behandling = lagBehandling()
+
+            val eksisterendeSøkerPersonIdent = randomFnr()
+            val nyBarnPersonIdent = randomFnr()
+            val persongrunnlag =
+                lagPersonopplysningGrunnlag(
+                    søkerPersonIdent = eksisterendeSøkerPersonIdent,
+                    barnasIdenter = listOf(nyBarnPersonIdent),
+                )
+
+            val forrigeVilkårsvurdering =
+                lagVilkårsvurdering(
+                    søkerAktør = persongrunnlag.søker.aktør,
+                    behandling = behandling,
                     resultat = Resultat.IKKE_OPPFYLT,
-                    periodeFom = LocalDate.now().minusYears(2),
-                    periodeTom = LocalDate.now().minusYears(1),
-                ),
+                    søkerPeriodeFom = LocalDate.of(2025, 1, 1),
+                    søkerPeriodeTom = LocalDate.of(2025, 12, 31),
+                    begrunnelse = "Forrige vilkårsvurdering",
+                )
+
+            val initiellVilkårsvurdering =
+                genererInitiellVilkårsvurdering(
+                    behandling = mockk(relaxed = true),
+                    forrigeVilkårsvurdering = null,
+                    personopplysningGrunnlag = persongrunnlag,
+                    adopsjonerIBehandling = emptyList(),
+                )
+
+            val eksisterendeSøkerVilkårResultaterFørKopiering =
+                initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == eksisterendeSøkerPersonIdent }.vilkårResultater
+            val nyBarnVilkårResultaterFørKopiering =
+                initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == nyBarnPersonIdent }.vilkårResultater
+
+            assertThat(eksisterendeSøkerVilkårResultaterFørKopiering).allSatisfy {
+                assertThat(it.begrunnelse).isEmpty()
+                assertThat(it.periodeTom).isNull()
+            }
+
+            assertThat(nyBarnVilkårResultaterFørKopiering).allSatisfy {
+                assertThat(it.begrunnelse).isNotEqualTo("Forrige vilkårsvurdering")
+            }
+
+            initiellVilkårsvurdering.kopierVilkårResultaterFraForrigeVilkårsvurdering(
+                forrigeVilkårsvurdering = forrigeVilkårsvurdering,
             )
-        personResultat.setSortedVilkårResultater(bosattIRiketVilkårResultater)
-        vilkårsvurderingForrigeBehandling.personResultater = setOf(personResultat)
 
-        initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
-            vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
-        )
+            val eksisterendeSøkerVilkårResultaterEtterKopiering = initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == eksisterendeSøkerPersonIdent }.vilkårResultater
 
-        val nyInitBosattIRiketVilkår =
-            initiellVilkårsvurdering.personResultater
-                .find { it.aktør.aktivFødselsnummer() == søkerFnr }
-                ?.vilkårResultater
-                ?.filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
-                ?: emptyList()
+            val nyBarnVilkårResultaterEtterKopiering = initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == nyBarnPersonIdent }.vilkårResultater
 
-        Assertions.assertTrue(nyInitBosattIRiketVilkår.isNotEmpty())
-        Assertions.assertTrue(nyInitBosattIRiketVilkår.single().resultat == Resultat.IKKE_VURDERT)
+            assertThat(eksisterendeSøkerVilkårResultaterEtterKopiering).allSatisfy {
+                assertThat(it.begrunnelse).isEqualTo("Forrige vilkårsvurdering")
+                assertThat(it.periodeTom).isEqualTo(LocalDate.of(2025, 12, 31))
+            }
+            assertThat(nyBarnVilkårResultaterEtterKopiering).allSatisfy {
+                assertThat(it.begrunnelse).isNotEqualTo("Forrige vilkårsvurdering")
+            }
+        }
     }
 
     @Test
@@ -248,77 +391,5 @@ class OppdaterVilkårsvurderingTest {
                 .any { it.type == AnnenVurderingType.OPPLYSNINGSPLIKT }
 
         Assertions.assertTrue(nyInitInnholderOpplysningspliktVilkår)
-    }
-
-    @Test
-    fun `genererInitiellVilkårsvurdering skal generere eøs spesifikke vilkår dersom det er en behandling med kategori EØS`() {
-        val søkerFnr = randomFnr()
-        val nyBehandling = lagBehandling(kategori = BehandlingKategori.EØS)
-
-        val persongrunnlag =
-            lagPersonopplysningGrunnlag(
-                behandlingId = nyBehandling.id,
-                søkerPersonIdent = søkerFnr,
-            )
-        val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(
-                behandling = nyBehandling,
-                forrigeVilkårsvurdering = null,
-                personopplysningGrunnlag = persongrunnlag,
-                adopsjonerIBehandling = emptyList(),
-            )
-
-        val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
-
-        assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering, Is(true))
-    }
-
-    @Test
-    fun `genererInitiellVilkårsvurdering skal generere eøs spesifikke vilkår dersom forrige behandling hadde eøs spesifikke vilkår selvom kategori nå er nasjonal`() {
-        val søkerFnr = randomFnr()
-        val nyBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
-
-        val persongrunnlag =
-            lagPersonopplysningGrunnlag(
-                behandlingId = nyBehandling.id,
-                søkerPersonIdent = søkerFnr,
-            )
-
-        val forrigeVilkårsvurdering = lagVilkårsvurderingOppfylt(personer = listOf(persongrunnlag.søker), skalOppretteEøsSpesifikkeVilkår = true)
-
-        val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(
-                behandling = nyBehandling,
-                forrigeVilkårsvurdering = forrigeVilkårsvurdering,
-                personopplysningGrunnlag = persongrunnlag,
-                adopsjonerIBehandling = emptyList(),
-            )
-
-        val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
-
-        assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering, Is(true))
-    }
-
-    @Test
-    fun `genererInitiellVilkårsvurdering skal generere ikke eøs spesifikke vilkår dersom det er en behandling med kategori NASJONAL`() {
-        val søkerFnr = randomFnr()
-        val nyBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
-
-        val persongrunnlag =
-            lagPersonopplysningGrunnlag(
-                behandlingId = nyBehandling.id,
-                søkerPersonIdent = søkerFnr,
-            )
-        val initiellVilkårsvurdering =
-            genererInitiellVilkårsvurdering(
-                behandling = nyBehandling,
-                forrigeVilkårsvurdering = null,
-                personopplysningGrunnlag = persongrunnlag,
-                adopsjonerIBehandling = emptyList(),
-            )
-
-        val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
-
-        assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering, Is(false))
     }
 }


### PR DESCRIPTION
### 📮 Favro: Nav-27402

### 💰 Hva skal gjøres, og hvorfor?
Når man legger til eller fjerner et nytt barn under en søknad i ks-sak, så blir hele vilkårsvurderingen resatt.
Dette er veldig tidskrevende for en SB som har brukt mye tid på å fylle ut vilkårsvurderingen, og deretter lagt til et nytt barn i søknaden.

Jeg legger derfor til en kopieringsfunksjon som kopierer fra aktiv vilkårsvurdering etter at ny initiell vilkårsvurdering opprettes. Merk at dette bare blir gjort i behandlingsårsak søknad.

Testet OK lokalt og i preprod:

https://github.com/user-attachments/assets/fb454bde-a3cb-4de4-af8b-f72a8aea0805


