### PR TITLE
Fiks utledning av behandlingsresultat ved opplysningsplikt 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatService.kt
@@ -37,14 +37,9 @@ class BehandlingsresultatService(
 
         val forrigeBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId = behandling.fagsak.id)
 
-        val tidligereAvsluttetBehandlingerIFagsak =
-            behandlingService
-                .hentBehandlingerPåFagsak(behandling.fagsak.id)
-                .filter { it.erAvsluttet() }
+        val tidligereAvsluttetBehandlingerIFagsak = behandlingService.hentBehandlingerPåFagsak(behandling.fagsak.id).filter { it.erAvsluttet() }
 
-        val harTidligereBareBehandlingerSomErAvslått =
-            tidligereAvsluttetBehandlingerIFagsak.isNotEmpty() &&
-                tidligereAvsluttetBehandlingerIFagsak.all { it.resultat.erAvslått() }
+        val harTidligereBareBehandlingerSomErAvslått = tidligereAvsluttetBehandlingerIFagsak.isNotEmpty() && tidligereAvsluttetBehandlingerIFagsak.all { it.resultat.erAvslått() }
 
         val søknadGrunnlag = søknadGrunnlagService.finnAktiv(behandlingId = behandling.id)
         val søknadDto = søknadGrunnlag?.tilSøknadDto()
