### PR TITLE
Vi fikser doble begrunnelser ved å bruke saveandflush

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterService.kt
@@ -23,7 +23,7 @@ class VedtaksperiodeHentOgPersisterService(
     fun lagre(vedtaksperiodeMedBegrunnelser: VedtaksperiodeMedBegrunnelser): VedtaksperiodeMedBegrunnelser {
         validerVedtaksperiodeMedBegrunnelser(vedtaksperiodeMedBegrunnelser)
 
-        return vedtaksperiodeRepository.save(vedtaksperiodeMedBegrunnelser)
+        return vedtaksperiodeRepository.saveAndFlush(vedtaksperiodeMedBegrunnelser)
     }
 
     fun lagre(vedtaksperiodeMedBegrunnelser: List<VedtaksperiodeMedBegrunnelser>): List<VedtaksperiodeMedBegrunnelser> {


### PR DESCRIPTION
### 📮 Favro: Nav-28489

### 💰 Hva skal gjøres, og hvorfor?

To feil i dette favrokortet.

Saksbehandler skal gi avslag på en søknad om kontantstøtte for tvillinger født i august 25. Det er søkt for tidlig. Behandlingen forstår ikke at det er tvillinger. I begrunnelsen står det barnet, ikke barna, og det er dannet en begrunnelse for hvert av barna. 

Det forventes at systemet fanger opp at det er to barn født samme dato og at det gis en begrunnelsestekst, som sier barna.



Løses ved at vi bytter til saveAndFlush for å unngå at begrunnelser vi har sletta kommer tilbake, i tillegg til at teksten måtte justeres i sanity for å benytte seg av flettefeltet 'Barnet barna ditt dine'. Saveandflush greiene kommer sikkert av at vi har oppdater til spring boot 4

FØR:
<img width="685" height="354" alt="Screenshot 2026-04-14 at 10 30 43" src="https://github.com/user-attachments/assets/a6c5a4f1-35be-4934-9751-414b87bdaa6f" />
<img width="640" height="393" alt="Screenshot 2026-04-14 at 10 36 04" src="https://github.com/user-attachments/assets/9a896136-7f6a-48f1-bccb-227274873557" />


Etter:
<img width="984" height="506" alt="Screenshot 2026-04-14 at 10 29 16" src="https://github.com/user-attachments/assets/f02a3641-42b7-4cb2-a7c0-b2554fce4a29" />
<img width="655" height="397" alt="Screenshot 2026-04-14 at 10 36 00" src="https://github.com/user-attachments/assets/272aa30d-8430-4247-b198-c63faf558af9" />