### PR TITLE
Sett readOnly transaksjon for metoder som uansett bare skal hentes ut data

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerService.kt
@@ -25,10 +25,10 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerService(
     private val endretUtbetalingAndelRepository: EndretUtbetalingAndelRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
 ) {
-    @Transactional
+    @Transactional(readOnly = true)
     fun finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandlingId: Long): List<AndelTilkjentYtelseMedEndreteUtbetalinger> = lagKombinator(behandlingId).lagAndelerMedEndringer()
 
-    @Transactional
+    @Transactional(readOnly = true)
     fun finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandlingId: Long): List<EndretUtbetalingAndelMedAndelerTilkjentYtelse> =
         lagKombinator(behandlingId).lagEndreteUtbetalingMedAndeler().map { endretUtbetalingAndelMedAndelTilkjentYtelse ->
             endretUtbetalingAndelMedAndelTilkjentYtelse


### PR DESCRIPTION
Dersom metoden kalles fra en ytre write-transaksjon skal readOnly ignoreres (propagasjon REQUIRED).

### 📮 Favro: 

### 💰 Hva skal gjøres, og hvorfor?
Fiks prodfeil som blokkerer opprett behandling i ef-sak. Ref call-id: `b61a492b-afd1-4d96-8c58-8728908e5a8b`

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Om endringen er trygg.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
