### PR TITLE
Støtte for egendefinert begrunnelse i forvalter-endepunkt for henleggelse av behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -403,6 +403,7 @@ class ForvaltningController(
     @PostMapping("/henlegg-behandling/{behandlingId}")
     fun henleggBehandling(
         @PathVariable behandlingId: Long,
+        @RequestBody begrunnelse: String = "Henlegger behandling via forvalterendepunkt.",
     ): ResponseEntity<Ressurs<String>> {
         tilgangService.validerTilgangTilHandling(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
@@ -413,7 +414,7 @@ class ForvaltningController(
             HenleggBehandlingTask.opprettTask(
                 behandlingId = behandlingId,
                 henleggÅrsak = HenleggÅrsak.TEKNISK_VEDLIKEHOLD,
-                begrunnelse = "Henlegger behandling via forvalterendepunkt. Behandling har gått i lås pga midlertidig teknisk feil i produksjon.",
+                begrunnelse = begrunnelse,
             ),
         )
 


### PR DESCRIPTION
Vi har et forvalterendepunkt for henleggelse av behandlinger som av ulike grunner er låst eller ikke lar seg henlegge av saksbehandler. Legger her til muligheten for å kunne legge inn en egendefinert begrunnelse ved en slik teknisk henleggelse.
