### PR TITLE
Legg til validering når man legger til perioder når det finnes avslått uten dato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtils.kt
@@ -190,17 +190,17 @@ private fun validerAvslagUtenPeriodeMedLøpende(
             return
         }
 
-        endretVilkårResultat.erAvslagUtenPeriode() && filtrerteVilkårResultater.any { it.resultat == Resultat.OPPFYLT } -> {
+        endretVilkårResultat.erAvslagUtenPeriode() && filtrerteVilkårResultater.any { !it.erAvslagUtenPeriode() && it.resultat != Resultat.IKKE_VURDERT } -> {
             throw FunksjonellFeil(
-                "Finnes oppfylte perioder ved forsøk på å legge til avslag uten periode.",
-                "Du kan ikke legge til avslagperiode uten datoer fordi det finnes oppfylte perioder på vilkåret. Disse må fjernes først.",
+                "Finnes perioder med datoer ved forsøk på å legge til avslag uten periode.",
+                "Du kan ikke legge til avslagperiode uten datoer fordi det allerede finnes perioder med datoer på vilkåret. Disse må fjernes først.",
             )
         }
 
-        endretVilkårResultat.resultat == Resultat.OPPFYLT && filtrerteVilkårResultater.any { it.erAvslagUtenPeriode() } -> {
+        !endretVilkårResultat.erAvslagUtenPeriode() && endretVilkårResultat.resultat != Resultat.IKKE_VURDERT && filtrerteVilkårResultater.any { it.erAvslagUtenPeriode() } -> {
             throw FunksjonellFeil(
-                "Finnes avslag uten periode ved forsøk på å legge til oppfylt periode.",
-                "Du kan ikke legge til perioden fordi det er vurdert avslag uten datoer på vilkåret. Denne må fjernes først.",
+                "Finnes avslag uten periode ved forsøk på å legge til periode med datoer.",
+                "Du kan ikke legge til perioden fordi det finnes perioder med avslag uten datoer på vilkåret. Disse må fjernes først.",
             )
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Utd
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Vilkår
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
@@ -365,99 +366,198 @@ class VilkårsvurderingUtilsTest {
         assertEquals(LocalDate.of(2024, 7, 31), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
 
-    @Test
-    fun `endreVilkårResultat - Skal kastes funksjonell feil hvis det forsøkes å lage en oppfylt periode mens det finnes en avslagsperiode uten periode`() {
-        val person = mockk<PersonResultat>(relaxed = true)
+    @Nested
+    inner class EndreVilkårResultatTest {
+        @Test
+        fun `Skal kastes funksjonell feil hvis det forsøkes å lage en oppfylt periode mens det finnes en avslagsperiode uten periode`() {
+            val person = mockk<PersonResultat>(relaxed = true)
 
-        val eksisterendeVilkårResultat =
-            listOf(
-                lagVilkårResultat(
-                    id = 1,
-                    personResultat = person,
-                    behandlingId = 1,
-                    periodeFom = null,
-                    periodeTom = null,
-                    resultat = Resultat.IKKE_OPPFYLT,
-                    vilkårType = Vilkår.BARNEHAGEPLASS,
-                    erEksplisittAvslagPåSøknad = true,
-                ),
-                lagVilkårResultat(
+            val eksisterendeVilkårResultat =
+                listOf(
+                    lagVilkårResultat(
+                        id = 1,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = null,
+                        periodeTom = null,
+                        resultat = Resultat.IKKE_OPPFYLT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                        erEksplisittAvslagPåSøknad = true,
+                    ),
+                    lagVilkårResultat(
+                        id = 2,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = null,
+                        periodeTom = null,
+                        resultat = Resultat.IKKE_VURDERT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                    ),
+                )
+
+            val vilkårDto =
+                VilkårResultatDto(
                     id = 2,
-                    personResultat = person,
-                    behandlingId = 1,
-                    periodeFom = null,
-                    periodeTom = null,
-                    resultat = Resultat.IKKE_VURDERT,
                     vilkårType = Vilkår.BARNEHAGEPLASS,
-                ),
-            )
-
-        val vilkårDto =
-            VilkårResultatDto(
-                id = 2,
-                vilkårType = Vilkår.BARNEHAGEPLASS,
-                periodeFom = januar,
-                periodeTom = desember,
-                resultat = Resultat.OPPFYLT,
-                endretTidspunkt = LocalDateTime.now(),
-                behandlingId = 1,
-                begrunnelse = "test",
-                endretAv = "VL",
-            )
-
-        val frontendFeilmelding =
-            assertThrows<FunksjonellFeil> {
-                endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
-            }.frontendFeilmelding
-
-        assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til perioden fordi det er vurdert avslag uten datoer på vilkåret. Denne må fjernes først.")
-    }
-
-    @Test
-    fun `endreVilkårResultat - Skal kastes funksjonell feil hvis det forsøkes å lage en avslagsperiode uten dato mens det finnes en oppfylt periode`() {
-        val person = mockk<PersonResultat>(relaxed = true)
-
-        val eksisterendeVilkårResultat =
-            listOf(
-                lagVilkårResultat(
-                    id = 1,
-                    personResultat = person,
-                    behandlingId = 1,
                     periodeFom = januar,
                     periodeTom = desember,
                     resultat = Resultat.OPPFYLT,
-                    vilkårType = Vilkår.BARNEHAGEPLASS,
-                ),
-                lagVilkårResultat(
-                    id = 2,
-                    personResultat = person,
+                    endretTidspunkt = LocalDateTime.now(),
                     behandlingId = 1,
+                    begrunnelse = "test",
+                    endretAv = "VL",
+                )
+
+            val frontendFeilmelding =
+                assertThrows<FunksjonellFeil> {
+                    endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
+                }.frontendFeilmelding
+
+            assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til perioden fordi det finnes perioder med avslag uten datoer på vilkåret. Disse må fjernes først.")
+        }
+
+        @Test
+        fun `Skal kastes funksjonell feil hvis det forsøkes å lage en avslagsperiode uten dato mens det finnes en oppfylt periode`() {
+            val person = mockk<PersonResultat>(relaxed = true)
+
+            val eksisterendeVilkårResultat =
+                listOf(
+                    lagVilkårResultat(
+                        id = 1,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = januar,
+                        periodeTom = desember,
+                        resultat = Resultat.OPPFYLT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                    ),
+                    lagVilkårResultat(
+                        id = 2,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = null,
+                        periodeTom = null,
+                        resultat = Resultat.IKKE_VURDERT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                    ),
+                )
+
+            val vilkårDto =
+                VilkårResultatDto(
+                    id = 2,
+                    vilkårType = Vilkår.BARNEHAGEPLASS,
                     periodeFom = null,
                     periodeTom = null,
-                    resultat = Resultat.IKKE_VURDERT,
+                    resultat = Resultat.IKKE_OPPFYLT,
+                    endretTidspunkt = LocalDateTime.now(),
+                    behandlingId = 1,
+                    begrunnelse = "test",
+                    endretAv = "VL",
+                    erEksplisittAvslagPåSøknad = true,
+                )
+
+            val frontendFeilmelding =
+                assertThrows<FunksjonellFeil> {
+                    endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
+                }.frontendFeilmelding
+
+            assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til avslagperiode uten datoer fordi det allerede finnes perioder med datoer på vilkåret. Disse må fjernes først.")
+        }
+
+        @Test
+        fun `Skal kaste funksjonell feil hvis det forsøkes å lage en periode med datoer mens det finnes avslag uten periode`() {
+            val person = mockk<PersonResultat>(relaxed = true)
+
+            val eksisterendeVilkårResultat =
+                listOf(
+                    lagVilkårResultat(
+                        id = 1,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = null,
+                        periodeTom = null,
+                        resultat = Resultat.IKKE_OPPFYLT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                        erEksplisittAvslagPåSøknad = true,
+                    ),
+                    lagVilkårResultat(
+                        id = 2,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = null,
+                        periodeTom = null,
+                        resultat = Resultat.IKKE_VURDERT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                    ),
+                )
+
+            val vilkårDto =
+                VilkårResultatDto(
+                    id = 2,
                     vilkårType = Vilkår.BARNEHAGEPLASS,
-                ),
-            )
+                    periodeFom = januar,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_OPPFYLT,
+                    endretTidspunkt = LocalDateTime.now(),
+                    behandlingId = 1,
+                    begrunnelse = "test",
+                    endretAv = "VL",
+                )
 
-        val vilkårDto =
-            VilkårResultatDto(
-                id = 2,
-                vilkårType = Vilkår.BARNEHAGEPLASS,
-                periodeFom = null,
-                periodeTom = null,
-                resultat = Resultat.IKKE_OPPFYLT,
-                endretTidspunkt = LocalDateTime.now(),
-                behandlingId = 1,
-                begrunnelse = "test",
-                endretAv = "VL",
-                erEksplisittAvslagPåSøknad = true,
-            )
+            val frontendFeilmelding =
+                assertThrows<FunksjonellFeil> {
+                    endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
+                }.frontendFeilmelding
 
-        val frontendFeilmelding =
-            assertThrows<FunksjonellFeil> {
-                endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
-            }.frontendFeilmelding
+            assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til perioden fordi det finnes perioder med avslag uten datoer på vilkåret. Disse må fjernes først.")
+        }
 
-        assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til avslagperiode uten datoer fordi det finnes oppfylte perioder på vilkåret. Disse må fjernes først.")
+        @Test
+        fun `Skal kaste funksjonell feil hvis det forsøkes å lage avslag uten periode mens det allerede finnes periode med datoer`() {
+            val person = mockk<PersonResultat>(relaxed = true)
+
+            val eksisterendeVilkårResultat =
+                listOf(
+                    lagVilkårResultat(
+                        id = 1,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = januar,
+                        periodeTom = null,
+                        resultat = Resultat.IKKE_OPPFYLT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                    ),
+                    lagVilkårResultat(
+                        id = 2,
+                        personResultat = person,
+                        behandlingId = 1,
+                        periodeFom = null,
+                        periodeTom = null,
+                        resultat = Resultat.IKKE_VURDERT,
+                        vilkårType = Vilkår.BARNEHAGEPLASS,
+                    ),
+                )
+
+            val vilkårDto =
+                VilkårResultatDto(
+                    id = 2,
+                    vilkårType = Vilkår.BARNEHAGEPLASS,
+                    periodeFom = null,
+                    periodeTom = null,
+                    resultat = Resultat.IKKE_OPPFYLT,
+                    endretTidspunkt = LocalDateTime.now(),
+                    behandlingId = 1,
+                    begrunnelse = "test",
+                    endretAv = "VL",
+                    erEksplisittAvslagPåSøknad = true,
+                )
+
+            val frontendFeilmelding =
+                assertThrows<FunksjonellFeil> {
+                    endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
+                }.frontendFeilmelding
+
+            assertThat(frontendFeilmelding).isEqualTo("Du kan ikke legge til avslagperiode uten datoer fordi det allerede finnes perioder med datoer på vilkåret. Disse må fjernes først.")
+        }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -262,7 +262,7 @@ internal class TilkjentYtelseValidatorTest {
                 ),
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterBarn1 + barnetsAlderVilkårResultaterBarn2,
                 adopsjonerIBehandling = emptyList(),
-                dagensDato = LocalDate.now()
+                dagensDato = LocalDate.now(),
             )
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -262,7 +262,7 @@ internal class TilkjentYtelseValidatorTest {
                 ),
                 alleBarnetsAlderVilkårResultater = barnetsAlderVilkårResultaterBarn1 + barnetsAlderVilkårResultaterBarn2,
                 adopsjonerIBehandling = emptyList(),
-                dagensDato = LocalDate.of(2025, 4, 1),
+                dagensDato = LocalDate.now()
             )
         }
     }


### PR DESCRIPTION
### 📮 Favro: Nav-28416

### 💰 Hva skal gjøres, og hvorfor?

Det oppstod en bug i dette favrokortet: [Nav-28405](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-28405)

Det viser seg at dersom det finnes en avslagsperiode UTEN fom og tom, og man legger til en ikke oppfylt periode med fom, så vil hele behandlingen kræsje, grunnet overlapp i tidslinjer.


https://github.com/user-attachments/assets/e007b528-41ef-4928-b81f-0a96a5defd85



Endrer derfor logikken slik at:

* Så lenge det finnes avslagsperiode uten fom/tom, så kan man ikke legge til noe perioder uten å fjerne denne først.
* Så lenge det finnes vurderte perioder fra før av, uavhengig av oppfylt eller ikke, så kan man ikke legge til avslagsperiode uten fom/tom uten at de vurderte periodene slettes.

Etter fiks:


https://github.com/user-attachments/assets/e5e4261d-c0b3-40b9-a60d-cf4d83ef4a76

