### PR TITLE
Fiks kopiering av EndretUtbetalingAndel og OvergangsordningAndel til å referere riktig persongrunnlag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelService.kt
@@ -23,7 +23,10 @@ import no.nav.familie.ks.sak.kjerne.endretutbetaling.EndretUtbetalingAndelValida
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndel
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.EndretUtbetalingAndelRepository
 import no.nav.familie.ks.sak.kjerne.endretutbetaling.domene.fraEndretUtbetalingAndelRequestDto
+import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -37,6 +40,8 @@ class EndretUtbetalingAndelService(
     private val endretUtbetalingAndelOppdatertAbonnementer: List<EndretUtbetalingAndelerOppdatertAbonnent> = emptyList(),
     private val sanityService: SanityService,
 ) {
+    private val logger = LoggerFactory.getLogger(EndretUtbetalingAndelService::class.java)
+
     fun hentEndredeUtbetalingAndeler(behandlingId: Long) = endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(behandlingId)
 
     @Transactional
@@ -130,16 +135,50 @@ class EndretUtbetalingAndelService(
     fun kopierEndretUtbetalingAndelFraForrigeBehandling(
         behandling: Behandling,
         forrigeBehandling: Behandling,
-    ) = hentEndredeUtbetalingAndeler(forrigeBehandling.id).forEach {
-        val kopiertOverEndretUtbetalingAndel =
-            it.copy(
+    ) {
+        val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
+        val personPerAktør = personopplysningGrunnlag.personer.associateBy { it.aktør }
+
+        hentEndredeUtbetalingAndeler(forrigeBehandling.id).forEach { forrigeEndretUtbetalingAndel ->
+            kopierEndretUtbetalingAndel(forrigeEndretUtbetalingAndel, behandling, forrigeBehandling, personPerAktør)
+        }
+    }
+
+    private fun kopierEndretUtbetalingAndel(
+        forrigeEndretUtbetalingAndel: EndretUtbetalingAndel,
+        behandling: Behandling,
+        forrigeBehandling: Behandling,
+        personPerAktør: Map<Aktør, Person>,
+    ) {
+        val nyePersoner = forrigeEndretUtbetalingAndel.personer.mapNotNull { personPerAktør[it.aktør] }
+        val droppedeAktørIder = forrigeEndretUtbetalingAndel.personer.map { it.aktør }.filterNot { it in personPerAktør }
+
+        if (droppedeAktørIder.isNotEmpty()) {
+            logger.warn(
+                "Dropper person(er) med aktørId ${droppedeAktørIder.joinToString(", ") { it.aktørId }} fra EndretUtbetalingAndel " +
+                    "${forrigeEndretUtbetalingAndel.id} ved kopiering fra behandling ${forrigeBehandling.id} " +
+                    "til behandling ${behandling.id}: finnes ikke i det nye persongrunnlaget",
+            )
+        }
+
+        if (nyePersoner.isEmpty()) {
+            logger.warn(
+                "Dropper EndretUtbetalingAndel ${forrigeEndretUtbetalingAndel.id} ved " +
+                    "kopiering fra behandling ${forrigeBehandling.id} til behandling " +
+                    "${behandling.id}: ingen av personene finnes i det nye persongrunnlaget",
+            )
+            return
+        }
+
+        endretUtbetalingAndelRepository.save(
+            forrigeEndretUtbetalingAndel.copy(
                 id = 0,
                 behandlingId = behandling.id,
                 erEksplisittAvslagPåSøknad = false,
                 vedtaksbegrunnelser = emptyList(),
-                personer = it.personer.toMutableSet(),
-            )
-        endretUtbetalingAndelRepository.save(kopiertOverEndretUtbetalingAndel)
+                personer = nyePersoner.toMutableSet(),
+            ),
+        )
     }
 
     private fun sanityBegrunnelseTilRestFormat(

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelService.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.Person
 import no.nav.familie.tidslinje.tilTidslinje
 import no.nav.familie.tidslinje.utvidelser.slåSammenLikePerioder
 import no.nav.familie.tidslinje.utvidelser.tilPerioderIkkeNull
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -32,6 +33,8 @@ class OvergangsordningAndelService(
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val overgangsordningAndelOppdatertAbonnementer: List<OvergangsordningAndelerOppdatertAbonnent> = emptyList(),
 ) {
+    private val logger = LoggerFactory.getLogger(OvergangsordningAndelService::class.java)
+
     fun hentOvergangsordningAndeler(behandlingId: Long) = overgangsordningAndelRepository.hentOvergangsordningAndelerForBehandling(behandlingId)
 
     fun hentUtfylteOvergangsordningAndeler(behandlingId: Long) = hentOvergangsordningAndeler(behandlingId).utfyltePerioder()
@@ -136,8 +139,26 @@ class OvergangsordningAndelService(
     fun kopierOvergangsordningAndelFraForrigeBehandling(
         behandling: Behandling,
         forrigeBehandling: Behandling,
-    ) = hentOvergangsordningAndeler(forrigeBehandling.id).map {
-        overgangsordningAndelRepository.save(it.copy(id = 0, behandlingId = behandling.id))
+    ): List<OvergangsordningAndel> {
+        val personopplysningGrunnlag = personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id)
+        val personPerAktør = personopplysningGrunnlag.personer.associateBy { it.aktør }
+
+        return hentOvergangsordningAndeler(forrigeBehandling.id).mapNotNull { forrige ->
+            val forrigeAktør = forrige.person?.aktør
+            val nyPerson = forrigeAktør?.let { personPerAktør[it] }
+
+            if (forrigeAktør != null && nyPerson == null) {
+                logger.warn(
+                    "Dropper OvergangsordningAndel ${forrige.id} ved kopiering fra behandling ${forrigeBehandling.id} " +
+                        "til behandling ${behandling.id}: person med aktørId $forrigeAktør finnes ikke i det nye persongrunnlaget",
+                )
+                return@mapNotNull null
+            }
+
+            overgangsordningAndelRepository.save(
+                forrige.copy(id = 0, behandlingId = behandling.id, person = nyPerson),
+            )
+        }
     }
 
     private fun finnOvergangsordningAndel(overgangsordningAndelId: Long) =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/endretutbetaling/EndretUtbetalingAndelServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagEndretUtbetalingAndel
 import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagTestPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.integrasjon.sanity.SanityService
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelse
 import no.nav.familie.ks.sak.integrasjon.sanity.domene.SanityBegrunnelseType
@@ -32,6 +33,7 @@ import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -58,56 +60,155 @@ class EndretUtbetalingAndelServiceTest {
             sanityService = sanityService,
         )
 
-    @Test
-    fun `kopierEndretUtbetalingAndelFraForrigeBehandling - skal kopiere over endrete utbetaling i forrige behandling og lagre disse på ny`() {
-        val gammelBehandling = lagBehandling()
-        val nyBehandling = lagBehandling()
+    @Nested
+    inner class KopierEndretUtbetalingAndelFraForrigeBehandling {
+        @Test
+        fun `skal kopiere over endrete utbetaling i forrige behandling og lagre disse på ny`() {
+            val gammelBehandling = lagBehandling()
+            val nyBehandling = lagBehandling()
 
-        every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) } returns
-            listOf(
-                mockk(relaxed = true),
-                mockk(relaxed = true),
-                mockk(relaxed = true),
-            )
-        every { endretUtbetalingAndelRepository.save(any()) } returns mockk()
+            val aktør1 = randomAktør()
+            val aktør2 = randomAktør()
+            val aktør3 = randomAktør()
 
-        endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
+            val personopplysningGrunnlag =
+                lagTestPersonopplysningGrunnlag(
+                    nyBehandling.id,
+                    lagPerson(aktør = aktør1, personType = PersonType.BARN),
+                    lagPerson(aktør = aktør2, personType = PersonType.BARN),
+                    lagPerson(aktør = aktør3, personType = PersonType.BARN),
+                )
 
-        verify(exactly = 1) { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) }
-        verify(exactly = 3) { endretUtbetalingAndelRepository.save(any()) }
-    }
+            every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns personopplysningGrunnlag
+            every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) } returns
+                listOf(
+                    lagEndretUtbetalingAndel(personer = setOf(lagPerson(aktør = aktør1, personType = PersonType.BARN))),
+                    lagEndretUtbetalingAndel(personer = setOf(lagPerson(aktør = aktør2, personType = PersonType.BARN))),
+                    lagEndretUtbetalingAndel(personer = setOf(lagPerson(aktør = aktør3, personType = PersonType.BARN))),
+                )
+            every { endretUtbetalingAndelRepository.save(any()) } returns mockk()
 
-    @Test
-    fun `kopierEndretUtbetalingAndelFraForrigeBehandling - skal sette avslag til false og tømme begrunnelser ved kopiering av endret utbetaling andel`() {
-        // Arrange
-        val gammelBehandling = lagBehandling()
-        val nyBehandling = lagBehandling()
-        val endretUtbetalingAndel =
-            lagEndretUtbetalingAndel(
-                årsak = Årsak.ETTERBETALING_3MND,
-                begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.AVSLAG_SØKT_FOR_SENT_ENDRINGSPERIODE),
-                erEksplisittAvslagPåSøknad = true,
-            )
-        val lagretEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
 
-        every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) } returns
-            listOf(
-                endretUtbetalingAndel,
-            )
-        every { endretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) } returnsArgument 0
+            verify(exactly = 1) { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) }
+            verify(exactly = 3) { endretUtbetalingAndelRepository.save(any()) }
+        }
 
