### PR TITLE
Lagre nytt vedtak før man lagrer vedtaksperioder på vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakService.kt
@@ -53,6 +53,7 @@ class VedtakService(
                 ?.let { vedtakRepository.saveAndFlush(it.also { it.aktiv = false }) }
 
         val nyttVedtak = Vedtak(behandling = behandling)
+        vedtakRepository.saveAndFlush(nyttVedtak)
 
         if (kopiervedtaksbegrunnelser && deaktivertVedtak != null) {
             vedtaksperiodeService.kopierOverVedtaksperioder(
@@ -60,7 +61,5 @@ class VedtakService(
                 aktivtVedtak = nyttVedtak,
             )
         }
-
-        vedtakRepository.save(nyttVedtak)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakServiceTest.kt
@@ -129,8 +129,7 @@ class VedtakServiceTest {
         every { behandling.steg } returns behandlingSteg
 
         every { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) } returns eksisterendeVedtak
-        every { vedtakRepository.saveAndFlush(eksisterendeVedtak) } returns eksisterendeVedtak
-        every { vedtakRepository.save(capture(slot)) } returns mockk(relaxed = true)
+        every { vedtakRepository.saveAndFlush(capture(slot)) } returns mockk(relaxed = true)
 
         vedtakService.opprettOgInitierNyttVedtakForBehandling(behandling, false)
 
@@ -138,7 +137,7 @@ class VedtakServiceTest {
 
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
         verify(exactly = 1) { eksisterendeVedtak setProperty "aktiv" value false }
-        verify(exactly = 1) { vedtakRepository.save(lagretVedtak) }
+        verify(exactly = 1) { vedtakRepository.saveAndFlush(lagretVedtak) }
 
         assertThat(lagretVedtak.behandling, Is(behandling))
     }
@@ -156,8 +155,7 @@ class VedtakServiceTest {
 
         every { vedtaksperiodeService.kopierOverVedtaksperioder(any(), any()) } returns mockk()
         every { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) } returns eksisterendeVedtak
-        every { vedtakRepository.saveAndFlush(eksisterendeVedtak) } returns eksisterendeVedtak
-        every { vedtakRepository.save(capture(slot)) } returns mockk(relaxed = true)
+        every { vedtakRepository.saveAndFlush(capture(slot)) } returns mockk(relaxed = true)
 
         vedtakService.opprettOgInitierNyttVedtakForBehandling(behandling, true)
 
@@ -166,7 +164,7 @@ class VedtakServiceTest {
         verify(exactly = 1) { vedtaksperiodeService.kopierOverVedtaksperioder(any(), any()) }
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
         verify(exactly = 1) { eksisterendeVedtak setProperty "aktiv" value false }
-        verify(exactly = 1) { vedtakRepository.save(lagretVedtak) }
+        verify(exactly = 1) { vedtakRepository.saveAndFlush(lagretVedtak) }
 
         assertThat(lagretVedtak.behandling, Is(behandling))
     }


### PR DESCRIPTION
### 📮 Favro: Nav-28395

### 💰 Hva skal gjøres, og hvorfor?
Siden vi i denne [PRn](https://github.com/navikt/familie-ks-sak/pull/1663) gikk over til å bruke saveandflush ved lagring av vedtaksperioder med begrunnelser, så kreves det også at selve vedtakene som settes inn i vedtaksperiodene er lagret. Lagrer derfor vedtaket først, også vedtaksperiodene (dette er uansett beste rekkefølge på ting)