### PR TITLE
Overfør 'sed-er-sendt-til-land' logikk fra ba

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManueltBrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/ManueltBrevDto.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ks.sak.kjerne.brev.domene.maler.UtbetalingEtterKAVedtakBre
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.VarselbrevMedÅrsakerDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.VarselbrevMedÅrsakerOgBarnDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.flettefelt
+import no.nav.familie.ks.sak.kjerne.brev.tilLandNavn
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Målform
 import java.time.LocalDate
 
@@ -50,11 +51,25 @@ data class ManueltBrevDto(
     val behandlingKategori: BehandlingKategori? = null,
     val manuelleBrevmottakere: List<BrevmottakerDto> = emptyList(),
     val fritekstAvsnitt: String? = null,
+    val mottakerlandSed: List<String> = emptyList(),
 ) {
     fun enhetNavn(): String = this.enhet?.enhetNavn ?: throw Feil("Finner ikke enhetsnavn på manuell brevrequest")
+
+    fun mottakerlandSedEllerNull(): List<String>? {
+        if (this.mottakerlandSed.contains("NO")) {
+            throw FunksjonellFeil(
+                melding = "Ugyldig mottakerland for SED på manuell brevrequest",
+                frontendFeilmelding = "Norge kan ikke velges som mottakerland.",
+            )
+        }
+        return this.mottakerlandSed.takeIf { it.isNotEmpty() }
+    }
 }
 