-        // Act
-        endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
+        @Test
+        fun `skal sette avslag til false og tømme begrunnelser ved kopiering av endret utbetaling andel`() {
+            // Arrange
+            val gammelBehandling = lagBehandling()
+            val nyBehandling = lagBehandling()
+            val aktør = randomAktør()
+            val personopplysningGrunnlag =
+                lagTestPersonopplysningGrunnlag(nyBehandling.id, lagPerson(aktør = aktør, personType = PersonType.BARN))
+            val endretUtbetalingAndel =
+                lagEndretUtbetalingAndel(
+                    personer = setOf(lagPerson(aktør = aktør, personType = PersonType.BARN)),
+                    årsak = Årsak.ETTERBETALING_3MND,
+                    begrunnelser = listOf(NasjonalEllerFellesBegrunnelse.AVSLAG_SØKT_FOR_SENT_ENDRINGSPERIODE),
+                    erEksplisittAvslagPåSøknad = true,
+                )
+            val lagretEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
 
-        // Assert
-        verify(exactly = 1) { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) }
-        verify(exactly = 1) { endretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) }
+            every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns personopplysningGrunnlag
+            every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) } returns
+                listOf(
+                    endretUtbetalingAndel,
+                )
+            every { endretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) } returnsArgument 0
 
