### PR TITLE
filtrer ut ordinære andeler før vi validerer så vi ikke validerer tomme lister

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidator.kt
@@ -53,47 +53,48 @@ object TilkjentYtelseValidator {
 
         val andelerPerAktør = tilkjentYtelse.andelerTilkjentYtelse.groupBy { it.aktør }
 
-        andelerPerAktør.filter { it.value.isNotEmpty() }.forEach { (aktør, andeler) ->
-            val ordinæreAndeler = andeler.ordinæreOgPraksisendringAndeler()
+        andelerPerAktør
+            .mapValues { it.value.ordinæreOgPraksisendringAndeler() }
+            .filter { it.value.isNotEmpty() }
+            .forEach { (aktør, andeler) ->
+                val stønadFom = andeler.minOf { it.stønadFom }
+                val stønadTom = andeler.maxOf { it.stønadTom }
 
-            val stønadFom = ordinæreAndeler.minOf { it.stønadFom }
-            val stønadTom = ordinæreAndeler.maxOf { it.stønadTom }
+                val relevantBarn = barna.single { it.aktør == aktør }
+                val adopsjonsdatoForBarn = adopsjonerIBehandling.firstOrNull { it.aktør == aktør }?.adopsjonsdato
 
-            val relevantBarn = barna.single { it.aktør == aktør }
-            val adopsjonsdatoForBarn = adopsjonerIBehandling.firstOrNull { it.aktør == aktør }?.adopsjonsdato
+                val vilkårLovverkInformasjonForBarn =
+                    if (alleBarnetsAlderVilkårResultater.any { it.erAdopsjonOppfylt() }) {
+                        VilkårLovverkInformasjonForBarn(
+                            fødselsdato = relevantBarn.fødselsdato,
+                            adopsjonsdato = adopsjonsdatoForBarn,
+                            periodeFomForAdoptertBarn = stønadFom,
+                            periodeTomForAdoptertBarn = stønadTom,
+                        )
+                    } else {
+                        VilkårLovverkInformasjonForBarn(fødselsdato = relevantBarn.fødselsdato, adopsjonsdato = adopsjonsdatoForBarn)
+                    }
 
-            val vilkårLovverkInformasjonForBarn =
-                if (alleBarnetsAlderVilkårResultater.any { it.erAdopsjonOppfylt() }) {
-                    VilkårLovverkInformasjonForBarn(
-                        fødselsdato = relevantBarn.fødselsdato,
-                        adopsjonsdato = adopsjonsdatoForBarn,
-                        periodeFomForAdoptertBarn = stønadFom,
-                        periodeTomForAdoptertBarn = stønadTom,
-                    )
-                } else {
-                    VilkårLovverkInformasjonForBarn(fødselsdato = relevantBarn.fødselsdato, adopsjonsdato = adopsjonsdatoForBarn)
+                val barnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater.filter { it.personResultat?.aktør == aktør }
+
+                val maksAntallMånederMedUtbetaling = utledMaksAntallMånederMedUtbetaling(vilkårLovverkInformasjonForBarn, barnetsAlderVilkårResultater)
+
+                val diff = Period.between(stønadFom.toLocalDate(), stønadTom.toLocalDate())
+                val antallMånederUtbetalt = diff.toTotalMonths() + 1
+
+                if (antallMånederUtbetalt > maksAntallMånederMedUtbetaling) {
+                    val feilmelding =
+                        "Kontantstøtte kan maks utbetales for $maksAntallMånederMedUtbetaling måneder. Du er i ferd med å utbetale $antallMånederUtbetalt måneder for barn med fnr ${aktør.aktivFødselsnummer()}. " +
+                            "Kontroller datoene på vilkårene eller ta kontakt med Team BAKS"
+                    throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
                 }
 
-            val barnetsAlderVilkårResultater = alleBarnetsAlderVilkårResultater.filter { it.personResultat?.aktør == aktør }
-
-            val maksAntallMånederMedUtbetaling = utledMaksAntallMånederMedUtbetaling(vilkårLovverkInformasjonForBarn, barnetsAlderVilkårResultater)
-
-            val diff = Period.between(stønadFom.toLocalDate(), stønadTom.toLocalDate())
-            val antallMånederUtbetalt = diff.toTotalMonths() + 1
-
-            if (antallMånederUtbetalt > maksAntallMånederMedUtbetaling) {
-                val feilmelding =
-                    "Kontantstøtte kan maks utbetales for $maksAntallMånederMedUtbetaling måneder. Du er i ferd med å utbetale $antallMånederUtbetalt måneder for barn med fnr ${aktør.aktivFødselsnummer()}. " +
-                        "Kontroller datoene på vilkårene eller ta kontakt med Team BAKS"
-                throw FunksjonellFeil(frontendFeilmelding = feilmelding, melding = feilmelding)
+                if (stønadFom > dagensDato.toYearMonth().plusMonths(1)) {
+                    throw FunksjonellFeil(
+                        melding = "Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 1 måned fram i tid. Dette gjelder barn født ${relevantBarn.fødselsdato}.",
+                    )
+                }
             }
-
-            if (stønadFom > dagensDato.toYearMonth().plusMonths(1)) {
-                throw FunksjonellFeil(
-                    melding = "Det er ikke mulig å innvilge kontantstøtte for perioder som er lengre enn 1 måned fram i tid. Dette gjelder barn født ${relevantBarn.fødselsdato}.",
-                )
-            }
-        }
 
         val tidslinjeMedAndeler = tilkjentYtelse.tilTidslinjeMedAndeler()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.lagAutomat
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.finnAktørIderMedUgyldigEtterbetalingsperiode
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.validerAtBarnIkkeFårFlereUtbetalingerSammePeriode
 import no.nav.familie.ks.sak.kjerne.beregning.TilkjentYtelseValidator.validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp
+import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.maksBeløp
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
@@ -46,6 +47,46 @@ internal class TilkjentYtelseValidatorTest {
         )
     var vilkårsvurdering = lagVilkårsvurdering(søkerAktør = søker.aktør, behandling = behandling, resultat = Resultat.OPPFYLT, søkerPeriodeFom = LocalDate.of(2021, 1, 1))
     private val tilkjentYtelse = lagInitieltTilkjentYtelse(behandling)
+
+    @Test
+    fun `kaster ikke feil på å validere andeler for barn som kun har overgangsandel`() {
+        val andelTilkjentYtelseOvergang =
+            lagAndelTilkjentYtelse(
+                tilkjentYtelse = tilkjentYtelse,
+                behandling = behandling,
+                fom = YearMonth.of(2024, 8),
+                tom = YearMonth.of(2024, 10),
+                ytelseType = YtelseType.OVERGANGSORDNING,
+                beløp = 7500,
+                aktør = barn2.aktør,
+            )
+
+        val andelTilkjentYtelseOrdinær =
+            lagAndelTilkjentYtelse(
+                tilkjentYtelse = tilkjentYtelse,
+                behandling = behandling,
+                fom = YearMonth.of(2025, 10),
+                tom = YearMonth.of(2026, 4),
+                ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
+                beløp = 7500,
+                aktør = barn.aktør,
+            )
+
+        tilkjentYtelse.andelerTilkjentYtelse.addAll(setOf(andelTilkjentYtelseOvergang, andelTilkjentYtelseOrdinær))
+
+        val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
+        val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 1, 1).minusMonths(11), adopsjonsdato = null)
+
+        assertDoesNotThrow {
+            validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
+                tilkjentYtelse = tilkjentYtelse,
+                personopplysningGrunnlag = personopplysningGrunnlag,
+                alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultater,
+                adopsjonerIBehandling = emptyList(),
+                dagensDato = LocalDate.of(2026, 3, 1),
+            )
+        }
+    }
 
     @Test
     fun `validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp skal kaste feil når utbetalingsperiode er mer enn 11 måneder`() {


### PR DESCRIPTION
### 📮 Favro: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-27835

### 💰 Hva skal gjøres, og hvorfor?
Vi filtrerer uansett vekk andeler som ikke er overgangsordning osv ved validering. Dvs at hvis et barn kun har overgangsandeler så vil metoden feile fordi den prøver å ta minOf() på en tom liste. 

Flytter filtreringen på typen andeler til før for-loopen sånn at dette ikke skjer. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
