### PR TITLE
Fiks: Legg til spring-boot-health for å rette deployment-feil etter Spring Boot 4.0.6-oppgradering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-health</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>


### PR DESCRIPTION
## Problem

Commit `55ed71c1` bumper Spring Boot fra 4.0.3 til 4.0.6. Spring Boot 4.0.6 fikset en kjent feil ([#50188](https://github.com/spring-projects/spring-boot/issues/50188)):

> *Default security is misconfigured when `spring-boot-actuator-autoconfigure` is present and `spring-boot-health` is not*

Etter denne fiksen endres sikkerhetsautokonfigurasjonen for actuator-endepunkter når `spring-boot-health` **ikke** er eksplisitt på klasstien. Dette kolliderer med sikkerhetskonfigurasjonen fra `no.nav.security:token-validation-spring`, og resulterer i at Spring Application Context ikke klarer å starte.

Symptomet er `connection refused` på liveness-proben (`/internal/health/liveness` på port 8083) fordi den innebygde serveren aldri starter — ikke en HTTP 401/403, men en TCP-feil.

## Løsning

Legg til `spring-boot-health` som en eksplisitt avhengighet i `pom.xml`. Versjonen styres av `spring-boot-starter-parent` (4.0.6) og trenger ikke å angis manuelt.

```xml
<dependency>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-health</artifactId>
</dependency>
```

## Test

`mvn compile` kjøres uten feil.