-        val lagretEndretUtbetalingAndel = lagretEndretUtbetalingAndelSlot.captured
+            // Act
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
 
-        assertThat(lagretEndretUtbetalingAndel.vedtaksbegrunnelser, Is(emptyList()))
-        assertThat(lagretEndretUtbetalingAndel.erEksplisittAvslagPåSøknad, Is(false))
-        assertThat(lagretEndretUtbetalingAndel.årsak, Is(Årsak.ETTERBETALING_3MND))
+            // Assert
+            verify(exactly = 1) { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) }
+            verify(exactly = 1) { endretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) }
+
+            val lagretEndretUtbetalingAndel = lagretEndretUtbetalingAndelSlot.captured
+
+            assertThat(lagretEndretUtbetalingAndel.vedtaksbegrunnelser, Is(emptyList()))
+            assertThat(lagretEndretUtbetalingAndel.erEksplisittAvslagPåSøknad, Is(false))
+            assertThat(lagretEndretUtbetalingAndel.årsak, Is(Årsak.ETTERBETALING_3MND))
+        }
+
+        @Test
+        fun `skal bruke personer fra inneværende behandling ved kopiering`() {
+            // Arrange
+            val gammelBehandling = lagBehandling()
+            val nyBehandling = lagBehandling()
+            val aktør = randomAktør()
+
+            val gammelPerson = lagPerson(aktør = aktør, personType = PersonType.BARN).copy(id = 1L)
+            val nyPerson = lagPerson(aktør = aktør, personType = PersonType.BARN).copy(id = 2L)
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(nyBehandling.id, nyPerson)
+
+            val endretUtbetalingAndel = lagEndretUtbetalingAndel(personer = setOf(gammelPerson))
+            val lagretEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
+
+            every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns personopplysningGrunnlag
+            every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) } returns listOf(endretUtbetalingAndel)
+            every { endretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) } returnsArgument 0
+
+            // Act
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
+
+            // Assert
+            val lagretPersoner = lagretEndretUtbetalingAndelSlot.captured.personer
+            assertThat(lagretPersoner.map { it.id }, Is(listOf(2L)))
+        }
+
+        @Test
+        fun `skal filtrere bort personer som ikke finnes i inneværende behandling`() {
+            // Arrange
+            val gammelBehandling = lagBehandling()
+            val nyBehandling = lagBehandling()
+
+            val aktørSomBlirMed = randomAktør()
+            val aktørSomFallerUt = randomAktør()
+
+            val gammelPersonSomBlirMed = lagPerson(aktør = aktørSomBlirMed, personType = PersonType.BARN).copy(id = 1L)
+            val gammelPersonSomFallerUt = lagPerson(aktør = aktørSomFallerUt, personType = PersonType.BARN).copy(id = 2L)
+            val nyPersonSomBlirMed = lagPerson(aktør = aktørSomBlirMed, personType = PersonType.BARN).copy(id = 3L)
+            // Nytt grunnlag inneholder ikke aktørSomFallerUt, f.eks. fordi barnet har falt ut av saken.
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(nyBehandling.id, nyPersonSomBlirMed)
+
+            val endretUtbetalingAndel = lagEndretUtbetalingAndel(personer = setOf(gammelPersonSomBlirMed, gammelPersonSomFallerUt))
+            val lagretEndretUtbetalingAndelSlot = slot<EndretUtbetalingAndel>()
+
+            every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns personopplysningGrunnlag
+            every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) } returns listOf(endretUtbetalingAndel)
+            every { endretUtbetalingAndelRepository.save(capture(lagretEndretUtbetalingAndelSlot)) } returnsArgument 0
+
+            // Act
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
+
+            // Assert
+            val lagretPersoner = lagretEndretUtbetalingAndelSlot.captured.personer
+            assertThat(lagretPersoner.map { it.id }, Is(listOf(3L)))
+        }
+
+        @Test
+        fun `skal ikke kopiere EndretUtbetalingAndel hvis ingen av personene finnes i inneværende behandling`() {
+            // Arrange
+            val gammelBehandling = lagBehandling()
+            val nyBehandling = lagBehandling()
+
+            val gammelPerson = lagPerson(personType = PersonType.BARN).copy(id = 1L)
+            // Nytt grunnlag inneholder en helt annen aktør enn den som var med i forrige EndretUtbetalingAndel.
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(nyBehandling.id, lagPerson(personType = PersonType.BARN).copy(id = 2L))
+
+            val endretUtbetalingAndel = lagEndretUtbetalingAndel(personer = setOf(gammelPerson))
+
+            every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns personopplysningGrunnlag
+            every { endretUtbetalingAndelRepository.hentEndretUtbetalingerForBehandling(gammelBehandling.id) } returns listOf(endretUtbetalingAndel)
+
+            // Act
+            endretUtbetalingAndelService.kopierEndretUtbetalingAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
+
+            // Assert
+            verify(exactly = 0) { endretUtbetalingAndelRepository.save(any()) }
+        }
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelServiceTest.kt
@@ -9,8 +9,11 @@ import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.util.tilKortString
 import no.nav.familie.ks.sak.common.util.toYearMonth
 import no.nav.familie.ks.sak.data.lagBehandling
