### PR TITLE
Vi bør ikke bruke behandlingsresultat som fasit for henting av simulering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringService.kt
@@ -13,7 +13,6 @@ import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.tilRestUtbe
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
-import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.domene.ØkonomiSimuleringMottaker
 import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.domene.ØkonomiSimuleringMottakerRepository
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
@@ -83,10 +82,7 @@ class SimuleringService(
     }
 
     private fun hentSimuleringFraFamilieOppdrag(vedtak: Vedtak): DetaljertSimuleringResultat? {
-        if (vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
-            vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
-            beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = vedtak.behandling)
-        ) {
+        if (!beregningService.sjekkOmDetErEndringIUtbetalingFraForrigeBehandlingSendtTilØkonomi(behandling = vedtak.behandling)) {
             return null
         }
 
@@ -115,9 +111,9 @@ class SimuleringService(
 
     private fun lagreSimuleringPåBehandling(
         simuleringMottakere: List<SimuleringMottaker>,
-        beahndling: Behandling,
+        behandling: Behandling,
     ): List<ØkonomiSimuleringMottaker> {
-        val vedtakSimuleringMottakere = simuleringMottakere.map { it.tilBehandlingSimuleringMottaker(beahndling) }
+        val vedtakSimuleringMottakere = simuleringMottakere.map { it.tilBehandlingSimuleringMottaker(behandling) }
         return øknomiSimuleringMottakerRepository.saveAll(vedtakSimuleringMottakere)
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -69,10 +69,10 @@ class BeregningService(
     }
 
     /**
-    For at endret utbetaling andeler skal fungere så må man generere andeler før man kobler endringene på andelene.
-    Dette er fordi en endring regnes som gyldig når den overlapper med en andel og har gyldig årsak.
-    Hvis man ikke genererer andeler før man kobler på endringene så vil ingen av endringene ses på som gyldige, altså ikke oppdatere noen andeler.
-    Dette gjøres spesifikt fra vilkårsvurdering steget da på dette tidspunktet så har man ikke generert andeler.
+     For at endret utbetaling andeler skal fungere så må man generere andeler før man kobler endringene på andelene.
+     Dette er fordi en endring regnes som gyldig når den overlapper med en andel og har gyldig årsak.
+     Hvis man ikke genererer andeler før man kobler på endringene så vil ingen av endringene ses på som gyldige, altså ikke oppdatere noen andeler.
+     Dette gjøres spesifikt fra vilkårsvurdering steget da på dette tidspunktet så har man ikke generert andeler.
      */
     fun oppdaterTilkjentYtelsePåBehandlingFraVilkårsvurdering(
         behandling: Behandling,
@@ -206,8 +206,8 @@ class BeregningService(
             barnMedUtbetalingSomIkkeBlittEndretISisteBehandling.intersect(nyeBarnISisteBehandling)
 
         return behandling.resultat == Behandlingsresultat.INNVILGET_OG_OPPHØRT &&
-                behandling.erSøknad() &&
-                nyeBarnMedUtebtalingSomIkkeErEndret.isEmpty()
+            behandling.erSøknad() &&
+            nyeBarnMedUtebtalingSomIkkeErEndret.isEmpty()
     }
 
     fun hentLøpendeAndelerTilkjentYtelseMedUtbetalingerForBehandlinger(
@@ -228,15 +228,18 @@ class BeregningService(
 
         if (nåværendeAndeler.isEmpty() && forrigeAndeler.isEmpty()) return false
 
-        return EndringIUtbetalingUtil.lagEndringIUtbetalingTidslinje(
-            nåværendeAndeler = nåværendeAndeler,
-            forrigeAndeler = forrigeAndeler,
-        ).tilPerioder().any { it.verdi == true }
+        return EndringIUtbetalingUtil
+            .lagEndringIUtbetalingTidslinje(
+                nåværendeAndeler = nåværendeAndeler,
+                forrigeAndeler = forrigeAndeler,
+            ).tilPerioder()
+            .any { it.verdi == true }
     }
 
     fun hentAndelerFraForrigeIverksattebehandling(behandling: Behandling): List<AndelTilkjentYtelse> {
         val forrigeIverksatteBehandling =
-            behandlingRepository.finnIverksatteBehandlinger(behandling.fagsak.id)
+            behandlingRepository
+                .finnIverksatteBehandlinger(behandling.fagsak.id)
                 .filter { it.aktivertTidspunkt.isBefore(behandling.aktivertTidspunkt) && it.steg == BehandlingSteg.AVSLUTT_BEHANDLING }
                 .maxByOrNull { it.aktivertTidspunkt }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
@@ -157,7 +157,7 @@ class SimuleringServiceTest {
                     erSimulering = any(),
                 )
             } returns
-                    lagBeregnetUtbetalingsoppdrag(vedtak = lagVedtak(behandling), listOf(lagUtbetalingsperiode(vedtak = lagVedtak(behandling))))
+                lagBeregnetUtbetalingsoppdrag(vedtak = lagVedtak(behandling), listOf(lagUtbetalingsperiode(vedtak = lagVedtak(behandling))))
 
             simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId = behandling.id)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringServiceTest.kt
@@ -136,9 +136,45 @@ class SimuleringServiceTest {
             names = ["IVERKSETTER_VEDTAK", "AVSLUTTET"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `skal returnere hente ny simulering dersom behandlingstatus er ulik IVERKSETTER_VEDTAK og AVSLUTTET og simulering ikke er hentet fra før`(
+        fun `Ved ingen endringer i utbetaling siden sist iverskatte behandling skal det ikke forsøkes å hente simulering fra oppdrag`(
             behandlingStatus: BehandlingStatus,
         ) {
+            every { beregningService.sjekkOmDetErEndringIUtbetalingFraForrigeBehandlingSendtTilØkonomi(any()) } returns false
+
+            val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD).also { it.status = behandlingStatus }
+
+            every { behandlingRepository.hentBehandling(behandling.id) } returns behandling
+
+            every { øknomiSimuleringMottakerRepository.findByBehandlingId(behandling.id) } returns emptyList()
+            every { øknomiSimuleringMottakerRepository.deleteByBehandlingId(any()) } just runs
+            every { øknomiSimuleringMottakerRepository.saveAll(any<List<ØkonomiSimuleringMottaker>>()) } returns mockk()
+            every { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) } returns Vedtak(behandling = behandling)
+            every { beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = behandling) } returns false
+            every {
+                utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
+                    vedtak = any(),
+                    saksbehandlerId = any(),
+                    erSimulering = any(),
+                )
+            } returns
+                    lagBeregnetUtbetalingsoppdrag(vedtak = lagVedtak(behandling), listOf(lagUtbetalingsperiode(vedtak = lagVedtak(behandling))))
+
+            simuleringService.oppdaterSimuleringPåBehandlingVedBehov(behandlingId = behandling.id)
+
+            verify(exactly = 0) { oppdragKlient.hentSimulering(any()) }
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = BehandlingStatus::class,
+            names = ["IVERKSETTER_VEDTAK", "AVSLUTTET"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal hente ny simulering dersom det har vært endring i utbetaling og simulering ikke er hentet fra før`(
+            behandlingStatus: BehandlingStatus,
+        ) {
+            every { beregningService.sjekkOmDetErEndringIUtbetalingFraForrigeBehandlingSendtTilØkonomi(any()) } returns true
+
             val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD).also { it.status = behandlingStatus }
             val nySimulering =
                 listOf(


### PR DESCRIPTION
### 📮 Favro: Nav-27549

### 💰 Hva skal gjøres, og hvorfor?
Når vi skal avgjøre om vi skal hente simulering, så sjekker vi per i dag på:

```
vedtak.behandling.resultat == Behandlingsresultat.FORTSATT_INNVILGET ||
            vedtak.behandling.resultat == Behandlingsresultat.AVSLÅTT ||
            beregningService.innvilgetSøknadUtenUtbetalingsperioderGrunnetEndringsPerioder(behandling = vedtak.behandling
```

Dette er egentlig ikke ideelt, vi burde ikke lene oss på behandlingsresultat for å se om vi skal hente simulering eller ikke.
For å gjøre det likt som BA, så endrer jeg det til at vi sjekker om det har vært endringer i utbetaling siden forrige iverksatte behandling. Dersom det har vært endring i utbetaling, så henter vi simulering.