### PR TITLE
Legg til forvaltning redirect-endepunkt i permitAll-liste

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/SecurityConfiguration.kt
@@ -45,6 +45,7 @@ class SecurityConfiguration(
                 "/swagger-ui/**",
                 "/swagger-ui.html",
                 "/favicon.ico",
+                "/api/forvaltning/redirect/behandling/**",
             )
             authorizeHttpRequests {
                 authorize(anyRequest, permitAll)


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Legger til `/api/forvaltning/redirect/behandling/**` i listen over endepunkter som er tilgjengelige uten autentisering (permitAll) i `SecurityConfiguration`. Dette gjør at redirect-endepunktet for forvaltning kan nås uten innlogging.