+import no.nav.familie.ks.sak.data.lagPerson
 import no.nav.familie.ks.sak.data.lagPersonopplysningGrunnlag
+import no.nav.familie.ks.sak.data.lagTestPersonopplysningGrunnlag
 import no.nav.familie.ks.sak.data.lagVilkårsvurderingOppfylt
+import no.nav.familie.ks.sak.data.randomAktør
 import no.nav.familie.ks.sak.data.randomFnr
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
 import no.nav.familie.ks.sak.kjerne.behandling.steg.vilkårsvurdering.VilkårsvurderingService
@@ -21,6 +24,7 @@ import no.nav.familie.ks.sak.kjerne.beregning.BeregningService
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndel
 import no.nav.familie.ks.sak.kjerne.overgangsordning.domene.OvergangsordningAndelRepository
 import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.PersonopplysningGrunnlagService
+import no.nav.familie.ks.sak.kjerne.personopplysninggrunnlag.domene.PersonType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -307,6 +311,8 @@ class OvergangsordningAndelServiceTest {
         val gammelBehandling = lagBehandling()
         val nyBehandling = lagBehandling()
 
+        every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns
+            lagPersonopplysningGrunnlag(behandlingId = nyBehandling.id)
         every { overgangsordningAndelRepository.hentOvergangsordningAndelerForBehandling(gammelBehandling.id) } returns
             listOf(
                 OvergangsordningAndel(id = 0, behandlingId = gammelBehandling.id),
@@ -327,5 +333,49 @@ class OvergangsordningAndelServiceTest {
 
         verify(exactly = 1) { overgangsordningAndelRepository.hentOvergangsordningAndelerForBehandling(gammelBehandling.id) }
         verify(exactly = 3) { overgangsordningAndelRepository.save(any()) }
+    }
+
+    @Nested
+    inner class KopierOvergangsordningAndelFraForrigeBehandling {
+        @Test
+        fun `skal bruke personer fra inneværende behandling ved kopiering`() {
+            val gammelBehandling = lagBehandling()
+            val nyBehandling = lagBehandling()
+            val aktør = randomAktør()
+
+            val gammelPerson = lagPerson(aktør = aktør, personType = PersonType.BARN).copy(id = 1L)
+            val nyPerson = lagPerson(aktør = aktør, personType = PersonType.BARN).copy(id = 2L)
+            val personopplysningGrunnlag = lagTestPersonopplysningGrunnlag(nyBehandling.id, nyPerson)
+
+            every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns personopplysningGrunnlag
+            every { overgangsordningAndelRepository.hentOvergangsordningAndelerForBehandling(gammelBehandling.id) } returns
+                listOf(OvergangsordningAndel(id = 0, behandlingId = gammelBehandling.id, person = gammelPerson))
+            every { overgangsordningAndelRepository.save(any()) } returnsArgument 0
+
+            val nyeOvergangsordningAndeler = overgangsordningAndelService.kopierOvergangsordningAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
+
+            assertThat(nyeOvergangsordningAndeler).hasSize(1)
+            assertThat(nyeOvergangsordningAndeler.single().person?.id).isEqualTo(2L)
+        }
+
+        @Test
+        fun `skal ikke kopiere andel hvis personen ikke finnes i inneværende behandling`() {
+            val gammelBehandling = lagBehandling()
+            val nyBehandling = lagBehandling()
+
+            val gammelPerson = lagPerson(personType = PersonType.BARN).copy(id = 1L)
+            // Nytt grunnlag inneholder en helt annen aktør enn den som var på forrige overgangsordningandel.
+            val personopplysningGrunnlag =
+                lagTestPersonopplysningGrunnlag(nyBehandling.id, lagPerson(personType = PersonType.BARN).copy(id = 2L))
+
+            every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(nyBehandling.id) } returns personopplysningGrunnlag
+            every { overgangsordningAndelRepository.hentOvergangsordningAndelerForBehandling(gammelBehandling.id) } returns
+                listOf(OvergangsordningAndel(id = 0, behandlingId = gammelBehandling.id, person = gammelPerson))
+
+            val nyeOvergangsordningAndeler = overgangsordningAndelService.kopierOvergangsordningAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
+
+            assertThat(nyeOvergangsordningAndeler).isEmpty()
+            verify(exactly = 0) { overgangsordningAndelRepository.save(any()) }
+        }
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29959

### 💰 Hva skal gjøres, og hvorfor?
`kopierEndretUtbetalingAndelFraForrigeBehandling` og `kopierOvergangsordningAndelFraForrigeBehandling` kopierte tidligere person-referansen direkte fra forrige behandling, slik at den nye behandlingens data pekte på Person-rader eid av forrige behandling sitt persongrunnlag i stedet for sitt eget.

Personer hentes nå fra den nye behandlingens eget persongrunnlag. Dersom en aktør ikke lenger finnes i det nye grunnlaget (f.eks. barn falt ut av saken), droppes personen/andelen med en logget advarsel.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.
