### PR TITLE
Hent vedtaksbrev fra joark

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/BrevController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.ks.sak.api.dto.BehandlingResponsDto
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.api.dto.MinimalFagsakResponsDto
-import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.VedtakService
@@ -137,8 +136,9 @@ class BrevController(
         )
 
         val vedtaksbrev =
-            vedtakService.hentAktivVedtakForBehandling(behandlingId).stønadBrevPdf
-                ?: throw Feil("Klarte ikke finne vedtaksbrev for behandling med id $behandlingId")
+            brevService.hentVedtaksbrevPdf(
+                vedtakService.hentAktivVedtakForBehandling(behandlingId),
+            )
 
         return Ressurs.success(vedtaksbrev)
     }

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -11,4 +11,7 @@ enum class FeatureToggle(
     // Ikke operasjonelle
     SKAL_HÅNDTERE_FALSK_IDENTITET("familie-ks-sak.skal-handtere-falsk-identitet"),
     HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE("familie-ks-sak.hent-arbeidsfordeling-med-behandlingstype"),
+
+    // NAV-29382
+    HENT_VEDTAKSBREV_FRA_JOARK("familie-ks-sak.hent-vedtaksbrev-fra-joark"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
@@ -1,9 +1,18 @@
 package no.nav.familie.ks.sak.kjerne.brev
 
+import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.NavIdent
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
+import no.nav.familie.kontrakter.felles.journalpost.Bruker
+import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
+import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
+import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
+import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.ks.sak.api.dto.ManuellAdresseInfo
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
+import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
@@ -19,6 +28,7 @@ import no.nav.familie.ks.sak.kjerne.behandling.SettBehandlingPåVentService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.steg.vedtak.domene.Vedtak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.AnnenVurderingType
 import no.nav.familie.ks.sak.kjerne.brev.domene.maler.Brevmal
@@ -289,6 +299,72 @@ class BrevService(
             .filter { !it.erHenlagt() && it.status == BehandlingStatus.AVSLUTTET }
             .maxByOrNull { it.aktivertTidspunkt }
 
+    fun hentVedtaksbrevPdf(vedtak: Vedtak): ByteArray {
+        val behandling = vedtak.behandling
+
+        val skalHenteVedtaksbrevFraJoark =
+            featureToggleService.isEnabled(FeatureToggle.HENT_VEDTAKSBREV_FRA_JOARK) &&
+                behandling.erAvsluttet() &&
+                !behandling.erHenlagt() &&
+                behandling.skalSendeVedtaksbrev(behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(behandling))
+
+        return if (skalHenteVedtaksbrevFraJoark) {
+            hentVedtaksbrevFraJoark(behandling)
+                ?: throw FunksjonellFeil(
+                    melding = "Fant ikke vedtaksbrev for behandling med id ${behandling.id} i Joark.",
+                    frontendFeilmelding = "Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.",
+                )
+        } else {
+            vedtak.stønadBrevPdf ?: throw Feil("Klarte ikke finne vedtaksbrev for behandling med id ${behandling.id}")
+        }
+    }
+
+    private fun hentVedtaksbrevFraJoark(behandling: Behandling): ByteArray? {
+        val eksternReferanseIdPrefiks = "${behandling.fagsak.id}_${behandling.id}_"
+
+        val journalposterForVedtaksbrev =
+            integrasjonKlient
+                .hentJournalposterForBruker(
+                    JournalposterForBrukerRequest(
+                        brukerId =
+                            Bruker(
+                                id = behandling.fagsak.aktør.aktivFødselsnummer(),
+                                type = BrukerIdType.FNR,
+                            ),
+                        antall = 1000,
+                        tema = listOf(Tema.KON),
+                        journalposttype = listOf(Journalposttype.U),
+                    ),
+                ).filter { it.eksternReferanseId?.startsWith(eksternReferanseIdPrefiks) == true }
+                .filter { it.journalstatus == Journalstatus.FERDIGSTILT || it.journalstatus == Journalstatus.EKSPEDERT }
+                .filter { it.hoveddokumentErVedtaksbrev() }
+
+        if (journalposterForVedtaksbrev.isEmpty()) {
+            logger.warn("Fant ingen journalpost med vedtaksbrev i Joark for behandling ${behandling.id}")
+            return null
+        }
+
+        if (journalposterForVedtaksbrev.size > 1) {
+            logger.info(
+                "Fant flere journalposter med vedtaksbrev i Joark for behandling ${behandling.id}: " +
+                    "${journalposterForVedtaksbrev.map { it.journalpostId }}. Brevet er likt for alle mottakere, bruker den første.",
+            )
+        }
+
+        val journalpost = journalposterForVedtaksbrev.first()
+        val hoveddokument = checkNotNull(journalpost.hentHoveddokument())
+
+        return integrasjonKlient.hentDokumentIJournalpost(dokumentId = hoveddokument.dokumentInfoId, journalpostId = journalpost.journalpostId)
+    }
+
+    // Hoveddokumentet er det eneste dokumentet i journalposten med brevkode, vedlegg journalføres uten
+    private fun Journalpost.hentHoveddokument(): DokumentInfo? = dokumenter?.firstOrNull { it.brevkode != null }
+
+    private fun Journalpost.hoveddokumentErVedtaksbrev(): Boolean {
+        val brevkode = hentHoveddokument()?.brevkode ?: return false
+        return brevkode in BREVKODER_FOR_VEDTAKSBREV
+    }
+
     private fun validerManuelleBrevmottakere(
         behandlingId: Long?,
         fagsak: Fagsak,
@@ -306,5 +382,17 @@ class BrevService(
                 ekstraBarnLagtTilIBrev = manueltBrevDto.barnIBrev,
             )
         }
+    }
+
+    companion object {
+        // Brevkodene vedtaksbrev journalføres med i familie-integrasjoner
+        private val BREVKODER_FOR_VEDTAKSBREV =
+            setOf(
+                "vedtak-om-kontantstøtte",
+                "vedtak-om-innvilgelse-kontantstøtte",
+                "vedtak-om-endret-kontantstøtte",
+                "vedtak-om-avslag-kontantstøtte",
+                "opphor",
+            )
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
@@ -7,12 +7,17 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
+import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
+import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
+import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.ks.sak.api.dto.Bruker
 import no.nav.familie.ks.sak.api.dto.FullmektigEllerVerge
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle.HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle.HENT_VEDTAKSBREV_FRA_JOARK
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
 import no.nav.familie.ks.sak.data.lagBehandling
@@ -20,6 +25,7 @@ import no.nav.familie.ks.sak.data.lagBrevmottakerDto
 import no.nav.familie.ks.sak.data.lagFagsak
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.data.lagVilkårsvurderingMedSøkersVilkår
 import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
@@ -32,6 +38,8 @@ import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.SettBehandlingPåVentService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingKategori
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingRepository
+import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingStatus
+import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandlingsresultat
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.domene.Resultat
@@ -451,5 +459,220 @@ class BrevServiceTest {
                 )
             }
         }
+    }
+
+    @Nested
+    inner class HentVedtaksbrevPdf {
+        @Test
+        fun `skal hente vedtaksbrev fra Joark når toggle er på og behandlingen er avsluttet`() {
+            // Arrange
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+            every { behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(any()) } returns false
+
+            val vedtak =
+                lagVedtak(
+                    behandling = lagBehandling(fagsak, status = BehandlingStatus.AVSLUTTET),
+                    stønadBrevPdF = byteArrayOf(9),
+                )
+            val fagsakId = vedtak.behandling.fagsak.id
+            val behandlingId = vedtak.behandling.id
+            val pdfFraJoark = byteArrayOf(1, 2, 3)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId1",
+                        dokumentInfoId = "10",
+                        tittel = "Innhente opplysninger",
+                        brevkode = "innhente-opplysninger",
+                    ),
+                    lagUtgåendeJournalpost(
+                        journalpostId = "4",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId3",
+                        dokumentInfoId = "40",
+                    ),
+                    lagUtgåendeJournalpost(
+                        journalpostId = "5",
+                        eksternReferanseId = "${fagsakId}_${behandlingId + 1}_callId4",
+                        dokumentInfoId = "50",
+                    ),
+                )
+            every { integrasjonKlient.hentDokumentIJournalpost(dokumentId = "40", journalpostId = "4") } returns pdfFraJoark
+
+            // Act
+            val vedtaksbrevPdf = brevService.hentVedtaksbrevPdf(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf).isEqualTo(pdfFraJoark)
+        }
+
+        @Test
+        fun `skal ikke bruke journalpost der hoveddokumentet ikke er et vedtaksbrev selv om tittelen inneholder vedtak`() {
+            // Arrange
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+            every { behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(any()) } returns false
+
+            val vedtak = lagVedtak(behandling = lagBehandling(fagsak, status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${vedtak.behandling.fagsak.id}_${vedtak.behandling.id}_callId",
+                        dokumentInfoId = "10",
+                        tittel = "Vedtak om tilbakekreving ved motregning",
+                        brevkode = "Vedtak om tilbakekreving ved motregning",
+                    ),
+                )
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    brevService.hentVedtaksbrevPdf(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
+        }
+
+        @Test
+        fun `skal bruke første journalpost når vedtaksbrevet er journalført for flere mottakere`() {
+            // Arrange
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+            every { behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(any()) } returns false
+
+            val vedtak = lagVedtak(behandling = lagBehandling(fagsak, status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
+            val fagsakId = vedtak.behandling.fagsak.id
+            val behandlingId = vedtak.behandling.id
+            val pdfFraJoark = byteArrayOf(1, 2, 3)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_callId1",
+                        dokumentInfoId = "10",
+                    ),
+                    lagUtgåendeJournalpost(
+                        journalpostId = "2",
+                        eksternReferanseId = "${fagsakId}_${behandlingId}_tilleggsmottaker_callId1",
+                        dokumentInfoId = "20",
+                    ),
+                )
+            every { integrasjonKlient.hentDokumentIJournalpost(dokumentId = "10", journalpostId = "1") } returns pdfFraJoark
+
+            // Act
+            val vedtaksbrevPdf = brevService.hentVedtaksbrevPdf(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf).isEqualTo(pdfFraJoark)
+        }
+
+        @Test
+        fun `skal hente vedtaksbrev med brevkode for opphør fra Joark`() {
+            // Arrange
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+            every { behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(any()) } returns false
+
+            val vedtak = lagVedtak(behandling = lagBehandling(fagsak, status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = null)
+            val pdfFraJoark = byteArrayOf(1, 2, 3)
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns
+                listOf(
+                    lagUtgåendeJournalpost(
+                        journalpostId = "1",
+                        eksternReferanseId = "${vedtak.behandling.fagsak.id}_${vedtak.behandling.id}_callId",
+                        dokumentInfoId = "10",
+                        tittel = "Vedtak om opphørt kontantstøtte",
+                        brevkode = "opphor",
+                    ),
+                )
+            every { integrasjonKlient.hentDokumentIJournalpost(dokumentId = "10", journalpostId = "1") } returns pdfFraJoark
+
+            // Act
+            val vedtaksbrevPdf = brevService.hentVedtaksbrevPdf(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf).isEqualTo(pdfFraJoark)
+        }
+
+        @Test
+        fun `skal hente vedtaksbrev fra databasen når toggle er på og behandlingen er henlagt`() {
+            // Arrange
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val pdfFraDatabasen = byteArrayOf(9)
+            val vedtak =
+                lagVedtak(
+                    behandling =
+                        lagBehandling(
+                            fagsak,
+                            status = BehandlingStatus.AVSLUTTET,
+                            resultat = Behandlingsresultat.HENLAGT_SØKNAD_TRUKKET,
+                        ),
+                    stønadBrevPdF = pdfFraDatabasen,
+                )
+
+            // Act
+            val vedtaksbrevPdf = brevService.hentVedtaksbrevPdf(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf).isEqualTo(pdfFraDatabasen)
+            verify(exactly = 0) { integrasjonKlient.hentJournalposterForBruker(any()) }
+        }
+
+        @Test
+        fun `skal hente vedtaksbrev fra databasen når toggle er på og behandlingen ikke er avsluttet`() {
+            // Arrange
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+
+            val pdfFraDatabasen = byteArrayOf(9)
+            val vedtak = lagVedtak(behandling = lagBehandling(fagsak, status = BehandlingStatus.UTREDES), stønadBrevPdF = pdfFraDatabasen)
+
+            // Act
+            val vedtaksbrevPdf = brevService.hentVedtaksbrevPdf(vedtak)
+
+            // Assert
+            assertThat(vedtaksbrevPdf).isEqualTo(pdfFraDatabasen)
+            verify(exactly = 0) { integrasjonKlient.hentJournalposterForBruker(any()) }
+        }
+
+        @Test
+        fun `skal kaste funksjonell feil når toggle er på og vedtaksbrevet ikke finnes i Joark`() {
+            // Arrange
+            every { featureToggleService.isEnabled(HENT_VEDTAKSBREV_FRA_JOARK) } returns true
+            every { behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(any()) } returns false
+
+            val vedtak = lagVedtak(behandling = lagBehandling(fagsak, status = BehandlingStatus.AVSLUTTET), stønadBrevPdF = byteArrayOf(9))
+
+            every { integrasjonKlient.hentJournalposterForBruker(any()) } returns emptyList()
+
+            // Act && Assert
+            val feilmelding =
+                assertThrows<FunksjonellFeil> {
+                    brevService.hentVedtaksbrevPdf(vedtak)
+                }.frontendFeilmelding
+
+            assertThat(feilmelding).isEqualTo("Fant ikke vedtaksbrevet i arkivet. Du kan finne brevet i dokumentoversikten.")
+        }
+
+        private fun lagUtgåendeJournalpost(
+            journalpostId: String,
+            eksternReferanseId: String,
+            dokumentInfoId: String,
+            journalstatus: Journalstatus = Journalstatus.FERDIGSTILT,
+            tittel: String? = "Vedtak om kontantstøtte",
+            brevkode: String? = "vedtak-om-kontantstøtte",
+        ) = Journalpost(
+            journalpostId = journalpostId,
+            journalposttype = Journalposttype.U,
+            journalstatus = journalstatus,
+            eksternReferanseId = eksternReferanseId,
+            dokumenter =
+                listOf(
+                    DokumentInfo(dokumentInfoId = dokumentInfoId, tittel = tittel, brevkode = brevkode),
+                    DokumentInfo(dokumentInfoId = "vedlegg-$dokumentInfoId", tittel = "Stønadsmottakerens rettigheter og plikter", brevkode = null),
+                ),
+        )
     }
 }


