### PR TITLE
Fiks forhåndsvisning av brev med riktig signaturer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/OpprettGrunnlagOgSignaturDataService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/OpprettGrunnlagOgSignaturDataService.kt
@@ -23,32 +23,28 @@ class OpprettGrunnlagOgSignaturDataService(
     fun opprett(vedtak: Vedtak): GrunnlagOgSignaturData {
         val behandling = vedtak.behandling
         val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id)
-        val totrinnskontroll = totrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id)
-        val innloggetSaksbehandlerNavn = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
-
-        val (saksbehandler, beslutter) = utledSaksbehandlerOgBeslutterSignatur(totrinnskontroll, behandling, innloggetSaksbehandlerNavn)
+        val (saksbehandler, beslutter) = utledSaksbehandlerOgBeslutterSignatur(behandling)
 
         val enhetNavn = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id).behandlendeEnhetNavn
         return GrunnlagOgSignaturData(
             grunnlag = personopplysningGrunnlag,
-            saksbehandler = saksbehandler ?: innloggetSaksbehandlerNavn,
-            beslutter = beslutter ?: "Beslutter",
+            saksbehandler = saksbehandler,
+            beslutter = beslutter,
             enhet = enhetNavn,
         )
     }
 
-    private fun utledSaksbehandlerOgBeslutterSignatur(
-        totrinnskontroll: Totrinnskontroll?,
-        behandling: Behandling,
-        innloggetSaksbehandlerNavn: String,
-    ): Pair<String?, String?> =
-        when {
+    private fun utledSaksbehandlerOgBeslutterSignatur(behandling: Behandling): Pair<String, String> {
+        val totrinnskontroll = totrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id)
+        val innloggetSaksbehandlerNavn = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+
+        return when {
             behandling.skalBehandlesAutomatisk() -> {
                 Pair(SikkerhetContext.SYSTEM_NAVN, SikkerhetContext.SYSTEM_NAVN)
             }
 
             totrinnskontroll?.godkjent == true -> {
-                Pair(totrinnskontroll.saksbehandler, totrinnskontroll.beslutter)
+                Pair(totrinnskontroll.saksbehandler, totrinnskontroll.beslutter!!)
             }
 
             behandling.steg.sekvens > BehandlingSteg.BESLUTTE_VEDTAK.sekvens -> {
@@ -57,18 +53,20 @@ class OpprettGrunnlagOgSignaturDataService(
 
             behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK -> {
                 val beslutter =
-                    if (totrinnskontroll?.saksbehandler == innloggetSaksbehandlerNavn) {
+                    if (totrinnskontroll!!.saksbehandler == innloggetSaksbehandlerNavn) {
                         "Beslutter"
                     } else {
                         innloggetSaksbehandlerNavn
                     }
-                Pair(totrinnskontroll?.saksbehandler, beslutter)
+
+                Pair(totrinnskontroll.saksbehandler, beslutter)
             }
 
             else -> {
                 throw Feil("Kunne ikke utlede signatur for behandling ${behandling.id}")
             }
         }
+    }
 }
 
 class GrunnlagOgSignaturData(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/OpprettGrunnlagOgSignaturDataService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/OpprettGrunnlagOgSignaturDataService.kt
@@ -1,10 +1,15 @@
 package no.nav.familie.ks.sak.kjerne.brev
 
+import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonopplysningGrunnlag
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
+import no.nav.familie.ks.sak.kjerne.totrinnskontroll.domene.Totrinnskontroll
+import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.springframework.stereotype.Service
 
@@ -13,21 +18,57 @@ class OpprettGrunnlagOgSignaturDataService(
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val totrinnskontrollService: TotrinnskontrollService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val saksbehandlerContext: SaksbehandlerContext,
 ) {
     fun opprett(vedtak: Vedtak): GrunnlagOgSignaturData {
-        val personopplysningGrunnlag =
-            personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = vedtak.behandling.id)
-        val totrinnskontroll =
-            totrinnskontrollService.finnAktivForBehandling(behandlingId = vedtak.behandling.id)
-        val enhetNavn =
-            arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = vedtak.behandling.id).behandlendeEnhetNavn
+        val behandling = vedtak.behandling
+        val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id)
+        val totrinnskontroll = totrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id)
+        val innloggetSaksbehandlerNavn = saksbehandlerContext.hentSaksbehandlerSignaturTilBrev()
+
+        val (saksbehandler, beslutter) = utledSaksbehandlerOgBeslutterSignatur(totrinnskontroll, behandling, innloggetSaksbehandlerNavn)
+
+        val enhetNavn = arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id).behandlendeEnhetNavn
         return GrunnlagOgSignaturData(
             grunnlag = personopplysningGrunnlag,
-            saksbehandler = totrinnskontroll?.saksbehandler ?: SikkerhetContext.hentSaksbehandlerNavn(),
-            beslutter = totrinnskontroll?.beslutter ?: "Beslutter",
+            saksbehandler = saksbehandler ?: innloggetSaksbehandlerNavn,
+            beslutter = beslutter ?: "Beslutter",
             enhet = enhetNavn,
         )
     }
