### PR TITLE
NAV-27633: Erstatter save med saveAndFlush for å unngå andel-overlapp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningService.kt
@@ -120,7 +120,7 @@ class BeregningService(
                 endreteUtbetalingAndeler,
             )
 
-        val lagretTilkjentYtelse = tilkjentYtelseRepository.save(tilkjentYtelse)
+        val lagretTilkjentYtelse = tilkjentYtelseRepository.saveAndFlush(tilkjentYtelse)
         tilkjentYtelseEndretAbonnenter.forEach { it.endretTilkjentYtelse(lagretTilkjentYtelse) }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/BeregningServiceTest.kt
@@ -381,7 +381,7 @@ class BeregningServiceTest {
             every { mockAndelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) } returns endretUtbetalingAndelerMedAndeler
             every { mockTilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling) } just runs
             every { mockTilkjentYtelseService.beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, capture(lagretEndretUtbetalingAndelerMedAndelerSlot)) } returns opprettetTilkjentYtelse
-            every { mockTilkjentYtelseRepository.save(opprettetTilkjentYtelse) } returns opprettetTilkjentYtelse
+            every { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse) } returns opprettetTilkjentYtelse
 
             // Act
             beregningService.oppdaterTilkjentYtelsePåBehandling(behandling, personopplysningGrunnlag, vilkårsvurdering)
@@ -390,7 +390,7 @@ class BeregningServiceTest {
             verify(exactly = 1) { mockAndelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) }
             verify(exactly = 1) { mockTilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling) }
             verify(exactly = 1) { mockTilkjentYtelseService.beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, capture(lagretEndretUtbetalingAndelerMedAndelerSlot)) }
-            verify(exactly = 1) { mockTilkjentYtelseRepository.save(opprettetTilkjentYtelse) }
+            verify(exactly = 1) { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse) }
 
             val lagretEndretUtbetalingAndelerMedAndeler = lagretEndretUtbetalingAndelerMedAndelerSlot.captured
 
@@ -421,7 +421,7 @@ class BeregningServiceTest {
             every { mockAndelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) } returns endretUtbetalingAndelerMedAndeler
             every { mockTilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling) } just runs
             every { mockTilkjentYtelseService.beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, capture(lagretEndretUtbetalingAndelerMedAndelerSlot)) } returns opprettetTilkjentYtelse
-            every { mockTilkjentYtelseRepository.save(opprettetTilkjentYtelse) } returns opprettetTilkjentYtelse
+            every { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse) } returns opprettetTilkjentYtelse
 
             // Act
             beregningService.oppdaterTilkjentYtelsePåBehandling(behandling, personopplysningGrunnlag, vilkårsvurdering)
@@ -430,7 +430,7 @@ class BeregningServiceTest {
             verify(exactly = 1) { mockAndelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) }
             verify(exactly = 1) { mockTilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling) }
             verify(exactly = 1) { mockTilkjentYtelseService.beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, capture(lagretEndretUtbetalingAndelerMedAndelerSlot)) }
-            verify(exactly = 1) { mockTilkjentYtelseRepository.save(opprettetTilkjentYtelse) }
+            verify(exactly = 1) { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse) }
 
             val lagretEndretUtbetalingAndelerMedAndeler = lagretEndretUtbetalingAndelerMedAndelerSlot.captured
 
@@ -460,7 +460,7 @@ class BeregningServiceTest {
             every { mockAndelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) } returns endretUtbetalingAndelerMedAndeler
             every { mockTilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling) } just runs
             every { mockTilkjentYtelseService.beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, capture(lagretEndretUtbetalingAndelerMedAndelerSlot)) } returns opprettetTilkjentYtelse
-            every { mockTilkjentYtelseRepository.save(opprettetTilkjentYtelse) } returns opprettetTilkjentYtelse
+            every { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse) } returns opprettetTilkjentYtelse
 
             // Act
             beregningService.oppdaterTilkjentYtelsePåBehandling(behandling, personopplysningGrunnlag, vilkårsvurdering, endretUtbetalingMedAndel1.endretUtbetalingAndel)
@@ -469,7 +469,7 @@ class BeregningServiceTest {
             verify(exactly = 1) { mockAndelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) }
             verify(exactly = 1) { mockTilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling) }
             verify(exactly = 1) { mockTilkjentYtelseService.beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, capture(lagretEndretUtbetalingAndelerMedAndelerSlot)) }
-            verify(exactly = 1) { mockTilkjentYtelseRepository.save(opprettetTilkjentYtelse) }
+            verify(exactly = 1) { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse) }
 
             val lagretEndretUtbetalingAndelerMedAndeler = lagretEndretUtbetalingAndelerMedAndelerSlot.captured
 
@@ -516,8 +516,7 @@ class BeregningServiceTest {
             verify(exactly = 1) { mockAndelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id) }
             verify(exactly = 1) { mockTilkjentYtelseRepository.slettTilkjentYtelseForBehandling(behandling) }
             verify(exactly = 2) { mockTilkjentYtelseService.beregnTilkjentYtelse(vilkårsvurdering, personopplysningGrunnlag, any()) }
-            verify(exactly = 1) { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse1) }
-            verify(exactly = 1) { mockTilkjentYtelseRepository.save(opprettetTilkjentYtelse2) }
+            verify(exactly = 2) { mockTilkjentYtelseRepository.saveAndFlush(opprettetTilkjentYtelse1) }
         }
     }
 }


### PR DESCRIPTION
### 📮 Favro: [NAV-27633](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-27633)

### 💰 Hva skal gjøres, og hvorfor?
Etter oppgradering til Spring Boot 4 oppstod det et problem i forbindelse med generering av `AndelTilkjentYtelse`, hvor det ble opprettet andeler som overlappet hverandre.

Problemet kom av følgende flyt:

```
val lagretTilkjentYtelse = tilkjentYtelseRepository.save(tilkjentYtelse)
        
...
// Logikk for å finne ut hvilke andeler som består etter at de er tilpasset kompetanse og hvilke som må oppdateres
...
        
lagretTilkjentYtelse.andelerTilkjentYtelse.clear()
lagretTilkjentYtelse.andelerTilkjentYtelse.addAll(bestående + oppdaterte)
tilkjentYtelseRepository.saveAndFlush(lagretTilkjentYtelse)
```

Det som skjer her er at den originale save-operasjonen ikke skjer før `saveAndFlush`, og da skal man også lagre en annen modifisert versjon av den "samme" tilkjenteYtelsen. Det fører til at JPA/Hibernate ikke skjønner at andelene som lå på den første versjonen av tilkjentYtelse egentlig skal fjernes, slik det forsøksvis gjøres med clear() senere. Altså lagres både de originale andelene og andelene justert i henhold til kompetanse, upb og valutakurs. Koden for å justere basert på kompetanse kjøres i alle behandlinger og ikke bare i de behandlingene som har kompetanse, så feilen treffer både EØS og Nasjonale saker.

Hvorfor dette ikke har skjedd tidligere og kun skjer etter oppgradering til spring boot 4 (i spring boot 4 branchen), er jeg ikke sikker på, men ser at det av og til funker dersom man debugger seg gjennom og det går "sakte" nok 🤷‍♂️ .

Løsningen på problemet var å endre `save` til `saveAndFlush`. Dette gjøres allerede i ba-sak.


### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

Har ikke skrevet nye tester, men tenker å gjøre det i en egen PR. Med en god integrasjonstest her ville vi oppdaget problemet før merge av Spring Boot 4.