### PR DESCRIPTION
### 📮 Favro: Nav-29935

### 💰 Hva skal gjøres, og hvorfor?
Vi gjør det samme som vi gjorde for BA: https://github.com/navikt/familie-ba-sak/pull/6368

Vedtaksbrev lagres i dag for evig i databasen (`vedtak.stonad_brev_pdf`), selv om de også arkiveres i Joark. For å kunne rydde opp i de lagrede brevene må visning av vedtaksbrev for avsluttede behandlinger hente brevet fra Joark i stedet for fra databasen.

Bak ny feature toggle `familie-ba-sak.hent-vedtaksbrev-fra-joark`:
- `GET /api/dokument/vedtaksbrev/{vedtakId}` henter brevet fra Joark når behandlingen er avsluttet og har vedtaksbrevutsending. Journalposten finnes via saf (`hentJournalposterForBruker`) ved å matche `eksternReferanseId`-prefikset `{fagsakId}_{behandlingId}_`, filtrert på ferdigstilte/ekspederte utgående journalposter der hoveddokumentets tittel inneholder "vedtak". Selve PDF-en hentes via det tilgangsstyrte hentdokument-endepunktet i familie-integrasjoner.
- Finnes ikke brevet i Joark, kastes en funksjonell feil som ber saksbehandler finne brevet i dokumentoversikten (vises som warning i frontend, se tilhørende PR i familie-ba-sak-frontend).
- Behandlinger som ikke er avsluttet, behandlinger uten vedtaksbrevutsending og toggle av gir uendret oppførsel (leser fra databasen som før).
