### PR TITLE
fix: bump okhttp til 5.2.1 og legg til okhttp-jvm eksplisitt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <logback-syslog4j.version>1.0.0</logback-syslog4j.version>
         <unleash.version>12.2.1</unleash.version>
         <microsoft-graph.version>6.63.0</microsoft-graph.version>
+        <okhttp-jvm.version>5.2.1</okhttp-jvm.version>
         <azure-identity.version>1.18.2</azure-identity.version>
 
         <!-- Test -->
@@ -67,7 +68,6 @@
         <testcontainers.postgresql.version>1.21.4</testcontainers.postgresql.version>
         <mockk.version>1.14.9</mockk.version>
         <wiremock.version>3.13.2</wiremock.version>
-        <okhttp3.version>4.9.0</okhttp3.version> <!-- Må settes for å kjøre opp mock-oauth2-server i unit-tester -->
         <springmockk.version>4.0.2</springmockk.version>
 
         <!-- Plugin -->
@@ -393,6 +393,11 @@
                     <artifactId>okhttp</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>${okhttp-jvm.version}</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>


### PR DESCRIPTION
Fikser deployment-brudd introdusert i `55ed71c1`.

**Feil:**
```
Failed to instantiate GraphServiceClient: okhttp3/Call$Factory
```

**Årsak:** `microsoft-graph` ekskluderer OkHttp fra sitt transitive tre. `kiota-http-okHttp` (som `microsoft-graph` bruker internt) finner da ikke `okhttp3.Call$Factory` ved oppstart.

I tillegg var `<okhttp3.version>4.9.0</okhttp3.version>` en no-op — Spring Boot 4.x managerer ikke OkHttp, så propertyen hadde ingen effekt.

**Fix:**
- Bump `okhttp3.version` fra `4.9.0` → `5.2.1` (matcher versjonen som `mock-oauth2-server` allerede bruker via `mockwebserver`)
- Legg til `com.squareup.okhttp3:okhttp-jvm:5.2.1` eksplisitt, slik at `kiota-http-okHttp` finner klassene den trenger