### PR TITLE
Tillat perioder for barnehageplassvilkår etter sluttdato for barnets alder-vilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingSteg.kt
@@ -7,6 +7,8 @@ import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.TIDENES_ENDE
 import no.nav.familie.ks.sak.common.util.erSenereEnnInneværendeMåned
 import no.nav.familie.ks.sak.common.util.erSenereEnnNesteMåned
+import no.nav.familie.ks.sak.common.util.førsteDagIInneværendeMåned
+import no.nav.familie.ks.sak.common.util.sisteDagIInneværendeMåned
 import no.nav.familie.ks.sak.common.util.sisteDagIMåned
 import no.nav.familie.ks.sak.common.util.slåSammen
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
@@ -27,9 +29,14 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.validering
 import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.eøs.kompetanse.KompetanseService
 import no.nav.familie.ks.sak.kjerne.eøs.vilkårsvurdering.VilkårsvurderingTidslinjer
+import no.nav.familie.ks.sak.kjerne.overgangsordning.beregnGyldigFom
+import no.nav.familie.ks.sak.kjerne.overgangsordning.beregnGyldigTom
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import no.nav.familie.tidslinje.TidslinjePeriodeMedDato
+import no.nav.familie.tidslinje.isSameOrAfter
+import no.nav.familie.tidslinje.isSameOrBefore
 import no.nav.familie.tidslinje.utvidelser.klipp
 import no.nav.familie.tidslinje.utvidelser.kombinerMed
 import no.nav.familie.tidslinje.validerIngenOverlapp
@@ -137,7 +144,7 @@ class VilkårsvurderingSteg(
         }
         validerAtAlleVilkårHarGyldigFomDato(vilkårsvurdering, personopplysningGrunnlag)
         validerAtDetIkkeErOverlappMellomGradertBarnehageplassOgDeltBosted(vilkårsvurdering)
-        validerAtPerioderIBarnehageplassSamsvarerMedPeriodeIBarnetsAlderVilkår(vilkårsvurdering)
+        validerAtPerioderIBarnehageplassSamsvarerMedPeriodeIBarnetsAlderVilkår(vilkårsvurdering, personopplysningGrunnlag)
         validerAtDetIkkeFinnesMerEnn2EndringerISammeMånedIBarnehageplassVilkår(vilkårsvurdering)
         barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(vilkårsvurdering = vilkårsvurdering, barna = personopplysningGrunnlag.barna)
         validerIkkeBlandetRegelverk(personopplysningGrunnlag, vilkårsvurdering)
@@ -251,6 +258,7 @@ class VilkårsvurderingSteg(
 
     private fun validerAtPerioderIBarnehageplassSamsvarerMedPeriodeIBarnetsAlderVilkår(
         vilkårsvurdering: Vilkårsvurdering,
+        personopplysningGrunnlag: PersonopplysningGrunnlag,
     ) {
         vilkårsvurdering.personResultater.filter { !it.erSøkersResultater() }.forEach { personResultat ->
 
@@ -273,8 +281,14 @@ class VilkårsvurderingSteg(
                 }
             }
 
+            val barn = personopplysningGrunnlag.personer.single { it.aktør == personResultat.aktør }
+
             val barnehageplassVilkårResultater =
-                personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.BARNEHAGEPLASS }
+                personResultat.vilkårResultater
+                    .filter { it.vilkårType == Vilkår.BARNEHAGEPLASS }
+                    .filterNot {
+                        periodeErInnenforPeriodeForOvergangsordning(barn = barn, fom = it.periodeFom, tom = it.periodeTom)
+                    }
 
             val barnetsAlderVilkårResultater =
                 personResultat.vilkårResultater.filter { it.vilkårType == Vilkår.BARNETS_ALDER }
@@ -289,11 +303,24 @@ class VilkårsvurderingSteg(
             ) {
                 throw FunksjonellFeil(
                     "Du har lagt til en periode på vilkåret ${Vilkår.BARNEHAGEPLASS.beskrivelse}" +
-                        " som starter etter at barnet har fylt 2 år eller startet på skolen. " +
-                        "Du må fjerne denne perioden for å kunne fortsette",
+                        " som starter etter at 'Barnets alder'-vilkåret er avsluttet. " +
+                        "Du må fjerne denne perioden for å kunne fortsette.",
                 )
             }
         }
