### PR TITLE
Sett flagg på fagsak som sier om det er strengt fortrolig personer i …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/HentFagsak.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/HentFagsak.kt
@@ -23,6 +23,7 @@ data class MinimalFagsakResponsDto(
     val løpendeKategori: BehandlingKategori?,
     val behandlinger: List<MinimalBehandlingResponsDto> = emptyList(),
     val gjeldendeUtbetalingsperioder: List<UtbetalingsperiodeResponsDto> = emptyList(),
+    val finnesStrengtFortroligPersonIFagsak: Boolean = false,
 )
 
 data class MinimalBehandlingResponsDto(

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/FagsakMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/mapper/FagsakMapper.kt
@@ -38,6 +38,7 @@ object FagsakMapper {
         aktivtBehandling: Behandling? = null,
         behandlinger: List<MinimalBehandlingResponsDto> = emptyList(),
         gjeldendeUtbetalingsperioder: List<UtbetalingsperiodeResponsDto> = emptyList(),
+        finnesStrengtFortroligPersonIFagsak: Boolean = false,
     ): MinimalFagsakResponsDto =
         MinimalFagsakResponsDto(
             opprettetTidspunkt = fagsak.opprettetTidspunkt,
@@ -48,6 +49,7 @@ object FagsakMapper {
             løpendeKategori = aktivtBehandling?.kategori,
             behandlinger = behandlinger,
             gjeldendeUtbetalingsperioder = gjeldendeUtbetalingsperioder,
+            finnesStrengtFortroligPersonIFagsak = finnesStrengtFortroligPersonIFagsak,
         )
 
     fun lagBehandlingResponsDto(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ks.sak.kjerne.fagsak
 
 import io.micrometer.core.instrument.Metrics
+import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.ks.sak.api.dto.FagsakRequestDto
 import no.nav.familie.ks.sak.api.dto.MinimalFagsakResponsDto
 import no.nav.familie.ks.sak.api.dto.tilUtbetalingsperiodeResponsDto
@@ -11,6 +12,7 @@ import no.nav.familie.ks.sak.common.ClockProvider
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ks.sak.integrasjon.pdl.PdlKlient
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
@@ -46,6 +48,7 @@ class FagsakService(
     private val andelerTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
     private val clockProvider: ClockProvider,
     private val adopsjonService: AdopsjonService,
+    private val pdlKlient: PdlKlient,
 ) {
     private val antallFagsakerOpprettetFraManuell =
         Metrics.counter("familie.ks.sak.fagsak.opprettet", "saksbehandling", "manuell")
@@ -103,6 +106,7 @@ class FagsakService(
                     )
                 },
             gjeldendeUtbetalingsperioder = gjeldendeUtbetalingsperioder ?: emptyList(),
+            finnesStrengtFortroligPersonIFagsak = harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak),
         )
     }
 
@@ -144,6 +148,19 @@ class FagsakService(
             melding = "Finner ikke fagsak med id $fagsakId",
             frontendFeilmelding = "Finner ikke fagsak med id $fagsakId",
         )
+
+    fun harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak: Fagsak): Boolean {
+        val identerFraPersongrunnlag = personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(fagsak.id).map { it.aktør.aktivFødselsnummer() }
+
+        return pdlKlient
+            .hentAdressebeskyttelseBolk(identerFraPersongrunnlag)
+            .filter { (_, person) ->
+                person.adressebeskyttelse.any { adressebeskyttelse ->
+                    adressebeskyttelse.gradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG ||
+                        adressebeskyttelse.gradering == ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND
+                }
+            }.isNotEmpty()
+    }
 
     fun finnFagsakForPerson(aktør: Aktør): Fagsak? = fagsakRepository.finnFagsakForAktør(aktør)
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretter.kt
@@ -47,6 +47,13 @@ class KlagebehandlingOppretter(
             throw FunksjonellFeil("Kan ikke opprette klage med krav mottatt frem i tid.")
         }
 
+        if (fagsakService.harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak)) {
+            throw FunksjonellFeil(
+                melding = "Kan ikke opprette klagebehandling på fagsak ${fagsak.id} fordi den inneholder personer med strengt fortrolig adressebeskyttelse.",
+                frontendFeilmelding = "Klagebehandling kan ikke opprettes når fagsaken inneholder personer med strengt fortrolig adressebeskyttelse. Slike klager må behandles manuelt.",
+            )
+        }
+
         val fødselsnummer = fagsak.aktør.aktivFødselsnummer()
         val navIdent = NavIdent(SikkerhetContext.hentSaksbehandler())
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/mocking/CucumberMock.kt
@@ -96,6 +96,7 @@ class CucumberMock(
             andelerTilkjentYtelseRepository = andelTilkjentYtelseRepositoryMock,
             clockProvider = clockProvider,
             adopsjonService = adopsjonServiceMock,
+            pdlKlient = pdlKlientMock,
         )
 
     val beregningService =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ks.sak.kjerne.fagsak
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.kontrakter.felles.personopplysning.Adressebeskyttelse
 import no.nav.familie.ks.sak.api.dto.FagsakRequestDto
 import no.nav.familie.ks.sak.common.ClockProvider
 import no.nav.familie.ks.sak.common.exception.Feil