@@ -65,15 +60,18 @@ class BehandlingsresultatService(
         val personerFremstiltKravFor =
             finnPersonerFremstiltKravFor(
                 behandling = behandling,
+                forrigeBehandling = forrigeBehandling,
                 søknadDto = søknadDto,
+                harTidligereBareBehandlingerSomErAvslått = harTidligereBareBehandlingerSomErAvslått,
             )
 
         val nåværendePersonResultat = vilkårsvurdering.personResultater
+
         BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(personerFremstiltKravFor = personerFremstiltKravFor, personResultater = nåværendePersonResultat)
 
         // 1 SØKNAD
         val søknadsresultat =
-            if (skalUtledeSøknadsresultatForBehandling(behandling)) {
+            if (skalUtledeSøknadsresultatForBehandling(behandling, harTidligereBareBehandlingerSomErAvslått)) {
                 BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                     nåværendeAndeler = andelerTilkjentYtelse,
                     forrigeAndeler = forrigeAndelerTilkjentYtelse,
@@ -129,17 +127,28 @@ class BehandlingsresultatService(
 
     internal fun finnPersonerFremstiltKravFor(
         behandling: Behandling,
+        forrigeBehandling: Behandling?,
         søknadDto: SøknadDto?,
+        harTidligereBareBehandlingerSomErAvslått: Boolean,
     ): List<Aktør> {
+        val behandlingÅrsak = behandling.opprettetÅrsak
+
         val personerFremstiltKravFor =
-            when (behandling.opprettetÅrsak) {
+            when (behandlingÅrsak) {
                 BehandlingÅrsak.SØKNAD -> {
-                    // alle barna som er krysset av på søknad
                     søknadDto?.barnaMedOpplysninger?.filter { it.erFolkeregistrert && it.inkludertISøknaden }?.map { personidentService.hentAktør(it.ident) } ?: emptyList()
                 }
 
                 BehandlingÅrsak.KLAGE -> {
                     personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id).personer.map { it.aktør }
+                }
+
+                BehandlingÅrsak.NYE_OPPLYSNINGER if harTidligereBareBehandlingerSomErAvslått -> {
+                    forrigeBehandling?.let {
+                        personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(forrigeBehandling.id).barna.map {
+                            it.aktør
+                        }
+                    } ?: emptyList()
                 }
 
                 else -> {

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtils.kt
@@ -24,7 +24,10 @@ import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat.OPPHØ
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 
 object BehandlingsresultatUtils {
-    internal fun skalUtledeSøknadsresultatForBehandling(behandling: Behandling): Boolean = behandling.opprettetÅrsak in listOf(BehandlingÅrsak.SØKNAD, BehandlingÅrsak.KLAGE)
+    internal fun skalUtledeSøknadsresultatForBehandling(
+        behandling: Behandling,
+        harTidligereBareBehandlingerSomErAvslått: Boolean,
+    ): Boolean = (behandling.opprettetÅrsak in listOf(BehandlingÅrsak.SØKNAD, BehandlingÅrsak.KLAGE)) || (harTidligereBareBehandlingerSomErAvslått && behandling.opprettetÅrsak == BehandlingÅrsak.NYE_OPPLYSNINGER)
 
     internal fun kombinerResultaterTilBehandlingsresultat(
         // Søknadsresultat er null hvis det ikke er en søknad/fødselshendelse/manuell migrering

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
@@ -57,6 +57,8 @@ class BehandlingsresultatServiceTest {
             behandlingsresultatService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 søknadDto = null,
+                forrigeBehandling = null,
+                harTidligereBareBehandlingerSomErAvslått = false,
             )
 
         assertThat(personerFramstiltForKrav, Is(emptyList()))
@@ -110,6 +112,8 @@ class BehandlingsresultatServiceTest {
             behandlingsresultatService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 søknadDto = søknadDto,
+                forrigeBehandling = null,
+                harTidligereBareBehandlingerSomErAvslått = false,
             )
 
         assertThat(personerFramstiltForKrav.single(), Is(mocketAktør))
@@ -152,6 +156,8 @@ class BehandlingsresultatServiceTest {
             behandlingsresultatService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
                 søknadDto = søknadDto,
+                forrigeBehandling = null,
+                harTidligereBareBehandlingerSomErAvslått = false,
             )
 
         assertThat(personerFramstiltForKrav.size, Is(1))

--- a/src/test/resources/cucumber/behandlingsresultat/innvilget_og_opphørt.feature
+++ b/src/test/resources/cucumber/behandlingsresultat/innvilget_og_opphørt.feature
@@ -65,3 +65,53 @@ Egenskap: Innvilgelse og opphør av kontantstøtte
     Og når behandlingsresultatet er utledet for behandling 2
 
     Så forvent at behandlingsresultatet er INNVILGET_OG_OPPHØRT på behandling 2
+
+  Scenario: Ved bare tidligere avslåtte behandlinger skal søknadsresultaten utledes på nytt ved nye opplysninger
+    Gitt følgende fagsaker
+      | FagsakId |
+      | 1        |
+
+    Og følgende behandlinger
+      | BehandlingId | FagsakId | ForrigeBehandlingId | Behandlingsårsak | Behandlingskategori | Behandlingsstatus | Behandlingsresultat |
+      | 1            | 1        |                     | SØKNAD           | NASJONAL            | AVSLUTTET         | AVSLÅTT             |
+      | 2            | 1        | 1                   | NYE_OPPLYSNINGER | NASJONAL            | UTREDES           |                     |
+
+    Og følgende persongrunnlag
+      | BehandlingId | AktørId | Persontype | Fødselsdato |
+      | 1            | 1       | SØKER      | 10.01.1991  |
+      | 1            | 2       | BARN       | 04.04.2024  |
+      | 2            | 1       | SØKER      | 10.01.1991  |
+      | 2            | 2       | BARN       | 04.04.2024  |
+
+    Og følgende dagens dato 20.04.2026
+
+    Og følgende vilkårresultater for behandling 1
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser                                       | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 10.01.1991 |            | OPPFYLT      | Nei                  |                                                            | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 10.01.1996 |            | OPPFYLT      | Nei                  |                                                            | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  |            |            | IKKE_OPPFYLT | Ja                   | AVSLAG_VURDERING_DEN_ANDRE_FORELDEREN_IKKE_MEDLEM_I_FEM_ÅR | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 04.04.2024 |            | OPPFYLT      | Nei                  |                                                            | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 04.04.2024 |            | OPPFYLT      | Nei                  |                                                            |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 04.04.2025 | 04.12.2025 | OPPFYLT      | Nei                  |                                                            |                  | Nei                                   |              |
+
+    Og følgende vilkårresultater for behandling 2
+      | AktørId | Vilkår                       | Utdypende vilkår | Fra dato   | Til dato   | Resultat     | Er eksplisitt avslag | Standardbegrunnelser | Vurderes etter   | Søker har meldt fra om barnehageplass | Antall timer |
+      | 1       | BOSATT_I_RIKET               |                  | 10.01.1991 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 1       | MEDLEMSKAP                   |                  | 10.01.1996 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+
+      | 2       | MEDLEMSKAP_ANNEN_FORELDER    |                  | 25.11.1996 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BOSATT_I_RIKET,BOR_MED_SØKER |                  | 04.04.2024 |            | OPPFYLT      | Nei                  |                      | NASJONALE_REGLER | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 04.04.2024 | 31.07.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNETS_ALDER                |                  | 04.04.2025 | 04.12.2025 | OPPFYLT      | Nei                  |                      |                  | Nei                                   |              |
+      | 2       | BARNEHAGEPLASS               |                  | 01.08.2025 |            | IKKE_OPPFYLT | Nei                  |                      |                  | Nei                                   | 44           |
+
+    Og andeler er beregnet for behandling 1
+
+    Og andeler er beregnet for behandling 2
+
+    Så forvent følgende andeler tilkjent ytelse for behandling 2
+      | AktørId | Fra dato   | Til dato   | Beløp | Ytelse type           | Prosent | Sats | Nasjonalt periodebeløp | Differanseberegnet beløp |
+      | 2       | 01.05.2025 | 31.07.2025 | 7500  | ORDINÆR_KONTANTSTØTTE | 100     | 7500 | 7500                   |                          |
+    Og når behandlingsresultatet er utledet for behandling 2
+    Så forvent at behandlingsresultatet er INNVILGET_OG_OPPHØRT på behandling 2


### PR DESCRIPTION
### 📮 Favro: Nav-28512
### 💰 Hva skal gjøres, og hvorfor?
Når en søker bare har avslåtte behandlinger, og det opprettes en behandling med nye opplysninger, så må se på den forrige behandlingen for å finne hvem krav er framstilt for.

Vi må i tillegg også utlede søknadsresultat.