-fun ManueltBrevDto.tilBrev(saksbehandlerNavn: String): BrevDto =
+fun ManueltBrevDto.tilBrev(
+    saksbehandlerNavn: String,
+    hentLandkoder: () -> Map<String, String>,
+): BrevDto =
     when (this.brevmal) {
         Brevmal.INFORMASJONSBREV_DELT_BOSTED -> {
             InformasjonsbrevDeltBostedBrevDto(
@@ -161,6 +176,11 @@ fun ManueltBrevDto.tilBrev(saksbehandlerNavn: String): BrevDto =
                     } else {
                         this.behandlingKategori == BehandlingKategori.EØS
                     },
+                mottakerlandSed =
+                    this
+                        .mottakerlandSedEllerNull()
+                        ?.map { it.tilLandNavn(hentLandkoder()).navn }
+                        ?.let { slåSammen(it) },
                 saksbehandlerNavn = saksbehandlerNavn,
             )
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ks.sak.common.util.formaterBeløp
 import no.nav.familie.ks.sak.common.util.storForbokstavIAlleNavn
 import no.nav.familie.ks.sak.common.util.tilDagMånedÅr
 import no.nav.familie.ks.sak.common.util.tilMånedÅr
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.BehandlingSteg
 import no.nav.familie.ks.sak.kjerne.behandling.steg.simulering.SimuleringService
@@ -54,6 +55,7 @@ import org.springframework.stereotype.Service
 @Service
 class GenererBrevService(
     private val brevKlient: BrevKlient,
+    private val integrasjonKlient: IntegrasjonKlient,
     private val personopplysningGrunnlagService: PersonopplysningGrunnlagService,
     private val vedtaksperiodeService: VedtaksperiodeService,
     private val brevPeriodeService: BrevPeriodeService,
@@ -77,7 +79,10 @@ class GenererBrevService(
         saksbehandlerSignaturTilBrev: String? = null, // Gjøres til non-nullable når man fjerner feature toggle
     ): ByteArray {
         try {
-            val brev = manueltBrevRequest.tilBrev(saksbehandlerSignaturTilBrev ?: saksbehandlerContext.hentSaksbehandlerSignaturTilBrev())
+            val brev =
+                manueltBrevRequest.tilBrev(
+                    saksbehandlerNavn = saksbehandlerSignaturTilBrev ?: saksbehandlerContext.hentSaksbehandlerSignaturTilBrev(),
+                ) { integrasjonKlient.hentLandkoderISO2() }
             return brevKlient.genererBrev(
                 målform = manueltBrevRequest.mottakerMålform.tilSanityFormat(),
                 brev = brev,

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/SvartidsbrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/domene/maler/SvartidsbrevDto.kt
@@ -13,6 +13,7 @@ data class SvartidsbrevDto(
         enhet: String,
         mal: Brevmal,
         erEøsBehandling: Boolean,
+        mottakerlandSed: String? = null,
         saksbehandlerNavn: String,
     ) : this(
         mal = mal,
@@ -31,6 +32,7 @@ data class SvartidsbrevDto(
                                 saksbehandlerNavn = saksbehandlerNavn,
                             ),
                         kontonummer = erEøsBehandling,
+                        sedErSendtTil = if (erEøsBehandling) mottakerlandSed?.let { SedErSendtTilDelmal(it) } else null,
                     ),
             ),
     )
@@ -57,5 +59,14 @@ data class SvartidsbrevDataDto(
     data class DelmalData(
         val signatur: SignaturDelmal,
         val kontonummer: Boolean,
+        val sedErSendtTil: SedErSendtTilDelmal? = null,
+    )
+}
+
+data class SedErSendtTilDelmal(
+    val mottakerlandSed: Flettefelt,
+) {
+    constructor(mottakerlandSed: String) : this(
+        mottakerlandSed = flettefelt(mottakerlandSed),
     )
 }

--- a/src/test/common/TestdataGenerator.kt
+++ b/src/test/common/TestdataGenerator.kt
@@ -1794,6 +1794,7 @@ fun lagManueltBrevDto(
     behandlingKategori: BehandlingKategori? = null,
     manuelleBrevmottakere: List<BrevmottakerDto> = emptyList(),
     fritekstAvsnitt: String? = null,
+    mottakerlandSed: List<String> = emptyList(),
 ): ManueltBrevDto =
     ManueltBrevDto(
         brevmal = brevmal,
@@ -1809,4 +1810,5 @@ fun lagManueltBrevDto(
         behandlingKategori = behandlingKategori,
         manuelleBrevmottakere = manuelleBrevmottakere,
         fritekstAvsnitt = fritekstAvsnitt,
+        mottakerlandSed = mottakerlandSed,
     )

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManueltBrevDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/ManueltBrevDtoTest.kt
@@ -3,7 +3,11 @@ package no.nav.familie.ks.sak.api.dto
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.data.randomFnr
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
+import no.nav.familie.ks.sak.kjerne.brev.LANDKODER
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.Brevmal
+import no.nav.familie.ks.sak.kjerne.brev.domene.maler.SvartidsbrevDataDto
+import no.nav.familie.ks.sak.kjerne.brev.domene.maler.SvartidsbrevDto
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.UtbetalingEtterKAVedtakDataDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -18,13 +22,17 @@ class ManueltBrevDtoTest {
     inner class TilBrev {
         @Test
         fun `skal generere UTBETALING_ETTER_KA_VEDTAK-brev`() {
+            // Arrange
             val manueltBrevDto =
                 lagManueltBrevDto(
                     brevmal = Brevmal.UTBETALING_ETTER_KA_VEDTAK,
                     fritekstAvsnitt = "Fritekst avsnitt",
                 )
 
-            val brevDto = manueltBrevDto.tilBrev("Saks Behandlersen").data as UtbetalingEtterKAVedtakDataDto
+            // Act
+            val brevDto = manueltBrevDto.tilBrev("Saks Behandlersen") { LANDKODER }.data as UtbetalingEtterKAVedtakDataDto
+
+            // Assert
             with(brevDto.flettefelter) {
                 assertThat(fodselsnummer).containsExactly(mottakerIdent)
                 assertThat(navn).containsExactly(mottakerNavn)
@@ -36,6 +44,7 @@ class ManueltBrevDtoTest {
 
         @Test
         fun `tilBrev genererer 'innhente opplysninger klage'-brev som forventet`() {
+            // Arrange
             val saksbehandler = "Saks Behandlersen"
             val fritekstAvsnitt = "Fritekst avsnitt"
             val manueltBrevDto =
@@ -43,7 +52,11 @@ class ManueltBrevDtoTest {
                     brevmal = Brevmal.INFORMASJONSBREV_INNHENTE_OPPLYSNINGER_KLAGE,
                     fritekstAvsnitt = fritekstAvsnitt,
                 )
-            val brev = manueltBrevDto.tilBrev(saksbehandler).data as InformasjonsbrevInnhenteOpplysningerKlageDataDto
+
+            // Act
+            val brev = manueltBrevDto.tilBrev(saksbehandler) { LANDKODER }.data as InformasjonsbrevInnhenteOpplysningerKlageDataDto
+
+            // Assert
             with(brev.flettefelter) {
                 assertThat(fodselsnummer).containsExactly(manueltBrevDto.mottakerIdent)
                 assertThat(navn).containsExactly(manueltBrevDto.mottakerNavn)
@@ -55,13 +68,73 @@ class ManueltBrevDtoTest {
 
         @Test
         fun `'innhente opplysninger klage'-brev krever at fritekst avsnitt har en verdi`() {
+            // Arrange
             val manueltBrevDto =
                 lagManueltBrevDto(
                     brevmal = Brevmal.INFORMASJONSBREV_INNHENTE_OPPLYSNINGER_KLAGE,
                     fritekstAvsnitt = null,
                 )
-            val funksjonellFeil = assertThrows<FunksjonellFeil> { manueltBrevDto.tilBrev("Saks Behandlersen") }
+
+            // Act & Assert
+            val funksjonellFeil = assertThrows<FunksjonellFeil> { manueltBrevDto.tilBrev("Saks Behandlersen") { LANDKODER } }
             assertThat(funksjonellFeil.melding).isEqualTo("Du må legge til fritekst for å forklare hvilke opplysninger du ønsker å innhente.")
+        }
+
+        @Test
+        fun `svartidsbrev med mottakerland skal gi svartidsbrev med SED-delmal`() {
+            // Arrange
+            val manueltBrevDto =
+                lagManueltBrevDto(
+                    brevmal = Brevmal.SVARTIDSBREV,
+                    behandlingKategori = BehandlingKategori.EØS,
+                    mottakerlandSed = listOf("SE", "DK"),
+                )
+
+            // Act
+            val brev = manueltBrevDto.tilBrev("Saks Behandlersen") { LANDKODER }
+
+            // Assert
+            assertThat(brev).isInstanceOf(SvartidsbrevDto::class.java)
+            val svartidsbrevData = brev.data as SvartidsbrevDataDto
+            assertThat(
+                svartidsbrevData.delmalData.sedErSendtTil!!
+                    .mottakerlandSed!!
+                    .single(),
+            ).isEqualTo("Sverige og Danmark")
+        }
+
+        @Test
+        fun `svartidsbrev uten mottakerland skal gi svartidsbrev uten SED-delmal`() {
+            // Arrange
+            val manueltBrevDto =
+                lagManueltBrevDto(
+                    brevmal = Brevmal.SVARTIDSBREV,
+                    behandlingKategori = BehandlingKategori.NASJONAL,
+                    mottakerlandSed = emptyList(),
+                )
+
+            // Act
+            val brev = manueltBrevDto.tilBrev("Saks Behandlersen") { LANDKODER }
+
+            // Assert
+            assertThat(brev).isInstanceOf(SvartidsbrevDto::class.java)
+            val svartidsbrevData = brev.data as SvartidsbrevDataDto
+            assertThat(svartidsbrevData.delmalData.sedErSendtTil).isNull()
+        }
+
+        @Test
+        fun `svartidsbrev med Norge som mottakerland skal kaste funksjonell feil`() {
+            // Arrange
+            val manueltBrevDto =
+                lagManueltBrevDto(
+                    brevmal = Brevmal.SVARTIDSBREV,
+                    behandlingKategori = BehandlingKategori.EØS,
+                    mottakerlandSed = listOf("NO"),
+                )
+
+            // Act & Assert
+            val funksjonellFeil = assertThrows<FunksjonellFeil> { manueltBrevDto.tilBrev("Saks Behandlersen") { LANDKODER } }
+            assertThat(funksjonellFeil.frontendFeilmelding).isEqualTo("Norge kan ikke velges som mottakerland.")
         }
     }
 
@@ -71,11 +144,15 @@ class ManueltBrevDtoTest {
         mottakerIdent: String = this.mottakerIdent,
         fritekstAvsnitt: String? = null,
         enhet: Enhet = Enhet("1234", "Enhet"),
+        behandlingKategori: BehandlingKategori? = null,
+        mottakerlandSed: List<String> = emptyList(),
     ) = ManueltBrevDto(
         brevmal = brevmal,
         mottakerIdent = mottakerIdent,
         mottakerNavn = mottakerNavn,
         fritekstAvsnitt = fritekstAvsnitt,
         enhet = enhet,
+        behandlingKategori = behandlingKategori,
+        mottakerlandSed = mottakerlandSed,
     )
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
@@ -332,7 +332,7 @@ class BrevServiceTest {
                     manuelleBrevmottakere = brevmottakere,
                 )
 
-            // Act & assert
+            // Act & Assert
             val exception =
                 assertThrows<FunksjonellFeil> {
                     brevService.sendBrev(fagsak, behandlingId = null, manueltBrevDto)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/GenererBrevServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.randomAktør
+import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -40,6 +41,7 @@ class GenererBrevServiceTest {
     val genererBrevService =
         GenererBrevService(
             brevKlient = brevKlient,
+            integrasjonKlient = mockk<IntegrasjonKlient>(),
             personopplysningGrunnlagService = personopplysningGrunnlagService,
             simuleringService = mockk<SimuleringService>(),
             vedtaksperiodeService = mockk<VedtaksperiodeService>(),
@@ -76,8 +78,10 @@ class GenererBrevServiceTest {
         mode = EnumSource.Mode.INCLUDE,
     )
     fun `genererManueltBrev - skal ikke journalføre brev for brevmaler som ikke kan sendes manuelt`(brevmal: Brevmal) {
+        // Arrange
         every { saksbehandlerContext.hentSaksbehandlerSignaturTilBrev() } returns "test"
 
+        // Act & Assert
         val feil =
             assertThrows<Feil> {
                 genererBrevService.genererManueltBrev(
@@ -92,6 +96,7 @@ class GenererBrevServiceTest {
 
     @Test
     fun `hentForhåndsvisningAvBrev - skal kaste feil dersom kall mot 'familie-brev' feiler`() {
+        // Arrange
         every { personopplysningGrunnlagService.hentSøker(behandlingId = behandling.id) } returns
             lagPerson(
                 lagPersonopplysningGrunnlag(behandlingId = behandling.id, søkerPersonIdent = søker.aktivFødselsnummer()),
@@ -110,6 +115,7 @@ class GenererBrevServiceTest {
             brevKlient.genererBrev(any(), any())
         } throws Exception("Kall mot familie-brev feilet")
 
+        // Act & Assert
         val feil =
             assertThrows<Feil> { genererBrevService.genererManueltBrev(manueltBrevDto, true) }
         assertEquals(


### PR DESCRIPTION
### 📮 Favro: Nav-29845 

### 💰 Hva skal gjøres, og hvorfor?
Saksbehandler skal kunne opplyse søker om at vi innhenter opplysninger fra annet EØS-land allerede i søknadsprosessen. Dette er tilsvarende funksjonalitet som ble lagt inn i ba-sak i navikt/familie-ba-sak#6351.