@@ -12,6 +14,8 @@ import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
+import no.nav.familie.ks.sak.integrasjon.pdl.PdlKlient
+import no.nav.familie.ks.sak.integrasjon.pdl.domene.PdlAdressebeskyttelsePerson
 import no.nav.familie.ks.sak.kjerne.adopsjon.AdopsjonService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -20,13 +24,18 @@ import no.nav.familie.ks.sak.kjerne.beregning.AndelerTilkjentYtelseOgEndreteUtbe
 import no.nav.familie.ks.sak.kjerne.beregning.domene.AndelTilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.fagsak.domene.FagsakRepository
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonEnkel
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonRepository
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlagRepository
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
 
 class FagsakServiceTest {
     private val personidentService = mockk<PersonidentService>()
@@ -40,6 +49,7 @@ class FagsakServiceTest {
     private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
     private val clockProvider = mockk<ClockProvider>()
     private val adopsjonService = mockk<AdopsjonService>()
+    private val pdlKlient = mockk<PdlKlient>()
 
     private val fagsakService =
         FagsakService(
@@ -54,11 +64,13 @@ class FagsakServiceTest {
             andelerTilkjentYtelseRepository = andelTilkjentYtelseRepository,
             clockProvider = clockProvider,
             adopsjonService = adopsjonService,
+            pdlKlient = pdlKlient,
         )
 
     @BeforeEach
     fun setup() {
         every { adopsjonService.hentAlleAdopsjonerForBehandling(any()) } returns emptyList()
+        every { pdlKlient.hentAdressebeskyttelseBolk(any()) } returns emptyMap()
     }
 
     @Nested
@@ -185,7 +197,9 @@ class FagsakServiceTest {
     inner class HentMinimalFagsak {
         @Test
         fun `Skal returnere fagsak med tilhørende behandlinger når forespurt fagsakId finnes i db`() {
-            val fagsak = lagFagsak(randomAktør())
+            val søker = randomAktør()
+            val fagsak = lagFagsak(søker)
+
             val barnehagelisteBehandling =
                 lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.BARNEHAGELISTE).apply { aktiv = true }
 
@@ -200,10 +214,13 @@ class FagsakServiceTest {
                 )
             every { behandlingRepository.findByFagsakAndAktiv(fagsak.id) } returns barnehagelisteBehandling
             every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mockk(relaxed = true)
+            every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(any()) } returns setOf(PersonEnkel(PersonType.SØKER, søker, LocalDate.of(2000, 1, 1), null, Målform.NB))
+            every { pdlKlient.hentAdressebeskyttelseBolk(any()) } returns mapOf(Pair(søker.aktørId, PdlAdressebeskyttelsePerson(listOf(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)))))
             val fagsakResponse = fagsakService.hentMinimalFagsak(fagsak.id)
 
             assertEquals(fagsak.id, fagsakResponse.id)
             assertEquals(2, fagsakResponse.behandlinger.size)
+            assertThat(fagsakResponse.finnesStrengtFortroligPersonIFagsak).isTrue()
         }
 
         @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/klage/KlagebehandlingOppretterTest.kt
@@ -49,6 +49,7 @@ class KlagebehandlingOppretterTest {
     @BeforeEach
     fun setup() {
         every { behandlingService.hentSisteBehandlingSomErVedtatt(any()) } returns lagBehandling()
+        every { fagsakService.harFagsakPersonMedStrengtFortroligAdressebeskyttelse(any()) } returns false
     }
 
     @Nested
@@ -65,6 +66,24 @@ class KlagebehandlingOppretterTest {
                     klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
                 }
             assertThat(exception.message).isEqualTo("Kan ikke opprette klage med krav mottatt frem i tid.")
+        }
+
+        @Test
+        fun `skal kaste FunksjonellFeil hvis fagsak inneholder person med strengt fortrolig adressebeskyttelse ved opprettelse av klage behandling`() {
+            // Arrange
+            val fagsak = lagFagsak()
+            val klageMottattDato = dagensDato
+
+            every { fagsakService.harFagsakPersonMedStrengtFortroligAdressebeskyttelse(fagsak) } returns true
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    klagebehandlingOppretter.opprettKlage(fagsak, klageMottattDato)
+                }
+            assertThat(exception.frontendFeilmelding).isEqualTo(
+                "Klagebehandling kan ikke opprettes når fagsaken inneholder personer med strengt fortrolig adressebeskyttelse. Slike klager må behandles manuelt.",
+            )
         }
 
         @Test


### PR DESCRIPTION
### 📮 Favro: Nav-28618

### 💰 Hva skal gjøres, og hvorfor?

- Vi må kaste funksjonellfeil dersom det forsøkes å opprettes en klagebehandling på en fagsak der det finnes personer som er strengt fortrolig
- Sende med flagg i fagsak dto som sier om personene i fagsaken er strengt fortrolige for å skjule klage som årsak/type hvis det er tilfellet. 