### PR TITLE
Audit manuell deploy når testene hoppes over

### DIFF
--- a/.github/workflows/manual-deploy-prod.yaml
+++ b/.github/workflows/manual-deploy-prod.yaml
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit
   notify-audit:
     name: Notify if audited deploy
-    if: github.ref != 'refs/heads/main'
+    if: always() && needs.deploy-with-new-image.result == 'success' && github.ref != 'refs/heads/main'
     permissions: {}
     needs: deploy-with-new-image
     uses: navikt/familie-baks-gha-workflows/.github/workflows/notify-audited-deploy.yaml@main # ratchet:exclude


### PR DESCRIPTION
### 📮 Favro: NAV-29361

### 💰 Hva skal gjøres, og hvorfor?
Defaulten til `needs` er at alle tidligere jobber har kjørt med resultat `success`. Når man hopper over testene vil de få resultat `skipped`, og `notify-audit` vil derfor ikke kjøres.

`notify-audit` er nå kun avhengig av at `deploy-with-new-image` har kjørt med resultat `success`