+
+    private fun utledSaksbehandlerOgBeslutterSignatur(
+        totrinnskontroll: Totrinnskontroll?,
+        behandling: Behandling,
+        innloggetSaksbehandlerNavn: String,
+    ): Pair<String?, String?> =
+        when {
+            behandling.skalBehandlesAutomatisk() -> {
+                Pair(SikkerhetContext.SYSTEM_NAVN, SikkerhetContext.SYSTEM_NAVN)
+            }
+
+            totrinnskontroll?.godkjent == true -> {
+                Pair(totrinnskontroll.saksbehandler, totrinnskontroll.beslutter)
+            }
+
+            behandling.steg.sekvens > BehandlingSteg.BESLUTTE_VEDTAK.sekvens -> {
+                Pair(innloggetSaksbehandlerNavn, "Beslutter")
+            }
+
+            behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK -> {
+                val beslutter =
+                    if (totrinnskontroll?.saksbehandler == innloggetSaksbehandlerNavn) {
+                        "Beslutter"
+                    } else {
+                        innloggetSaksbehandlerNavn
+                    }
+                Pair(totrinnskontroll?.saksbehandler, beslutter)
+            }
+
+            else -> {
+                throw Feil("Kunne ikke utlede signatur for behandling ${behandling.id}")
+            }
+        }
 }
 
 class GrunnlagOgSignaturData(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/cucumber/StepDefinition.kt
@@ -288,7 +288,7 @@ class StepDefinition {
     }
 
     @Og("når behandlingsresultatet er utledet for behandling {}")
-    fun `når behandlingsresultatet er utledet for behehandling`(
+    fun `når behandlingsresultatet er utledet for behandling`(
         behandlingId: Long,
     ) {
         val behandling = behandlinger[behandlingId]!!

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/OpprettGrunnlagOgSignaturDataServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/OpprettGrunnlagOgSignaturDataServiceTest.kt
@@ -2,72 +2,227 @@ package no.nav.familie.ks.sak.kjerne.brev
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
+import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagToTrinnskontroll
 import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStegTilstand
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
+import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingStegStatus
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
 import no.nav.familie.ks.sak.kjerne.totrinnskontroll.TotrinnskontrollService
+import no.nav.familie.ks.sak.sikkerhet.SaksbehandlerContext
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class OpprettGrunnlagOgSignaturDataServiceTest {
     private val mockedPersonopplysningGrunnlagService: PersonopplysningGrunnlagService = mockk()
     private val mockedTotrinnskontrollService: TotrinnskontrollService = mockk()
     private val mockedArbeidsfordelingService: ArbeidsfordelingService = mockk()
+    private val mockedSaksbehandlerContext: SaksbehandlerContext = mockk()
     private val opprettGrunnlagOgSignaturDataService: OpprettGrunnlagOgSignaturDataService =
         OpprettGrunnlagOgSignaturDataService(
             personopplysningGrunnlagService = mockedPersonopplysningGrunnlagService,
             totrinnskontrollService = mockedTotrinnskontrollService,
             arbeidsfordelingService = mockedArbeidsfordelingService,
+            saksbehandlerContext = mockedSaksbehandlerContext,
         )
 
-    @Test
-    fun `skal generere grunnlag og singatur data`() {
-        // Arrange
-        val vedtak = lagVedtak()
+    @Nested
+    inner class OpprettGrunnlagOgSignaturData {
+        @Test
+        fun `skal bruke saksbehandler og beslutter fra godkjent totrinnskontroll`() {
+            // Arrange
+            val vedtak = lagVedtak()
+            val behandling = vedtak.behandling
 
-        val personopplysningGrunnlag =
-            lagPersonopplysningGrunnlag(
-                behandlingId = vedtak.behandling.id,
-            )
+            val totrinnskontroll =
+                lagToTrinnskontroll(
+                    behandling = vedtak.behandling,
+                    saksbehandler = "Saksbehandler Navn",
+                    beslutter = "Beslutter Navn",
+                    godkjent = true,
+                )
 
-        every {
-            mockedPersonopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(
-                behandlingId = vedtak.behandling.id,
-            )
-        } returns personopplysningGrunnlag
+            every { mockedPersonopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id) } returns lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+            every { mockedArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            every { mockedTotrinnskontrollService.finnAktivForBehandling(behandlingId = vedtak.behandling.id) } returns totrinnskontroll
+            every { mockedSaksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "Innlogget Saksbehandler"
 
-        val toTrinnskontroll =
-            lagToTrinnskontroll(
-                behandling = vedtak.behandling,
-            )
+            // Act
+            val result = opprettGrunnlagOgSignaturDataService.opprett(vedtak)
 
-        every {
-            mockedTotrinnskontrollService.finnAktivForBehandling(
-                behandlingId = vedtak.behandling.id,
-            )
-        } returns toTrinnskontroll
+            // Assert
+            assertThat(result.saksbehandler).isEqualTo("Saksbehandler Navn")
+            assertThat(result.beslutter).isEqualTo("Beslutter Navn")
+            assertThat(result.enhet).isEqualTo("Test enhet")
+        }
 
-        val arbeidsfordelingPåBehandling =
-            lagArbeidsfordelingPåBehandling(
-                behandlingId = vedtak.behandling.id,
-            )
+        @Test
+        fun `skal bruke SYSTEM_NAVN for automatisk behandling`() {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    opprettetÅrsak = BehandlingÅrsak.LOVENDRING_2024,
+                )
+            val vedtak = lagVedtak(behandling = behandling)
 
-        every {
-            mockedArbeidsfordelingService.hentArbeidsfordelingPåBehandling(
-                behandlingId = vedtak.behandling.id,
-            )
-        } returns arbeidsfordelingPåBehandling
+            every { mockedPersonopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id) } returns lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+            every { mockedArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            every { mockedTotrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id) } returns null
+            every { mockedSaksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "Innlogget Saksbehandler"
 
-        // Act
-        val grunnlagOgSignaturData = opprettGrunnlagOgSignaturDataService.opprett(vedtak)
+            // Act
+            val result = opprettGrunnlagOgSignaturDataService.opprett(vedtak)
 
-        // Assert
-        assertThat(grunnlagOgSignaturData.grunnlag).isEqualTo(personopplysningGrunnlag)
-        assertThat(grunnlagOgSignaturData.saksbehandler).isEqualTo("saksbehandler")
-        assertThat(grunnlagOgSignaturData.beslutter).isEqualTo("beslutter")
-        assertThat(grunnlagOgSignaturData.enhet).isEqualTo("Test enhet")
+            // Assert
+            assertThat(result.saksbehandler).isEqualTo(SikkerhetContext.SYSTEM_NAVN)
+            assertThat(result.beslutter).isEqualTo(SikkerhetContext.SYSTEM_NAVN)
+        }
+
+        @Test
+        fun `skal bruke innlogget saksbehandler og Beslutter når steg er etter BESLUTTE_VEDTAK`() {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            BehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.IVERKSETT_MOT_OPPDRAG,
+                                behandlingStegStatus = BehandlingStegStatus.KLAR,
+                            ),
+                        )
+                    },
+                )
+            val vedtak = lagVedtak(behandling = behandling)
+
+            val totrinnskontroll =
+                lagToTrinnskontroll(
+                    behandling = behandling,
+                    godkjent = false,
+                )
+
+            every { mockedPersonopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id) } returns lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+            every { mockedArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            every { mockedTotrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id) } returns totrinnskontroll
+            every { mockedSaksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "Innlogget Saksbehandler"
+
+            // Act
+            val result = opprettGrunnlagOgSignaturDataService.opprett(vedtak)
+
+            // Assert
+            assertThat(result.saksbehandler).isEqualTo("Innlogget Saksbehandler")
+            assertThat(result.beslutter).isEqualTo("Beslutter")
+        }
+
+        @Test
+        fun `skal bruke saksbehandler fra totrinnskontroll og innlogget bruker som beslutter når de er forskjellige i BESLUTTE_VEDTAK steg`() {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            BehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.BESLUTTE_VEDTAK,
+                                behandlingStegStatus = BehandlingStegStatus.KLAR,
+                            ),
+                        )
+                    },
+                )
+            val vedtak = lagVedtak(behandling = behandling)
+
+            val totrinnskontroll =
+                lagToTrinnskontroll(
+                    behandling = behandling,
+                    saksbehandler = "Opprinnelig Saksbehandler",
+                    godkjent = false,
+                )
+
+            every { mockedPersonopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id) } returns lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+            every { mockedArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            every { mockedTotrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id) } returns totrinnskontroll
+            every { mockedSaksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "Beslutter Person"
+
+            // Act
+            val result = opprettGrunnlagOgSignaturDataService.opprett(vedtak)
+
+            // Assert
+            assertThat(result.saksbehandler).isEqualTo("Opprinnelig Saksbehandler")
+            assertThat(result.beslutter).isEqualTo("Beslutter Person")
+        }
+
+        @Test
+        fun `skal bruke Beslutter som placeholder når innlogget bruker er samme som saksbehandler i BESLUTTE_VEDTAK steg`() {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            BehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.BESLUTTE_VEDTAK,
+                                behandlingStegStatus = BehandlingStegStatus.KLAR,
+                            ),
+                        )
+                    },
+                )
+            val vedtak = lagVedtak(behandling = behandling)
+
+            val totrinnskontroll =
+                lagToTrinnskontroll(
+                    behandling = behandling,
+                    saksbehandler = "Samme Person",
+                    godkjent = false,
+                )
+
+            every { mockedPersonopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id) } returns lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+            every { mockedArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            every { mockedTotrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id) } returns totrinnskontroll
+            every { mockedSaksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "Samme Person"
+
+            // Act
+            val result = opprettGrunnlagOgSignaturDataService.opprett(vedtak)
+
+            // Assert
+            assertThat(result.saksbehandler).isEqualTo("Samme Person")
+            assertThat(result.beslutter).isEqualTo("Beslutter")
+        }
+
+        @Test
+        fun `skal kaste Feil når behandling er i et steg før BESLUTTE_VEDTAK og ingen andre betingelser matcher`() {
+            // Arrange
+            val behandling =
+                lagBehandling(
+                    lagBehandlingStegTilstander = {
+                        setOf(
+                            BehandlingStegTilstand(
+                                behandling = it,
+                                behandlingSteg = BehandlingSteg.VILKÅRSVURDERING,
+                                behandlingStegStatus = BehandlingStegStatus.KLAR,
+                            ),
+                        )
+                    },
+                )
+            val vedtak = lagVedtak(behandling = behandling)
+            every { mockedPersonopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandlingId = behandling.id) } returns lagPersonopplysningGrunnlag(behandlingId = behandling.id)
+            every { mockedArbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandlingId = behandling.id) } returns lagArbeidsfordelingPåBehandling(behandlingId = behandling.id)
+            every { mockedTotrinnskontrollService.finnAktivForBehandling(behandlingId = behandling.id) } returns null
+            every { mockedSaksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "Innlogget Saksbehandler"
+
+            // Act & Assert
+            assertThatThrownBy { opprettGrunnlagOgSignaturDataService.opprett(vedtak) }
+                .isInstanceOf(Feil::class.java)
+                .hasMessageContaining("Kunne ikke utlede signatur for behandling")
+        }
     }
 }


### PR DESCRIPTION
### 📮 Favro: Nav-29033

### 💰 Hva skal gjøres, og hvorfor?
I familie-ks per i dag så har vi en bug som fører til feil visning av signaturer ved forhåndsvisning av brev.
Dersom en sak har vært sendt inn av SB1 og underkjent av SB2 - og saken deretter blir jobbet på av SB3, 
så vil signaturene i den forrige totrinnskontrollen vises. Da vises SB1 og SB2.

Fikser logikken slik at:

- Hvis det er en automatisk behandling, bruk system forkortelse for begge
- Hvis totrinnskontroll finnes og den er godkjent, bruk saksbehandler og beslutter navn
- Hvis man er før beslutting av vedtak, bruk innlogget brukers navn som saksbehandler + "Beslutter" placeholder
- Hvis man beslutter vedtak og forhåndsviser brev så vises man som beslutter. Hvis det er samme person som har sendt inn vedtaket, så bruker man saksbehandler + beslutter placeholder.
