### PR TITLE
Kast funksjonell feil ved begrunnelser som ikke matcher vedtaksperiode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlient.kt
@@ -28,12 +28,20 @@ class BrevKlient(
 
         secureLogger.info("Kaller familie brev($uri) med data ${brev.data.toBrevString()}")
 
-        return kallEksternTjeneste(
-            FAMILIE_BREV_TJENESTENAVN,
-            uri,
-            "Hente pdf for vedtaksbrev",
-        ) {
-            postForEntity(uri, brev.data)
+        return try {
+            kallEksternTjeneste(
+                FAMILIE_BREV_TJENESTENAVN,
+                uri,
+                "Hente pdf for vedtaksbrev",
+            ) {
+                postForEntity(uri, brev.data)
+            }
+        } catch (exception: HttpClientErrorException.BadRequest) {
+            log.warn("En bad request oppstod ved generering av brev. Se SecureLogs for detaljer.")
+            secureLogger.warn("En bad request oppstod ved generering av brev.", exception)
+            throw FunksjonellFeil(
+                "Det oppsto en feil ved generering av brev. Sjekk at begrunnelsene som er valgt er riktige og kontakt brukerstøtte hvis problemet vedvarer.",
+            )
         }
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevKlientTest.kt
@@ -5,6 +5,9 @@ import io.mockk.mockk
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.data.lagNasjonalOgFellesBegrunnelseDataDto
 import no.nav.familie.ks.sak.kjerne.brev.begrunnelser.NasjonalOgFellesBegrunnelseDataDto
+import no.nav.familie.ks.sak.kjerne.brev.domene.maler.BrevDataDto
+import no.nav.familie.ks.sak.kjerne.brev.domene.maler.BrevDto
+import no.nav.familie.ks.sak.kjerne.brev.domene.maler.Brevmal
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -28,6 +31,77 @@ class BrevKlientTest {
             "dataset",
             mockedRestOperations,
         )
+
+    @Nested
+    inner class GenererBrevTest {
+        @Test
+        fun `skal kaste funksjonell feil ved bad request exception`() {
+            // Arrange
+            val brevDto = mockk<BrevDto>()
+            val brevMal = Brevmal.VEDTAK_FØRSTEGANGSVEDTAK
+            val brevDataDto = mockk<BrevDataDto>()
+
+            every { brevDto.mal } returns brevMal
+            every { brevDto.data } returns brevDataDto
+            every { brevDataDto.toBrevString() } returns "test"
+
+            every {
+                mockedRestOperations.exchange<ByteArray>(
+                    eq(URI("$baseUri/api/dataset/dokument/NB/${brevMal.apiNavn}/pdf")),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<BrevDataDto>>(),
+                )
+            } throws
+                HttpClientErrorException.create(
+                    HttpStatus.BAD_REQUEST,
+                    "text",
+                    HttpHeaders.EMPTY,
+                    "msg".toByteArray(),
+                    null,
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<FunksjonellFeil> {
+                    brevKlient.genererBrev("NB", brevDto)
+                }
+            assertThat(exception.message).isEqualTo(
+                "Det oppsto en feil ved generering av brev. Sjekk at begrunnelsene som er valgt er riktige og kontakt brukerstøtte hvis problemet vedvarer.",
+            )
+        }
+
+        @Test
+        fun `skal ikke konvertere andre exceptions enn bad request exception til funksjonell feil`() {
+            // Arrange
+            val brevDto = mockk<BrevDto>()
+            val brevMal = Brevmal.VEDTAK_FØRSTEGANGSVEDTAK
+            val brevDataDto = mockk<BrevDataDto>()
+
+            every { brevDto.mal } returns brevMal
+            every { brevDto.data } returns brevDataDto
+            every { brevDataDto.toBrevString() } returns "test"
+
+            every {
+                mockedRestOperations.exchange<ByteArray>(
+                    eq(URI("$baseUri/api/dataset/dokument/NB/${brevMal.apiNavn}/pdf")),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<BrevDataDto>>(),
+                )
+            } throws
+                HttpClientErrorException.create(
+                    HttpStatus.FORBIDDEN,
+                    "text",
+                    HttpHeaders.EMPTY,
+                    "msg".toByteArray(),
+                    null,
+                )
+
+            // Act & assert
+            assertThrows<HttpClientErrorException.Forbidden> {
+                brevKlient.genererBrev("NB", brevDto)
+            }
+        }
+    }
 
     @Nested
     inner class HentBegrunnelsestekstTest {


### PR DESCRIPTION
### 📮 Favro: NAV-29162

### 💰 Hva skal gjøres, og hvorfor?
Per i dag er det slik at dersom man genererer brev med upassende begrunnelser i ba-sak, så catches dette som en funksjonell feil. Vi bør få inn dette mønsteret i ks-sak da det støyer mye grunnet dette.

<img width="2389" height="92" alt="Screenshot 2026-05-19 at 09 58 25" src="https://github.com/user-attachments/assets/f85fad8e-08a9-4943-96f8-6132df801639" />