+    }
+
+    private fun periodeErInnenforPeriodeForOvergangsordning(
+        barn: Person,
+        fom: LocalDate?,
+        tom: LocalDate?,
+    ): Boolean {
+        val august2024 = LocalDate.of(2024, 8, 1)
+        val april2025 = LocalDate.of(2025, 4, 30)
+        val barn20Måneder = beregnGyldigFom(barn).førsteDagIInneværendeMåned()
+        val barn23Måneder = beregnGyldigTom(barn).sisteDagIInneværendeMåned()
+        return fom?.isSameOrAfter(barn20Måneder) == true && fom.isSameOrAfter(august2024) &&
+            tom?.isSameOrBefore(barn23Måneder) == true && tom.isSameOrBefore(april2025)
     }
 
     private fun validerAtDetIkkeFinnesMerEnn2EndringerISammeMånedIBarnehageplassVilkår(vilkårsvurdering: Vilkårsvurdering) {

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -85,6 +85,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Utd
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.VilkårResultat
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkårsvurdering
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.lagAutomatiskGenererteVilkårForBarnetsAlder
 import no.nav.familie.ks.sak.kjerne.beregning.EndretUtbetalingAndelMedAndelerTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelse
 import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelse
@@ -674,14 +675,12 @@ fun lagVilkårResultaterForBarn(
     Vilkår.hentVilkårFor(PersonType.BARN).forEach {
         when (it) {
             Vilkår.BARNETS_ALDER -> {
-                vilkårResultaterForBarn.add(
-                    lagVilkårResultat(
+                vilkårResultaterForBarn.addAll(
+                    lagAutomatiskGenererteVilkårForBarnetsAlder(
                         personResultat = personResultat,
-                        vilkårType = it,
-                        periodeFom = barnFødselsdato.plusYears(1),
-                        periodeTom = barnFødselsdato.plusYears(2),
                         behandlingId = behandlingId,
-                        regelverk = regelverk,
+                        fødselsdato = barnFødselsdato,
+                        adopsjonsdato = null,
                     ),
                 )
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ks.sak.common.util.NullablePeriode
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPerson
+import no.nav.familie.ks.sak.data.lagPersonResultat
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårResultat
 import no.nav.familie.ks.sak.data.lagVilkårResultaterForBarn
@@ -49,6 +50,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -392,10 +394,62 @@ class VilkårsvurderingStegTest {
         val exception = assertThrows<FunksjonellFeil> { vilkårsvurderingSteg.utførSteg(behandling.id) }
         assertEquals(
             "Du har lagt til en periode på vilkåret ${Vilkår.BARNEHAGEPLASS.beskrivelse}" +
-                " som starter etter at barnet har fylt 2 år eller startet på skolen. " +
-                "Du må fjerne denne perioden for å kunne fortsette",
+                " som starter etter at 'Barnets alder'-vilkåret er avsluttet. " +
+                "Du må fjerne denne perioden for å kunne fortsette.",
             exception.message,
         )
+    }
+
+    @Test
+    fun `utførSteg - skal ikke kaste feil hvis barnehageplass perioder starter i periode for overgangsordning etter siste dato i barnets alder vilkår`() {
+        val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 1, 1))
+        val personopplysningGrunnlag =
+            lagPersonopplysningGrunnlag(
+                behandlingId = behandling.id,
+                søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
+                søkerAktør = søker.aktør,
+                barnAktør = listOf(barn.aktør),
+                barnasFødselsdatoer = listOf(barn.fødselsdato),
+            )
+
+        val vilkårsvurdering =
+            lagVilkårsvurderingMedSøkersVilkår(
+                søkerAktør = søker.aktør,
+                behandling = behandling,
+            ).apply {
+                personResultater = personResultater +
+                    lagPersonResultat(
+                        vilkårsvurdering = this,
+                        aktør = barn.aktør,
+                        lagVilkårResultater = {
+                            lagVilkårResultaterForBarn(
+                                behandlingId = behandling.id,
+                                personResultat = it,
+                                barnFødselsdato = barn.fødselsdato,
+                                barnehageplassPerioder =
+                                    listOf(
+                                        NullablePeriode(
+                                            LocalDate.of(2023, 1, 1),
+                                            LocalDate.of(2024, 8, 31),
+                                        ) to null,
+                                        NullablePeriode(
+                                            // periode starter i barnets 20 månederes dato, som er innenfor overgangsordning
+                                            LocalDate.of(2024, 9, 1),
+                                            LocalDate.of(2024, 12, 31),
+                                        ) to BigDecimal(30),
+                                    ),
+                            )
+                        },
+                    )
+            }
+
+        every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns personopplysningGrunnlag
+        every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) } returns vilkårsvurdering
+        every { behandlingService.hentSisteBehandlingSomErVedtatt(behandling.fagsak.id) } returns null
+        every { behandlingService.endreBehandlingstemaPåBehandling(any(), any()) } returns behandling
+        every { kompetanseService.hentKompetanser(BehandlingId(behandling.id)) } returns emptyList()
+
+        assertDoesNotThrow { vilkårsvurderingSteg.utførSteg(behandling.id) }
     }
 
     @Test


### PR DESCRIPTION
### 📮 Favro: NAV-27853

### 💰 Hva skal gjøres, og hvorfor?
Ettersom overgangsordning kan innvilges i en periode etter sluttdato for barnets alder-vilkåret, må det også være mulig å opprette en periode for barnehageplassvikåret i samme periode. Endrer litt på valideringen slik at periode barnehageplassvilkår kan starte etter sluttdato på barnets alder-vilkår. Begrenser tillat periode for barnehageplassvilkår til perioden overgangsordningen kan gjelde (aug 24 til apr 25) og perioden barnet kan få overgangsordning (fra og med 20 til og med 23 måneder)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.