### PR TITLE
NAV-27587: Forbedrer logiken rundt hvorvidt søker må melde om endring i barnehageplass

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -12,4 +12,5 @@ enum class FeatureToggle(
     // Ikke operasjonelle
     SKAL_HÅNDTERE_FALSK_IDENTITET("familie-ks-sak.skal-handtere-falsk-identitet"),
     HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE("familie-ks-sak.hent-arbeidsfordeling-med-behandlingstype"),
+    BRUK_NY_LOGIKK_FOR_SØKERS_MELDEPLIKT("familie-ks-sak.bruk-ny-meldepliktlogikk"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/SøkersMeldepliktService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/SøkersMeldepliktService.kt
@@ -1,16 +1,28 @@
 package no.nav.familie.ks.sak.kjerne.brev
 
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class SøkersMeldepliktService(
     private val vilkårsvurderingService: VilkårsvurderingService,
+    private val behandlingService: BehandlingService,
+    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
+    private val featureToggleService: FeatureToggleService,
 ) {
+    private val logger = LoggerFactory.getLogger(SøkersMeldepliktService::class.java)
+
     fun skalSøkerMeldeFraOmEndringerEøsSelvstendigRett(
         vedtak: Vedtak,
     ): Boolean {
@@ -40,10 +52,46 @@ class SøkersMeldepliktService(
 
     fun harSøkerMeldtFraOmBarnehagePlass(
         vedtak: Vedtak,
-    ): Boolean =
-        vilkårsvurderingService
-            .hentAktivVilkårsvurderingForBehandling(behandlingId = vedtak.behandling.id)
-            .personResultater
-            .flatMap { it.vilkårResultater }
-            .any { it.søkerHarMeldtFraOmBarnehageplass ?: false }
+    ): Boolean {
+        if (featureToggleService.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_SØKERS_MELDEPLIKT)) {
+            val behandling = vedtak.behandling
+            val forrigeBehandling = behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+
+            val barnIBehandling = personopplysningGrunnlagService.hentBarnaThrows(behandling.id).map { it.aktør }
+
+            val barnIForrigeBehandling =
+                if (forrigeBehandling != null) {
+                    personopplysningGrunnlagService.hentBarnaThrows(forrigeBehandling.id).map { it.aktør }
+                } else {
+                    emptyList()
+                }
+
+            val relevanteBarn =
+                // Det er mulig å ha flere førstegangsbehandlinger på en fagsak
+                if (behandling.type == BehandlingType.FØRSTEGANGSBEHANDLING) {
+                    barnIBehandling.minus(barnIForrigeBehandling)
+                } else {
+                    barnIBehandling
+                }
+
+            if (relevanteBarn.isEmpty()) {
+                logger.error("Forventer minst et relevant barn ment fant ingen for behandlingId=${behandling.id}")
+                throw Feil("Forventer minst et relevant barn ment fant ingen for behandlingId=${behandling.id}")
+            }
+
+            return vilkårsvurderingService
+                .hentAktivVilkårsvurderingForBehandling(behandlingId = vedtak.behandling.id)
+                .personResultater
+                .filter { relevanteBarn.contains(it.aktør) }
+                .flatMap { it.vilkårResultater }
+                .filter { it.vilkårType == Vilkår.BARNEHAGEPLASS }
+                .all { it.søkerHarMeldtFraOmBarnehageplass == true }
+        } else {
+            return vilkårsvurderingService
+                .hentAktivVilkårsvurderingForBehandling(behandlingId = vedtak.behandling.id)
+                .personResultater
+                .flatMap { it.vilkårResultater }
+                .any { it.søkerHarMeldtFraOmBarnehageplass ?: false }
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/PersonopplysningGrunnlagService.kt
@@ -109,6 +109,8 @@ class PersonopplysningGrunnlagService(
 
     fun hentBarna(behandlingId: Long): List<Person>? = personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandlingId)?.barna
 
+    fun hentBarnaThrows(behandlingId: Long): List<Person> = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandlingId).barna
+
     fun hentSøkerOgBarnPåFagsak(fagsakId: Long): Set<PersonEnkel>? =
         personopplysningGrunnlagRepository
             .finnSøkerOgBarnAktørerTilFagsak(fagsakId)

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -162,6 +162,22 @@ fun fnrTilAktør(
 }
 
 fun lagPersonopplysningGrunnlag(
+    id: Long = 0L,
+    behandlingId: Long = 0L,
+    personer: (personopplysningGrunnlag: PersonopplysningGrunnlag) -> Set<Person> = { emptySet() },
+    aktiv: Boolean = true,
+): PersonopplysningGrunnlag {
+    val personopplysningGrunnlag =
+        PersonopplysningGrunnlag(
+            id = id,
+            behandlingId = behandlingId,
+            aktiv = aktiv,
+        )
+    personopplysningGrunnlag.personer.addAll(personer(personopplysningGrunnlag))
+    return personopplysningGrunnlag
+}
+
+fun lagPersonopplysningGrunnlag(
     behandlingId: Long = 0L,
     søkerPersonIdent: String = randomFnr(fødselsdato = LocalDate.of(1947, 1, 1)),
     // FGB med register søknad steg har ikke barnasidenter

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/SøkersMeldepliktServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/SøkersMeldepliktServiceTest.kt
@@ -2,28 +2,50 @@ package no.nav.familie.ks.sak.kjerne.brev
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ks.sak.common.exception.Feil
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagFagsak
+import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonResultat
 import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.lagVilkårsvurdering
 import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingType
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.UtdypendeVilkårsvurdering
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
 class SøkersMeldepliktServiceTest {
     private val mockedVilkårsvurderingService: VilkårsvurderingService = mockk()
+    private val behandlingService: BehandlingService = mockk()
+    private val personopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk()
+    private val featureToggleService: FeatureToggleService = mockk()
     private val søkersMeldepliktService: SøkersMeldepliktService =
         SøkersMeldepliktService(
             vilkårsvurderingService = mockedVilkårsvurderingService,
+            behandlingService = behandlingService,
+            personopplysningGrunnlagService = personopplysningGrunnlagService,
+            featureToggleService = featureToggleService,
         )
+
+    @BeforeEach
+    fun setUp() {
+        every { featureToggleService.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_SØKERS_MELDEPLIKT) } returns true
+    }
 
     @Nested
     inner class SkalMeldeFraOmEndringerEøsSelvstendigRettTest {
@@ -266,7 +288,682 @@ class SøkersMeldepliktServiceTest {
     @Nested
     inner class HarSøkerMeldtFraOmBarnehagePlassTest {
         @Test
+        fun `skal returnere true om søker har meldt fra om barnehageplass på barnet som ikke var i forrige behandling`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(id = 1, fagsak = fagsak)
+            val forrigeBehandling = lagBehandling(id = 2, fagsak = fagsak, status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
+
+            val vedtak = lagVedtak(behandling)
+
+            val barn1 = lagPerson()
+            val barn2 = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn1.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                aktør = barn2.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = false,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns forrigeBehandling
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn1, barn2)
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(forrigeBehandling.id)
+            } returns listOf(barn2)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om søker kun har meldt fra om barnehageplass på barnet som også var i forrige behandling`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(id = 1, fagsak = fagsak)
+            val forrigeBehandling = lagBehandling(id = 2, fagsak = fagsak, status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
+
+            val vedtak = lagVedtak(behandling)
+
+            val barn1 = lagPerson()
+            val barn2 = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn1.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = false,
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                aktør = barn2.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns forrigeBehandling
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn1, barn2)
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(forrigeBehandling.id)
+            } returns listOf(barn2)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om søker har meldt fra om barnehageplass på både barnet som er ny i nåværende behandling og barnet i forrige behandling`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(id = 1, fagsak = fagsak)
+            val forrigeBehandling = lagBehandling(id = 2, fagsak = fagsak, status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
+
+            val vedtak = lagVedtak(behandling)
+
+            val barn1 = lagPerson()
+            val barn2 = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn1.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                aktør = barn2.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns forrigeBehandling
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn1, barn2)
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(forrigeBehandling.id)
+            } returns listOf(barn2)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om søker ikke har meldt fra om barnehageplass på et av de relevante barna`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(id = 1, fagsak = fagsak)
+
+            val vedtak = lagVedtak(behandling)
+
+            val barn1 = lagPerson()
+            val barn2 = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn1.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                aktør = barn2.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = false,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns null
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn1, barn2)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true kun hvis søker har meldt fra om barnehageplass på alle barna i en revurdering`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(id = 1, fagsak = fagsak, type = BehandlingType.REVURDERING)
+            val forrigeBehandling = lagBehandling(id = 2, fagsak = fagsak, status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
+
+            val vedtak = lagVedtak(behandling)
+
+            val barn1 = lagPerson()
+            val barn2 = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn1.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                aktør = barn2.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns forrigeBehandling
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn1, barn2)
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(forrigeBehandling.id)
+            } returns listOf(barn1, barn2)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false hvis søker ikke har meldt fra om barnehageplass på alle barna i en revurdering`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(id = 1, fagsak = fagsak, type = BehandlingType.REVURDERING)
+            val forrigeBehandling = lagBehandling(id = 2, fagsak = fagsak, status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
+
+            val vedtak = lagVedtak(behandling)
+
+            val barn1 = lagPerson()
+            val barn2 = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn1.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = false,
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                aktør = barn2.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns forrigeBehandling
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn1, barn2)
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(forrigeBehandling.id)
+            } returns listOf(barn1, barn2)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isFalse()
+        }
+
+        @Test
+        fun `skal kaste exception om ingen relevante barn finnes`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val behandling = lagBehandling(id = 1, fagsak = fagsak)
+            val forrigeBehandling = lagBehandling(id = 2, fagsak = fagsak, status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
+
+            val vedtak = lagVedtak(behandling)
+
+            val barn = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                            lagPersonResultat(
+                                aktør = barn.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = false,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns forrigeBehandling
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn)
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(forrigeBehandling.id)
+            } returns listOf(barn)
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                        vedtak = vedtak,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Forventer minst et relevant barn ment fant ingen for behandlingId=${behandling.id}")
+        }
+
+        @Test
         fun `skal returnere true om søker har meldt fra om barnehageplass`() {
+            // Arrange
+            val vedtak = lagVedtak()
+            val barn = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = true,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns null
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om søker ikke har meldt fra om barnehageplass`() {
+            // Arrange
+            val vedtak = lagVedtak()
+            val barn = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = false,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns null
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om søker har meldt fra om barnehageplass ikke er oppgitt`() {
+            // Arrange
+            val vedtak = lagVedtak()
+            val barn = lagPerson()
+
+            val vilkårsvurdering =
+                lagVilkårsvurdering(
+                    behandling = vedtak.behandling,
+                    lagPersonResultat = {
+                        setOf(
+                            lagPersonResultat(
+                                aktør = barn.aktør,
+                                vilkårsvurdering = it,
+                                lagVilkårResultater = {
+                                    setOf(
+                                        lagVilkårResultat(
+                                            vilkårType = Vilkår.BARNEHAGEPLASS,
+                                            personResultat = it,
+                                            søkerHarMeldtFraOmBarnehageplass = null,
+                                        ),
+                                    )
+                                },
+                            ),
+                        )
+                    },
+                )
+
+            every {
+                mockedVilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(
+                    behandlingId = vedtak.behandling.id,
+                )
+            } returns vilkårsvurdering
+
+            every {
+                behandlingService.hentForrigeBehandlingSomErVedtatt(vedtak.behandling)
+            } returns null
+
+            every {
+                personopplysningGrunnlagService.hentBarnaThrows(vedtak.behandling.id)
+            } returns listOf(barn)
+
+            // Act
+            val harSøkerMeldtFraOmBarnehagePlass =
+                søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
+                    vedtak = vedtak,
+                )
+
+            // Assert
+            assertThat(harSøkerMeldtFraOmBarnehagePlass).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om søker har meldt fra om barnehageplass når toggle er av`() {
             // Arrange
             val vedtak = lagVedtak()
 
@@ -296,6 +993,8 @@ class SøkersMeldepliktServiceTest {
                 )
             } returns vilkårsvurdering
 
+            every { featureToggleService.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_SØKERS_MELDEPLIKT) } returns false
+
             // Act
             val harSøkerMeldtFraOmBarnehagePlass =
                 søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
@@ -307,7 +1006,7 @@ class SøkersMeldepliktServiceTest {
         }
 
         @Test
-        fun `skal returnere false om søker ikke har meldt fra om barnehageplass`() {
+        fun `skal returnere false om søker ikke har meldt fra om barnehageplass når toggle er av`() {
             // Arrange
             val vedtak = lagVedtak()
 
@@ -337,6 +1036,8 @@ class SøkersMeldepliktServiceTest {
                 )
             } returns vilkårsvurdering
 
+            every { featureToggleService.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_SØKERS_MELDEPLIKT) } returns false
+
             // Act
             val harSøkerMeldtFraOmBarnehagePlass =
                 søkersMeldepliktService.harSøkerMeldtFraOmBarnehagePlass(
@@ -348,7 +1049,7 @@ class SøkersMeldepliktServiceTest {
         }
 
         @Test
-        fun `skal returnere false om søker har meldt fra om barnehageplass ikke er oppgitt`() {
+        fun `skal returnere false om søker har meldt fra om barnehageplass ikke er oppgitt når toggle er av`() {
             // Arrange
             val vedtak = lagVedtak()
 
@@ -377,6 +1078,8 @@ class SøkersMeldepliktServiceTest {
                     behandlingId = vedtak.behandling.id,
                 )
             } returns vilkårsvurdering
+
+            every { featureToggleService.isEnabled(FeatureToggle.BRUK_NY_LOGIKK_FOR_SØKERS_MELDEPLIKT) } returns false
 
             // Act
             val harSøkerMeldtFraOmBarnehagePlass =


### PR DESCRIPTION
### 📮 Favro
NAV-27587

### 💰 Hva skal gjøres, og hvorfor?
I revurderinger ønsker vi å se på alle barna om hvorvidt "Søker har meldt fra om barnehageplass" er blitt huket av.

I andre behandlinger ønsker vi å se på om de relevante barna (dvs. nye barn i behandlingen som ikke har blitt behandlet i forrige vedtatte behandling) har fått huket av "Søker har meldt fra om barnehageplass". 

Logikken er lagt bak en toggle. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.