### PR TITLE
NAV-27658: Utvider BehandlingResponsDto med "aktiv"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingResponsDto.kt
@@ -29,6 +29,7 @@ data class BehandlingResponsDto(
     val opprettetTidspunkt: LocalDateTime,
     val aktivertTidspunkt: LocalDateTime,
     val endretAv: String,
+    val aktiv: Boolean,
     val arbeidsfordelingPåBehandling: ArbeidsfordelingResponsDto,
     val søknadsgrunnlag: SøknadDto?,
     val behandlingPåVent: BehandlingPåVentDto?,

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/BehandlingMapper.kt
@@ -90,6 +90,7 @@ object BehandlingMapper {
         opprettetTidspunkt = behandling.opprettetTidspunkt,
         aktivertTidspunkt = behandling.aktivertTidspunkt,
         endretAv = behandling.endretAv,
+        aktiv = behandling.aktiv,
         arbeidsfordelingPåBehandling = lagArbeidsfordelingRespons(arbeidsfordelingPåBehandling),
         søknadsgrunnlag = søknadsgrunnlag,
         personer = personer,


### PR DESCRIPTION
### 📮 Favro
NAV-27658

### 💰 Hva skal gjøres, og hvorfor?
Utvider UtvidetBehandlingDto med "aktiv"  pga. endringer som er nødvendig i frontend, se [PR](https://github.com/navikt/familie-ks-sak-frontend/pull/1645). 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ingen eksiterende tester og er for mye jobb for å bare utvide kontrakten litt. 