### PR TITLE
arrange act assert på alle tester

### DIFF
--- a/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
+++ b/src/test/common/no/nav/familie/ks/sak/kjerne/eøs/vilkårsvurdering/VilkårsvurderingTidslinjeServiceTest.kt
@@ -47,6 +47,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
 
     @Test
     fun `skal forskyve fom med 1 mnd for periode med erAnnenForelderOmfattetAvNorskLovgivning`() {
+        // Arrange
         val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
         val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør())
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -91,6 +92,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
 
     @Test
     fun `skal ikke gi overlapp feil dersom tom i forrige periode og fom i neste periode er i samme måned`() {
+        // Arrange
         val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
         val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør())
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -159,6 +161,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
 
     @Test
     fun `skal ikke gi noen oppfylte perioder hvis vilkår kun oppfylt innenfor én måned`() {
+        // Arrange
         val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
         val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør())
         val fagsak = Fagsak(aktør = søker.aktør)
@@ -194,6 +197,7 @@ internal class VilkårsvurderingTidslinjeServiceTest {
 
     @Test
     fun `skal gi false i perioder som er gyldige men som ikke har utdypende vilkårsvurdering ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING`() {
+        // Arrange
         val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
         val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør())
         val fagsak = Fagsak(aktør = søker.aktør)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/bisys/BisysServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/bisys/BisysServiceTest.kt
@@ -90,6 +90,7 @@ internal class BisysServiceTest {
 
     @Test
     fun `hentUtbetalingsinfo skal hente utbetalingsinfo fra både ks-sak og infotrygd`() {
+        // Arrange
         every {
             infotrygdReplikaKlient.hentKontantstøttePerioderFraInfotrygd(barnIdenter)
         } returns
@@ -113,7 +114,10 @@ internal class BisysServiceTest {
                     ),
             )
 
+        // Act
         val utbetalinger = bisysService.hentUtbetalingsinfo(LocalDate.now().minusMonths(32), barnIdenter)
+
+        // Assert
         assertTrue { utbetalinger.infotrygdPerioder.isNotEmpty() }
         assertTrue { utbetalinger.infotrygdPerioder.size == 2 }
 
@@ -146,11 +150,15 @@ internal class BisysServiceTest {
 
     @Test
     fun `hentUtbetalingsinfo skal hente utbetalingsinfo kun fra ks-sak`() {
+        // Arrange
         every {
             infotrygdReplikaKlient.hentKontantstøttePerioderFraInfotrygd(barnIdenter)
         } returns InnsynResponse(data = emptyList())
 
+        // Act
         val utbetalinger = bisysService.hentUtbetalingsinfo(LocalDate.now().minusMonths(32), barnIdenter)
+
+        // Assert
         assertTrue { utbetalinger.infotrygdPerioder.isNullOrEmpty() }
         assertTrue { utbetalinger.ksSakPerioder.size == 2 }
 
@@ -170,6 +178,7 @@ internal class BisysServiceTest {
 
     @Test
     fun `hentUtbetalingsinfo skal hente utbetalingsinfo fra både ks-sak og infotrygd og filtrere på fomdato`() {
+        // Arrange
         every {
             infotrygdReplikaKlient.hentKontantstøttePerioderFraInfotrygd(barnIdenter)
         } returns
@@ -193,7 +202,10 @@ internal class BisysServiceTest {
                     ),
             )
 
+        // Act
         val utbetalinger = bisysService.hentUtbetalingsinfo(LocalDate.now().minusMonths(4), barnIdenter)
+
+        // Assert
         assertTrue { utbetalinger.infotrygdPerioder.isNotEmpty() }
         assertTrue { utbetalinger.infotrygdPerioder.size == 1 }
 
@@ -221,12 +233,16 @@ internal class BisysServiceTest {
 
     @Test
     fun `hentUtbetalingsinfo filtrerer vekk identer med bare NPID`() {
+        // Arrange
         every {
             infotrygdReplikaKlient.hentKontantstøttePerioderFraInfotrygd(barnIdenter)
         } returns InnsynResponse(data = emptyList())
         every { personidentService.hentIdenter(any(), false) } returns listOf(PdlIdent("NPID", false, Type.NPID.name))
 
+        // Act
         val utbetalinger = bisysService.hentUtbetalingsinfo(LocalDate.now().minusMonths(32), listOf("NPID"))
+
+        // Assert
         assertTrue { utbetalinger.infotrygdPerioder.isEmpty() }
         assertTrue { utbetalinger.ksSakPerioder.isEmpty() }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/EøsSkjemaTidslinjerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/tidslinje/utvidelser/EøsSkjemaTidslinjerTest.kt
@@ -14,6 +14,7 @@ import java.time.YearMonth
 internal class EøsSkjemaTidslinjerTest {
     @Test
     fun `skal håndtere to påfølgende perioder i fremtiden, men de komprimeres ikke`() {
+        // Arrange
         val barn = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
         val kompetanse1 =
             Kompetanse(
@@ -29,6 +30,8 @@ internal class EøsSkjemaTidslinjerTest {
             )
 
         val kompetanseTidslinje = listOf(kompetanse1, kompetanse2).tilTidslinje()
+
+        // Act & Assert
         assertEquals(1, kompetanseTidslinje.tilPerioder().size)
 
         val periode = kompetanseTidslinje.tilPerioder()[0]

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/util/TidKtTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/util/TidKtTest.kt
@@ -22,8 +22,10 @@ internal class TidKtTest {
 
     @Test
     fun `LocalDate tilyyyyMMdd() skal formatere dato til yyyy-MM-dd format`() {
+        // Arrange
         val localDate = LocalDate.of(2020, 12, 16)
 
+        // Act & Assert
         assertThat(localDate.tilyyyyMMdd(), Is("2020-12-16"))
     }
 
@@ -36,8 +38,10 @@ internal class TidKtTest {
 
     @Test
     fun `LocalDate tilDagMånedÅr() skal formatere dato til d MMMM yyyy format`() {
+        // Arrange
         val localDate = LocalDate.of(2020, 12, 16)
 
+        // Act & Assert
         assertThat(localDate.tilDagMånedÅr(), Is("16. desember 2020"))
     }
 
@@ -50,9 +54,11 @@ internal class TidKtTest {
 
     @Test
     fun `LocalDate tilYearMonth() skal konverte LocalDate til YearMonth`() {
+        // Arrange
         val localDate = LocalDate.of(2020, 12, 16)
         val yearMonth = localDate.tilYearMonth()
 
+        // Act & Assert
         assertThat(yearMonth, Is(YearMonth.of(2020, 12)))
     }
 
@@ -65,8 +71,10 @@ internal class TidKtTest {
 
     @Test
     fun `YearMonth tilKortString() skal formatere dato til MM yy format`() {
+        // Arrange
         val yearMonth = YearMonth.of(2020, 12)
 
+        // Act & Assert
         assertThat(yearMonth.tilKortString(), Is("12.20"))
     }
 
@@ -94,6 +102,9 @@ internal class TidKtTest {
 
     @Test
     fun `LocalDate erHelligDag skal returnere true for alle helligedager`() {
+        // Arrange
+
+        // Act & Assert
         assertTrue { LocalDate.of(2022, 1, 1).erHelligdag() }
         assertTrue { LocalDate.of(2022, 5, 1).erHelligdag() }
         assertTrue { LocalDate.of(2022, 5, 17).erHelligdag() }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/util/UtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/common/util/UtilsTest.kt
@@ -9,15 +9,25 @@ import org.junit.jupiter.api.Test
 internal class UtilsTest {
     @Test
     fun `konverterEnumsTilString - skal konvertere liste av enum verdier til semikolon-separert string`() {
+        // Arrange
         val enums: List<Vilkår> = listOf(Vilkår.MEDLEMSKAP, Vilkår.BARNEHAGEPLASS, Vilkår.BOR_MED_SØKER)
+
+        // Act
         val enumString = konverterEnumsTilString(enums)
+
+        // Assert
         assertEquals("${Vilkår.MEDLEMSKAP};${Vilkår.BARNEHAGEPLASS};${Vilkår.BOR_MED_SØKER}", enumString)
     }
 
     @Test
     fun `konverterStringTilEnums - skal konvertere semikolon-separert enumString til liste av enum verdier`() {
+        // Arrange
         val enumString = "${Vilkår.MEDLEMSKAP};${Vilkår.BARNEHAGEPLASS};${Vilkår.BOR_MED_SØKER}"
+
+        // Act
         val enums = konverterStringTilEnums<Vilkår>(enumString)
+
+        // Assert
         assertEquals(listOf(Vilkår.MEDLEMSKAP, Vilkår.BARNEHAGEPLASS, Vilkår.BOR_MED_SØKER), enums)
     }
 
@@ -28,8 +38,13 @@ internal class UtilsTest {
     inner class TilEtterfølgendePar {
         @Test
         fun `skal plukke ut to og to etterfølgende elementer inkludert det siste elementet`() {
+            // Arrange
             val liste = listOf(1, 2, 3, 4, 5)
+
+            // Act
             val par = liste.tilEtterfølgendePar { a, b -> a to b }
+
+            // Assert
             assertThat(par).hasSize(5)
             assertThat(par[0]).isEqualTo(Pair(1, 2))
             assertThat(par[1]).isEqualTo(Pair(2, 3))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/KafkaErrorHandlerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/KafkaErrorHandlerTest.kt
@@ -15,6 +15,7 @@ class KafkaErrorHandlerTest {
 
     @Test
     fun `handle skal stoppe container hvis man mottar feil med en tom liste med records`() {
+        // Arrange & Act
         val exceptionThrown =
             Assertions.assertThatThrownBy {
                 errorHandler.handleRemaining(
@@ -24,6 +25,8 @@ class KafkaErrorHandlerTest {
                     container,
                 )
             }
+
+        // Assert
         exceptionThrown.hasCauseExactlyInstanceOf(Exception::class.java)
 
         val cause = exceptionThrown.cause()
@@ -33,7 +36,10 @@ class KafkaErrorHandlerTest {
 
     @Test
     fun `handle skal stoppe container hvis man mottar feil med en liste med records`() {
+        // Arrange
         val consumerRecord = ConsumerRecord("topic", 1, 1, 1, "record")
+
+        // Act & Assert
         val exceptionThrown =
             Assertions.assertThatThrownBy {
                 errorHandler.handleRemaining(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/UnleashServiceInjectionTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/UnleashServiceInjectionTest.kt
@@ -12,12 +12,14 @@ import org.springframework.stereotype.Service
 class UnleashServiceInjectionTest {
     @Test
     fun `UnleashService skal kun være injected i FeatureToggleService`() {
+        // Arrange
         val scanner =
             ClassPathScanningCandidateComponentProvider(false).apply {
                 addIncludeFilter(AnnotationTypeFilter(Service::class.java))
                 addIncludeFilter(AnnotationTypeFilter(Component::class.java))
             }
 
+        // Act
         val classesWithUnleashServiceInjection =
             scanner
                 .findCandidateComponents("no.nav.familie.ks.sak")
@@ -38,6 +40,7 @@ class UnleashServiceInjectionTest {
                     hasConstructorInjection || hasFieldInjection
                 }.map { it.simpleName }
 
+        // Assert
         assertThat(classesWithUnleashServiceInjection)
             .describedAs(
                 "UnleashService er feilaktig injected. Bruk FeatureToggleService i stedet.",

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/distributering/DistribuerDødsfallBrevPåFagsakTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/distributering/DistribuerDødsfallBrevPåFagsakTaskTest.kt
@@ -17,26 +17,32 @@ class DistribuerDødsfallBrevPåFagsakTaskTest {
 
     @Test
     fun `doTask skal stoppes dersom task er eldre enn 6 måneder og brev skal ikke bli forsøkt distribuert`() {
+        // Arrange
         val mockedTask = mockk<Task>()
 
         every { mockedTask.payload } returns "{\"journalpostId\":\"testId\",\"brevmal\":\"VEDTAK_OPPHØR_DØDSFALL\"}"
         every { mockedTask.opprettetTid } returns LocalDateTime.of(2021, 10, 10, 0, 0)
 
+        // Act
         distribuerDødsfallBrevPåFagsakTask.doTask(mockedTask)
 
+        // Assert
         verify(exactly = 0) { brevService.prøvDistribuerBrevOgLoggHendelse(any(), any(), any(), any()) }
     }
 
     @Test
     fun `doTask skal forsøke å distribuere brev dersom task ikke er eldre enn 6mnd`() {
+        // Arrange
         val mockedTask = mockk<Task>()
 
         every { mockedTask.payload } returns "{\"journalpostId\":\"testId\",\"brevmal\":\"VEDTAK_OPPHØR_DØDSFALL\"}"
         every { brevService.prøvDistribuerBrevOgLoggHendelse(any(), any(), any(), any()) } just runs
         every { mockedTask.opprettetTid } returns LocalDateTime.now()
 
+        // Act
         distribuerDødsfallBrevPåFagsakTask.doTask(mockedTask)
 
+        // Assert
         verify(exactly = 1) { brevService.prøvDistribuerBrevOgLoggHendelse(any(), any(), any(), any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/ecb/ECBServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/ecb/ECBServiceTest.kt
@@ -41,6 +41,7 @@ class ECBServiceTest {
 
     @Test
     fun `Hent valutakurs for utenlandsk valuta til NOK og sjekk at beregning av kurs er riktig`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 6, 28)
         val ecbExchangeRatesData =
             createECBResponse(
@@ -58,12 +59,15 @@ class ECBServiceTest {
                 valutakursDato,
             )
         } returns ecbExchangeRatesData.toExchangeRates()
+        // Act
         val sekTilNOKValutakurs = ecbService.hentValutakurs("SEK", valutakursDato)
+        // Assert
         assertEquals(BigDecimal.valueOf(0.9702185972), sekTilNOKValutakurs)
     }
 
     @Test
     fun `Test at ECBService kaster ECBServiceException dersom de returnerte kursene ikke inneholder kurs for forespurt valuta`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 7, 22)
         val ecbExchangeRatesData =
             createECBResponse(
@@ -84,6 +88,7 @@ class ECBServiceTest {
 
     @Test
     fun `Test at ECBService kaster FunksjonellFeil dersom ValutakursRestClient kaster IngenValutakursException`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2024, 3, 29)
         every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns null
         every { ecbClient.hentValutakurs(any(), any(), any()) } throws IngenValutakursException(message = "Fant ikke valutakurser", cause = null)
@@ -94,6 +99,7 @@ class ECBServiceTest {
 
     @Test
     fun `Test at ECBService kaster ECBServiceException dersom ValutakursRestClient kaster ValutakursException`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2024, 3, 29)
         every { evbValutakursCacheRepository.findByValutakodeAndValutakursdato(any(), any()) } returns null
         every { ecbClient.hentValutakurs(any(), any(), any()) } throws ValutakursException(message = "En feil har skjedd", cause = null)
@@ -104,6 +110,7 @@ class ECBServiceTest {
 
     @Test
     fun `Test at ECBService kaster ECBServiceException dersom de returnerte kursene ikke inneholder kurser med forespurt dato`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 7, 20)
         val ecbExchangeRatesData =
             createECBResponse(
@@ -124,6 +131,7 @@ class ECBServiceTest {
 
     @Test
     fun `Test at ECBService returnerer NOK til EUR dersom den forespurte valutaen er EUR`() {
+        // Arrange
         val nokTilEur = BigDecimal.valueOf(9.4567)
         val valutakursDato = LocalDate.of(2022, 7, 20)
         val ecbExchangeRatesData =

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonServiceTest.kt
@@ -23,6 +23,7 @@ internal class IntegrasjonServiceTest {
 
     @Test
     fun `hentMaskertPersonInfoVedManglendeTilgang skal returnere maskert personinfo hvis SB ikke har tilgang til aktør`() {
+        // Arrange
         val aktør = mockk<Aktør>()
         val aktørFnr = "1234567891234"
 
@@ -33,8 +34,10 @@ internal class IntegrasjonServiceTest {
 
         mockBrukerContext()
 
+        // Act
         val maskertPersonInfo = integrasjonService.hentMaskertPersonInfoVedManglendeTilgang(aktør)!!
 
+        // Assert
         verify(exactly = 1) { integrasjonKlient.sjekkTilgangTilPersoner(listOf(aktørFnr)) }
         verify(exactly = 1) { pdlKlient.hentAdressebeskyttelse(aktør) }
 
@@ -49,6 +52,7 @@ internal class IntegrasjonServiceTest {
 
     @Test
     fun `hentMaskertPersonInfoVedManglendeTilgang skal returnere null hvis SB har tilgang til aktør`() {
+        // Arrange
         val aktør = mockk<Aktør>()
         val aktørFnr = "1234567891234"
 
@@ -58,8 +62,10 @@ internal class IntegrasjonServiceTest {
 
         mockBrukerContext()
 
+        // Act
         val maskertPersonInfo = integrasjonService.hentMaskertPersonInfoVedManglendeTilgang(aktør)
 
+        // Assert
         verify(exactly = 1) { integrasjonKlient.sjekkTilgangTilPersoner(listOf(aktørFnr)) }
 
         assertThat(maskertPersonInfo, Is(nullValue()))
@@ -69,12 +75,15 @@ internal class IntegrasjonServiceTest {
 
     @Test
     fun `hentJournalpost skal returnere journalpost fra familie-integrasjoner`() {
+        // Arrange
         val mocketJournalPost = mockk<Journalpost>()
 
         every { integrasjonKlient.hentJournalpost("test") } returns mocketJournalPost
 
+        // Act
         val hentetJournalPost = integrasjonService.hentJournalpost("test")
 
+        // Assert
         verify(exactly = 1) { integrasjonKlient.hentJournalpost("test") }
 
         assertThat(hentetJournalPost, Is(mocketJournalPost))
@@ -82,6 +91,7 @@ internal class IntegrasjonServiceTest {
 
     @Test
     fun `sjekkTilgangTilPersoner skal sjekke om SB har tilgang til personidenter`() {
+        // Arrange
         val listeMedIdenter = listOf("Ident1", "Ident2")
 
         every { integrasjonKlient.sjekkTilgangTilPersoner(listeMedIdenter) } returns
@@ -96,8 +106,10 @@ internal class IntegrasjonServiceTest {
 
         mockBrukerContext()
 
+        // Act
         val tilgang = integrasjonService.sjekkTilgangTilPersoner(listeMedIdenter)
 
+        // Assert
         verify(exactly = 1) { integrasjonKlient.sjekkTilgangTilPersoner(listeMedIdenter) }
 
         assertThat(tilgang.all { it.harTilgang }, Is(true))
@@ -108,12 +120,15 @@ internal class IntegrasjonServiceTest {
 
     @Test
     fun `sjekkTilgangTilPersoner skal gi tilgang om SB er systembruker`() {
+        // Arrange
         val listeMedIdenter = listOf("Ident1", "Ident2")
 
         mockBrukerContext("VL")
 
+        // Act
         val tilgang = integrasjonService.sjekkTilgangTilPersoner(listeMedIdenter)
 
+        // Assert
         verify(exactly = 0) { integrasjonKlient.sjekkTilgangTilPersoner(listeMedIdenter) }
 
         assertThat(tilgang.all { it.harTilgang }, Is(true))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragKlientTest.kt
@@ -30,12 +30,14 @@ internal class OppdragKlientTest {
 
     @Test
     fun `hentSimulering - skal hente simulering for utbetalingsoppdrag`() {
+        // Arrange
         wiremockServerItem.stubFor(
             WireMock
                 .post(WireMock.urlEqualTo("/simulering/v1"))
                 .willReturn(WireMock.okJson(readFile("hentSimulering.json"))),
         )
 
+        // Act
         val simulering =
             oppdragKlient.hentSimulering(
                 Utbetalingsoppdrag(
@@ -63,19 +65,23 @@ internal class OppdragKlientTest {
                 ),
             )
 
+        // Assert
         assertThat(simulering.simuleringMottaker.size, Is(1))
     }
 
     @Test
     fun `hentStatus - skal hente status for oppdragId`() {
+        // Arrange
         wiremockServerItem.stubFor(
             WireMock
                 .post(WireMock.urlEqualTo("/status"))
                 .willReturn(WireMock.okJson(readFile("hentStatus.json"))),
         )
 
+        // Act
         val oppdragStatus = oppdragKlient.hentStatus(OppdragId("KS", "12345678910", "1"))
 
+        // Assert
         assertThat(oppdragStatus, Is(OppdragStatus.KVITTERT_OK))
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/FerdigstillOppgaverTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppgave/FerdigstillOppgaverTaskTest.kt
@@ -20,6 +20,7 @@ class FerdigstillOppgaverTaskTest {
 
     @Test
     fun `doTask skal forsøke å ferdigstille oppgave som ble lagret ned`() {
+        // Arrange
         val mockedTask = mockk<Task>()
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
@@ -27,8 +28,10 @@ class FerdigstillOppgaverTaskTest {
         every { behandlingService.hentBehandling(1) } returns behandling
         every { oppgaveService.ferdigstillOppgaver(behandling, Oppgavetype.BehandleSak) } just runs
 
+        // Act
         ferdigstillOppgaverTask.doTask(mockedTask)
 
+        // Assert
         verify(exactly = 1) { mockedTask.payload }
         verify(exactly = 1) { behandlingService.hentBehandling(1) }
         verify(exactly = 1) { oppgaveService.ferdigstillOppgaver(behandling, Oppgavetype.BehandleSak) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PdlKlientTest.kt
@@ -30,6 +30,7 @@ internal class PdlKlientTest {
 
     @Test
     fun `hentPerson skal hente enkel persondata fra PDL med ENKEL query`() {
+        // Arrange
         wiremockServerItem.stubFor(
             WireMock
                 .post(WireMock.urlEqualTo("/${PdlConfig.PATH_GRAPHQL}"))
@@ -38,14 +39,17 @@ internal class PdlKlientTest {
 
         val randomAktør = randomAktør()
 
+        // Act
         val pdlPersonData = pdlKlient.hentPerson(randomAktør, PersonInfoQuery.ENKEL)
 
+        // Assert
         assertThat(pdlPersonData.navn.single().fulltNavn(), Is("ENGASJERT FYR"))
         assertThat(pdlPersonData.kjoenn.single().kjoenn, Is(KJOENN.MANN))
     }
 
     @Test
     fun `hentPerson skal kaste exception når person ikke eksisterer i PDL`() {
+        // Arrange
         wiremockServerItem.stubFor(
             WireMock
                 .post(WireMock.urlEqualTo("/${PdlConfig.PATH_GRAPHQL}"))
@@ -54,6 +58,7 @@ internal class PdlKlientTest {
 
         val randomAktør = randomAktør()
 
+        // Act & Assert
         val feil =
             assertThrows<PdlNotFoundException> {
                 pdlKlient.hentPerson(randomAktør, PersonInfoQuery.ENKEL)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/sanity/SanityServiceTest.kt
@@ -18,6 +18,7 @@ class SanityServiceTest {
 
     @Test
     fun `Skal hente SanityBegrunnelser`() {
+        // Arrange
         every { cachedSanityKlient.hentSanityBegrunnelserCached() } returns
             listOf(
                 SanityBegrunnelse(
@@ -38,11 +39,13 @@ class SanityServiceTest {
                 ),
             )
 
+        // Assert
         assertThat(sanityService.hentSanityBegrunnelser()).hasSize(1)
     }
 
     @Test
     fun `Skal ikke returnere SanityBegrunnelser som er markert ikke i bruk`() {
+        // Arrange
         every { cachedSanityKlient.hentSanityBegrunnelserCached() } returns
             listOf(
                 SanityBegrunnelse(
@@ -63,19 +66,23 @@ class SanityServiceTest {
                 ),
             )
 
+        // Assert
         assertThat(sanityService.hentSanityBegrunnelser()).isEmpty()
     }
 
     @Test
     fun `Skal kaste feil hvis det ikke er mulig å hente fra Sanity eller finnes i Cache`() {
+        // Arrange
         every { cachedSanityKlient.hentSanityBegrunnelserCached() } throws RuntimeException("Feil ved henting av begrunnelser i test")
 
+        // Act & Assert
         val e = assertThrows<RuntimeException> { sanityService.hentSanityBegrunnelser() }
         assertThat(e.message).isEqualTo("Feil ved henting av begrunnelser i test")
     }
 
     @Test
     fun `Skal bruke allerede lagret cache hvis det feiler mot sanity`() {
+        // Arrange
         every { cachedSanityKlient.hentSanityBegrunnelserCached() } returns
             listOf(
                 SanityBegrunnelse(
@@ -96,6 +103,7 @@ class SanityServiceTest {
                 ),
             ) andThenThrows RuntimeException("Feil får å teste cachet versjon")
 
+        // Assert
         assertThat(sanityService.hentSanityBegrunnelser()).hasSize(1)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingServiceTest.kt
@@ -35,6 +35,7 @@ class InternKonsistensavstemmingServiceTest {
 
     @Test
     fun `skal summere overgangsordningandeler i intern konsistensavstemming`() {
+        // Arrange
         val behandling = lagBehandling()
         val fagsakId = behandling.fagsak.id
         val aktør = behandling.fagsak.aktør
@@ -97,9 +98,11 @@ class InternKonsistensavstemmingServiceTest {
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandlinger(any()) } returns listOf(ordinæreAndel, overgangsordningAndel)
         every { oppdragKlient.hentSisteUtbetalingsoppdragForFagsaker(any()) } returns listOf(utbetalingsoppdragMedBehandlingOgFagsak)
 
+        // Act
         val (andeler, utbetalingsoppdrag) =
             internKonsistensavstemmingService.hentFagsakTilSisteUtbetalingsoppdragOgSisteAndelerMap(fagsakIder = setOf(fagsakId)).getValue(fagsakId)
 
+        // Assert
         assertThat(
             erForskjellMellomAndelerOgOppdrag(
                 andeler = andeler,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/internkonsistensavstemming/InternKonsistensavstemmingUtilTest.kt
@@ -14,6 +14,7 @@ import java.time.YearMonth
 class InternKonsistensavstemmingUtilTest {
     @Test
     fun `Skal ignorere forskjeller før første utbetalingsoppdragsperiode`() {
+        // Arrange
         val andelerSisteVedtatteBehandling =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -39,6 +40,7 @@ class InternKonsistensavstemmingUtilTest {
             )
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
 
+        // Act & Assert
         Assertions.assertFalse(
             erForskjellMellomAndelerOgOppdrag(
                 andelerSisteVedtatteBehandling,
@@ -50,6 +52,7 @@ class InternKonsistensavstemmingUtilTest {
 
     @Test
     fun `skal se at vi mangler andel for oppdragsperiode`() {
+        // Arrange
         val andelerSisteVedtatteBehandling =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -70,11 +73,13 @@ class InternKonsistensavstemmingUtilTest {
             )
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(mockUtbetalingsoppdrag)
 
+        // Act & Assert
         Assertions.assertTrue(erForskjellMellomAndelerOgOppdrag(andelerSisteVedtatteBehandling, utbetalingsoppdrag, 0L))
     }
 
     @Test
     fun `skal se at andel og oppdragsperiode har forskjellig beløp`() {
+        // Arrange
         val andelerSisteVedtatteBehandling =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -105,6 +110,7 @@ class InternKonsistensavstemmingUtilTest {
 
     @Test
     fun `skal ikke si det er forskjell ved riktig utbetalingsoppdrag når det er flere kjeder`() {
+        // Arrange
         val andelStringer =
             listOf(
                 "2021-05,2021-08,1354",
@@ -127,6 +133,7 @@ class InternKonsistensavstemmingUtilTest {
 
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockMedUtvidet)
 
+        // Act & Assert
         Assertions.assertFalse(
             erForskjellMellomAndelerOgOppdrag(
                 andelerSisteVedtatteBehandling,
@@ -138,6 +145,7 @@ class InternKonsistensavstemmingUtilTest {
 
     @Test
     fun `skal ikke si det er forskjell ved riktig utbetalingsoppdrag når kun ett barn ble endret i siste behandling som iverksatte`() {
+        // Arrange
         val andelStringer =
             listOf(
                 // barn 1, ble laget i siste behandling som iverksatte
@@ -164,6 +172,7 @@ class InternKonsistensavstemmingUtilTest {
 
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockEndringKunEttBarn)
 
+        // Act & Assert
         Assertions.assertFalse(
             erForskjellMellomAndelerOgOppdrag(
                 andelerSisteVedtatteBehandling,
@@ -175,6 +184,7 @@ class InternKonsistensavstemmingUtilTest {
 
     @Test
     fun `skal ikke si det er forskjell ved opphør`() {
+        // Arrange
         val andelStringer =
             listOf(
                 "2016-02,2019-02,970,2193974415300",
@@ -198,6 +208,7 @@ class InternKonsistensavstemmingUtilTest {
 
         val utbetalingsoppdrag = jsonMapper.readValue<Utbetalingsoppdrag>(utbetalingsoppdragMockOpphør)
 
+        // Act & Assert
         Assertions.assertFalse(
             erForskjellMellomAndelerOgOppdrag(
                 andelerSisteVedtatteBehandling,
@@ -209,6 +220,7 @@ class InternKonsistensavstemmingUtilTest {
 
     @Test
     fun `skal si andelene og utbetalingene er like dersom andel blir splittet opp, men betaler ut det samme i periodene`() {
+        // Arrange
         val andelStringer =
             listOf(
                 "2021-01,2022-03,1054",

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGeneratorTest.kt
@@ -276,6 +276,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         tilkjentYtelseIAndreBehandling.andelerTilkjentYtelse.addAll(andelTilkjentYtelserIAndreBehandling)
 
+        // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
                 saksbehandlerId = "123abc",
@@ -288,6 +289,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
 
+        // Assert
         assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(3))
         assertThat(utbetalingsoppdrag.utbetalingsperiode.all { it.sats == BigDecimal(7500) }, Is(true))
         assertThat(
@@ -316,6 +318,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
     @Test
     fun `lagTilkjentYtelseMedUtbetalingsoppdrag skal opprette revurdering med nytt barn`() {
+        // Arrange
         val tidNå = LocalDate.now()
 
         val aktør = fnrTilAktør(randomFnr())
@@ -396,6 +399,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         tilkjentYtelseIAndreBehandling.andelerTilkjentYtelse.addAll(andelTilkjentYtelserIAndreBehandling)
 
+        // Act
         val oppdatertTilkjentYtelseIAndreBehandling =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
                 saksbehandlerId = "123abc",
@@ -408,6 +412,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         val utbetalingsoppdrag = oppdatertTilkjentYtelseIAndreBehandling.utbetalingsoppdrag
 
+        // Assert
         assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(3))
         assertThat(utbetalingsoppdrag.utbetalingsperiode.all { it.sats == BigDecimal(7500) }, Is(true))
         assertThat(
@@ -436,6 +441,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
     @Test
     fun `lagUtbetalingsoppdrag skal ikke generere utbetalingsperioder for andeler som er uendret`() {
+        // Arrange
         val tidNå = LocalDate.now()
 
         val aktør = fnrTilAktør(randomFnr())
@@ -530,6 +536,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         tilkjentYtelseIAndreBehandling.andelerTilkjentYtelse.addAll(andelTilkjentYtelserIAndreBehandling)
 
+        // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
                 saksbehandlerId = "123abc",
@@ -542,11 +549,13 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
 
+        // Assert
         assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(0))
     }
 
     @Test
     fun `lagUtbetalingsoppdrag skal ikke generere utbetalingsperioder for overgangsordningAndeler som har uendret sum`() {
+        // Arrange
         val tidNå = LocalDate.now()
 
         val aktør = fnrTilAktør(randomFnr())
@@ -649,6 +658,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         tilkjentYtelseIAndreBehandling.andelerTilkjentYtelse.addAll(andelTilkjentYtelserIAndreBehandling)
 
+        // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
                 saksbehandlerId = "123abc",
@@ -665,11 +675,13 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
 
+        // Assert
         assertThat("Det er uventede utbetalingsperioder: ${utbetalingsoppdrag.utbetalingsperiode}", utbetalingsoppdrag.utbetalingsperiode.size, Is(0))
     }
 
     @Test
     fun `lagUtbetalingsoppdrag skal generere én utbetalingsperiode for overgangsordning per barn `() {
+        // Arrange
         val tidNå = LocalDate.now()
 
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
@@ -689,6 +701,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         tilkjentYtelse.andelerTilkjentYtelse.addAll(andelTilkjentYtelser)
 
+        // Act
         val beregnetUtbetalingsoppdragLongId =
             utbetalingsoppdragGenerator.lagUtbetalingsoppdrag(
                 saksbehandlerId = "123abc",
@@ -701,6 +714,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
         val utbetalingsoppdrag = beregnetUtbetalingsoppdragLongId.utbetalingsoppdrag
 
+        // Assert
         assertThat(utbetalingsoppdrag.kodeEndring, Is(no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.KodeEndring.NY))
         assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(3))
         assertThat(
@@ -731,6 +745,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
     @Test
     fun `lagUtbetalingsoppdrag skal summere overgangsordning og ordinær andel for utbetalingsmåned i overgangsordningandelen per barn`() {
+        // Arrange
         val tidNå = LocalDate.now()
 
         val aktør = fnrTilAktør(randomFnr())
@@ -778,6 +793,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                     )
                 }
 
+        // Act
         val utbetalingsoppdrag =
             utbetalingsoppdragGenerator
                 .lagUtbetalingsoppdrag(
@@ -789,6 +805,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                     erSimulering = false,
                 ).utbetalingsoppdrag
 
+        // Assert
         assertThat(utbetalingsoppdrag.kodeEndring, Is(Utbetalingsoppdrag.KodeEndring.ENDR))
         assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(3))
 
@@ -817,6 +834,7 @@ internal class UtbetalingsoppdragGeneratorTest {
 
     @Test
     fun `lagUtbetalingsoppdrag skal ta hensyn til overgangsordningsandeler dersom den siste andelen i kjeden er overgangsordning andel`() {
+        // Arrange
         val tidNå = LocalDate.now()
 
         val aktør = fnrTilAktør(randomFnr())
@@ -870,6 +888,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                     )
                 }
 
+        // Act
         val utbetalingsoppdrag =
             utbetalingsoppdragGenerator
                 .lagUtbetalingsoppdrag(
@@ -881,6 +900,7 @@ internal class UtbetalingsoppdragGeneratorTest {
                     erSimulering = false,
                 ).utbetalingsoppdrag
 
+        // Assert
         assertThat(utbetalingsoppdrag.kodeEndring, Is(Utbetalingsoppdrag.KodeEndring.ENDR))
         assertThat(utbetalingsoppdrag.utbetalingsperiode.size, Is(1))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragValidatorTest.kt
@@ -20,6 +20,7 @@ import java.time.LocalDate
 internal class UtbetalingsoppdragValidatorTest {
     @Test
     fun `valider skal kaste feil dersom utbetalingsoppdrag inneholder perioder og resultat er FORTSATT_INNVILGET`() {
+        // Arrange
         val utbetalingsoppdrag =
             lagBeregnetUtbetalingsoppdrag(
                 lagVedtak(),
@@ -39,6 +40,7 @@ internal class UtbetalingsoppdragValidatorTest {
                 ),
             )
 
+        // Act & Assert
         val funksjonellFeil =
             assertThrows<FunksjonellFeil> {
                 utbetalingsoppdrag.valider(
@@ -51,12 +53,14 @@ internal class UtbetalingsoppdragValidatorTest {
 
     @Test
     fun `valider ikke skal kaste feil dersom utbetalingsoppdrag ikke inneholder perioder og resultat er FORTSATT_INNVILGET`() {
+        // Arrange
         val utbetalingsoppdrag =
             lagBeregnetUtbetalingsoppdrag(
                 lagVedtak(),
                 emptyList(),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             utbetalingsoppdrag.valider(
                 behandlingsresultat = Behandlingsresultat.FORTSATT_INNVILGET,
@@ -67,6 +71,7 @@ internal class UtbetalingsoppdragValidatorTest {
     @ParameterizedTest
     @EnumSource(value = Behandlingsresultat::class, names = ["FORTSATT_INNVILGET"], mode = EnumSource.Mode.EXCLUDE)
     fun `valider skal ikke kaste feil dersom utbetalingsoppdrag inneholder perioder og resultat ikke er FORTSATT_INNVILGET`(behandlingsresultat: Behandlingsresultat) {
+        // Arrange
         val utbetalingsoppdrag =
             lagBeregnetUtbetalingsoppdrag(
                 lagVedtak(),
@@ -86,6 +91,7 @@ internal class UtbetalingsoppdragValidatorTest {
                 ),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             utbetalingsoppdrag.valider(
                 behandlingsresultat = behandlingsresultat,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -48,6 +48,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett - skal ikke iverksette mot oppdrag hvis det ikke finnes utbetalingsperioder`() {
+        // Arrange
         every { tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(any()) } just runs
         every { oppdragKlient.iverksettOppdrag(any()) } returns ""
 
@@ -63,16 +64,19 @@ internal class UtbetalingsperiodeServiceTest {
             tilkjentYtelseSlot = tilkjentYtelseSlot,
         )
 
+        // Act
         utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
             vedtak = vedtak,
             "abc123",
         )
 
+        // Assert
         verify(exactly = 0) { oppdragKlient.iverksettOppdrag(any()) }
     }
 
     @Test
     fun `oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett - skal iverksette mot oppdrag hvis det finnes utbetalingsperioder`() {
+        // Arrange
         every { tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(any()) } just runs
         every { oppdragKlient.iverksettOppdrag(any()) } returns ""
 
@@ -111,16 +115,19 @@ internal class UtbetalingsperiodeServiceTest {
             tilkjentYtelseSlot = tilkjentYtelseSlot,
         )
 
+        // Act
         utbetalingsoppdragService.oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett(
             vedtak = vedtak,
             "abc123",
         )
 
+        // Assert
         verify(exactly = 1) { oppdragKlient.iverksettOppdrag(any()) }
     }
 
     @Test
     fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset når det ikke finnes en forrige behandling`() {
+        // Arrange
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
         val person = tilfeldigPerson()
@@ -156,12 +163,14 @@ internal class UtbetalingsperiodeServiceTest {
             tilkjentYtelseSlot = tilkjentYtelseSlot,
         )
 
+        // Act
         val beregnetUtbetalingsoppdrag =
             utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
                 vedtak = vedtak,
                 "abc123",
             )
 
+        // Assert
         val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
 
         verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
@@ -182,6 +191,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset når det finnes en forrige behandling`() {
+        // Arrange
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
         val person = tilfeldigPerson()
@@ -239,12 +249,14 @@ internal class UtbetalingsperiodeServiceTest {
             tilkjentYtelseSlot = tilkjentYtelseSlot,
         )
 
+        // Act
         val beregnetUtbetalingsoppdrag =
             utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
                 vedtak = vedtak,
                 "abc123",
             )
 
+        // Assert
         val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
 
         verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
@@ -263,6 +275,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset for 2 personer`() {
+        // Arrange
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
         val person = tilfeldigPerson()
@@ -341,6 +354,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset for 2 personer og tidligere behandling`() {
+        // Arrange
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
         val person = tilfeldigPerson()
@@ -446,6 +460,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag og oppdatere andeler med offset for 2 personer og tidligere behandling for overgangsordning`() {
+        // Arrange
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
         val person = tilfeldigPerson()
@@ -537,12 +552,14 @@ internal class UtbetalingsperiodeServiceTest {
             forrigeTilkjentYtelse = forrigeTilkjentYtelse,
         )
 
+        // Act
         val beregnetUtbetalingsoppdrag =
             utbetalingsoppdragService.genererUtbetalingsoppdragOgOppdaterTilkjentYtelse(
                 vedtak = vedtak,
                 "abc123",
             )
 
+        // Assert
         val lagredeAndeler = tilkjentYtelseSlot.captured.andelerTilkjentYtelse
 
         verify(exactly = 1) { tilkjentYtelseRepository.save(any()) }
@@ -563,6 +580,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `genererUtbetalingsoppdrag - skal generere nytt utbetalingsoppdrag for simulering med en eksisterende kjede og en ny kjede`() {
+        // Arrange
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
         val person = tilfeldigPerson()
@@ -650,6 +668,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `genererUtbetalingsoppdrag - revurdering hvor 0-utbetaling går til betaling skal ikke opprette noe opphør ved simulering`() {
+        // Arrange
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
         val person = tilfeldigPerson()
@@ -725,6 +744,7 @@ internal class UtbetalingsperiodeServiceTest {
 
     @Test
     fun `genererUtbetalingsoppdrag - revurdering hvor en overgangsordningandel settes til 0 skal ikke inkludere den andelen`() {
+        // Arrange
         val barn = tilfeldigPerson()
 
         val forrigeBehandling = lagBehandling()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/AvstemmingServiceTest.kt
@@ -30,11 +30,13 @@ internal class AvstemmingServiceTest {
 
     @Test
     fun `hentDataForKonsistensavstemming skal hente data for konsistensavstemming`() {
+        // Arrange
         every { beregningService.hentLøpendeAndelerTilkjentYtelseMedUtbetalingerForBehandlinger(any(), any()) } returns
             listOf(lagAndelTilkjentYtelse(behandling = behandling, periodeOffset = 1))
         every { behandlingService.hentAktivtFødselsnummerForBehandlinger(any()) } returns
             mapOf(behandling.id to behandling.fagsak.aktør.aktivFødselsnummer())
 
+        // Act & Assert
         val perioderForBehandling =
             assertDoesNotThrow {
                 avstemmingService.hentDataForKonsistensavstemming(LocalDateTime.now(), listOf(behandling.id))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/GrensesnittavstemmingSchedulerTest.kt
@@ -36,12 +36,15 @@ internal class GrensesnittavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal utføre scheduler når det ikke finnes ferdige tasker`() {
+        // Arrange
         every { taskService.finnTasksMedStatus(any(), any(), any()) } returns emptyList()
         val taskDataSlot = slot<Task>()
         every { taskService.save(capture(taskDataSlot)) } returns mockk()
 
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.finnTasksMedStatus(any(), any(), any()) }
         verify(exactly = 1) { taskService.save(any()) }
 
@@ -52,6 +55,7 @@ internal class GrensesnittavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal utføre scheduler når det finnes siste ferdig task`() {
+        // Arrange
         // siste kjørte task er på tirsdag for fom mandag 28.11.2022 00:00 og tom tirsdag 29.11.2022 00:00
         val fom = LocalDate.of(2022, 12, 1) // torsdag
         val tom = fom.plusDays(1) // tirsdag
@@ -59,8 +63,10 @@ internal class GrensesnittavstemmingSchedulerTest {
         val taskDataSlot = slot<Task>()
         every { taskService.save(capture(taskDataSlot)) } returns mockk()
 
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.finnTasksMedStatus(any(), any(), any()) }
         verify(exactly = 1) { taskService.save(any()) }
 
@@ -71,6 +77,7 @@ internal class GrensesnittavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal utføre scheduler når scheduler kjører på mandag`() {
+        // Arrange
         // siste kjørte task er på fredag for fom torsdag 24.11.2022 00:00 og tom fredag 25.11.2022 00:00
         val fom = LocalDate.of(2022, 11, 24)
         val tom = fom.plusDays(1)
@@ -78,8 +85,10 @@ internal class GrensesnittavstemmingSchedulerTest {
         val taskDataSlot = slot<Task>()
         every { taskService.save(capture(taskDataSlot)) } returns mockk()
 
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.finnTasksMedStatus(any(), any(), any()) }
         verify(exactly = 1) { taskService.save(any()) }
 
@@ -91,14 +100,19 @@ internal class GrensesnittavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal ikke utføre scheduler dersom det er helligdag`() {
+        // Arrange
         every { LocalDate.now().erHelligdag() } returns true
+
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 0) { taskService.finnTasksMedStatus(any(), any(), any()) }
     }
 
     @Test
     fun `utfør skal utføre scheduler når scheduler kjører på siste dag i desember, tom blir 2 januar`() {
+        // Arrange
         // siste kjørte task er for fom 30.12.2022 00:00 og tom 31.12.2022 00:00
         val fom = LocalDate.of(2022, 12, 30)
         val tom = fom.plusDays(1)
@@ -106,8 +120,10 @@ internal class GrensesnittavstemmingSchedulerTest {
         val taskDataSlot = slot<Task>()
         every { taskService.save(capture(taskDataSlot)) } returns mockk()
 
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.finnTasksMedStatus(any(), any(), any()) }
         verify(exactly = 1) { taskService.save(any()) }
 
@@ -119,6 +135,7 @@ internal class GrensesnittavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal utføre scheduler når scheduler kjører på siste dag i april, tom blir 2 mai`() {
+        // Arrange
         // siste kjørte task er for fom 29.04.2022 00:00 og tom 30.04.2022 00:00
         val fom = LocalDate.of(2022, 4, 29)
         val tom = fom.plusDays(1)
@@ -126,8 +143,10 @@ internal class GrensesnittavstemmingSchedulerTest {
         val taskDataSlot = slot<Task>()
         every { taskService.save(capture(taskDataSlot)) } returns mockk()
 
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.finnTasksMedStatus(any(), any(), any()) }
         verify(exactly = 1) { taskService.save(any()) }
 
@@ -139,6 +158,7 @@ internal class GrensesnittavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal utføre scheduler når scheduler kjører på 16 mai, tom blir 18 mai`() {
+        // Arrange
         // siste kjørte task er for fom 15.05.2022 00:00 og tom 16.05.2022 00:00
         val fom = LocalDate.of(2022, 5, 15)
         val tom = fom.plusDays(1)
@@ -146,8 +166,10 @@ internal class GrensesnittavstemmingSchedulerTest {
         val taskDataSlot = slot<Task>()
         every { taskService.save(capture(taskDataSlot)) } returns mockk()
 
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.finnTasksMedStatus(any(), any(), any()) }
         verify(exactly = 1) { taskService.save(any()) }
 
@@ -159,6 +181,7 @@ internal class GrensesnittavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal utføre scheduler når scheduler kjører på 24 desember, tom blir 27 desember`() {
+        // Arrange
         // siste kjørte task er for fom 23.12.2022 00:00 og tom 24.12.2022 00:00
         val fom = LocalDate.of(2022, 12, 23)
         val tom = fom.plusDays(1)
@@ -166,8 +189,10 @@ internal class GrensesnittavstemmingSchedulerTest {
         val taskDataSlot = slot<Task>()
         every { taskService.save(capture(taskDataSlot)) } returns mockk()
 
+        // Act
         grensesnittavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.finnTasksMedStatus(any(), any(), any()) }
         verify(exactly = 1) { taskService.save(any()) }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/KonsistensavstemmingSchedulerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/KonsistensavstemmingSchedulerTest.kt
@@ -37,11 +37,14 @@ internal class KonsistensavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal utføre konsistensavstemming og lager task når dagensdato matchher med kjøreplan`() {
+        // Arrange
         every { konsistensavstemmingKjøreplanService.plukkLedigKjøreplanFor(any()) } returns
             KonsistensavstemmingKjøreplan(kjøredato = LocalDate.now())
 
+        // Act
         konsistensavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 1) { taskService.save(any()) }
 
         val taskData = taskSlot.captured
@@ -53,10 +56,13 @@ internal class KonsistensavstemmingSchedulerTest {
 
     @Test
     fun `utfør skal ikke utføre konsistensavstemming når dagensdato ikke matchher med kjøreplan`() {
+        // Arrange
         every { konsistensavstemmingKjøreplanService.plukkLedigKjøreplanFor(any()) } returns null
 
+        // Act
         konsistensavstemmingScheduler.utfør()
 
+        // Assert
         verify(exactly = 0) { taskService.save(any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/KonsistensavstemmingTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/avstemming/KonsistensavstemmingTaskTest.kt
@@ -39,15 +39,20 @@ internal class KonsistensavstemmingTaskTest {
 
     @Test
     fun `doTask skal ikke utføre task når kjøreplan status er FERDIG`() {
+        // Arrange
         every { konsistensavstemmingKjøreplanService.harKjøreplanStatusFerdig(1) } returns true
 
+        // Act
         konsistensavstemmingTask.doTask(lagTask())
+
+        // Assert
         verify(exactly = 0) { avstemmingService.sendKonsistensavstemmingStartMelding(any(), any()) }
         verify(exactly = 0) { konsistensavstemmingKjøreplanService.lagreNyStatus(any<KonsistensavstemmingKjøreplan>(), any()) }
     }
 
     @Test
     fun `doTask skal utføre task for 25000 løpende behandlinger`() {
+        // Arrange
         val behandlingIder = (1..4999).map { it.toLong() }
 
         val page = mockk<Page<Long>>()
@@ -60,8 +65,10 @@ internal class KonsistensavstemmingTaskTest {
         every { behandlingService.hentSisteIverksatteBehandlingerFraLøpendeFagsaker(any()) } returns page
         every { avstemmingService.hentDataForKonsistensavstemming(any(), any()) } returns mockk()
 
+        // Act
         konsistensavstemmingTask.doTask(lagTask())
 
+        // Assert
         verify(exactly = 1) { avstemmingService.sendKonsistensavstemmingStartMelding(any(), any()) }
         verify(exactly = 50) { avstemmingService.sendKonsistensavstemmingData(any(), any(), any()) }
         verify(exactly = 1) { avstemmingService.sendKonsistensavstemmingAvsluttMelding(any(), any()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/HenleggBehandlingServiceTest.kt
@@ -77,9 +77,11 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal ikke henlegge behandling når den allerede er avsluttet`() {
+        // Arrange
         every { behandlingRepository.hentBehandling(behandlingId) } returns
             behandling.copy(status = BehandlingStatus.AVSLUTTET)
 
+        // Act & Assert
         val exception =
             assertThrows<Feil> {
                 henleggBehandlingService.henleggBehandling(
@@ -97,8 +99,10 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal ikke henlegge behandling for årsak TEKNISK_VEDLIKEHOLD når toggelen er ikke på`() {
+        // Arrange
         every { featureToggleService.isEnabled(FeatureToggle.TEKNISK_VEDLIKEHOLD_HENLEGGELSE) } returns false
 
+        // Act & Assert
         val exception =
             assertThrows<Feil> {
                 henleggBehandlingService.henleggBehandling(
@@ -117,11 +121,13 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal ikke henlegge TEKNISK_ENDRING behandling når toggelen er ikke på`() {
+        // Arrange
         val tekniskEndringBehandling = behandling.copy(opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING)
 
         every { behandlingRepository.hentBehandling(behandlingId) } returns tekniskEndringBehandling
         every { featureToggleService.isEnabled(FeatureToggle.TEKNISK_ENDRING) } returns false
 
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 henleggBehandlingService.henleggBehandling(
@@ -141,6 +147,7 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal ikke henlegge behandling for årsak  FEILAKTIG_OPPRETTET når behandling er i IVERKSETT_MOT_OPPDRAG steg`() {
+        // Arrange
         behandling.behandlingStegTilstand.add(
             BehandlingStegTilstand(
                 behandlingSteg = BehandlingSteg.IVERKSETT_MOT_OPPDRAG,
@@ -150,6 +157,7 @@ internal class HenleggBehandlingServiceTest {
 
         every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
 
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 henleggBehandlingService.henleggBehandling(
@@ -168,6 +176,7 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal henlegge behandling for årsak TEKNISK_VEDLIKEHOLD når behandling er i IVERKSETT_MOT_OPPDRAG steg`() {
+        // Arrange
         behandling.behandlingStegTilstand.add(
             BehandlingStegTilstand(
                 behandlingSteg = BehandlingSteg.IVERKSETT_MOT_OPPDRAG,
@@ -177,6 +186,7 @@ internal class HenleggBehandlingServiceTest {
 
         every { behandlingRepository.hentBehandling(behandlingId) } returns behandling
 
+        // Act
         assertDoesNotThrow {
             henleggBehandlingService.henleggBehandling(
                 behandlingId = behandlingId,
@@ -184,6 +194,8 @@ internal class HenleggBehandlingServiceTest {
                 begrunnelse = "",
             )
         }
+
+        // Assert
         verify(exactly = 1) { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling) }
         verify(exactly = 1) {
             loggService.opprettHenleggBehandlingLogg(
@@ -204,6 +216,7 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal henlegge behandling for årsak SØKNAD_TRUKKET og sende brev`() {
+        // Act
         assertDoesNotThrow {
             henleggBehandlingService.henleggBehandling(
                 behandlingId = behandlingId,
@@ -211,6 +224,8 @@ internal class HenleggBehandlingServiceTest {
                 begrunnelse = "",
             )
         }
+
+        // Assert
         verify(exactly = 1) { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling) }
         verify(exactly = 1) {
             loggService.opprettHenleggBehandlingLogg(
@@ -231,6 +246,7 @@ internal class HenleggBehandlingServiceTest {
 
     @Test
     fun `henleggBehandling skal henlegge behandling og aktivere siste vedtatt behandling når fagsak har flere behandlinger`() {
+        // Arrange
         val sisteVedtattBehandling =
             lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD).also {
                 it.aktiv = false
@@ -241,6 +257,7 @@ internal class HenleggBehandlingServiceTest {
         every { behandlingRepository.finnBehandlinger(behandling.fagsak.id) } returns listOf(sisteVedtattBehandling, behandling)
         every { behandlingRepository.saveAndFlush(capture(sisteVedtattBehandlingSlot)) } returns mockk()
 
+        // Act
         assertDoesNotThrow {
             henleggBehandlingService.henleggBehandling(
                 behandlingId = behandlingId,
@@ -248,6 +265,8 @@ internal class HenleggBehandlingServiceTest {
                 begrunnelse = "",
             )
         }
+
+        // Assert
         verify(exactly = 1) { oppgaveService.hentOppgaverSomIkkeErFerdigstilt(behandling) }
         verify(exactly = 1) {
             loggService.opprettHenleggBehandlingLogg(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/SettBehandlingPåVentServiceTest.kt
@@ -39,6 +39,7 @@ class SettBehandlingPåVentServiceTest {
     @Test
     fun `settBehandlingPåVent - skal sette behandling på vent og forlenge frist på oppgave`() {
         every { behandlingRepository.hentBehandling(any()) } returns behandling
+        // Arrange
         every { stegService.settBehandlingstegPåVent(any(), any(), VenteÅrsak.AVVENTER_DOKUMENTASJON) } just runs
         every { oppgaveService.settNyFristÅpneOppgaverPåBehandling(any(), any()) } just runs
 
@@ -49,6 +50,7 @@ class SettBehandlingPåVentServiceTest {
             VenteÅrsak.AVVENTER_DOKUMENTASJON,
         )
 
+        // Act & Assert
         verify(exactly = 1) { behandlingRepository.hentBehandling(any()) }
         verify(exactly = 1) { stegService.settBehandlingstegPåVent(any(), any(), VenteÅrsak.AVVENTER_DOKUMENTASJON) }
         verify(exactly = 1) { oppgaveService.settNyFristÅpneOppgaverPåBehandling(any(), any()) }
@@ -57,12 +59,15 @@ class SettBehandlingPåVentServiceTest {
     @Test
     fun `settBehandlingPåVent - skal kaste feil når behandling allerede er satt på vent`() {
         behandling.behandlingStegTilstand.single { it.behandlingSteg == behandling.steg }.behandlingStegStatus =
+            // Arrange
             BehandlingStegStatus.VENTER
         every { behandlingRepository.hentBehandling(any()) } returns behandling
 
         val frist = LocalDate.now().plusWeeks(1)
 
         val funksjonellFeil =
+
+            // Act & Assert
             assertThrows<FunksjonellFeil> {
                 settBehandlingPåVentService.settBehandlingPåVent(
                     behandling.id,
@@ -78,9 +83,12 @@ class SettBehandlingPåVentServiceTest {
     fun `settBehandlingPåVent - skal kaste feil når frist er før dagens dato`() {
         every { behandlingRepository.hentBehandling(any()) } returns behandling
 
+        // Arrange
         val frist = LocalDate.now().minusWeeks(1)
 
         val funksjonellFeil =
+
+            // Act & Assert
             assertThrows<FunksjonellFeil> {
                 settBehandlingPåVentService.settBehandlingPåVent(
                     behandling.id,
@@ -100,9 +108,12 @@ class SettBehandlingPåVentServiceTest {
         behandling.status = BehandlingStatus.AVSLUTTET
         every { behandlingRepository.hentBehandling(any()) } returns behandling
 
+        // Arrange
         val frist = LocalDate.now().plusWeeks(1)
 
         val funksjonellFeil =
+
+            // Act & Assert
             assertThrows<FunksjonellFeil> {
                 settBehandlingPåVentService.settBehandlingPåVent(
                     behandling.id,
@@ -122,9 +133,12 @@ class SettBehandlingPåVentServiceTest {
         behandling.aktiv = false
         every { behandlingRepository.hentBehandling(any()) } returns behandling
 
+        // Arrange
         val frist = LocalDate.now().plusWeeks(1)
 
         val funksjonellFeil =
+
+            // Act & Assert
             assertThrows<FunksjonellFeil> {
                 settBehandlingPåVentService.settBehandlingPåVent(
                     behandling.id,
@@ -145,7 +159,9 @@ class SettBehandlingPåVentServiceTest {
         val frist = LocalDate.now().plusWeeks(2)
 
         every { behandlingRepository.hentBehandling(any()) } returns behandling
+        // Arrange
         every {
+            // Act & Assert
             stegService.oppdaterBehandlingstegFristOgÅrsak(
                 any(),
                 any(),
@@ -175,8 +191,11 @@ class SettBehandlingPåVentServiceTest {
     @Test
     fun `gjenopptaBehandlingPåVent - skal gjenoppta ventende behandling, oppdatere logg og sette ny frist på oppgave`() {
         behandling.behandlingStegTilstand.single { it.behandlingSteg == behandling.steg }.behandlingStegStatus =
+            // Arrange
             BehandlingStegStatus.VENTER
         every { behandlingRepository.hentBehandling(any()) } returns behandling
+
+        // Act & Assert
         every { stegService.utførSteg(any(), any()) } just runs
         every { loggService.opprettBehandlingGjenopptattLogg(behandling) } just runs
         every { oppgaveService.settFristÅpneOppgaverPåBehandlingTil(any(), any()) } just runs

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/IverksettMotOppdragStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/IverksettMotOppdragStegTest.kt
@@ -41,6 +41,7 @@ class IverksettMotOppdragStegTest {
 
     @Test
     fun `utførSteg skal kaste feil dersom totrinnskontroll er ugyldig `() {
+        // Arrange
         val mocketBehandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val mocketTotrinnskontroll =
             Totrinnskontroll(
@@ -56,6 +57,7 @@ class IverksettMotOppdragStegTest {
         every { tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(mocketBehandling) } just runs
         every { totrinnskontrollService.hentAktivForBehandling(mocketBehandling.id) } returns mocketTotrinnskontroll
 
+        // Act & Assert
         val feil = assertThrows<Feil> { iverksettMotOppdragSteg.utførSteg(200, iverksettMotOppdragDto) }
 
         assertThat(feil.message, Is("Totrinnskontroll($mocketTotrinnskontroll) er ugyldig ved iverksetting"))
@@ -64,6 +66,7 @@ class IverksettMotOppdragStegTest {
 
     @Test
     fun `utførSteg skal kaste feil dersom totrinnskontroll ikke er godkjent`() {
+        // Arrange
         val mocketBehandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val mocketTotrinnskontroll =
             Totrinnskontroll(
@@ -77,6 +80,7 @@ class IverksettMotOppdragStegTest {
         every { tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(mocketBehandling) } just runs
         every { totrinnskontrollService.hentAktivForBehandling(mocketBehandling.id) } returns mocketTotrinnskontroll
 
+        // Act & Assert
         val feil = assertThrows<Feil> { iverksettMotOppdragSteg.utførSteg(200, iverksettMotOppdragDto) }
 
         assertThat(feil.message, Is("Prøver å iverksette et underkjent vedtak"))
@@ -84,6 +88,7 @@ class IverksettMotOppdragStegTest {
 
     @Test
     fun `utførSteg skal lage utbetalingsoppdrag hvis totrinnskontroll er gyldig og godkjent`() {
+        // Arrange
         val mocketBehandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val mocketTotrinnskontroll =
             Totrinnskontroll(
@@ -102,8 +107,10 @@ class IverksettMotOppdragStegTest {
         } returns mockk()
         every { behandlingService.hentSisteBehandlingSomErVedtatt(any()) } returns null
 
+        // Act
         iverksettMotOppdragSteg.utførSteg(200, iverksettMotOppdragDto)
 
+        // Assert
         verify(exactly = 1) { behandlingService.hentBehandling(any()) }
         verify(exactly = 1) {
             tilkjentYtelseValideringService.validerAtIngenUtbetalingerOverstiger100Prosent(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersongrunnlagEnhetTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersongrunnlagEnhetTest.kt
@@ -48,14 +48,17 @@ class RegistrerPersongrunnlagEnhetTest {
 
     @Test
     fun `Kopierer kompetanser, valutakurser og utenlandsk periodebeløp til ny behandling`() {
+        // Arrange
         val sisteVedtatteBehandling = lagBehandling(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.INNVILGET)
         val behandling2 = lagBehandling()
 
         every { behandlingRepository.hentBehandling(behandling2.id) } returns behandling2
         every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling)
 
+        // Act
         registrerPersongrunnlagSteg.utførSteg(behandlingId = behandling2.id)
 
+        // Assert
         verify(exactly = 1) {
             kompetanseService.kopierOgErstattKompetanser(
                 BehandlingId(sisteVedtatteBehandling.id),
@@ -82,14 +85,17 @@ class RegistrerPersongrunnlagEnhetTest {
 
     @Test
     fun `Skal ikke kopierer kompetanser, valutakurser og utenlandsk periodebeløp for man ikke har noen siste behandling er henlagt`() {
+        // Arrange
         val sisteVedtatteBehandling = lagBehandling(status = BehandlingStatus.AVSLUTTET, resultat = Behandlingsresultat.HENLAGT_FEILAKTIG_OPPRETTET)
         val behandling2 = lagBehandling()
 
         every { behandlingRepository.hentBehandling(behandling2.id) } returns behandling2
         every { behandlingRepository.finnBehandlinger(behandling2.fagsak.id) } returns listOf(sisteVedtatteBehandling)
 
+        // Act
         registrerPersongrunnlagSteg.utførSteg(behandlingId = behandling2.id)
 
+        // Assert
         verify(exactly = 0) {
             kompetanseService.kopierOgErstattKompetanser(
                 BehandlingId(sisteVedtatteBehandling.id),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatEndringUtilsTest.kt
@@ -45,6 +45,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `utledEndringsresultat skal returnere INGEN_ENDRING dersom det ikke finnes noe endringer i behandling`() {
         val endringsresultat =
+            // Arrange
             utledEndringsresultat(
                 nåværendeAndeler = emptyList(),
                 forrigeAndeler = emptyList(),
@@ -65,6 +66,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i beløp`() {
         val person = lagPerson(aktør = randomAktør())
 
+        // Arrange
         val forrigeAndel =
             lagAndelTilkjentYtelse(
                 fom = jan22,
@@ -92,6 +94,7 @@ class BehandlingsresultatEndringUtilsTest {
 
     @Test
     fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i vilkårsvurderingen`() {
+        // Arrange
         val fødselsdato = LocalDate.of(2015, 1, 1)
         val barn = lagPerson(aktør = barn1Aktør, fødselsdato = fødselsdato)
         val forrigeAndeler =
@@ -162,6 +165,7 @@ class BehandlingsresultatEndringUtilsTest {
                 vilkårResultater = nåværendeVilkårResultater.toMutableSet(),
             )
 
+        // Act
         val endringsresultat =
             utledEndringsresultat(
                 forrigeAndeler = forrigeAndeler,
@@ -176,11 +180,13 @@ class BehandlingsresultatEndringUtilsTest {
                 personerIForrigeBehandling = setOf(barn),
             )
 
+        // Assert
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
     }
 
     @Test
     fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i kompetanse`() {
+        // Arrange
         val forrigeBehandling = lagBehandling()
         val nåværendeBehandling = lagBehandling()
 
@@ -200,6 +206,7 @@ class BehandlingsresultatEndringUtilsTest {
                 tom = null,
             )
 
+        // Act
         val endringsresultat =
             utledEndringsresultat(
                 nåværendeAndeler = emptyList(),
@@ -219,6 +226,7 @@ class BehandlingsresultatEndringUtilsTest {
                 personerIForrigeBehandling = setOf(barnPerson),
             )
 
+        // Assert
         assertThat(endringsresultat, Is(Endringsresultat.ENDRING))
     }
 
@@ -226,6 +234,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `utledEndringsresultat skal returnere ENDRING dersom det finnes endringer i endret utbetaling andeler`() {
         val barn = lagPerson(aktør = barn1Aktør)
 
+        // Arrange
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
@@ -256,6 +265,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i beløp - Skal returnere false dersom eneste endring er opphør`() {
         val forrigeAndeler =
+            // Arrange
             listOf(
                 lagAndelTilkjentYtelse(
                     fom = jan22,
@@ -281,6 +291,7 @@ class BehandlingsresultatEndringUtilsTest {
                 endretAndelerForForrigeBehandling = emptyList(),
             )
 
+        // Act
         val erEndringIBeløp =
             erEndringIBeløpForPerson(
                 nåværendeAndelerForPerson = nåværendeAndeler,
@@ -289,12 +300,14 @@ class BehandlingsresultatEndringUtilsTest {
                 erFremstiltKravForPerson = false,
             )
 
+        // Assert
         assertEquals(false, erEndringIBeløp)
     }
 
     @Test
     fun `Endring i beløp - Skal returnere true når beløp i periode har gått fra større enn 0 til null og det er søkt for person`() {
         val barn2Aktør = randomAktør()
+        // Arrange
         val personerFramstiltKravFor = listOf(barn1Aktør)
 
         val forrigeAndeler =
@@ -328,6 +341,7 @@ class BehandlingsresultatEndringUtilsTest {
                 ),
             )
 
+        // Act
         val erEndringIBeløp =
             listOf(barn1Aktør, barn2Aktør).any { aktør ->
                 val erFremstiltKravForPerson = personerFramstiltKravFor.contains(aktør)
@@ -350,6 +364,7 @@ class BehandlingsresultatEndringUtilsTest {
                 erEndringIBeløpForPerson
             }
 
+        // Assert
         assertEquals(true, erEndringIBeløp)
     }
 
@@ -357,6 +372,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `Endring i beløp - Skal returnere false når beløp i periode har gått fra større enn 0 til at annet tall større enn 0 og det er søkt for person`() {
         val barn2Aktør = randomAktør()
 
+        // Arrange
         val personerFramstiltKravFor = listOf(barn1Aktør)
 
         val forrigeAndeler =
@@ -396,6 +412,7 @@ class BehandlingsresultatEndringUtilsTest {
                 ),
             )
 
+        // Act
         val erEndringIBeløp =
             listOf(barn1Aktør, barn2Aktør).any { aktør ->
                 val erFremstiltKravForPerson = personerFramstiltKravFor.contains(aktør)
@@ -418,6 +435,7 @@ class BehandlingsresultatEndringUtilsTest {
                 erEndringIBeløpForPerson
             }
 
+        // Assert
         assertEquals(false, erEndringIBeløp)
     }
 
@@ -425,6 +443,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `Endring i beløp - Skal returnere true når beløp i periode har gått fra null til et tall større enn 0 og det ikke er søkt for person`() {
         val barn2Aktør = randomAktør()
 
+        // Arrange
         val forrigeAndeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -456,6 +475,7 @@ class BehandlingsresultatEndringUtilsTest {
                 ),
             )
 
+        // Act
         val erEndringIBeløp =
             listOf(barn1Aktør, barn2Aktør).any { aktør ->
                 val opphørstidspunktForBehandling =
@@ -476,6 +496,7 @@ class BehandlingsresultatEndringUtilsTest {
                 erEndringIBeløpForPerson
             }
 
+        // Assert
         assertEquals(true, erEndringIBeløp)
     }
 
@@ -483,6 +504,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `Endring i beløp - Skal returnere false når beløp i periode har gått fra null til et tall større enn 0 og det er søkt for person`() {
         val barn2Aktør = randomAktør()
 
+        // Arrange
         val personerFramstiltKravFor = listOf(barn1Aktør)
 
         val forrigeAndeler =
@@ -516,6 +538,7 @@ class BehandlingsresultatEndringUtilsTest {
                 ),
             )
 
+        // Act
         val erEndringIBeløp =
             listOf(barn1Aktør, barn2Aktør).any { aktør ->
                 val erFremstiltKravForPerson = personerFramstiltKravFor.contains(aktør)
@@ -538,6 +561,7 @@ class BehandlingsresultatEndringUtilsTest {
                 erEndringIBeløpForPerson
             }
 
+        // Assert
         assertEquals(false, erEndringIBeløp)
     }
 
@@ -545,6 +569,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `Endring i beløp - Skal returnere true når beløp i periode har gått fra større enn 0 til at annet tall større enn 0 og det ikke er søkt for person`() {
         val barn2Aktør = randomAktør()
 
+        // Arrange
         val forrigeAndeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -582,6 +607,7 @@ class BehandlingsresultatEndringUtilsTest {
                 ),
             )
 
+        // Act
         val erEndringIBeløp =
             listOf(barn1Aktør, barn2Aktør).any { aktør ->
 
@@ -603,6 +629,7 @@ class BehandlingsresultatEndringUtilsTest {
                 erEndringIBeløpForPerson
             }
 
+        // Assert
         assertEquals(true, erEndringIBeløp)
     }
 
@@ -610,6 +637,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `Endring i endret utbetaling andel - skal returnere true hvis årsak er endret`() {
         val barn = lagPerson(aktør = randomAktør())
 
+        // Arrange
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
@@ -632,6 +660,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i endret utbetaling andel - skal returnere false hvis prosent er endret`() {
         val barn = lagPerson(aktør = randomAktør())
+        // Arrange
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
@@ -654,6 +683,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i endret utbetaling andel - skal returnere true hvis eneste endring er at perioden blir lenger`() {
         val barn = lagPerson(aktør = randomAktør())
+        // Arrange
         val forrigeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
@@ -677,6 +707,7 @@ class BehandlingsresultatEndringUtilsTest {
     fun `Endring i endret utbetaling andel - skal returnere true hvis endringsperiode oppstår i nåværende behandling`() {
         val barn = lagPerson(aktør = randomAktør())
 
+        // Arrange
         val nåværendeEndretAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = 0,
@@ -699,6 +730,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i endret utbetaling andel - skal returnere true hvis et av to barn har endring på årsak`() {
         val barn1 = lagPerson(aktør = randomAktør())
+        // Arrange
         val barn2 = lagPerson(aktør = randomAktør())
 
         val forrigeEndretAndelBarn1 =
@@ -733,6 +765,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere false når ingenting endrer seg`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -760,6 +793,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere true når søkers aktivitetsland endrer seg`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -790,6 +824,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere true når søkers aktivitet endrer seg`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -822,6 +857,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere true når annen forelders aktivitetsland endrer seg`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -854,6 +890,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere true når annen forelders aktivitet endrer seg`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -886,6 +923,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere true når barnets bostedsland endrer seg`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -916,6 +954,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere true når resultat på kompetansen endrer seg`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -948,6 +987,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i kompetanse - skal returnere false når det kun blir lagt på en ekstra kompetanseperiode`() {
         val forrigeBehandling = lagBehandling()
+        // Arrange
         val nåværendeBehandling = lagBehandling()
         val forrigeKompetanse =
             lagKompetanse(
@@ -980,6 +1020,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i vilkårsvurdering - skal returnere false dersom vilkårresultatene er helt like`() {
         val fødselsdato = LocalDate.of(2015, 1, 1)
+        // Arrange
         val nåværendeVilkårResultat =
             setOf(
                 VilkårResultat(
@@ -1058,6 +1099,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i vilkårsvurdering - skal returnere true dersom det har vært endringer i regelverk`() {
         val fødselsdato = LocalDate.of(2015, 1, 1)
+        // Arrange
         val nåværendeVilkårResultat =
             setOf(
                 VilkårResultat(
@@ -1108,6 +1150,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i vilkårsvurdering - skal returnere true dersom det har vært endringer i utdypendevilkårsvurdering`() {
         val fødselsdato = LocalDate.of(2015, 1, 1)
+        // Arrange
         val nåværendeVilkårResultat =
             setOf(
                 VilkårResultat(
@@ -1158,6 +1201,7 @@ class BehandlingsresultatEndringUtilsTest {
     @Test
     fun `Endring i vilkårsvurdering - skal returnere false hvis det kun er opphørt`() {
         val fødselsdato = LocalDate.of(2015, 1, 1)
+        // Arrange
         val nåværendeVilkårResultat =
             setOf(
                 VilkårResultat(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatOpphørUtilsTest.kt
@@ -52,6 +52,7 @@ class BehandlingsresultatOpphørUtilsTest {
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere IKKE_OPPHØRT dersom nåværende andeler strekker seg lengre enn dagens dato`() {
+        // Arrange
         val barn1Aktør = randomAktør()
         val barn2Aktør = randomAktør()
 
@@ -87,6 +88,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -98,11 +100,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom nåværende andeler opphører mens forrige andeler ikke opphører til og med dagens dato`() {
+        // Arrange
         val barn1Aktør = randomAktør()
         val barn2Aktør = randomAktør()
 
@@ -138,6 +142,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -149,11 +154,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom nåværende andeler opphører tidligere enn forrige andeler og dagens dato`() {
+        // Arrange
         val barn1Aktør = randomAktør()
         val barn2Aktør = randomAktør()
 
@@ -189,6 +196,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -200,11 +208,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom vi går fra andeler på person til fullt opphør på person`() {
+        // Arrange
         val barn1Aktør = randomAktør()
 
         val forrigeAndeler =
@@ -217,6 +227,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = emptyList(),
@@ -228,11 +239,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere FORTSATT_OPPHØRT dersom nåværende andeler har lik opphørsdato som forrige andeler`() {
+        // Arrange
         val barn1Aktør = randomAktør()
         val barn2Aktør = randomAktør()
 
@@ -268,6 +281,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -279,11 +293,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.FORTSATT_OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere IKKE_OPPHØRT dersom nåværende andeler har lik opphørsdato som forrige andeler men det er i fremtiden`() {
+        // Arrange
         val barn1Aktør = randomAktør()
         val barn2Aktør = randomAktør()
 
@@ -319,6 +335,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -330,12 +347,14 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
     }
 
     @ParameterizedTest
     @EnumSource(Årsak::class, names = ["ALLEREDE_UTBETALT", "ETTERBETALING_3MND", "FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024"])
     internal fun `filtrerBortIrrelevanteAndeler - skal filtrere andeler som har 0 i beløp og endret utbetaling andel med årsak ALLEREDE_UTBETALT, FULLTIDSPLASS_I_BARNEHAGE_AUGUST_2024  eller ETTERBETALING_3ÅR`(årsak: Årsak) {
+        // Arrange
         val barn = lagPerson(aktør = randomAktør())
         val barnAktør = barn.aktør
 
@@ -379,14 +398,17 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val andelerEtterFiltrering = andeler.filtrerBortIrrelevanteAndeler(endretUtBetalingAndeler)
 
+        // Assert
         assertEquals(andelerEtterFiltrering.minOf { it.stønadFom }, for1mndSiden)
         assertEquals(andelerEtterFiltrering.maxOf { it.stønadTom }, om1mnd)
     }
 
     @Test
     internal fun `filtrerBortIrrelevanteAndeler - skal ikke filtrere andeler som har 0 i beløp grunnet differanseberegning`() {
+        // Arrange
         val barn = lagPerson(aktør = randomAktør())
         val barnAktør = barn.aktør
         val søker = lagPerson(aktør = randomAktør())
@@ -417,14 +439,17 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val andelerEtterFiltrering = andeler.filtrerBortIrrelevanteAndeler(endretAndeler = emptyList())
 
+        // Assert
         assertEquals(andelerEtterFiltrering.minOf { it.stønadFom }, for3mndSiden)
         assertEquals(andelerEtterFiltrering.maxOf { it.stønadTom }, om4mnd)
     }
 
     @Test
     fun `utledOpphørsdatoForNåværendeBehandlingMedFallback - skal returnere null hvis det ikke finnes andeler i inneværende behandling og kun irrelevante nullutbetalinger i forrige behandling`() {
+        // Arrange
         val barn = lagPerson(aktør = randomAktør())
 
         val forrigeAndeler =
@@ -463,6 +488,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørstidspunktInneværendeBehandling =
             emptyList<AndelTilkjentYtelse>().utledOpphørsdatoForNåværendeBehandlingMedFallback(
                 forrigeAndelerIBehandling = forrigeAndeler,
@@ -470,11 +496,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåværendeEndretAndelerIBehandling = emptyList(),
             )
 
+        // Assert
         assertNull(opphørstidspunktInneværendeBehandling)
     }
 
     @Test
     fun `utledOpphørsdatoForNåværendeBehandlingMedFallback - skal returnere tidligste fom på andeler i forrige behandling hvis det ikke finnes andeler i inneværende behandling`() {
+        // Arrange
         val barn = lagPerson(aktør = randomAktør())
 
         val forrigeAndeler =
@@ -505,6 +533,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørstidspunktInneværendeBehandling =
             emptyList<AndelTilkjentYtelse>().utledOpphørsdatoForNåværendeBehandlingMedFallback(
                 forrigeAndelerIBehandling = forrigeAndeler,
@@ -512,11 +541,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåværendeEndretAndelerIBehandling = emptyList(),
             )
 
+        // Assert
         assertEquals(for1mndSiden, opphørstidspunktInneværendeBehandling)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT bruker har krysset av for meldt barnehageplass på alle barn`() {
+        // Arrange
         val barn1 = lagPerson(aktør = randomAktør())
         val barn2 = lagPerson(aktør = randomAktør())
 
@@ -562,6 +593,7 @@ class BehandlingsresultatOpphørUtilsTest {
                     ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = listOf(lagAndelTilkjentYtelse(aktør = barn1.aktør), lagAndelTilkjentYtelse(aktør = barn2.aktør)),
@@ -573,11 +605,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere FORTSATT_OPPHØRT hvis bruker har krysset av for meldt barnehageplass på alle barn med løpende andeler i forrige og nåværende behandling`() {
+        // Arrange
         val barn1 = lagPerson(aktør = randomAktør())
         val barn2 = lagPerson(aktør = randomAktør())
 
@@ -623,6 +657,7 @@ class BehandlingsresultatOpphørUtilsTest {
                     ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = listOf(lagAndelTilkjentYtelse(aktør = barn1.aktør), lagAndelTilkjentYtelse(aktør = barn2.aktør)),
@@ -634,11 +669,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.FORTSATT_OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal ikke returnere OPPHØRT dersom ikke alle barn med løpende ytelse har blitt krysset av for meldt barnehageplass`() {
+        // Arrange
         val barn1 = lagPerson(aktør = randomAktør())
         val barn2 = lagPerson(aktør = randomAktør())
 
@@ -682,6 +719,7 @@ class BehandlingsresultatOpphørUtilsTest {
                     ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = listOf(lagAndelTilkjentYtelse(aktør = barn2.aktør)),
@@ -693,11 +731,13 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.IKKE_OPPHØRT, opphørsresultat)
     }
 
     @Test
     fun `hentOpphørsresultatPåBehandling skal returnere OPPHØRT dersom kontantstøtten opphører to måneder fram i tid`() {
+        // Arrange
         val barn1Aktør = randomAktør()
 
         val nåværendeAndeler =
@@ -710,6 +750,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 ),
             )
 
+        // Act
         val opphørsresultat =
             hentOpphørsresultatPåBehandling(
                 nåværendeAndeler = nåværendeAndeler,
@@ -721,6 +762,7 @@ class BehandlingsresultatOpphørUtilsTest {
                 nåMåned = YearMonth.now(),
             )
 
+        // Assert
         assertEquals(Opphørsresultat.OPPHØRT, opphørsresultat)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatServiceTest.kt
@@ -51,8 +51,10 @@ class BehandlingsresultatServiceTest {
 
     @Test
     fun `finnPersonerFremstiltKravFor skal returnere tom liste dersom behandlingen ikke er søknad, fødselshendelse eller manuell migrering`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.BARNEHAGELISTE)
 
+        // Act
         val personerFramstiltForKrav =
             behandlingsresultatService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
@@ -61,11 +63,13 @@ class BehandlingsresultatServiceTest {
                 harTidligereBareBehandlingerSomErAvslått = false,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav, Is(emptyList()))
     }
 
     @Test
     fun `finnPersonerFremstiltKravFor skal bare returnere barn som er folkeregistret og krysset av på søknad`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val barn1Fnr = randomFnr()
         val mocketAktør = mockk<Aktør>()
@@ -108,6 +112,7 @@ class BehandlingsresultatServiceTest {
 
         every { personidentService.hentAktør(barn1Fnr) } returns mocketAktør
 
+        // Act
         val personerFramstiltForKrav =
             behandlingsresultatService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
@@ -116,6 +121,7 @@ class BehandlingsresultatServiceTest {
                 harTidligereBareBehandlingerSomErAvslått = false,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.single(), Is(mocketAktør))
 
         verify(exactly = 1) { personidentService.hentAktør(barn1Fnr) }
@@ -123,6 +129,7 @@ class BehandlingsresultatServiceTest {
 
     @Test
     fun `finnPersonerFremstiltKravFor skal ikke returnere duplikater av personer`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val barn = lagPerson(aktør = randomAktør())
 
@@ -152,6 +159,7 @@ class BehandlingsresultatServiceTest {
         every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(any()) } returns Vilkårsvurdering(behandling = behandling)
         every { personidentService.hentAktør(barn.aktør.aktivFødselsnummer()) } returns barn.aktør
 
+        // Act
         val personerFramstiltForKrav =
             behandlingsresultatService.finnPersonerFremstiltKravFor(
                 behandling = behandling,
@@ -160,6 +168,7 @@ class BehandlingsresultatServiceTest {
                 harTidligereBareBehandlingerSomErAvslått = false,
             )
 
+        // Assert
         assertThat(personerFramstiltForKrav.size, Is(1))
         assertThat(personerFramstiltForKrav.single(), Is(barn.aktør))
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatSøknadUtilsTest.kt
@@ -344,6 +344,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
     @Test
     fun `kombinerSøknadsresultater skal returnere DELVIS_INNVILGET dersom lista består av INNVILGET, AVSLÅTT OG INGEN_RELEVANTE_ENDRINGER`() {
+        // Arrange
         val listeMedSøknadsresultat =
             listOf(
                 Søknadsresultat.INNVILGET,
@@ -351,13 +352,16 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 Søknadsresultat.INGEN_RELEVANTE_ENDRINGER,
             )
 
+        // Act
         val kombinertResultat = listeMedSøknadsresultat.kombinerSøknadsresultater(behandlingÅrsak = BehandlingÅrsak.SØKNAD)
 
+        // Assert
         assertThat(kombinertResultat, Is(Søknadsresultat.DELVIS_INNVILGET))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal kaste feil dersom man har endt opp med ingen resultater`() {
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -373,6 +377,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
 
     @Test
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom det er søkt for barn som ikke er registrert`() {
+        // Arrange
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -384,11 +389,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = true,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere AVSLÅTT dersom er eksplisitt avslag på minst en person det er framstilt krav for`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -406,6 +413,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -417,11 +425,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.AVSLÅTT))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere INNVILGET dersom barnet det er søkt for har fått andeler med positive beløp som er annerledes enn forrige gang`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -448,6 +458,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -459,11 +470,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.INNVILGET))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere DELVIS_INNVILGET dersom det finnes et barn som har fått innvilget men også et barn som ikke er registrert`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -490,6 +503,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = emptyList(),
@@ -501,11 +515,13 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = true,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.DELVIS_INNVILGET))
     }
 
     @Test
     fun `utledResultatPåSøknad - skal returnere INGEN_RELEVANTE_ENDRINGER dersom barnet det er søkt for har fått helt lik andel som forrige behandling`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val vikårsvurdering = Vilkårsvurdering(behandling = behandling)
 
@@ -532,6 +548,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 lagFullstendigVilkårResultat = true,
             )
 
+        // Act
         val resultatPåSøknad =
             BehandlingsresultatSøknadUtils.utledResultatPåSøknad(
                 forrigeAndeler = andeler,
@@ -543,6 +560,7 @@ internal class BehandlingsresultatSøknadUtilsTest {
                 finnesUregistrerteBarn = false,
             )
 
+        // Assert
         assertThat(resultatPåSøknad, Is(Søknadsresultat.INGEN_RELEVANTE_ENDRINGER))
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatUtilsTest.kt
@@ -21,6 +21,7 @@ internal class BehandlingsresultatUtilsTest {
         opphørsresultat: Opphørsresultat,
         behandlingsresultat: Behandlingsresultat,
     ) {
+        // Act
         val kombinertResultat =
             BehandlingsresultatUtils.kombinerResultaterTilBehandlingsresultat(
                 søknadsresultat,
@@ -28,6 +29,7 @@ internal class BehandlingsresultatUtilsTest {
                 opphørsresultat,
             )
 
+        // Assert
         assertEquals(kombinertResultat, behandlingsresultat)
     }
 
@@ -38,6 +40,7 @@ internal class BehandlingsresultatUtilsTest {
         endringsresultat: Endringsresultat,
         opphørsresultat: Opphørsresultat,
     ) {
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             BehandlingsresultatUtils.kombinerResultaterTilBehandlingsresultat(
                 søknadsresultat,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/behandlingsresultat/BehandlingsresultatValideringUtilsTest.kt
@@ -16,6 +16,7 @@ import java.time.LocalDate
 internal class BehandlingsresultatValideringUtilsTest {
     @Test
     fun `Valider eksplisitt avlag - Skal kaste feil hvis eksplisitt avslått for barn det ikke er fremstilt krav for`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val vilkårsvurdering =
             lagVilkårsvurdering(
@@ -49,6 +50,7 @@ internal class BehandlingsresultatValideringUtilsTest {
                 erEksplisittAvslagPåSøknad = true,
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
                 personResultater = setOf(barn1PersonResultat, barn2PersonResultat),
@@ -59,6 +61,7 @@ internal class BehandlingsresultatValideringUtilsTest {
 
     @Test
     fun `Valider eksplisitt avslag - Skal ikke kaste feil hvis person med eksplsitt avslag er fremstilt krav for`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
         val vilkårsvurdering =
             lagVilkårsvurdering(
@@ -92,6 +95,7 @@ internal class BehandlingsresultatValideringUtilsTest {
                 erEksplisittAvslagPåSøknad = true,
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             BehandlingsresultatValideringUtils.validerAtBarePersonerFremstiltKravForEllerSøkerHarFåttEksplisittAvslag(
                 personResultater = setOf(barn1PersonResultat, barn2PersonResultat),

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/HentStatusFraOppdragTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/HentStatusFraOppdragTaskTest.kt
@@ -69,8 +69,10 @@ internal class HentStatusFraOppdragTaskTest {
 
     @Test
     fun `doTask skal kaste feil når oppdrag returnerer med status LAGT_PÅ_KØ`() {
+        // Arrange
         every { oppdragKlient.hentStatus(any()) } returns OppdragStatus.LAGT_PÅ_KØ
 
+        // Act & Assert
         val exception = assertThrows<RekjørSenereException> { hentStatusFraOppdragTask.doTask(lagTask()) }
         assertEquals("Mottok ${OppdragStatus.LAGT_PÅ_KØ.name} fra oppdrag.", exception.årsak)
         assertNotNull(exception.triggerTid)
@@ -78,25 +80,32 @@ internal class HentStatusFraOppdragTaskTest {
 
     @Test
     fun `doTask skal sette task til manuell oppfølging når oppdrag returnerer med KVITTERT_TEKNISK_FEIL`() {
+        // Arrange
         every { oppdragKlient.hentStatus(any()) } returns OppdragStatus.KVITTERT_TEKNISK_FEIL
         val taskSlot = slot<Task>()
+
+        // Act
         assertDoesNotThrow { hentStatusFraOppdragTask.doTask(lagTask()) }
 
+        // Assert
         verify(exactly = 1) { taskService.save(capture(taskSlot)) }
         assertEquals(Status.MANUELL_OPPFØLGING, taskSlot.captured.status)
     }
 
     @Test
     fun `doTask skal utføre task når oppdrag returnerer med KVITTERT_OK`() {
+        // Arrange
         every { oppdragKlient.hentStatus(any()) } returns OppdragStatus.KVITTERT_OK
         every { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) } just runs
 
+        // Act & Assert
         assertDoesNotThrow { hentStatusFraOppdragTask.doTask(lagTask()) }
         verify(exactly = 1) { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) }
     }
 
     @Test
     fun `doTask skal ikke hente status fra oppdrag hvis utbetalingsperiode er en tom liste`() {
+        // Arrange
         every { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) } just runs
         every { tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(any()) } returns
             lagTilkjentYtelse(
@@ -113,6 +122,7 @@ internal class HentStatusFraOppdragTaskTest {
                     ),
             )
 
+        // Act & Assert
         assertDoesNotThrow { hentStatusFraOppdragTask.doTask(lagTask()) }
         verify(exactly = 1) { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) }
         verify(exactly = 0) { oppdragKlient.hentStatus(any()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/SøknadGrunnlagServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/SøknadGrunnlagServiceTest.kt
@@ -22,10 +22,12 @@ class SøknadGrunnlagServiceTest {
 
     @Test
     fun `lagreOgDeaktiverGammel - skal hente eksisterende aktiv søknad tilknyttet behandlingId og sette den til inaktiv og deretter lagre ny`() {
+        // Arrange
         val deaktivertSøknadSlot = slot<SøknadGrunnlag>()
         val nySøknadSlot = slot<SøknadGrunnlag>()
 
         val nySøknadGrunnlag =
+            // Act
             SøknadGrunnlag(
                 behandlingId = 0,
                 aktiv = true,
@@ -45,13 +47,16 @@ class SøknadGrunnlagServiceTest {
 
         søknadGrunnlagService.lagreOgDeaktiverGammel(nySøknadGrunnlag)
 
+        // Assert
         assertFalse(deaktivertSøknadSlot.captured.aktiv)
         assertTrue(nySøknadSlot.captured.aktiv)
     }
 
     @Test
     fun `finnAktiv - skal hente aktiv søknad tilknyttet behandlingId når den finnes`() {
+        // Arrange
         val søknadGrunnlag =
+            // Act
             SøknadGrunnlag(
                 behandlingId = 0,
                 aktiv = true,
@@ -61,21 +66,27 @@ class SøknadGrunnlagServiceTest {
 
         val aktivSøknad = søknadGrunnlagService.finnAktiv(0L)
 
+        // Assert
         assertNotNull(aktivSøknad)
     }
 
     @Test
     fun `finnAktiv - skal returnere null dersom søknad tilknyttet behandlingId ikke finnes`() {
+        // Arrange
         every { søknadGrunnlagRepository.finnAktiv(any()) } returns null
 
         val aktivSøknad = søknadGrunnlagService.finnAktiv(404L)
 
+        // Assert
         assertNull(aktivSøknad)
+        // Act
     }
 
     @Test
     fun `hentAktiv - skal hente aktiv søknad tilknyttet behandlingId når den finnes`() {
+        // Arrange
         val søknadGrunnlag =
+            // Act
             SøknadGrunnlag(
                 behandlingId = 0,
                 aktiv = true,
@@ -85,14 +96,18 @@ class SøknadGrunnlagServiceTest {
 
         val aktivSøknad = søknadGrunnlagService.hentAktiv(0L)
 
+        // Assert
         assertNotNull(aktivSøknad)
     }
 
     @Test
     fun `hentAktiv - skal kaste feil dersom søknad tilknyttet behandlingId ikke finnes`() {
+        // Arrange
         every { søknadGrunnlagRepository.finnAktiv(0L) } returns null
 
         val feil =
+            // Act
+            // Assert
             assertThrows<Feil> {
                 søknadGrunnlagService.hentAktiv(0L)
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringStegTest.kt
@@ -38,9 +38,11 @@ internal class SimuleringStegTest {
 
     @Test
     fun `skal utføre steg for revurdering når det ikke finnes åpen tilbakekrevingsbehandling`() {
+        // Arrange
         every { tilbakekrevingService.harÅpenTilbakekrevingsbehandling(revurderingsbehandling.fagsak.id) } returns false
         every { simuleringService.hentFeilutbetaling(revurderingsbehandling.id) } returns BigDecimal(3500)
 
+        // Act & Assert
         assertDoesNotThrow { simuleringSteg.utførSteg(revurderingsbehandling.id, lagTilbakekrevingDto()) }
         verify(exactly = 1) { simuleringService.hentFeilutbetaling(revurderingsbehandling.id) }
         verify(exactly = 1) { tilbakekrevingService.lagreTilbakekreving(any(), any()) }
@@ -48,8 +50,10 @@ internal class SimuleringStegTest {
 
     @Test
     fun `skal utføre steg for revurdering når det finnes åpen tilbakekrevingsbehandling`() {
+        // Arrange
         every { tilbakekrevingService.harÅpenTilbakekrevingsbehandling(revurderingsbehandling.fagsak.id) } returns true
 
+        // Act & Assert
         assertDoesNotThrow { simuleringSteg.utførSteg(revurderingsbehandling.id, lagTilbakekrevingDto()) }
         verify(exactly = 0) { simuleringService.hentFeilutbetaling(revurderingsbehandling.id) }
         verify(exactly = 0) { tilbakekrevingService.lagreTilbakekreving(any(), any()) }
@@ -57,9 +61,11 @@ internal class SimuleringStegTest {
 
     @Test
     fun `skal ikke utføre steg for revurdering når det ikke finnes en feilutbetaling men frontend sender tilbakekrevingDto`() {
+        // Arrange
         every { tilbakekrevingService.harÅpenTilbakekrevingsbehandling(revurderingsbehandling.fagsak.id) } returns false
         every { simuleringService.hentFeilutbetaling(revurderingsbehandling.id) } returns BigDecimal.ZERO
 
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 simuleringSteg.utførSteg(revurderingsbehandling.id, lagTilbakekrevingDto())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/simulering/SimuleringUtilTest.kt
@@ -138,15 +138,18 @@ class SimuleringUtilTest {
 
     @Test
     fun `tilSimuleringDto - Total feilutbetaling skal bli 0 i periode med negativ feilutbetaling`() {
+        // Arrange
         val økonomiSimuleringMottaker =
             mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = økonomiSimuleringPosteringerMedNegativFeilutbetaling)
         val simuleringDto = listOf(økonomiSimuleringMottaker).tilSimuleringDto()
 
+        // Act & Assert
         Assertions.assertEquals(BigDecimal.valueOf(0), simuleringDto.feilutbetaling)
     }
 
     @Test
     fun `tilSimuleringDto - Skal gi 0 etterbetaling og sum feilutbetaling ved positiv feilutbetaling`() {
+        // Arrange
         val økonomiSimuleringPosteringerMedPositivFeilutbetaling =
             listOf(
                 mockVedtakSimuleringPostering(beløp = 500, posteringType = PosteringType.FEILUTBETALING),
@@ -159,12 +162,14 @@ class SimuleringUtilTest {
             mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = økonomiSimuleringPosteringerMedPositivFeilutbetaling)
         val simuleringDto = listOf(økonomiSimuleringMottaker).tilSimuleringDto()
 
+        // Act & Assert
         Assertions.assertEquals(BigDecimal.valueOf(0), simuleringDto.etterbetaling)
         Assertions.assertEquals(BigDecimal.valueOf(500), simuleringDto.feilutbetaling)
     }
 
     @Test
     fun `hentEtterbetalingIPeriode - Test at bare perioder med passert forfalldato blir inludert i summeringen av etterbetaling`() {
+        // Arrange
         val vedtaksimuleringPosteringer =
             listOf(
                 mockVedtakSimuleringPostering(
@@ -179,6 +184,7 @@ class SimuleringUtilTest {
                 ),
             )
 
+        // Act & Assert
         Assertions.assertEquals(
             BigDecimal.valueOf(200),
             hentEtterbetalingIPeriode(
@@ -197,6 +203,7 @@ class SimuleringUtilTest {
      */
     @Test
     fun `ytelse på 10000 korrigert til 2000`() {
+        // Arrange
         val redusertYtelseTil2000 =
             listOf(
                 mockVedtakSimuleringPostering(
@@ -233,9 +240,12 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = redusertYtelseTil2000))
+
+        // Act
         val simuleringsperioder = økonomiSimuleringMottakere.tilSimuleringsPerioder()
         val oppsummering = økonomiSimuleringMottakere.tilSimuleringDto()
 
+        // Assert
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(10000.toBigDecimal())
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(2000.toBigDecimal())
@@ -246,6 +256,7 @@ class SimuleringUtilTest {
 
     @Test
     fun `ytelse på 2000 korrigert til 3000`() {
+        // Arrange
         val øktYtelseFra2000Til3000 =
             listOf(
                 mockVedtakSimuleringPostering(
@@ -278,9 +289,12 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = øktYtelseFra2000Til3000))
+
+        // Act
         val simuleringsperioder = økonomiSimuleringMottakere.tilSimuleringsPerioder()
         val oppsummering = økonomiSimuleringMottakere.tilSimuleringDto()
 
+        // Assert
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(2000.toBigDecimal())
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(3000.toBigDecimal())
@@ -291,6 +305,7 @@ class SimuleringUtilTest {
 
     @Test
     fun `ytelse på 3000 korrigert til 12000`() {
+        // Arrange
         val øktYtelseFra3000Til12000 =
             listOf(
                 mockVedtakSimuleringPostering(
@@ -323,9 +338,12 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = øktYtelseFra3000Til12000))
+
+        // Act
         val simuleringsperioder = økonomiSimuleringMottakere.tilSimuleringsPerioder()
         val oppsummering = økonomiSimuleringMottakere.tilSimuleringDto()
 
+        // Assert
         assertThat(simuleringsperioder.size).isEqualTo(1)
         assertThat(simuleringsperioder[0].tidligereUtbetalt).isEqualTo(3000.toBigDecimal())
         assertThat(simuleringsperioder[0].nyttBeløp).isEqualTo(12000.toBigDecimal())
@@ -344,20 +362,25 @@ class SimuleringUtilTest {
 
     @Test
     fun `førstegangsbehandling 18 nov`() {
+        // Arrange
         val førstegangsbehandling18nov =
             mockVedtakSimuleringPosteringer(YearMonth.of(2021, 2), 3, 17_153, PosteringType.YTELSE) +
                 mockVedtakSimuleringPosteringer(YearMonth.of(2021, 5), 6, 18_195, PosteringType.YTELSE)
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = førstegangsbehandling18nov))
+
+        // Act
         val oppsummering = økonomiSimuleringMottakere.tilSimuleringDto()
 
+        // Assert
         assertThat(oppsummering.feilutbetaling).isEqualTo(0.toBigDecimal())
         assertThat(oppsummering.etterbetaling).isEqualTo(160_629.toBigDecimal())
     }
 
     @Test
     fun `revurdering 22 nov`() {
+        // Arrange
         val revurering22nov =
             // Forrige ytelse
             mockVedtakSimuleringPosteringer(YearMonth.of(2021, 2), 3, -17_153, PosteringType.YTELSE) +
@@ -375,14 +398,18 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = revurering22nov))
+
+        // Act
         val oppsummering = økonomiSimuleringMottakere.tilSimuleringDto()
 
+        // Assert
         assertThat(oppsummering.feilutbetaling).isEqualTo(3_752.toBigDecimal())
         assertThat(oppsummering.etterbetaling).isEqualTo(0.toBigDecimal())
     }
 
     @Test
     fun `revurdering 23 nov`() {
+        // Arrange
         val revurdering23nov =
             // Forrige ytelse
             mockVedtakSimuleringPosteringer(YearMonth.of(2021, 2), 3, -17_153, PosteringType.YTELSE) +
@@ -400,9 +427,12 @@ class SimuleringUtilTest {
 
         val økonomiSimuleringMottakere =
             listOf(mockØkonomiSimuleringMottaker(økonomiSimuleringPostering = revurdering23nov))
+
+        // Act
         val simuleringsperioder = økonomiSimuleringMottakere.tilSimuleringsPerioder()
         val oppsummering = økonomiSimuleringMottakere.tilSimuleringDto()
 
+        // Assert
         (3..6).forEach {
             assertThat(simuleringsperioder[it].tidligereUtbetalt).isEqualTo(17_257.toBigDecimal())
             assertThat(simuleringsperioder[it].resultat).isEqualTo(1_125.toBigDecimal())

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakServiceTest.kt
@@ -40,10 +40,13 @@ class VedtakServiceTest {
 
     @Test
     fun `hentVedtak - skal hente vedtak fra VedtakRepository`() {
+        // Arrange
         every { vedtakRepository.hentVedtak(1) } returns mockk()
 
+        // Act
         val hentetVedtak = vedtakService.hentVedtak(1)
 
+        // Assert
         Assertions.assertNotNull(hentetVedtak)
         verify(exactly = 1) { vedtakRepository.hentVedtak(1) }
     }
@@ -53,6 +56,7 @@ class VedtakServiceTest {
     fun `oppdaterVedtakMedDatoOgStønadsbrev - skal oppdatere vedtak med dato og stønadsbrev`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = behandlingÅrsak, resultat = ENDRET_OG_OPPHØRT)
         val vedtak = lagVedtak(behandling)
         val brev = "brev".toByteArray()
@@ -65,8 +69,10 @@ class VedtakServiceTest {
         every { behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(any()) } returns false
         every { LocalDateTime.now() } returns LocalDateTime.of(2024, 1, 1, 0, 0)
 
+        // Act
         val oppdatertVedtak = vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
 
+        // Assert
         assertThat(oppdatertVedtak.stønadBrevPdf, Is(brev))
         assertThat(oppdatertVedtak.vedtaksdato, Is(LocalDateTime.of(2024, 1, 1, 0, 0)))
 
@@ -82,6 +88,7 @@ class VedtakServiceTest {
     fun `oppdaterVedtakMedDatoOgStønadsbrev - skal oppdatere vedtak med dato, men ikke stønadsbrev`(
         behandlingÅrsak: BehandlingÅrsak,
     ) {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = behandlingÅrsak, resultat = INNVILGET, type = REVURDERING)
         val vedtak = lagVedtak(behandling)
 
@@ -92,8 +99,10 @@ class VedtakServiceTest {
         every { behandlingService.erLovendringOgFremtidigOpphørOgHarFlereAndeler(any()) } returns false
         every { LocalDateTime.now() } returns LocalDateTime.of(2024, 1, 1, 0, 0)
 
+        // Act
         val oppdatertVedtak = vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(behandling)
 
+        // Assert
         assertThat(oppdatertVedtak.stønadBrevPdf, IsNull())
         assertThat(oppdatertVedtak.vedtaksdato, Is(LocalDateTime.of(2024, 1, 1, 0, 0)))
 
@@ -109,9 +118,11 @@ class VedtakServiceTest {
     fun `opprettOgInitierNyttVedtakForBehandling - skal kaste feil hvis steg ikke er BESLUTTE_VEDTAK eller REGISTRERE_PERSONGRUNNLAG`(
         behandlingSteg: BehandlingSteg,
     ) {
+        // Arrange
         val behandling = mockk<Behandling>()
         every { behandling.steg } returns behandlingSteg
 
+        // Act & Assert
         val feil = assertThrows<Feil> { vedtakService.opprettOgInitierNyttVedtakForBehandling(behandling, false) }
 
         assertThat(feil.message, Is("Forsøker å initiere vedtak på steg ${behandlingSteg.name}"))
@@ -122,6 +133,7 @@ class VedtakServiceTest {
     fun `opprettOgInitierNyttVedtakForBehandling - skal lagre ny vedtak og deaktivere gamle hvis steg er BESLUTTE_VEDTAK eller REGISTRERE_PERSONGRUNNLAG`(
         behandlingSteg: BehandlingSteg,
     ) {
+        // Arrange
         val behandling = mockk<Behandling>(relaxed = true)
         val eksisterendeVedtak = mockk<Vedtak>(relaxed = true)
         val slot = slot<Vedtak>()
@@ -131,10 +143,12 @@ class VedtakServiceTest {
         every { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) } returns eksisterendeVedtak
         every { vedtakRepository.saveAndFlush(capture(slot)) } returns mockk(relaxed = true)
 
+        // Act
         vedtakService.opprettOgInitierNyttVedtakForBehandling(behandling, false)
 
         val lagretVedtak = slot.captured
 
+        // Assert
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
         verify(exactly = 1) { eksisterendeVedtak setProperty "aktiv" value false }
         verify(exactly = 1) { vedtakRepository.saveAndFlush(lagretVedtak) }
@@ -147,6 +161,7 @@ class VedtakServiceTest {
     fun `opprettOgInitierNyttVedtakForBehandling - skal kopiere over vedtaksperioder dersom det eksisterer gammmelt vedtak og kopierOverVedtaksperioder er satt til true`(
         behandlingSteg: BehandlingSteg,
     ) {
+        // Arrange
         val behandling = mockk<Behandling>(relaxed = true)
         val eksisterendeVedtak = mockk<Vedtak>(relaxed = true)
         val slot = slot<Vedtak>()
@@ -157,10 +172,12 @@ class VedtakServiceTest {
         every { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) } returns eksisterendeVedtak
         every { vedtakRepository.saveAndFlush(capture(slot)) } returns mockk(relaxed = true)
 
+        // Act
         vedtakService.opprettOgInitierNyttVedtakForBehandling(behandling, true)
 
         val lagretVedtak = slot.captured
 
+        // Assert
         verify(exactly = 1) { vedtaksperiodeService.kopierOverVedtaksperioder(any(), any()) }
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
         verify(exactly = 1) { eksisterendeVedtak setProperty "aktiv" value false }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/VedtakStegTest.kt
@@ -51,16 +51,19 @@ class VedtakStegTest {
 
     @Test
     fun `utførSteg skal kaste feil dersom behandlingen er henlagt`() {
+        // Arrange
         val mocketBehandling = mockk<Behandling>()
 
         every { mocketBehandling.erHenlagt() } returns true
         every { behandlingService.hentBehandling(200) } returns mocketBehandling
 
+        // Act & Assert
         val feil =
             assertThrows<Feil> {
                 vedtakSteg.utførSteg(200)
             }
 
+        // Assert
         assertThat(feil.message, Is("Behandlingen er henlagt og dermed så kan ikke vedtak foreslås."))
     }
 
@@ -69,6 +72,7 @@ class VedtakStegTest {
     fun `utførSteg skal kaste feil dersom det er flere enn 1 steg i behandlingen som har status VENTER eller KLAR`(
         behandlingStegStatus: BehandlingStegStatus,
     ) {
+        // Arrange
         val mocketBehandling = mockk<Behandling>()
         val mocketStegTilstand = mockk<BehandlingStegTilstand>()
         val mocketStegTilstand2 = mockk<BehandlingStegTilstand>()
@@ -79,16 +83,19 @@ class VedtakStegTest {
         every { mocketBehandling.behandlingStegTilstand } returns mutableSetOf(mocketStegTilstand, mocketStegTilstand2)
         every { behandlingService.hentBehandling(200) } returns mocketBehandling
 
+        // Act & Assert
         val feil =
             assertThrows<Feil> {
                 vedtakSteg.utførSteg(200)
             }
 
+        // Assert
         assertThat(feil.message, Is("Behandlingen har mer enn ett ikke fullført steg."))
     }
 
     @Test
     fun `utførSteg lage logg, ny godkjennevedtak task og sette status på behandling til fatter vedtak`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
         every { behandlingService.hentBehandling(200) } returns behandling
@@ -101,8 +108,10 @@ class VedtakStegTest {
         every { sammensattKontrollsakService.finnSammensattKontrollsakForBehandling(any()) } returns null
         every { vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(any()) } returns mockk()
 
+        // Act
         vedtakSteg.utførSteg(200)
 
+        // Assert
         verify(exactly = 1) { behandlingService.hentBehandling(200) }
         verify(exactly = 1) { loggService.opprettSendTilBeslutterLogg(behandling.id) }
         verify(exactly = 1) { totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling) }
@@ -115,6 +124,7 @@ class VedtakStegTest {
 
     @Test
     fun `utførSteg skal kaste FunksjonellFeil hvis sammensatt kontrollsak finnes med tom fritekst`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
         every { behandlingService.hentBehandling(200) } returns behandling
@@ -123,16 +133,19 @@ class VedtakStegTest {
         every { sammensattKontrollsakService.finnSammensattKontrollsakForBehandling(any()) } returns
             SammensattKontrollsak(behandlingId = behandling.id, fritekst = "   ")
 
+        // Act & Assert
         val feil =
             assertThrows<FunksjonellFeil> {
                 vedtakSteg.utførSteg(200)
             }
 
+        // Assert
         assertThat(feil.frontendFeilmelding, Is("Fritekstfeltet i sammensatt kontrollsak kan ikke være tomt ved sending til beslutter."))
     }
 
     @Test
     fun `utførSteg skal ikke kaste feil hvis sammensatt kontrollsak finnes med utfylt fritekst`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
         every { behandlingService.hentBehandling(200) } returns behandling
@@ -146,11 +159,13 @@ class VedtakStegTest {
         every { sammensattKontrollsakService.finnSammensattKontrollsakForBehandling(any()) } returns
             SammensattKontrollsak(behandlingId = behandling.id, fritekst = "En begrunnelse")
 
+        // Act
         vedtakSteg.utførSteg(200)
     }
 
     @Test
     fun `utførSteg skal ikke kaste feil hvis ingen sammensatt kontrollsak finnes`() {
+        // Arrange
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
 
         every { behandlingService.hentBehandling(200) } returns behandling
@@ -163,6 +178,7 @@ class VedtakStegTest {
         every { vedtakService.oppdaterVedtakMedDatoOgStønadsbrev(any()) } returns mockk()
         every { sammensattKontrollsakService.finnSammensattKontrollsakForBehandling(any()) } returns null
 
+        // Act
         vedtakSteg.utførSteg(200)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/feilutbetaltvaluta/FeilutbetaltValutaServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/feilutbetaltvaluta/FeilutbetaltValutaServiceTest.kt
@@ -26,36 +26,46 @@ class FeilutbetaltValutaServiceTest {
 
     @Test
     fun `hentFeilutbetaltValuta - skal returnere feilutbetaltValuta dersom det finnes en med oppgitt id`() {
+        // Arrange
         val feilutbetaltValutaSomSkalFinnes = mockk<FeilutbetaltValuta>()
 
         every { feilutbetaltValutaRepository.finnFeilutbetaltValuta(any()) } returns feilutbetaltValutaSomSkalFinnes
 
+        // Act
         val feilutbetaltValuta = feilutbetaltValutaService.hentFeilutbetaltValuta(0)
 
+        // Assert
         assertThat(feilutbetaltValuta, Is(feilutbetaltValutaSomSkalFinnes))
     }
 
     @Test
     fun `hentAlleFeilutbetaltValutaForBehandling - skal returnere alle feilutbetaltValuta for behandling`() {
+        // Arrange
         every { feilutbetaltValutaRepository.finnFeilutbetalteValutaForBehandling(0) } returns listOf(mockk(), mockk())
 
+        // Act
         val alleFeilutbetaltValutaForBehandling =
             feilutbetaltValutaService.hentAlleFeilutbetaltValutaForBehandling(0)
 
+        // Assert
         assertThat(alleFeilutbetaltValutaForBehandling.size, Is(2))
     }
 
     @Test
     fun `hentFeilutbetaltValuta - skal kaste feil dersom feilutbetaltValuta med oppgitt id ikke finnes`() {
+        // Arrange
         every { feilutbetaltValutaRepository.finnFeilutbetaltValuta(any()) } returns null
 
+        // Act & Assert
         val feil = assertThrows<Feil> { feilutbetaltValutaService.hentFeilutbetaltValuta(0) }
 
+        // Assert
         assertThat(feil.message, Is("Finner ikke feilutbetalt valuta med id=0"))
     }
 
     @Test
     fun `leggTilFeilutbetaltValuta - skal lagre feilutbetaltValuta og lagre logg på det`() {
+        // Arrange
         val feilutbetaltValuta =
             FeilutbetaltValuta(
                 behandlingId = 0,
@@ -68,8 +78,10 @@ class FeilutbetaltValutaServiceTest {
         every { feilutbetaltValutaRepository.save(any()) } returnsArgument 0
         every { loggService.opprettFeilutbetaltValutaLagtTilLogg(feilutbetaltValuta) } returns mockk()
 
+        // Act
         val lagtTilFeilutbetaltValuta = feilutbetaltValutaService.leggTilFeilutbetaltValuta(feilutbetaltValuta)
 
+        // Assert
         assertThat(lagtTilFeilutbetaltValuta, Is(feilutbetaltValuta))
 
         verify(exactly = 1) { feilutbetaltValutaRepository.save(any()) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeHentOgPersisterServiceTest.kt
@@ -22,8 +22,10 @@ class VedtaksperiodeHentOgPersisterServiceTest {
 
     @Test
     fun `hentVedtaksperiodeThrows - skal kaste feil dersom det ikke finnes noe vedtaksperiode med gitt id`() {
+        // Arrange
         every { vedtaksperiodeRepository.finnVedtaksperiode(404) } returns null
 
+        // Act & Assert
         val exception =
             assertThrows<RuntimeException> {
                 vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(404)
@@ -34,41 +36,53 @@ class VedtaksperiodeHentOgPersisterServiceTest {
 
     @Test
     fun `hentVedtaksperiodeThrows - skal returnere vedtaksperiode med gitt id dersom det finnes`() {
+        // Arrange
         val mocketVedtaksperiode = mockk<VedtaksperiodeMedBegrunnelser>()
         every { vedtaksperiodeRepository.finnVedtaksperiode(404) } returns mocketVedtaksperiode
 
+        // Act
         val vedtaksperiode = vedtaksperiodeHentOgPersisterService.hentVedtaksperiodeThrows(404)
 
+        // Assert
         assertThat(vedtaksperiode, Is(mocketVedtaksperiode))
     }
 
     @Test
     fun `slettVedtaksperioderFor - skal slette vedtaksperioder for vedtak`() {
+        // Arrange
         val mocketVedtak = mockk<Vedtak>()
         every { vedtaksperiodeRepository.slettVedtaksperioderForVedtak(mocketVedtak) } just runs
 
+        // Act
         vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(vedtak = mocketVedtak)
 
+        // Assert
         verify(exactly = 1) { vedtaksperiodeRepository.slettVedtaksperioderForVedtak(mocketVedtak) }
     }
 
     @Test
     fun `finnVedtaksperioderFor - skal returnere vedtaksperioder for vedtak`() {
+        // Arrange
         every { vedtaksperiodeRepository.finnVedtaksperioderForVedtak(200) } returns listOf(mockk())
 
+        // Act
         val vedtaksperioder = vedtaksperiodeHentOgPersisterService.hentVedtaksperioderFor(200)
 
+        // Assert
         assertThat(vedtaksperioder.size, Is(1))
     }
 
     @Test
     fun `slettVedtaksperioderFor - skal slette vedtaksperioder for behandling`() {
+        // Arrange
         val mocketVedtak = mockk<Vedtak>()
         every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mocketVedtak
         every { vedtaksperiodeRepository.slettVedtaksperioderForVedtak(mocketVedtak) } just runs
 
+        // Act
         vedtaksperiodeHentOgPersisterService.slettVedtaksperioderFor(behandlingId = 200)
 
+        // Assert
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(200) }
         verify(exactly = 1) { vedtaksperiodeRepository.slettVedtaksperioderForVedtak(mocketVedtak) }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/VedtaksperiodeUtilTest.kt
@@ -19,6 +19,7 @@ class VedtaksperiodeUtilTest {
     fun `validerVedtaksperiodeMedBegrunnelser - skal kaste FunksjonellFeil dersom det er fritekst uten stanadard begrunnelser i opphør eller avslag`(
         vedtaksperiodetype: Vedtaksperiodetype,
     ) {
+        // Arrange
         val vedtaksperiodeMedBegrunnelser =
             VedtaksperiodeMedBegrunnelser(
                 vedtak = mockk(),
@@ -26,11 +27,13 @@ class VedtaksperiodeUtilTest {
                 fritekster = mutableListOf(mockk()),
             )
 
+        // Act & Assert
         val funksjonellFeil =
             assertThrows<FunksjonellFeil> {
                 validerVedtaksperiodeMedBegrunnelser(vedtaksperiodeMedBegrunnelser)
             }
 
+        // Assert
         assertThat(
             funksjonellFeil.message,
             Is(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiode/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiode/UtbetalingsperiodeMedBegrunnelserServiceTest.kt
@@ -98,6 +98,7 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
 
     @Test
     fun `lagFørskjøvetVilkårResultatTidslinjeMap - skal håndtere bor med søker-overlapp`() {
+        // Arrange
         val søker = lagPerson(personType = PersonType.SØKER, aktør = randomAktør())
         val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2021, 10, 5))
         val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
@@ -161,6 +162,7 @@ class UtbetalingsperiodeMedBegrunnelserServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
                 personopplysningGrunnlag = personopplysningGrunnlag,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiode/UtbetalingsperiodeUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/vedtaksperiode/utbetalingsperiode/UtbetalingsperiodeUtilTest.kt
@@ -59,6 +59,7 @@ internal class UtbetalingsperiodeUtilTest {
 
     @Test
     fun `hentPerioderMedUtbetaling skal beholde split i andel tilkjent ytelse`() {
+        // Arrange
         val mars2020 = YearMonth.of(2020, 3)
         val april2020 = YearMonth.of(2020, 4)
         val mai2020 = YearMonth.of(2020, 5)
@@ -127,6 +128,7 @@ internal class UtbetalingsperiodeUtilTest {
                 vilkårsvurdering.lagGodkjentPersonResultatForBarn(barn2),
             )
 
+        // Act
         val faktiskResultat =
             hentPerioderMedUtbetaling(
                 andelerTilkjentYtelse = listOf(andelPerson1MarsTilApril, andelPerson1MaiTilJuli, andelPerson2MarsTilJuli),
@@ -139,6 +141,7 @@ internal class UtbetalingsperiodeUtilTest {
                 kompetanser = emptyList(),
             )
 
+        // Assert
         assertEquals(
             forventetResultat.map { Periode(it, it.fom ?: TIDENES_MORGEN, it.tom ?: TIDENES_ENDE) },
             faktiskResultat.map { Periode(it, it.fom ?: TIDENES_MORGEN, it.tom ?: TIDENES_ENDE) },
@@ -152,6 +155,7 @@ internal class UtbetalingsperiodeUtilTest {
 
     @Test
     fun `hentPerioderMedUtbetaling skal splitte på forskjellige personer`() {
+        // Arrange
         val mars2020 = YearMonth.of(2020, 3)
         val april2020 = YearMonth.of(2020, 4)
         val mai2020 = YearMonth.of(2020, 5)
@@ -215,6 +219,7 @@ internal class UtbetalingsperiodeUtilTest {
                 vilkårsvurdering.lagGodkjentPersonResultatForBarn(barn2),
             )
 
+        // Act
         val faktiskResultat =
             hentPerioderMedUtbetaling(
                 andelerTilkjentYtelse = listOf(andelPerson1MarsTilMai, andelPerson2MaiTilJuli),
@@ -227,6 +232,7 @@ internal class UtbetalingsperiodeUtilTest {
                 kompetanser = emptyList(),
             )
 
+        // Assert
         assertEquals(
             forventetResultat.map { Periode(it, it.fom ?: TIDENES_MORGEN, it.tom ?: TIDENES_ENDE) },
             faktiskResultat.map { Periode(it, it.fom ?: TIDENES_MORGEN, it.tom ?: TIDENES_ENDE) },
@@ -242,6 +248,7 @@ internal class UtbetalingsperiodeUtilTest {
     inner class EØS {
         @Test
         fun `Skal lage ny vedtaksperiode dersom vi får en ny kompetansene`() {
+            // Arrange
             val (vilkårsvurdering, tilkjentYtelse) = kjørBehandlingFramTilBehandlingsresultatMedAltGodkjent()
             val forskjøvetVilkårResultatTidslinjeMap =
                 vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
@@ -249,6 +256,7 @@ internal class UtbetalingsperiodeUtilTest {
                     adopsjonerIBehandling = emptyList(),
                 )
 
+            // Act
             val vedtaksperioderUtenKompetanse =
                 hentPerioderMedUtbetaling(
                     andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) },
@@ -257,6 +265,7 @@ internal class UtbetalingsperiodeUtilTest {
                     kompetanser = emptyList(),
                 )
 
+            // Assert
             assertThat(vedtaksperioderUtenKompetanse.size).isEqualTo(2)
 
             val kompetanser =
@@ -285,6 +294,7 @@ internal class UtbetalingsperiodeUtilTest {
 
         @Test
         fun `Skal lage ny vedtaksperiode dersom det er endring i kompetansene`() {
+            // Arrange
             val (vilkårsvurdering, tilkjentYtelse) = kjørBehandlingFramTilBehandlingsresultatMedAltGodkjent()
             val forskjøvetVilkårResultatTidslinjeMap =
                 vilkårsvurdering.personResultater.tilForskjøvetOppfylteVilkårResultatTidslinjeMap(
@@ -292,6 +302,7 @@ internal class UtbetalingsperiodeUtilTest {
                     adopsjonerIBehandling = emptyList(),
                 )
 
+            // Act
             val vedtaksperioderUtenKompetanse =
                 hentPerioderMedUtbetaling(
                     andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse.map { AndelTilkjentYtelseMedEndreteUtbetalinger(it, emptyList()) },
@@ -300,6 +311,7 @@ internal class UtbetalingsperiodeUtilTest {
                     kompetanser = emptyList(),
                 )
 
+            // Assert
             assertThat(vedtaksperioderUtenKompetanse.size).isEqualTo(2)
 
             val kompetanser =
@@ -342,6 +354,7 @@ internal class UtbetalingsperiodeUtilTest {
     inner class HentBegrunnelserForOvergangsordningPerioder {
         @Test
         fun `skal ikke returnere noe begrunnelser dersom det ikke finnes noe overgangsordningandeler i perioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -361,13 +374,16 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).isEmpty()
         }
 
         @Test
         fun `skal ikke returnere noe begrunnelser dersom overgangsordning andelene ikke overlapper med vedtaksperioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -387,13 +403,16 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).isEmpty()
         }
 
         @Test
         fun `skal returnere noe begrunnelser dersom overgangsordning andelene ikke overlapper med vedtaksperioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -413,13 +432,16 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).isEmpty()
         }
 
         @Test
         fun `skal returnere INNVILGET_OVERGANGSORDNING begrunnelse dersom det eksisterer overgangsordning andeler med full sats som overlapper med vedtak perioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -439,14 +461,17 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).size().isEqualTo(1)
             assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING)
         }
 
         @Test
         fun `skal returnere INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING begrunnelse dersom det eksisterer overgangsordning andeler med gradert sats som overlapper med vedtak perioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -466,14 +491,17 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).size().isEqualTo(1)
             assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING)
         }
 
         @Test
         fun `skal returnere INNVILGET_OVERGANGSORDNING_DELT_BOSTED begrunnelse dersom det eksisterer overgangsordning andeler med halv sats som overlapper med vedtak perioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -493,14 +521,17 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).size().isEqualTo(1)
             assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED)
         }
 
         @Test
         fun `skal returnere INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING begrunnelse dersom det både eksisterer overgangsordning andeler med gradert sats og full sats som overlapper med vedtak perioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -524,14 +555,17 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).size().isEqualTo(1)
             assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_GRADERT_UTBETALING)
         }
 
         @Test
         fun `skal returnere INNVILGET_OVERGANGSORDNING_DELT_BOSTED begrunnelse dersom det både eksisterer overgangsordning andeler med halv sats og full sats som overlapper med vedtak perioden`() {
+            // Arrange
             val andeler =
                 listOf(
                     AndelTilkjentYtelseMedEndreteUtbetalinger(
@@ -555,8 +589,10 @@ internal class UtbetalingsperiodeUtilTest {
                     tom = LocalDate.of(2024, 12, 31),
                 )
 
+            // Act
             val begrunnelser = hentBegrunnelserForOvergangsordningPerioder(splittKriteriePeriode)
 
+            // Assert
             assertThat(begrunnelser).size().isEqualTo(1)
             assertThat(begrunnelser.single()).isEqualTo(NasjonalEllerFellesBegrunnelse.INNVILGET_OVERGANGSORDNING_DELT_BOSTED)
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AnnenVurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/AnnenVurderingServiceTest.kt
@@ -26,11 +26,14 @@ class AnnenVurderingServiceTest {
 
     @Test
     fun `endreAnnenVurdering - skal kaste feil dersom AnnenVurdering med forespurt id ikke finnes i db`() {
+        // Arrange
         every { annenVurderingRepository.findById(any()) } returns Optional.ofNullable(null)
 
         val annenVurderingDto =
+            // Act
             AnnenVurderingDto(404L, Resultat.OPPFYLT, AnnenVurderingType.OPPLYSNINGSPLIKT, "Begrunnelse")
         val funksjonellFeil =
+            // Assert
             assertThrows<FunksjonellFeil> {
                 annenVurderingService.endreAnnenVurdering(
                     annenVurderingDto,
@@ -42,8 +45,10 @@ class AnnenVurderingServiceTest {
 
     @Test
     fun `endreAnnenVurdering - endre AnnenVurdering med forespurt id`() {
+        // Arrange
         val endretAnnenVurderingSlot = slot<AnnenVurdering>()
         val eksisterendeAnnenVurdering =
+            // Act
             AnnenVurdering(
                 200L,
                 PersonResultat(
@@ -66,6 +71,7 @@ class AnnenVurderingServiceTest {
 
         val endretAnnenVurdering = endretAnnenVurderingSlot.captured
 
+        // Assert
         assertEquals(Resultat.OPPFYLT, endretAnnenVurdering.resultat)
         assertEquals("Begrunnelse", endretAnnenVurdering.begrunnelse)
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/OppdaterVilkårsvurderingTest.kt
@@ -28,9 +28,11 @@ class OppdaterVilkårsvurderingTest {
     inner class KopierResultaterFraForrigeBehandlingTest {
         @Test
         fun `Skal legge til nytt vilkår`() {
+            // Arrange
             val søkerPersonIdent = randomFnr()
             val barnPersonIdent = randomFnr()
             val persongrunnlag =
+                // Act
                 lagPersonopplysningGrunnlag(
                     søkerPersonIdent = søkerPersonIdent,
                     barnasIdenter = listOf(barnPersonIdent),
@@ -57,6 +59,7 @@ class OppdaterVilkårsvurderingTest {
             val barnVilkårResultater =
                 initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
 
+            // Assert
             Assertions.assertEquals(2, søkerVilkårResultater.size)
             Assertions.assertEquals(5, barnVilkårResultater.size)
 
@@ -77,8 +80,10 @@ class OppdaterVilkårsvurderingTest {
 
         @Test
         fun `Skal legge til person på vilkårsvurdering`() {
+            // Arrange
             val søkerPersonIdent = randomFnr()
             val persongrunnlag1 =
+                // Act
                 lagPersonopplysningGrunnlag(
                     søkerPersonIdent = søkerPersonIdent,
                 )
@@ -108,6 +113,7 @@ class OppdaterVilkårsvurderingTest {
             val barnVilkårResultater =
                 initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == barnPersonIdent }.vilkårResultater
 
+            // Assert
             Assertions.assertEquals(2, initiellVilkårsvurdering.personResultater.size)
 
             Vilkår.hentVilkårFor(persongrunnlag2.søker.type).forEach { vilkår ->
@@ -137,7 +143,9 @@ class OppdaterVilkårsvurderingTest {
 
         @Test
         fun `Skal fjerne person på vilkårsvurdering`() {
+            // Arrange
             val persongrunnlagRevurdering =
+                // Act
                 lagPersonopplysningGrunnlag(
                     søkerPersonIdent = randomFnr(),
                 )
@@ -166,16 +174,19 @@ class OppdaterVilkårsvurderingTest {
             initiellVilkårsvurdering.kopierResultaterFraForrigeBehandling(
                 vilkårsvurderingForrigeBehandling = vilkårsvurderingForrigeBehandling,
             )
+            // Assert
             Assertions.assertEquals(1, initiellVilkårsvurdering.personResultater.size)
         }
 
         @Test
         fun `Skal ha med tomt vilkår på person hvis vilkåret ble avslått forrige behandling`() {
+            // Arrange
             val søkerFnr = randomFnr()
             val nyBehandling = lagBehandling(type = BehandlingType.REVURDERING)
             val forrigeBehandling = lagBehandling()
 
             val persongrunnlag =
+                // Act
                 lagPersonopplysningGrunnlag(
                     behandlingId = nyBehandling.id,
                     søkerPersonIdent = søkerFnr,
@@ -217,6 +228,7 @@ class OppdaterVilkårsvurderingTest {
                     ?.filter { it.vilkårType == Vilkår.BOSATT_I_RIKET }
                     ?: emptyList()
 
+            // Assert
             Assertions.assertTrue(nyInitBosattIRiketVilkår.isNotEmpty())
             Assertions.assertTrue(nyInitBosattIRiketVilkår.single().resultat == Resultat.IKKE_VURDERT)
         }
@@ -226,10 +238,12 @@ class OppdaterVilkårsvurderingTest {
     inner class GenererInitiellVilkårsvurderingTest {
         @Test
         fun `Skal generere eøs spesifikke vilkår dersom det er en behandling med kategori EØS`() {
+            // Arrange
             val søkerFnr = randomFnr()
             val nyBehandling = lagBehandling(kategori = BehandlingKategori.EØS)
 
             val persongrunnlag =
+                // Act
                 lagPersonopplysningGrunnlag(
                     behandlingId = nyBehandling.id,
                     søkerPersonIdent = søkerFnr,
@@ -244,15 +258,18 @@ class OppdaterVilkårsvurderingTest {
 
             val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
 
+            // Assert
             assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering).isTrue()
         }
 
         @Test
         fun `Skal generere eøs spesifikke vilkår dersom forrige behandling hadde eøs spesifikke vilkår selvom kategori nå er nasjonal`() {
+            // Arrange
             val søkerFnr = randomFnr()
             val nyBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
 
             val persongrunnlag =
+                // Act
                 lagPersonopplysningGrunnlag(
                     behandlingId = nyBehandling.id,
                     søkerPersonIdent = søkerFnr,
@@ -270,15 +287,18 @@ class OppdaterVilkårsvurderingTest {
 
             val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
 
+            // Assert
             assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering).isTrue()
         }
 
         @Test
         fun `Skal generere ikke eøs spesifikke vilkår dersom det er en behandling med kategori NASJONAL`() {
+            // Arrange
             val søkerFnr = randomFnr()
             val nyBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
 
             val persongrunnlag =
+                // Act
                 lagPersonopplysningGrunnlag(
                     behandlingId = nyBehandling.id,
                     søkerPersonIdent = søkerFnr,
@@ -293,6 +313,7 @@ class OppdaterVilkårsvurderingTest {
 
             val finnesEøsSpesifikkeVilkårIVilkårsvurdering = initiellVilkårsvurdering.personResultater.flatMap { it.vilkårResultater }.any { it.vilkårType.eøsSpesifikt }
 
+            // Assert
             assertThat(finnesEøsSpesifikkeVilkårIVilkårsvurdering).isFalse()
         }
     }
@@ -301,11 +322,13 @@ class OppdaterVilkårsvurderingTest {
     inner class KopierVilkårResultaterFraForrigeVilkårsvurderingTest {
         @Test
         fun `Skal kopiere vilkårene til eksisterende personer fra forrige vilkårsvurdering`() {
+            // Arrange
             val behandling = lagBehandling()
 
             val eksisterendeSøkerPersonIdent = randomFnr()
             val nyBarnPersonIdent = randomFnr()
             val persongrunnlag =
+                // Act
                 lagPersonopplysningGrunnlag(
                     søkerPersonIdent = eksisterendeSøkerPersonIdent,
                     barnasIdenter = listOf(nyBarnPersonIdent),
@@ -334,6 +357,7 @@ class OppdaterVilkårsvurderingTest {
             val nyBarnVilkårResultaterFørKopiering =
                 initiellVilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == nyBarnPersonIdent }.vilkårResultater
 
+            // Assert
             assertThat(eksisterendeSøkerVilkårResultaterFørKopiering).allSatisfy {
                 assertThat(it.begrunnelse).isEmpty()
                 assertThat(it.periodeTom).isNull()
@@ -363,10 +387,12 @@ class OppdaterVilkårsvurderingTest {
 
     @Test
     fun `kopierOverOppfylteOgIkkeAktuelleResultaterFraForrigeBehandling skal beholde andreVurderinger lagt til på inneværende behandling`() {
+        // Arrange
         val søkerAktørId = randomAktør()
         val nyBehandling = lagBehandling()
 
         val initiellVilkårsvurderingUtenAndreVurderinger =
+            // Act
             lagVilkårsvurderingOppfylt(
                 behandling = nyBehandling,
                 personer =
@@ -390,6 +416,7 @@ class OppdaterVilkårsvurderingTest {
                 .andreVurderinger
                 .any { it.type == AnnenVurderingType.OPPLYSNINGSPLIKT }
 
+        // Assert
         Assertions.assertTrue(nyInitInnholderOpplysningspliktVilkår)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingServiceTest.kt
@@ -65,12 +65,14 @@ class VilkårsvurderingServiceTest {
 
     @Test
     fun `opprettVilkårsvurdering - skal opprette tom vilkårsvurdering dersom det ikke finnes tidligere vedtatte behandlinger på fagsak`() {
+        // Arrange
         val barn1 = randomAktør()
         val barn2 = randomAktør()
 
         val lagretVilkårsvurderingSlot = slot<Vilkårsvurdering>()
         every { vilkårsvurderingRepository.finnAktivForBehandling(any()) } returns null
         every { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) } returns
+            // Act
             lagPersonopplysningGrunnlag(
                 behandlingId = behandling.id,
                 søkerPersonIdent = søker.aktivFødselsnummer(),
@@ -82,6 +84,7 @@ class VilkårsvurderingServiceTest {
 
         val lagretVilkårsvurdering = lagretVilkårsvurderingSlot.captured
 
+        // Assert
         assertEquals(3, lagretVilkårsvurdering.personResultater.size)
         assertThat(
             lagretVilkårsvurdering.personResultater
@@ -152,11 +155,13 @@ class VilkårsvurderingServiceTest {
 
     @Test
     fun `opprettVilkårsvurdering - skal opprette tom vilkårsvurdering og deaktivere eksisterende dersom det ikke finnes tidligere vedtatte behandlinger på fagsak`() {
+        // Arrange
         val barn1 = randomAktør()
         val barn2 = randomAktør()
         val lagretDeaktivertVilkårsvurderingSlot = slot<Vilkårsvurdering>()
         val lagretVilkårsvurderingSlot = slot<Vilkårsvurdering>()
         every { vilkårsvurderingRepository.finnAktivForBehandling(any()) } returns
+            // Act
             lagVilkårsvurderingMedSøkersVilkår(
                 søkerAktør = søker,
                 behandling = behandling,
@@ -176,13 +181,16 @@ class VilkårsvurderingServiceTest {
         val lagretVilkårsvurdering = lagretVilkårsvurderingSlot.captured
         val lagretDeaktivertVilkårsvurdering = lagretDeaktivertVilkårsvurderingSlot.captured
 
+        // Assert
         assertEquals(3, lagretVilkårsvurdering.personResultater.size)
         assertFalse(lagretDeaktivertVilkårsvurdering.aktiv)
     }
 
     @Test
     fun `hentVilkårsbegrunnelser - skal returnere et map med begrunnelsestyper mappet mot liste av begrunnelser`() {
+        // Arrange
         every { sanityService.hentSanityBegrunnelser() } returns
+            // Act
             listOf(
                 SanityBegrunnelse(
                     NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE.sanityApiNavn,
@@ -205,15 +213,19 @@ class VilkårsvurderingServiceTest {
         val vilkårsbegrunnelser = vilkårsvurderingService.hentVilkårsbegrunnelser()
 
         // TODO: Endre denne testen når vi får lagt inn riktige Begrunnelser og EØSBegrunnelser
+        // Assert
         assertEquals(9, vilkårsbegrunnelser.size)
         assertEquals(0, vilkårsbegrunnelser[BegrunnelseType.AVSLAG]?.size)
     }
 
     @Test
     fun `hentAktivVilkårsvurderingForBehandling - skal kaste feil hvis aktiv vilkårsvurdering for behandling ikke eksisterer`() {
+        // Arrange
         every { vilkårsvurderingRepository.finnAktivForBehandling(404) } returns null
 
         val feil =
+            // Act
+            // Assert
             assertThrows<Feil> {
                 vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(404)
             }
@@ -223,18 +235,23 @@ class VilkårsvurderingServiceTest {
 
     @Test
     fun `hentAktivVilkårsvurderingForBehandling - skal returnere aktiv vilkårsvurdering for behandling`() {
+        // Arrange
         val mocketVilkårsvurdering = mockk<Vilkårsvurdering>()
 
         every { vilkårsvurderingRepository.finnAktivForBehandling(404) } returns mocketVilkårsvurdering
 
         val hentetVilkårsvurdering = vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(404)
 
+        // Assert
         assertThat(mocketVilkårsvurdering, Is(hentetVilkårsvurdering))
+        // Act
     }
 
     @Test
     fun `slettVilkårPåBehandling - skal kaste feil dersom vilkåret som forsøkes å slettes ikke finnes`() {
+        // Arrange
         val vilkårsvurdering =
+            // Act
             lagVilkårsvurderingMedSøkersVilkår(
                 søkerAktør = søker,
                 behandling = behandling,
@@ -245,6 +262,7 @@ class VilkårsvurderingServiceTest {
         every { vilkårsvurderingRepository.finnAktivForBehandling(200) } returns vilkårsvurdering
 
         val feil =
+            // Assert
             assertThrows<Feil> {
                 vilkårsvurderingService.slettVilkårPåBehandling(200, 404, søker)
             }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingStegTest.kt
@@ -145,11 +145,13 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste funksjonell feil hvis behandlingsårsak er DØDSFALL og det eksisterer vilkår lengre fram i tid enn søkers dødsdato`() {
+        // Arrange
         val behandling = behandling.copy(opprettetÅrsak = BehandlingÅrsak.DØDSFALL)
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
 
         val barn = randomAktør()
         val personopplysningGrunnlag =
+            // Act
             lagPersonopplysningGrunnlag(
                 behandlingId = behandling.id,
                 søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
@@ -181,6 +183,7 @@ class VilkårsvurderingStegTest {
         every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) } returns vilkårsvurderingForSøker
 
         val feil =
+            // Assert
             assertThrows<FunksjonellFeil> {
                 vilkårsvurderingSteg.utførSteg(behandling.id)
             }
@@ -199,10 +202,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste funksjonell feil hvis det er periode overlapp mellom delt bosted og gradert barnehageplass vilkår`() {
+        // Arrange
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -247,6 +252,7 @@ class VilkårsvurderingStegTest {
         every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) } returns vilkårsvurderingForSøker
 
         val feil =
+            // Assert
             assertThrows<IllegalStateException> {
                 vilkårsvurderingSteg.utførSteg(behandling.id)
             }
@@ -263,8 +269,10 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste funksjonell feil hvis det ikke er noe barn i personopplysningsgrunnlaget`() {
+        // Arrange
         val søknadGrunnlagMock = mockk<SøknadGrunnlag>(relaxed = true)
 
+        // Act
         mockkObject(SøknadGrunnlagMapper)
         with(SøknadGrunnlagMapper) {
             every { søknadGrunnlagMock.tilSøknadDto() } returns
@@ -306,6 +314,7 @@ class VilkårsvurderingStegTest {
         every { søknadGrunnlagService.finnAktiv(behandling.id) } returns søknadGrunnlagMock
 
         val feil =
+            // Assert
             assertThrows<FunksjonellFeil> {
                 vilkårsvurderingSteg.utførSteg(behandling.id)
             }
@@ -328,7 +337,9 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste feil hvis barnehageplass perioder ikke dekker perioder i barnets alder vilkår`() {
+        // Arrange
         val vilkårsvurdering =
+            // Act
             lagVilkårsvurderingMedSøkersVilkår(
                 søkerAktør = søker.aktør,
                 behandling = behandling,
@@ -356,6 +367,7 @@ class VilkårsvurderingStegTest {
 
         every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) } returns vilkårsvurdering
 
+        // Assert
         val exception = assertThrows<FunksjonellFeil> { vilkårsvurderingSteg.utførSteg(behandling.id) }
         assertEquals(
             "Det mangler vurdering på vilkåret ${Vilkår.BARNEHAGEPLASS.beskrivelse}. " +
@@ -366,7 +378,9 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste feil hvis barnehageplass perioder starter etter siste dato i barnets alder vilkår`() {
+        // Arrange
         val vilkårsvurdering =
+            // Act
             lagVilkårsvurderingMedSøkersVilkår(
                 søkerAktør = søker.aktør,
                 behandling = behandling,
@@ -398,6 +412,7 @@ class VilkårsvurderingStegTest {
 
         every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) } returns vilkårsvurdering
 
+        // Assert
         val exception = assertThrows<FunksjonellFeil> { vilkårsvurderingSteg.utførSteg(behandling.id) }
         assertEquals(
             "Du har lagt til en periode på vilkåret ${Vilkår.BARNEHAGEPLASS.beskrivelse}" +
@@ -409,8 +424,10 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal ikke kaste feil hvis barnehageplass perioder starter i periode for overgangsordning etter siste dato i barnets alder vilkår`() {
+        // Arrange
         val barn = lagPerson(personType = PersonType.BARN, aktør = randomAktør(), fødselsdato = LocalDate.of(2023, 1, 1))
         val personopplysningGrunnlag =
+            // Act
             lagPersonopplysningGrunnlag(
                 behandlingId = behandling.id,
                 søkerPersonIdent = søker.aktør.aktivFødselsnummer(),
@@ -461,7 +478,9 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste feil hvis det finnes mer enn 2 barnehageplass vilkår i en måned`() {
+        // Arrange
         val vilkårsvurdering =
+            // Act
             lagVilkårsvurderingMedSøkersVilkår(
                 søkerAktør = søker.aktør,
                 behandling = behandling,
@@ -496,6 +515,7 @@ class VilkårsvurderingStegTest {
 
         every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) } returns vilkårsvurdering
 
+        // Assert
         val exception = assertThrows<FunksjonellFeil> { vilkårsvurderingSteg.utførSteg(behandling.id) }
         assertEquals(
             "Du har lagt inn flere enn 2 endringer i barnehagevilkåret i samme måned. " +
@@ -506,10 +526,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste feil når det er blanding av regelverk på vilkårene for barnet`() {
+        // Arrange
         val vilkårsvurdering = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = søker.aktør)
         // BOSATT I RIKET er vurdert etter både NASJONALE_REGLER og EØS_FORORDNINGEN
         // mens MEDLEMSKAP er vurdert etter kun NASJONALE_REGLER
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 lagVilkårResultat(
@@ -564,6 +586,7 @@ class VilkårsvurderingStegTest {
 
         every { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) } returns vilkårsvurdering
 
+        // Assert
         val exception = assertThrows<FunksjonellFeil> { vilkårsvurderingSteg.utførSteg(behandling.id) }
         assertEquals(
             "Det er forskjellig regelverk for en eller flere perioder for søker eller barna",
@@ -573,10 +596,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal validere vilkårsvurderingen`() {
+        // Arrange
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -615,6 +640,7 @@ class VilkårsvurderingStegTest {
 
         vilkårsvurderingSteg.utførSteg(behandling.id)
 
+        // Assert
         verify(exactly = 1) { behandlingService.hentBehandling(behandling.id) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) }
         verify(exactly = 1) { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) }
@@ -624,10 +650,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste feil dersom det finnes vilkår som har fom dato satt senere enn inneværende måned`() {
+        // Arrange
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -665,6 +693,7 @@ class VilkårsvurderingStegTest {
         every { kompetanseService.hentKompetanser(BehandlingId(behandling.id)) } returns emptyList()
 
         val feilmelding =
+            // Assert
             assertThrows<FunksjonellFeil> {
                 vilkårsvurderingSteg.utførSteg(behandling.id)
             }.melding
@@ -674,10 +703,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal kaste feil dersom det finnes barnehageplass vilkår som har fom dato satt senere enn neste måned`() {
+        // Arrange
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -715,6 +746,7 @@ class VilkårsvurderingStegTest {
         every { kompetanseService.hentKompetanser(BehandlingId(behandling.id)) } returns emptyList()
 
         val feilmelding =
+            // Assert
             assertThrows<FunksjonellFeil> {
                 vilkårsvurderingSteg.utførSteg(behandling.id)
             }.melding
@@ -724,10 +756,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal oppdatere behandlingstema med EØS hvis nåværende behandling inneholder vilkår vurdert etter EØS ordningen`() {
+        // Arrange
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -762,6 +796,7 @@ class VilkårsvurderingStegTest {
 
         vilkårsvurderingSteg.utførSteg(behandling.id)
 
+        // Assert
         verify(exactly = 1) { behandlingService.hentBehandling(behandling.id) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) }
         verify(exactly = 1) { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) }
@@ -772,10 +807,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal oppdatere behandlingstema med EØS hvis forrige behandling inneholder løpende vilkår vurdert etter EØS ordningen`() {
+        // Arrange
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -853,6 +890,7 @@ class VilkårsvurderingStegTest {
 
         vilkårsvurderingSteg.utførSteg(behandling.id)
 
+        // Assert
         verify(exactly = 1) { behandlingService.hentBehandling(behandling.id) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) }
         verify(exactly = 1) { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) }
@@ -864,10 +902,12 @@ class VilkårsvurderingStegTest {
 
     @Test
     fun `utførSteg - skal ikke oppdatere behandlingstema med EØS hvis forrige behandling inneholder løpende vilkår vurdert etter EØS ordningen men som er utløpt`() {
+        // Arrange
         val vilkårsvurderingForSøker = Vilkårsvurdering(behandling = behandling)
         val søkerPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = søker.aktør)
         val barnPersonResultat = PersonResultat(vilkårsvurdering = vilkårsvurderingForSøker, aktør = barn.aktør)
 
+        // Act
         søkerPersonResultat.setSortedVilkårResultater(
             setOf(
                 VilkårResultat(
@@ -949,6 +989,7 @@ class VilkårsvurderingStegTest {
 
         vilkårsvurderingSteg.utførSteg(behandling.id)
 
+        // Assert
         verify(exactly = 1) { behandlingService.hentBehandling(behandling.id) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(any()) }
         verify(exactly = 1) { vilkårsvurderingService.hentAktivVilkårsvurderingForBehandling(behandling.id) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/VilkårsvurderingUtilsTest.kt
@@ -238,6 +238,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `tilpassVilkårForEndretVilkår - skal ikke endre gamle vilkår som når det nye er av en annen type`() {
+        // Arrange
         val vilkårResultat1 =
             lagVilkårResultat(
                 id = 50,
@@ -257,6 +258,7 @@ class VilkårsvurderingUtilsTest {
                 vilkårType = Vilkår.BOSATT_I_RIKET,
             )
 
+        // Act
         val resultat =
             tilpassVilkårForEndretVilkår(
                 endretVilkårResultatId = vilkårResultat2.id,
@@ -264,6 +266,7 @@ class VilkårsvurderingUtilsTest {
                 endretVilkårResultat = vilkårResultat2,
             )
 
+        // Assert
         assertEquals(1, resultat.size)
 
         assertEquals(januar, resultat[0].periodeFom)
@@ -276,6 +279,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `oppdaterMedDødsdatoer skal oppdatere vikårsvurdering slik at den avsluttes ved dødsdato dersom den starter før dødsdato`() {
+        // Arrange
         val søkerPersonIdent = randomFnr()
         val personIdentBarn1 = randomFnr()
         val personIdentBarn2 = randomFnr()
@@ -296,8 +300,10 @@ class VilkårsvurderingUtilsTest {
 
         val vilkårsvurdering = lagVilkårsvurderingOppfylt(personer = persongrunnlag.personer)
 
+        // Act
         vilkårsvurdering.oppdaterMedDødsdatoer(persongrunnlag)
 
+        // Assert
         // Siden barnet dør før vilkårResulatatene starter skal vi ikke gjøre noe med dem
         val personResultaterBarn1 = vilkårsvurdering.personResultater.single { it.aktør.aktivFødselsnummer() == personIdentBarn1 }
         personResultaterBarn1.vilkårResultater.forEach { assertEquals(fødselsDatoBarn1.plusMonths(19), it.periodeTom) }
@@ -308,6 +314,7 @@ class VilkårsvurderingUtilsTest {
 
     @Test
     fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter hvis periode krysser lovendringsdato`() {
+        // Arrange
         val vilkårResultat =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNETS_ALDER,
@@ -316,13 +323,16 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
+        // Act
         val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
+        // Assert
         assertEquals(LocalDate.of(2024, 12, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
 
     @Test
     fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter ikke hvis periode ikke krysser lovendringsdato`() {
+        // Arrange
         val vilkårResultat =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNETS_ALDER,
@@ -331,13 +341,16 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
+        // Act
         val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
+        // Assert
         assertEquals(LocalDate.of(2024, 7, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
 
     @Test
     fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter hvis periode er laget etter nytt lovverk og er lengre enn 7 mnd`() {
+        // Arrange
         val vilkårResultat =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNETS_ALDER,
@@ -346,13 +359,16 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
+        // Act
         val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
+        // Assert
         assertEquals(LocalDate.of(2025, 3, 1), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
 
     @Test
     fun `forkortHvisSkalForkortesEtterRegelverkEndring forkorter til lovendringsdato hvis den forkortes under 7 mnder`() {
+        // Arrange
         val vilkårResultat =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNETS_ALDER,
@@ -361,8 +377,10 @@ class VilkårsvurderingUtilsTest {
                 utdypendeVilkårsvurderinger = listOf(UtdypendeVilkårsvurdering.ADOPSJON),
             )
 
+        // Act
         val resultat = listOf(vilkårResultat).forkortTomTilGyldigLengde()
 
+        // Assert
         assertEquals(LocalDate.of(2024, 7, 31), resultat.first { it.vilkårType == Vilkår.BARNETS_ALDER }.periodeTom)
     }
 
@@ -370,6 +388,7 @@ class VilkårsvurderingUtilsTest {
     inner class EndreVilkårResultatTest {
         @Test
         fun `Skal kastes funksjonell feil hvis det forsøkes å lage en oppfylt periode mens det finnes en avslagsperiode uten periode`() {
+            // Arrange
             val person = mockk<PersonResultat>(relaxed = true)
 
             val eksisterendeVilkårResultat =
@@ -408,6 +427,7 @@ class VilkårsvurderingUtilsTest {
                     endretAv = "VL",
                 )
 
+            // Act & Assert
             val frontendFeilmelding =
                 assertThrows<FunksjonellFeil> {
                     endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
@@ -418,6 +438,7 @@ class VilkårsvurderingUtilsTest {
 
         @Test
         fun `Skal kastes funksjonell feil hvis det forsøkes å lage en avslagsperiode uten dato mens det finnes en oppfylt periode`() {
+            // Arrange
             val person = mockk<PersonResultat>(relaxed = true)
 
             val eksisterendeVilkårResultat =
@@ -456,6 +477,7 @@ class VilkårsvurderingUtilsTest {
                     erEksplisittAvslagPåSøknad = true,
                 )
 
+            // Act & Assert
             val frontendFeilmelding =
                 assertThrows<FunksjonellFeil> {
                     endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
@@ -466,6 +488,7 @@ class VilkårsvurderingUtilsTest {
 
         @Test
         fun `Skal kaste funksjonell feil hvis det forsøkes å lage en periode med datoer mens det finnes avslag uten periode`() {
+            // Arrange
             val person = mockk<PersonResultat>(relaxed = true)
 
             val eksisterendeVilkårResultat =
@@ -504,6 +527,7 @@ class VilkårsvurderingUtilsTest {
                     endretAv = "VL",
                 )
 
+            // Act & Assert
             val frontendFeilmelding =
                 assertThrows<FunksjonellFeil> {
                     endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)
@@ -514,6 +538,7 @@ class VilkårsvurderingUtilsTest {
 
         @Test
         fun `Skal kaste funksjonell feil hvis det forsøkes å lage avslag uten periode mens det allerede finnes periode med datoer`() {
+            // Arrange
             val person = mockk<PersonResultat>(relaxed = true)
 
             val eksisterendeVilkårResultat =
@@ -552,6 +577,7 @@ class VilkårsvurderingUtilsTest {
                     erEksplisittAvslagPåSøknad = true,
                 )
 
+            // Act & Assert
             val frontendFeilmelding =
                 assertThrows<FunksjonellFeil> {
                     endreVilkårResultat(eksisterendeVilkårResultat, vilkårDto)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/validering/BarnetsVilkårValidatorTest.kt
@@ -58,6 +58,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når vilkår resulat er oppfylt men mangler fom`() {
+        // Arrange
         val fom = null
         val tom = LocalDate.now().plusMonths(7)
 
@@ -78,6 +79,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -92,6 +94,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når vilkår resulat fom er før barnets fødselsdato`() {
+        // Arrange
         val fom = barnPerson.fødselsdato.minusMonths(2)
         val tom = fom.plusMonths(5)
 
@@ -112,6 +115,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -126,6 +130,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal ikke kaste feil når vilkår resulat mangler fom, tom med eksplisitt avslag`() {
+        // Arrange
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn =
             setOf(
@@ -144,6 +149,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         assertDoesNotThrow {
             barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
                 vilkårsvurdering,
@@ -154,6 +160,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når BARNETS_ALDER vilkår resulat har fom etter barnets 1 års dag når barn er født før august 2023`() {
+        // Arrange
         val barnFødtJuli23 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("30062312345"))
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtJuli23.aktør)
         val vilkårResultaterForBarn =
@@ -182,6 +189,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -194,6 +202,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når BARNETS_ALDER vilkår resulat har tom etter barnet fyller 19 måneder for barn født i 2023 og senere`() {
+        // Arrange
         val barnFødtAugust22 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01012312345"))
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtAugust22.aktør)
         val vilkårResultaterForBarn =
@@ -222,6 +231,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -234,6 +244,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når BARNETS_ALDER vilkår resulat har fom etter barnet blir 13 måneder og barn er født etter 2023`() {
+        // Arrange
         val barnFødtAugust22 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01082212345"))
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtAugust22.aktør)
         val vilkårResultaterForBarn =
@@ -252,6 +263,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -264,6 +276,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når BARNETS_ALDER vilkår resulat har tom etter barnet fyller 2 år og barn er født før 2023`() {
+        // Arrange
         val barnFødtAugust22 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01122212345"))
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtAugust22.aktør)
         val vilkårResultaterForBarn =
@@ -282,6 +295,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -294,6 +308,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når BARNETS_ALDER med adopsjon vilkår resulat har tom etter barnets 6 år`() {
+        // Arrange
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn =
             setOf(
@@ -316,6 +331,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -328,6 +344,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil når BARNETS_ALDER med adopsjon vilkår resulat har diff mellom fom,tom mer enn 1 år og 1 dag`() {
+        // Arrange
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn =
             setOf(
@@ -346,6 +363,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
@@ -358,6 +376,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal ikke kaste feil når BARNETS_ALDER med adopsjon vilkår resulat har tom etter August barnet fyller 6 år`() {
+        // Arrange
         val tom = barnPerson.fødselsdato.plusYears(6).withMonth(Month.AUGUST.value)
         val fom = tom.minusMonths(5)
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
@@ -378,6 +397,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         assertDoesNotThrow {
             barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
                 vilkårsvurdering,
@@ -388,6 +408,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal ikke kaste feil når MEDLEMSKAP_ANNEN_FORELDER har fom før barnets fødselsdato`() {
+        // Arrange
         val fom = barnPerson.fødselsdato.minusYears(10)
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn1)
         val vilkårResultaterForBarn =
@@ -406,6 +427,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         assertDoesNotThrow {
             barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
                 vilkårsvurdering,
@@ -416,6 +438,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal ikke kaste feil dersom tom på barnetsalder vilkår er satt til barnets dødsfallsdato`() {
+        // Arrange
         val dødsfallsdato = barnPerson.fødselsdato.plusYears(1).plusMonths(5)
 
         val barnPersonMedDødsfallsdato =
@@ -440,6 +463,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         assertDoesNotThrow {
             barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(
                 vilkårsvurdering,
@@ -450,6 +474,7 @@ class BarnetsVilkårValidatorTest {
 
     @Test
     fun `validerAtDatoErKorrektIBarnasVilkår skal kaste funksjonell feil dersom det finnes avslag i barnets alder vilkår uten fom og tom samtidig som det finnes oppfylte barnets alder vilkår`() {
+        // Arrange
         val barnFødtAugust22 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01012312345"))
         val personResultatForBarn = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtAugust22.aktør)
         val vilkårResultaterForBarn =
@@ -479,6 +504,7 @@ class BarnetsVilkårValidatorTest {
         personResultatForBarn.setSortedVilkårResultater(vilkårResultaterForBarn)
         vilkårsvurdering.personResultater = setOf(personResultatForBarn)
 
+        // Act & Assert
         val exception =
             org.junit.jupiter.api.assertThrows<FunksjonellFeil> {
                 barnetsVilkårValidator.validerAtDatoErKorrektIBarnasVilkår(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest.kt
@@ -54,6 +54,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
 
     @Test
     fun `finnAndelerTilkjentYtelseMedEndreteUtbetalinger finner andeler med overlappende endrete utbetalinger`() {
+        // Arrange
         val fom = YearMonth.now().minusMonths(6)
         val tom = YearMonth.now().plusMonths(5)
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id) } returns
@@ -86,8 +87,11 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
                 ),
             )
 
+        // Act
         val andeler =
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnAndelerTilkjentYtelseMedEndreteUtbetalinger(behandling.id)
+
+        // Assert
         assertTrue { andeler.size == 1 }
 
         val andelTilkjentYtelse = andeler[0].andel
@@ -105,6 +109,7 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
 
     @Test
     fun `finnEndreteUtbetalingerMedAndelerTilkjentYtelse finner endrete utbetalinger med overlappende andeler`() {
+        // Arrange
         val fom = YearMonth.now().minusMonths(6)
         val tom = YearMonth.now().minusMonths(1)
         every { andelTilkjentYtelseRepository.finnAndelerTilkjentYtelseForBehandling(behandling.id) } returns
@@ -149,8 +154,11 @@ class AndelerTilkjentYtelseOgEndreteUtbetalingerServiceTest {
 
         every { vilkårsvurderingRepository.finnAktivForBehandling(behandling.id) } returns vilkårsvurdering
 
+        // Act
         val endreteUtbetalinger =
             andelerTilkjentYtelseOgEndreteUtbetalingerService.finnEndreteUtbetalingerMedAndelerTilkjentYtelse(behandling.id)
+
+        // Assert
         assertTrue { endreteUtbetalinger.size == 1 }
 
         val endretUtbetalingAndel = endreteUtbetalinger[0].endretUtbetaling

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/TilkjentYtelseValidatorTest.kt
@@ -50,6 +50,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `kaster ikke feil på å validere andeler for barn som kun har overgangsandel`() {
+        // Arrange
         val andelTilkjentYtelseOvergang =
             lagAndelTilkjentYtelse(
                 tilkjentYtelse = tilkjentYtelse,
@@ -77,6 +78,7 @@ internal class TilkjentYtelseValidatorTest {
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 1, 1).minusMonths(11), adopsjonsdato = null)
 
+        // Assert
         assertDoesNotThrow {
             validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
                 tilkjentYtelse = tilkjentYtelse,
@@ -90,6 +92,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp skal kaste feil når utbetalingsperiode er mer enn 11 måneder`() {
+        // Arrange
         val andelTilkjentYtelse1 =
             lagAndelTilkjentYtelse(
                 tilkjentYtelse = tilkjentYtelse,
@@ -125,12 +128,14 @@ internal class TilkjentYtelseValidatorTest {
             "Kontantstøtte kan maks utbetales for 11 måneder. Du er i ferd med å utbetale 12 måneder for barn med fnr ${barn.aktør.aktivFødselsnummer()}. " +
                 "Kontroller datoene på vilkårene eller ta kontakt med Team BAKS"
 
+        // Assert
         assertEquals(feilmelding, exception.frontendFeilmelding)
         assertEquals(feilmelding, exception.message)
     }
 
     @Test
     fun `validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp skal kaste feil når utbetalingsperiode er mer enn 7 måneder når barn er født i 2023 og treffes av nytt lovverk fra august 2024`() {
+        // Arrange
         val barnFødtIJanuar2023 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01012312345"))
 
         val andelTilkjentYtelse1 =
@@ -175,12 +180,14 @@ internal class TilkjentYtelseValidatorTest {
             "Kontantstøtte kan maks utbetales for 7 måneder. Du er i ferd med å utbetale 8 måneder for barn med fnr ${barnFødtIJanuar2023.aktør.aktivFødselsnummer()}. " +
                 "Kontroller datoene på vilkårene eller ta kontakt med Team BAKS"
 
+        // Assert
         assertEquals(feilmelding, exception.frontendFeilmelding)
         assertEquals(feilmelding, exception.message)
     }
 
     @Test
     fun `validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp skal kaste feil når utbetalingsperiode er mer enn 11 måneder når barn er født før september 2022 og kun treffes av gammelt lovverk`() {
+        // Arrange
         val barnFødtIAugust2022 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01082212345"))
 
         val andelTilkjentYtelse1 =
@@ -196,6 +203,7 @@ internal class TilkjentYtelseValidatorTest {
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtIAugust2022.aktør)
         val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 8, 1), adopsjonsdato = null)
 
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
@@ -223,6 +231,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp skal ikke kaste feil når selvom utbetalingsperioden er over 11 måneder dersom det er fordelt på flere barn`() {
+        // Arrange
         val barnFødtAugust2023 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01082312345"))
         val barnFødtAugust2022 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01082212345"))
 
@@ -250,6 +259,7 @@ internal class TilkjentYtelseValidatorTest {
         val personResultatBarn2 = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barnFødtAugust2023.aktør)
         val barnetsAlderVilkårResultaterBarn2 = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultatBarn2, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 8, 1), adopsjonsdato = null)
 
+        // Assert
         assertDoesNotThrow {
             validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
                 tilkjentYtelse = tilkjentYtelse,
@@ -269,6 +279,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp skal kaste feil når søkers andel ikke er tom`() {
+        // Arrange
         val andelTilkjentYtelseForSøker =
             lagAndelTilkjentYtelse(
                 tilkjentYtelse = tilkjentYtelse,
@@ -302,6 +313,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp skal kaste feil når barn har andel med beløp som er større en maks beløp`() {
+        // Arrange
         val barnFødtJuli2023 = lagPerson(personType = PersonType.BARN, aktør = randomAktør("01072312345"))
 
         val andelTilkjentYtelseForBarn =
@@ -351,6 +363,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtBarnIkkeFårFlereUtbetalingerSammePeriode - skal kaste feil dersom et eller flere barn får flere utbetalinger samme periode`() {
+        // Arrange
         val andelTilkjentYtelseForBarn =
             lagAndelTilkjentYtelse(
                 tilkjentYtelse = tilkjentYtelse,
@@ -396,6 +409,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtBarnIkkeFårFlereUtbetalingerSammePeriode - skal ikke kaste feil dersom ingen barn har flere utbetalinger i samme periode`() {
+        // Arrange
         val andelTilkjentYtelseForBarn =
             lagAndelTilkjentYtelse(
                 tilkjentYtelse = tilkjentYtelse,
@@ -439,6 +453,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtBarnIkkeFårFlereUtbetalingerSammePeriode - skal tillate 1 måned overlapp mellom 2024 august og 2025 februar`() {
+        // Arrange
         val andelTilkjentYtelseForBarn =
             lagAndelTilkjentYtelse(
                 tilkjentYtelse = tilkjentYtelse,
@@ -484,6 +499,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `validerAtBarnIkkeFårFlereUtbetalingerSammePeriode - skal ikke tillate 1 måned overlapp dersom andelen ikke utbetales mellom 2024 august og 2025 februar`() {
+        // Arrange
         val andelTilkjentYtelseForBarn =
             lagAndelTilkjentYtelse(
                 tilkjentYtelse = tilkjentYtelse,
@@ -532,6 +548,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `finnAktørIderMedUgyldigEtterbetalingsperiode - skal returnere liste over aktører med ugyldig etterbetalingsperiode når det finnes andeler med fom før gyldig etterbetallings fom hvor beløpet har økt`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -555,12 +572,14 @@ internal class TilkjentYtelseValidatorTest {
         val aktørerMedUgyldigEtterbetalingsperiode =
             finnAktørIderMedUgyldigEtterbetalingsperiode(forrigeAndeler, andeler, LocalDateTime.now())
 
+        // Assert
         assertEquals(1, aktørerMedUgyldigEtterbetalingsperiode.size)
         assertEquals(aktørerMedUgyldigEtterbetalingsperiode.single(), barn.aktør.aktørId)
     }
 
     @Test
     fun `finnAktørIderMedUgyldigEtterbetalingsperiode - skal returnere liste over aktører med ugyldig etterbetalingsperiode når det er lagt til nye andeler før gyldig etterbetalings fom med beløp større enn 0`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -584,6 +603,7 @@ internal class TilkjentYtelseValidatorTest {
         var aktørerMedUgyldigEtterbetalingsperiode =
             finnAktørIderMedUgyldigEtterbetalingsperiode(forrigeAndeler, andeler, LocalDateTime.now())
 
+        // Assert
         assertEquals(1, aktørerMedUgyldigEtterbetalingsperiode.size)
         assertEquals(aktørerMedUgyldigEtterbetalingsperiode.single(), barn.aktør.aktørId)
 
@@ -596,6 +616,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `finnAktørIderMedUgyldigEtterbetalingsperiode - skal returnere tom liste over aktører når andel tilkjent ytelse er uendret selv om fom er mer enn 3 mnd tilbake i tid`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -619,11 +640,13 @@ internal class TilkjentYtelseValidatorTest {
         val aktørerMedUgyldigEtterbetalingsperiode =
             finnAktørIderMedUgyldigEtterbetalingsperiode(forrigeAndeler, andeler, LocalDateTime.now())
 
+        // Assert
         assertEquals(0, aktørerMedUgyldigEtterbetalingsperiode.size)
     }
 
     @Test
     fun `finnAktørIderMedUgyldigEtterbetalingsperiode - skal returnere tom liste over aktører når andel tilkjent ytelse er endret innenfor siste 3 mnd`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -647,11 +670,13 @@ internal class TilkjentYtelseValidatorTest {
         val aktørerMedUgyldigEtterbetalingsperiode =
             finnAktørIderMedUgyldigEtterbetalingsperiode(forrigeAndeler, andeler, LocalDateTime.now())
 
+        // Assert
         assertEquals(0, aktørerMedUgyldigEtterbetalingsperiode.size)
     }
 
     @Test
     fun `Validering ved adopsjonssaker skal være gyldig uavhengig av alder med lovverk fra februar 2025`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -668,6 +693,7 @@ internal class TilkjentYtelseValidatorTest {
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2024, 2, 1), adopsjonsdato = LocalDate.of(2024, 4, 10))
 
+        // Assert
         assertDoesNotThrow {
             validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
                 tilkjentYtelse = tilkjentYtelse,
@@ -681,6 +707,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `Validering ved adopsjonssaker skal være gyldig uavhengig av alder med lovverk før august 2024`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -697,6 +724,7 @@ internal class TilkjentYtelseValidatorTest {
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2022, 8, 1), adopsjonsdato = LocalDate.of(2022, 10, 10))
 
+        // Assert
         assertDoesNotThrow {
             validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
                 tilkjentYtelse = tilkjentYtelse,
@@ -710,6 +738,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `Validering ved adopsjonssaker skal være gyldig uavhengig av alder med regelverk august 2024`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -726,6 +755,7 @@ internal class TilkjentYtelseValidatorTest {
         val personResultat = PersonResultat(vilkårsvurdering = vilkårsvurdering, aktør = barn.aktør)
         val barnetsAlderVilkårResultater = lagAutomatiskGenererteVilkårForBarnetsAlder(personResultat = personResultat, behandlingId = behandling.id, fødselsdato = LocalDate.of(2023, 7, 1), adopsjonsdato = LocalDate.of(2023, 10, 10))
 
+        // Assert
         assertDoesNotThrow {
             validerAtTilkjentYtelseHarFornuftigePerioderOgBeløp(
                 tilkjentYtelse = tilkjentYtelse,
@@ -739,6 +769,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `Det skal kastes feil dersom det forsøkes å innvilge mer enn 1 måned fram i tid`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(
@@ -771,6 +802,7 @@ internal class TilkjentYtelseValidatorTest {
 
     @Test
     fun `Validering ved adopsjonssaker skal være ugyldig dersom mer enn 7 mnd`() {
+        // Arrange
         val andeler =
             listOf(
                 lagAndelTilkjentYtelse(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/EndretUtbetalingAndelTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/EndretUtbetalingAndelTest.kt
@@ -41,11 +41,14 @@ class EndretUtbetalingAndelTest {
 
     @Test
     fun `validerUtfyltEndring skal kaste feil når EndretUtbetalingAndel ikke har prosent fylt ut`() {
+        // Arrange
         val endretUtbetalingAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = behandling.id,
                 personer = setOf(person),
             )
+
+        // Act & Assert
         val exception =
             assertThrows<RuntimeException> {
                 endretUtbetalingAndel.validerUtfyltEndring()
@@ -58,6 +61,7 @@ class EndretUtbetalingAndelTest {
 
     @Test
     fun `validerUtfyltEndring skal kaste feil når EndretUtbetalingAndel har feil fom, tom`() {
+        // Arrange
         val endretUtbetalingAndel =
             lagEndretUtbetalingAndel(
                 behandlingId = behandling.id,
@@ -66,6 +70,8 @@ class EndretUtbetalingAndelTest {
                 periodeFom = YearMonth.now(),
                 periodeTom = YearMonth.now().minusYears(1),
             )
+
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 endretUtbetalingAndel.validerUtfyltEndring()

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/SatsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/beregning/domene/SatsTest.kt
@@ -12,6 +12,7 @@ internal class SatsTest {
 
     @Test
     fun `hentGyldigSatsFor skal utlede 100 prosent sats når barn ikke har fått barnehageplass`() {
+        // Act
         val satsPeriode =
             hentGyldigSatsFor(
                 antallTimer = null,
@@ -20,11 +21,13 @@ internal class SatsTest {
                 stønadTom = stønadTom,
             )
 
+        // Assert
         assertSatsPeriode(BigDecimal(100), satsPeriode)
     }
 
     @Test
     fun `hentGyldigSatsFor skal utlede 80 prosent sats når barn har fått barnehageplass i 8 timer`() {
+        // Act
         val satsPeriode =
             hentGyldigSatsFor(
                 antallTimer = BigDecimal(8.99),
@@ -32,11 +35,13 @@ internal class SatsTest {
                 stønadFom = stønadFom,
                 stønadTom = stønadTom,
             )
+        // Assert
         assertSatsPeriode(BigDecimal(80), satsPeriode)
     }
 
     @Test
     fun `hentGyldigSatsFor skal utlede 60 prosent sats når barn har fått barnehageplass mindre enn 16 timer`() {
+        // Act
         val satsPeriode =
             hentGyldigSatsFor(
                 antallTimer = BigDecimal(13.55),
@@ -44,11 +49,13 @@ internal class SatsTest {
                 stønadFom = stønadFom,
                 stønadTom = stønadTom,
             )
+        // Assert
         assertSatsPeriode(BigDecimal(60), satsPeriode)
     }
 
     @Test
     fun `hentGyldigSatsFor skal utlede 40 prosent sats når barn har fått barnehageplass mindre enn 24 timer`() {
+        // Act
         val satsPeriode =
             hentGyldigSatsFor(
                 antallTimer = BigDecimal(22),
@@ -56,11 +63,13 @@ internal class SatsTest {
                 stønadFom = stønadFom,
                 stønadTom = stønadTom,
             )
+        // Assert
         assertSatsPeriode(BigDecimal(40), satsPeriode)
     }
 
     @Test
     fun `hentGyldigSatsFor skal utlede 20 prosent sats når barn har fått barnehageplass i 32 timer`() {
+        // Act
         val satsPeriode =
             hentGyldigSatsFor(
                 antallTimer = BigDecimal(32.85),
@@ -68,11 +77,13 @@ internal class SatsTest {
                 stønadFom = stønadFom,
                 stønadTom = stønadTom,
             )
+        // Assert
         assertSatsPeriode(BigDecimal(20), satsPeriode)
     }
 
     @Test
     fun `hentGyldigSatsFor skal utlede 0 prosent sats når barn har fått barnehageplass mer enn 32 timer`() {
+        // Act
         val satsPeriode =
             hentGyldigSatsFor(
                 antallTimer = BigDecimal(35),
@@ -80,11 +91,13 @@ internal class SatsTest {
                 stønadFom = stønadFom,
                 stønadTom = stønadTom,
             )
+        // Assert
         assertSatsPeriode(BigDecimal(0), satsPeriode)
     }
 
     @Test
     fun `hentGyldigSatsFor skal utlede 50 prosent sats når barn har delt bosted`() {
+        // Act
         val satsPeriode =
             hentGyldigSatsFor(
                 antallTimer = null,
@@ -92,6 +105,7 @@ internal class SatsTest {
                 stønadFom = stønadFom,
                 stønadTom = stønadTom,
             )
+        // Assert
         assertSatsPeriode(BigDecimal(50), satsPeriode)
     }
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevPeriodeContextTest.kt
@@ -51,6 +51,7 @@ import java.time.YearMonth
 class BrevPeriodeContextTest {
     @Test
     fun `genererBrevPeriodeDto skal gi riktig output for innvilgetIkkeBarnehage-begrunnelse når alle vilkår er oppfylt`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 3, 15)
 
         val personerIbehandling =
@@ -75,6 +76,7 @@ class BrevPeriodeContextTest {
                 skalOppretteEndretUtbetalingAndeler = false,
             ).genererBrevPeriodeDto()
 
+        // Act & Assert
         Assertions.assertEquals(
             listOf(barnFødselsdato.plusYears(1).førsteDagINesteMåned().tilDagMånedÅr()),
             brevPeriodeDto?.fom,
@@ -122,6 +124,7 @@ class BrevPeriodeContextTest {
 
     @Test
     fun `genererBrevPeriodeDto skal gi riktig output for innvilgetDeltidBarnehage-begrunnelse ved 17 timer barnehageplass`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 3, 15)
 
         val personerIbehandling =
@@ -154,6 +157,7 @@ class BrevPeriodeContextTest {
                 skalOppretteEndretUtbetalingAndeler = false,
             ).genererBrevPeriodeDto()
 
+        // Act & Assert
         Assertions.assertEquals(
             NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
@@ -176,6 +180,7 @@ class BrevPeriodeContextTest {
 
     @Test
     fun `genererBrevPeriodeDto skal gi riktig output for innvilgetDeltidBarnehageAdopsjon ved 17 timer barnehageplass`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 3, 15)
 
         val personerIbehandling =
@@ -214,6 +219,7 @@ class BrevPeriodeContextTest {
                 skalOppretteEndretUtbetalingAndeler = false,
             ).genererBrevPeriodeDto()
 
+        // Act & Assert
         Assertions.assertEquals(
             NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
@@ -236,6 +242,7 @@ class BrevPeriodeContextTest {
 
     @Test
     fun `genererBrevPeriodeDto skal gi riktig output for innvilgetIkkeBarnehageAdopsjon`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 3, 15)
 
         val personerIbehandling =
@@ -268,6 +275,7 @@ class BrevPeriodeContextTest {
                 skalOppretteEndretUtbetalingAndeler = false,
             ).genererBrevPeriodeDto()
 
+        // Act & Assert
         Assertions.assertEquals(
             NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,
@@ -290,6 +298,7 @@ class BrevPeriodeContextTest {
 
     @Test
     fun `genererBrevPeriodeDto skal gi true for gjelderAnnenForelder feltet dersom annen forelder ikke er vurdert i MedlemskapAnnenForelder vilkåret`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 3, 15)
 
         val personerIbehandling =
@@ -351,6 +360,7 @@ class BrevPeriodeContextTest {
 
     @Test
     fun `genererBrevPeriodeDto skal gi false for gjelderAnnenForelder feltet dersom annen forelder ikke er vurdert i MedlemskapAnnenForelder vilkåret`() {
+        // Arrange
         val barnFødselsdato = LocalDate.of(2021, 3, 15)
 
         val personerIbehandling =
@@ -390,6 +400,7 @@ class BrevPeriodeContextTest {
                 skalOppretteEndretUtbetalingAndeler = true,
             ).genererBrevPeriodeDto()
 
+        // Act & Assert
         Assertions.assertEquals(
             NasjonalOgFellesBegrunnelseDataDto(
                 vedtakBegrunnelseType = BegrunnelseType.INNVILGET,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/BegrunnelserForPeriodeContextTest.kt
@@ -66,6 +66,7 @@ class BegrunnelserForPeriodeContextTest {
 
     @Test
     fun `hentGyldigeBegrunnelserForVedtaksperiode - skal returnere standardbegrunnelsen INNVILGET_IKKE_BARNEHAGE når antall timer barnehage er 0 eller mer enn 33 og barnet ikke er adoptert`() {
+        // Arrange
         val personResultatBarn =
             PersonResultat(
                 aktør = barnAktør,
@@ -94,6 +95,7 @@ class BegrunnelserForPeriodeContextTest {
                 personResultatSøker,
             )
 
+        // Act
         val begrunnelser =
             lagFinnGyldigeBegrunnelserForPeriodeContext(
                 personResultater,
@@ -101,12 +103,15 @@ class BegrunnelserForPeriodeContextTest {
                 barnAktør,
             ).hentGyldigeBegrunnelserForVedtaksperiode()
 
+        // Assert
         assertEquals(1, begrunnelser.size)
+        // Assert
         assertEquals(NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE, begrunnelser.first())
     }
 
     @Test
     fun `hentGyldigeBegrunnelserForVedtaksperiode - skal returnere standardbegrunnelsen INNVILGET_IKKE_BARNEHAGE_ADOPSJON når antall timer barnehage er 0 eller mer enn 33 og barnet er adoptert`() {
+        // Arrange
         val personResultatBarn =
             PersonResultat(
                 aktør = barnAktør,
@@ -150,6 +155,7 @@ class BegrunnelserForPeriodeContextTest {
                 personResultatSøker,
             )
 
+        // Act
         val begrunnelser =
             lagFinnGyldigeBegrunnelserForPeriodeContext(
                 personResultater,
@@ -157,11 +163,13 @@ class BegrunnelserForPeriodeContextTest {
                 barnAktør,
             ).hentGyldigeBegrunnelserForVedtaksperiode()
 
+        // Assert
         assertTrue(begrunnelser.contains(NasjonalEllerFellesBegrunnelse.INNVILGET_IKKE_BARNEHAGE_ADOPSJON))
     }
 
     @Test
     fun `hentGyldigeBegrunnelserForVedtaksperiode - skal returnere standardbegrunnelsen INNVILGET_DELTID_BARNEHAGE når antall timer barnehage er større enn 0 og mindre enn 33 og barnet ikke er adoptert`() {
+        // Arrange
         val personResultatBarn =
             PersonResultat(
                 aktør = barnAktør,
@@ -205,6 +213,7 @@ class BegrunnelserForPeriodeContextTest {
                 personResultatSøker,
             )
 
+        // Act
         val begrunnelser =
             lagFinnGyldigeBegrunnelserForPeriodeContext(
                 personResultater,
@@ -212,12 +221,15 @@ class BegrunnelserForPeriodeContextTest {
                 barnAktør,
             ).hentGyldigeBegrunnelserForVedtaksperiode()
 
+        // Assert
         assertEquals(1, begrunnelser.size)
+        // Assert
         assertEquals(NasjonalEllerFellesBegrunnelse.INNVILGET_DELTID_BARNEHAGE, begrunnelser.first())
     }
 
     @Test
     fun `hentGyldigeBegrunnelserForVedtaksperiode - skal returnere standardbegrunnelsen INNVILGET_DELTID_BARNEHAGE_ADOPSJON når antall timer barnehage er større enn 0 og mindre enn 33 og barnet er adoptert`() {
+        // Arrange
         val personResultatBarn =
             PersonResultat(
                 aktør = barnAktør,
@@ -266,6 +278,7 @@ class BegrunnelserForPeriodeContextTest {
                 personResultatSøker,
             )
 
+        // Act
         val begrunnelser =
             lagFinnGyldigeBegrunnelserForPeriodeContext(
                 personResultater,
@@ -273,11 +286,13 @@ class BegrunnelserForPeriodeContextTest {
                 barnAktør,
             ).hentGyldigeBegrunnelserForVedtaksperiode()
 
+        // Assert
         assertTrue(begrunnelser.contains(NasjonalEllerFellesBegrunnelse.INNVILGET_DELTID_BARNEHAGE_ADOPSJON))
     }
 
     @Test
     fun `hentGyldigeBegrunnelserForVedtaksperiode - skal returnere 1 begrunnelse av type Standard i tillegg til INNVILGET_BOSATT_I_NORGE når vilkåret BOSATT_I_RIKET trigger vedtaksperioden`() {
+        // Arrange
         val barn1ÅrSanityNasjonalEllerFellesBegrunnelse =
             SanityBegrunnelse(
                 apiNavn = NasjonalEllerFellesBegrunnelse.INNVILGET_BOSATT_I_NORGE.sanityApiNavn,
@@ -336,6 +351,7 @@ class BegrunnelserForPeriodeContextTest {
                 personResultatSøker,
             )
 
+        // Act
         val begrunnelser =
             lagFinnGyldigeBegrunnelserForPeriodeContext(
                 personResultater,
@@ -343,7 +359,9 @@ class BegrunnelserForPeriodeContextTest {
                 barnAktør,
             ).hentGyldigeBegrunnelserForVedtaksperiode()
 
+        // Assert
         assertEquals(2, begrunnelser.size)
+        // Assert
         assertThat(
             begrunnelser,
             containsInAnyOrder(
@@ -355,6 +373,7 @@ class BegrunnelserForPeriodeContextTest {
 
     @Test
     fun `hentGyldigeBegrunnelserForVedtaksperiode - skal returnere 1 begrunnelse av type Standard i tillegg til 1 tilleggstekst som skal vises når BOSATT_I_RIKET for søker trigger vedtaksperioden`() {
+        // Arrange
         val bosattIRiketBegrunnelser =
             listOf(
                 SanityBegrunnelse(
@@ -414,6 +433,7 @@ class BegrunnelserForPeriodeContextTest {
                 personResultatSøker,
             )
 
+        // Act
         val begrunnelser =
             lagFinnGyldigeBegrunnelserForPeriodeContext(
                 personResultater,
@@ -421,7 +441,9 @@ class BegrunnelserForPeriodeContextTest {
                 søkerAktør,
             ).hentGyldigeBegrunnelserForVedtaksperiode()
 
+        // Assert
         assertEquals(2, begrunnelser.size)
+        // Assert
         assertThat(
             begrunnelser,
             containsInAnyOrder(
@@ -435,6 +457,7 @@ class BegrunnelserForPeriodeContextTest {
     inner class EØS {
         @Test
         fun `Skal kunne få opp eøs som gyldige begrunnelser dersom det er en kompetanse i perioden`() {
+            // Arrange
             val eøsBegrunnelse =
                 SanityBegrunnelse(
                     apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BARNET_BOR_I_NORGE.sanityApiNavn,
@@ -468,14 +491,18 @@ class BegrunnelserForPeriodeContextTest {
                     vedtaksperiodeSluttTidpunkt = 31.jan(2020),
                     andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = jan(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
+            // Act
             val begrunnelser =
+                // Act
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
 
+            // Assert
             assertThat(begrunnelser).contains(EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BARNET_BOR_I_NORGE)
         }
 
         @Test
         fun `Kompetanser som ikke gjelder for perioden skal ikke føre til gyldige begrunnelser`() {
+            // Arrange
             val eøsBegrunnelse =
                 SanityBegrunnelse(
                     apiNavn = EØSBegrunnelse.INNVILGET_PRIMÆRLAND_BARNET_BOR_I_NORGE.sanityApiNavn,
@@ -509,14 +536,18 @@ class BegrunnelserForPeriodeContextTest {
                     vedtaksperiodeSluttTidpunkt = 28.feb(2021),
                     andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = feb(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
+            // Act
             val begrunnelser =
+                // Act
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
 
+            // Assert
             assertThat(begrunnelser.filter { it.begrunnelseType != BegrunnelseType.FORTSATT_INNVILGET }.size).isEqualTo(0)
         }
 
         @Test
         fun `Skal kunne få opp eøs-opphør som gyldige begrunnelser dersom det er en kompetanse som slutter måneden før`() {
+            // Arrange
             val eøsBegrunnelse =
                 SanityBegrunnelse(
                     apiNavn = EØSBegrunnelse.OPPHØR_EØS_STANDARD.sanityApiNavn,
@@ -551,14 +582,18 @@ class BegrunnelserForPeriodeContextTest {
                     vedtaksperiodeSluttTidpunkt = 28.feb(2020),
                     andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = jan(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
+            // Act
             val begrunnelser =
+                // Act
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
 
+            // Assert
             assertThat(begrunnelser.size).isEqualTo(1)
         }
 
         @Test
         fun `Skal ikke få opp eøs-opphør som gyldige begrunnelser dersom det er en kompetanse som slutter måneden før når vi fremdeles har kompetanse`() {
+            // Arrange
             val eøsBegrunnelse =
                 SanityBegrunnelse(
                     apiNavn = EØSBegrunnelse.OPPHØR_EØS_STANDARD.sanityApiNavn,
@@ -597,14 +632,18 @@ class BegrunnelserForPeriodeContextTest {
                     vedtaksperiodeSluttTidpunkt = 28.feb(2020),
                     andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = feb(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
+            // Act
             val begrunnelser =
+                // Act
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
 
+            // Assert
             assertThat(begrunnelser.size).isEqualTo(0)
         }
 
         @Test
         fun `Skal få opp fortsatt innvilget tekster dersom det ikke er forandring i kompetanse`() {
+            // Arrange
             val eøsBegrunnelse =
                 SanityBegrunnelse(
                     apiNavn = EØSBegrunnelse.FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD.sanityApiNavn,
@@ -642,14 +681,18 @@ class BegrunnelserForPeriodeContextTest {
                     vedtaksperiodeSluttTidpunkt = 28.feb(2020),
                     andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = feb(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
+            // Act
             val begrunnelser =
+                // Act
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
 
+            // Assert
             assertThat(begrunnelser).contains(EØSBegrunnelse.FORTSATT_INNVILGET_PRIMÆRLAND_STANDARD)
         }
 
         @Test
         fun `Skal kunne få opp eøs-opphør selv om kompetanse som varer evig når det ikke er noen utbetaling på barnet`() {
+            // Arrange
             val eøsBegrunnelse =
                 SanityBegrunnelse(
                     apiNavn = EØSBegrunnelse.OPPHØR_EØS_STANDARD.sanityApiNavn,
@@ -684,9 +727,12 @@ class BegrunnelserForPeriodeContextTest {
                     vedtaksperiodeSluttTidpunkt = 28.feb(2020),
                     andelerTilkjentYtelse = listOf(AndelTilkjentYtelseMedEndreteUtbetalinger(lagAndelTilkjentYtelse(fom = jan(2020), tom = jan(2020), aktør = barnAktør), endreteUtbetalingerAndeler = emptyList())),
                 )
+            // Act
             val begrunnelser =
+                // Act
                 begrunnelseContext.hentGyldigeBegrunnelserForVedtaksperiode()
 
+            // Assert
             assertThat(begrunnelser.size).isEqualTo(1)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/IBegrunnelseDeserializerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/IBegrunnelseDeserializerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 class IBegrunnelseDeserializerTest {
     @Test
     fun `deserialiserer liste av enumverdier til IBegrunnelse`() {
+        // Arrange
         val testdata =
             EndretUtbetalingAndelRequestDto(
                 id = 1L,
@@ -28,6 +29,8 @@ class IBegrunnelseDeserializerTest {
             )
         val json = jsonMapper.writeValueAsString(testdata)
         val forventetJson = """{"id":1,"personIdent":"12345678903","personIdenter":["12345678903"],"prosent":100,"fom":"2023-01","tom":"2023-12","årsak":"ALLEREDE_UTBETALT","søknadstidspunkt":"2023-01-01","begrunnelse":"en begrunnelse","erEksplisittAvslagPåSøknad":false,"vedtaksbegrunnelser":["NasjonalEllerFellesBegrunnelse${'$'}AVSLAG_ENDRINGSPERIODE_ALLEREDE_UTBETALT_SØKER","NasjonalEllerFellesBegrunnelse${'$'}AVSLAG_ENDRINGSPERIODE_ALLEREDE_UTBETALT_ANNEN_FORELDER"]}"""
+
+        // Act & Assert
         assertEquals(forventetJson, json)
         assertEquals(testdata, jsonMapper.readValue(json, EndretUtbetalingAndelRequestDto::class.java))
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/INasjonalEllerFellesBegrunnelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/begrunnelser/INasjonalEllerFellesBegrunnelseTest.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test
 class INasjonalEllerFellesBegrunnelseTest {
     @Test
     fun `Skal ikke være to begrunnelser med samme Apinavn`() {
+        // Arrange
         val alleBegrunnelserApiNain = (NasjonalEllerFellesBegrunnelse.entries + EØSBegrunnelse.entries).map { it.sanityApiNavn }
 
+        // Assert
         assertThat(alleBegrunnelserApiNain.size).isEqualTo(alleBegrunnelserApiNain.toSet().size)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/mottaker/BrevmottakerServiceTest.kt
@@ -32,9 +32,13 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal lage mottakere når brevmottaker er FULLMEKTIG og bruker har norsk adresse`() {
+        // Arrange
         val brevmottakere = listOf(lagBrevMottaker(søkersnavn, mottakerType = MottakerType.FULLMEKTIG))
+
+        // Act
         val mottakerInfo = brevmottakerService.lagMottakereFraBrevMottakere(brevmottakere)
 
+        // Assert
         assertTrue { mottakerInfo.size == 2 }
 
         assertTrue(mottakerInfo.first() is Bruker)
@@ -46,6 +50,7 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal lage mottakere når brevmottaker er FULLMEKTIG og bruker har utenlandsk adresse`() {
+        // Arrange
         val brevmottakere =
             listOf(
                 lagBrevMottaker(mottakerType = MottakerType.FULLMEKTIG, navn = "Fullmektig navn"),
@@ -58,8 +63,10 @@ internal class BrevmottakerServiceTest {
             )
         // every { brevmottakerRepository.finnBrevMottakereForBehandling(any()) } returns brevmottakere.map { it.tilBrevMottakerDb(1) }
 
+        // Act
         val mottakerInfo = brevmottakerService.lagMottakereFraBrevMottakere(brevmottakere)
 
+        // Assert
         assertTrue { mottakerInfo.size == 2 }
 
         assertTrue(mottakerInfo.first().navn.isEmpty()) // (kun adressen til bruker som overstyres)
@@ -72,6 +79,7 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal lage mottakere når brevmottaker er VERGE og bruker har utenlandsk adresse`() {
+        // Arrange
         val brevmottakere =
             listOf(
                 lagBrevMottaker(mottakerType = MottakerType.VERGE, navn = "Verge navn"),
@@ -83,8 +91,10 @@ internal class BrevmottakerServiceTest {
                 ),
             )
 
+        // Act
         val mottakerInfo = brevmottakerService.lagMottakereFraBrevMottakere(brevmottakere)
 
+        // Assert
         assertTrue { mottakerInfo.size == 2 }
 
         assertTrue(mottakerInfo.first().navn.isEmpty()) // (kun adressen til bruker som overstyres)
@@ -97,6 +107,7 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal lage mottakere når bruker har utenlandsk adresse`() {
+        // Arrange
         val brevmottakere =
             listOf(
                 lagBrevMottaker(
@@ -107,8 +118,10 @@ internal class BrevmottakerServiceTest {
                 ),
             )
 
+        // Act
         val mottakerInfo = brevmottakerService.lagMottakereFraBrevMottakere(brevmottakere)
 
+        // Assert
         assertTrue { mottakerInfo.size == 1 }
 
         assertTrue(mottakerInfo.first().navn.isEmpty()) // (kun adressen som overstyrers)
@@ -118,6 +131,7 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal lage mottakere når bruker har dødsbo`() {
+        // Arrange
         val brevmottakere =
             listOf(
                 lagBrevMottaker(
@@ -128,8 +142,10 @@ internal class BrevmottakerServiceTest {
                 ),
             )
 
+        // Act
         val mottakerInfo = brevmottakerService.lagMottakereFraBrevMottakere(brevmottakere)
 
+        // Assert
         assertTrue { mottakerInfo.size == 1 }
 
         assertEquals(søkersnavn, mottakerInfo.first().navn)
@@ -139,6 +155,7 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `lagMottakereFraBrevMottakere skal kaste feil når brevmottakere inneholder ugyldig kombinasjon`() {
+        // Arrange
         val brevmottakere =
             listOf(
                 lagBrevMottaker(
@@ -155,6 +172,7 @@ internal class BrevmottakerServiceTest {
                 ),
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             brevmottakerService.lagMottakereFraBrevMottakere(brevmottakere)
         }.also {
@@ -164,6 +182,7 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `leggTilBrevmottaker skal lagre logg på at brevmottaker legges til`() {
+        // Arrange
         val brevmottakerDto = mockk<BrevmottakerDto>(relaxed = true)
 
         every {
@@ -176,16 +195,20 @@ internal class BrevmottakerServiceTest {
         every { loggService.opprettBrevmottakerLogg(any(), false) } just runs
         every { brevmottakerRepository.save(any()) } returns mockk()
 
+        // Act
         brevmottakerService.leggTilBrevmottaker(brevmottakerDto, 200)
 
+        // Assert
         verify { loggService.opprettBrevmottakerLogg(any(), false) }
         verify { brevmottakerRepository.save(any()) }
     }
 
     @Test
     fun `fjernBrevmottaker skal kaste feil dersom brevmottakeren ikke finnes`() {
+        // Arrange
         every { brevmottakerRepository.findByIdOrNull(404) } returns null
 
+        // Act & Assert
         assertThrows<Feil> {
             brevmottakerService.fjernBrevmottaker(404)
         }
@@ -195,14 +218,17 @@ internal class BrevmottakerServiceTest {
 
     @Test
     fun `fjernBrevmottaker skal lagre logg på at brevmottaker fjernes`() {
+        // Arrange
         val mocketBrevmottaker = mockk<BrevmottakerDb>()
 
         every { brevmottakerRepository.findByIdOrNull(200) } returns mocketBrevmottaker
         every { loggService.opprettBrevmottakerLogg(mocketBrevmottaker, true) } just runs
         every { brevmottakerRepository.deleteById(200) } just runs
 
+        // Act
         brevmottakerService.fjernBrevmottaker(200)
 
+        // Assert
         verify { brevmottakerRepository.findByIdOrNull(200) }
         verify { loggService.opprettBrevmottakerLogg(mocketBrevmottaker, true) }
         verify { brevmottakerRepository.deleteById(200) }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/mottaker/ValiderBrevmottakerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/mottaker/ValiderBrevmottakerServiceTest.kt
@@ -41,13 +41,16 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal ikke kaste funksjonell feil når en behandling ikke inneholder noen manuelle brevmottakere`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns emptyList()
 
+        // Act
         validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
             behandlingId,
             ekstraBarnLagtTilIBrev = emptyList(),
         )
 
+        // Assert
         verify(exactly = 1) { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) }
         verify(exactly = 0) { persongrunnlagService.finnAktivPersonopplysningGrunnlag(any()) }
         verify(exactly = 0) {
@@ -59,6 +62,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal kaste en FunksjonellFeil exception når en behandling inneholder minst en strengt fortrolig person og minst en manuell brevmottaker`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns listOf(brevmottaker)
         every { persongrunnlagService.finnAktivPersonopplysningGrunnlag(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -70,6 +74,7 @@ class ValiderBrevmottakerServiceTest {
                 søker.aktør.aktivFødselsnummer(),
             )
 
+        // Act & Assert
         assertThatThrownBy {
             validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
                 behandlingId,
@@ -81,6 +86,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal ikke kaste funksjonell feil når behandling ikke inneholder noen strengt fortrolige personer og inneholder minst en manuell brevmottaker`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns listOf(brevmottaker)
         every { persongrunnlagService.finnAktivPersonopplysningGrunnlag(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -89,10 +95,13 @@ class ValiderBrevmottakerServiceTest {
             )
         every { personOpplysningerService.hentIdenterMedStrengtFortroligAdressebeskyttelse(any()) } returns emptyList()
 
+        // Act
         validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
             behandlingId,
             ekstraBarnLagtTilIBrev = emptyList(),
         )
+
+        // Assert
         verify(exactly = 1) {
             personOpplysningerService.hentIdenterMedStrengtFortroligAdressebeskyttelse(
                 any(),
@@ -102,6 +111,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal ikke kaste en exception når en behandling inneholder minst en strengt fortrolig person og ingen manuelle brevmottakere`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns emptyList()
         every { persongrunnlagService.finnAktivPersonopplysningGrunnlag(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -113,6 +123,7 @@ class ValiderBrevmottakerServiceTest {
                 søker.aktør.aktivFødselsnummer(),
             )
 
+        // Act
         validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
             behandlingId,
             ekstraBarnLagtTilIBrev = emptyList(),
@@ -121,6 +132,7 @@ class ValiderBrevmottakerServiceTest {
 
     @Test
     fun `Skal kaste en FunksjonellFeil exception når en behandling inneholder minst en strengt fortrolig person og det blir forsøkt lagt til en ny manuell brevmottaker`() {
+        // Arrange
         every { brevmottakerRepository.finnBrevMottakereForBehandling(behandlingId) } returns emptyList()
         every { persongrunnlagService.finnAktivPersonopplysningGrunnlag(behandlingId) } returns
             lagTestPersonopplysningGrunnlag(
@@ -132,6 +144,7 @@ class ValiderBrevmottakerServiceTest {
                 søker.aktør.aktivFødselsnummer(),
             )
 
+        // Act & Assert
         assertThatThrownBy {
             validerBrevmottakerService.validerAtBehandlingIkkeInneholderStrengtFortroligePersonerMedManuelleBrevmottakere(
                 behandlingId,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/differanseberegning/DifferanseberegningsUtilsTest.kt
@@ -20,82 +20,98 @@ import java.time.YearMonth
 class DifferanseberegningsUtilsTest {
     @Test
     fun `Skal multiplisere valutabeløp med valutakurs`() {
+        // Arrange
         val valutabeløp = 1200.i("EUR")
         val kurs = 9.731.kronerPer("EUR")
 
+        // Assert
         assertThat((valutabeløp * kurs)?.round(MathContext(5))).isEqualTo(11_677.toBigDecimal())
     }
 
     @Test
     fun `Skal ikke multiplisere valutabeløp med valutakurs når valuta er forskjellig, men returnere null`() {
+        // Arrange
         val valutabeløp = 1200.i("EUR")
         val kurs = 9.73.kronerPer("DKK")
 
+        // Assert
         assertThat(valutabeløp * kurs).isNull()
     }
 
     @Test
     fun `Skal konvertere årlig utenlandsk periodebeløp til månedlig`() {
+        // Arrange
         val månedligValutabeløp =
             1200
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(ÅRLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         assertThat(månedligValutabeløp).isEqualTo(100.i("EUR"))
     }
 
     @Test
     fun `Skal konvertere kvartalsvis utenlandsk periodebeløp til månedlig`() {
+        // Arrange
         val månedligValutabeløp =
             300
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(KVARTALSVIS)
                 .tilMånedligValutabeløp()
 
+        // Assert
         assertThat(månedligValutabeløp).isEqualTo(100.i("EUR"))
     }
 
     @Test
     fun `Månedlig utenlandsk periodebeløp skal ikke endres`() {
+        // Arrange
         val månedligValutabeløp =
             100
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(MÅNEDLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         assertThat(månedligValutabeløp).isEqualTo(100.i("EUR"))
     }
 
     @Test
     fun `Skal konvertere ukentlig utenlandsk periodebeløp til månedlig`() {
+        // Arrange
         val månedligValutabeløp =
             25
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(UKENTLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         assertThat(månedligValutabeløp).isEqualTo(108.75.i("EUR"))
     }
 
     @Test
     fun `Skal ha presisjon i kronekonverteringen til norske kroner`() {
+        // Arrange
         val månedligValutabeløp =
             0.0123767453453
                 .i("EUR")
                 .somUtenlandskPeriodebeløp(ÅRLIG)
                 .tilMånedligValutabeløp()
 
+        // Assert
         assertThat(månedligValutabeløp).isEqualTo(0.0010313954.i("EUR"))
     }
 
     @Test
     fun `Skal håndtere gjentakende endring og differanseberegning på andel tilkjent ytelse`() {
+        // Arrange
         val aty1 =
             lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(
                 100.toBigDecimal(),
             )
 
+        // Act & Assert
         assertThat(aty1?.kalkulertUtbetalingsbeløp).isEqualTo(0)
         assertThat(aty1?.differanseberegnetPeriodebeløp).isEqualTo(-50)
         assertThat(aty1?.nasjonaltPeriodebeløp).isEqualTo(50)
@@ -121,11 +137,13 @@ class DifferanseberegningsUtilsTest {
 
     @Test
     fun `Skal fjerne desimaler i utenlandskperiodebeløp, effektivt øke den norske ytelsen med inntil én krone`() {
+        // Arrange
         val aty1 =
             lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(
                 100.987654.toBigDecimal(),
             ) // Blir til rundet til 100
 
+        // Assert
         assertThat(aty1?.kalkulertUtbetalingsbeløp).isEqualTo(0)
         assertThat(aty1?.differanseberegnetPeriodebeløp).isEqualTo(-50)
         assertThat(aty1?.nasjonaltPeriodebeløp).isEqualTo(50)
@@ -133,11 +151,13 @@ class DifferanseberegningsUtilsTest {
 
     @Test
     fun `Skal beholde originalt nasjonaltPeriodebeløp når vi oppdatererDifferanseberegning gjentatte ganger`() {
+        // Arrange
         var aty1 =
             lagAndelTilkjentYtelse(beløp = 50).oppdaterDifferanseberegning(
                 100.987654.toBigDecimal(),
             )
 
+        // Act & Assert
         assertThat(aty1?.kalkulertUtbetalingsbeløp).isEqualTo(0)
         aty1 = aty1.oppdaterDifferanseberegning(13.6.toBigDecimal())
         assertThat(aty1?.kalkulertUtbetalingsbeløp).isEqualTo(37)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/differanseberegning/TilkjentYtelseDifferanseberegningTest.kt
@@ -33,6 +33,7 @@ class TilkjentYtelseDifferanseberegningTest {
 
     @Test
     fun `skal gjøre differanseberegning på en tilkjent ytelse med endringsperioder`() {
+        // Arrange
         val barnsFødselsdato = 13.jan(2020)
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
@@ -97,6 +98,7 @@ class TilkjentYtelseDifferanseberegningTest {
                 .medOrdinær("                 $$$$$", 100, nasjonalt = { it }, differanse = { it - 54 }) { it - 54 }
                 .bygg()
 
+        // Act & Assert
         val andelerMedDifferanse =
             beregnDifferanse(tilkjentYtelse.andelerTilkjentYtelse.toList(), utenlandskePeriodebeløp, valutakurser)
 
@@ -107,6 +109,7 @@ class TilkjentYtelseDifferanseberegningTest {
 
     @Test
     fun `skal fjerne differanseberegning når utenlandsk periodebeløp eller valutakurs nullstilles`() {
+        // Arrange
         val barnsFødselsdato = 13.jan(2020)
         val søker = tilfeldigPerson(personType = PersonType.SØKER)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = barnsFødselsdato)
@@ -157,6 +160,7 @@ class TilkjentYtelseDifferanseberegningTest {
                 .medOrdinær("      $$$$$$$$$$$$$$$$", nasjonalt = { it }, differanse = { it - 54 }) { it - 54 }
                 .bygg()
 
+        // Act & Assert
         val andelerMedDiff =
             beregnDifferanse(tilkjentYtelse.andelerTilkjentYtelse.toMutableList(), utenlandskePeriodebeløp, valutakurser)
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/differanseberegning/TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest.kt
@@ -26,6 +26,7 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
 
     @Test
     fun `skal ikke kaste exception hvis tilkjent ytelse oppdateres med gyldige andeler`() {
+        // Arrange
         val behandling = lagBehandling()
 
         val forrigeTilkjentYtelse =
@@ -41,11 +42,13 @@ class TilkjentYtelseRepositoryOppdaterTilkjentYtelseTest {
 
         every { tilkjentYtelseRepository.saveAndFlush(any()) } returns nyTilkjentYtelse
 
+        // Act
         tilkjentYtelseRepository.oppdaterTilkjentYtelse(
             forrigeTilkjentYtelse,
             nyTilkjentYtelse.andelerTilkjentYtelse,
         )
 
+        // Assert
         verify(exactly = 1) { tilkjentYtelseRepository.saveAndFlush(any()) }
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/kompetanse/KompetanseServiceTest.kt
@@ -510,6 +510,7 @@ internal class KompetanseServiceTest {
 
         @Test
         fun `tilpassKompetanse skal opprette kompetanse med sluttdato når et av barnets regelverk-tidslinjer avsluttes før nåtidspunktet`() {
+            // Arrange
             val nåDato = LocalDate.of(2024, 10, 1)
             val fom = nåDato.minusMonths(6).førsteDagIInneværendeMåned()
             val tom = fom.plusMonths(10).sisteDagIMåned()
@@ -528,8 +529,10 @@ internal class KompetanseServiceTest {
                         ),
                 )
 
+            // Act
             kompetanseService.tilpassKompetanse(behandlingId)
 
+            // Assert
             // henter kompetanse perioder som opprettes automatisk etter vilkårsvurdering
             val kompetanser = kompetanseService.hentKompetanser(behandlingId).sortedBy { it.fom }
             assertThat(kompetanser.size == 2)
@@ -550,6 +553,7 @@ internal class KompetanseServiceTest {
 
         @Test
         fun `tilpassKompetanse skal opprette tomme kompetanser for perioder med overgangsordningandeler`() {
+            // Arrange
             val vilkårFom = LocalDate.of(2024, 5, 1)
             val vilkårTom = LocalDate.of(2024, 9, 1)
             val kompetanseFom = vilkårFom.plusMonths(1).toYearMonth()
@@ -583,8 +587,10 @@ internal class KompetanseServiceTest {
                     ),
                 )
 
+            // Act
             kompetanseService.tilpassKompetanse(behandlingId)
 
+            // Assert
             val kompetanser = kompetanseService.hentKompetanser(behandlingId).sortedBy { it.fom }
             assertThat(kompetanser)
                 .hasSize(3)
@@ -606,6 +612,7 @@ internal class KompetanseServiceTest {
 
         @Test
         fun `tilpassKompetanse skal ikke opprette kompetanser for perioder med overgangsordningandeler i nasjonale saker`() {
+            // Arrange
             val vilkårFom = LocalDate.of(2024, 5, 1)
             val vilkårTom = LocalDate.of(2024, 9, 1)
             val nasjonalBehandling = lagBehandling(kategori = BehandlingKategori.NASJONAL)
@@ -641,14 +648,17 @@ internal class KompetanseServiceTest {
                     ),
                 )
 
+            // Act
             kompetanseService.tilpassKompetanse(nasjonalBehandling.behandlingId)
 
+            // Assert
             val kompetanser = kompetanseService.hentKompetanser(nasjonalBehandling.behandlingId).sortedBy { it.fom }
             assertThat(kompetanser).isEmpty()
         }
 
         @Test
         fun `tilpassKompetanse skal tilpasse kompetanser til endrede regelverk-tidslinjer`() {
+            // Arrange
             val eksisterendeKompetanse1 =
                 lagKompetanse(
                     behandlingId = behandlingId.id,
@@ -715,8 +725,10 @@ internal class KompetanseServiceTest {
                         ),
                 )
 
+            // Act
             kompetanseService.tilpassKompetanse(behandlingId)
 
+            // Assert
             // henter kompetanse perioder som tilpasses etter endringer i vilkårsvurdering
             val kompetanser = kompetanseService.hentKompetanser(behandlingId).sortedBy { it.fom }
             assertThat(kompetanser.size == 6)
@@ -760,6 +772,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal kopiere over kompetanse-skjema fra forrige behandling til ny behandling`() {
+        // Arrange
         val behandlingId1 = BehandlingId(10L)
         val behandlingId2 = BehandlingId(11L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
@@ -786,8 +799,10 @@ internal class KompetanseServiceTest {
                     erAnnenForelderOmfattetAvNorskLovgivning = true,
                 ).lagreTil(kompetanseRepository)
 
+        // Act
         kompetanseService.kopierOgErstattKompetanser(behandlingId1, behandlingId2)
 
+        // Assert
         val kompetanserBehandling2 = kompetanseService.hentKompetanser(behandlingId2)
 
         assertThat(kompetanserBehandling2).hasSize(kompetanserBehandling2.size).containsAll(kompetanser)
@@ -807,6 +822,7 @@ internal class KompetanseServiceTest {
 
     @Test
     fun `skal kopiere kompetanser fra en behandling til en annen behandling, og overskrive eksisterende`() {
+        // Arrange
         val behandlingId1 = BehandlingId(10L)
         val behandlingId2 = BehandlingId(22L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
@@ -824,8 +840,10 @@ internal class KompetanseServiceTest {
             .medKompetanse("PPPSSSPPPPPPP", barn1, barn2, barn3)
             .lagreTil(kompetanseRepository)
 
+        // Act
         kompetanseService.kopierOgErstattKompetanser(behandlingId1, behandlingId2)
 
+        // Assert
         val kompetanserBehandling2EtterEndring = kompetanseService.hentKompetanser(behandlingId2)
 
         assertThat(kompetanserBehandling2EtterEndring).hasSize(kompetanserBehandling2EtterEndring.size).containsAll(kompetanser1)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/TilpassUtenlandskePeriodebeløpTilKompetanserTest.kt
@@ -22,6 +22,7 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
 
     @Test
     fun `test tilpasning av utenlandske periodebeløp mot kompleks endring av kompetanse`() {
+        // Arrange
         val forrigeUtenlandskePeriodebeløp =
             UtenlandskPeriodebeløpBuilder(jan2020)
                 .medBeløp("--3456789-----", "EUR", "N", barn1, barn2)
@@ -41,9 +42,11 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .medBeløp(" -        ", null, "N", barn1, barn3)
                 .bygg()
 
+        // Act
         val faktiskeUtenlandskePeriodebeløp =
             tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser)
 
+        // Assert
         assertThat(faktiskeUtenlandskePeriodebeløp)
             .containsAll(forventedeUtenlandskePeriodebeløp)
             .hasSize(forventedeUtenlandskePeriodebeløp.size)
@@ -51,6 +54,7 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
 
     @Test
     fun `test at endret annennForeldersAktivitetsland i kompetanse fører til endring i utenlandsk periodebeløp`() {
+        // Arrange
         val forrigeUtenlandskePeriodebeløp =
             UtenlandskPeriodebeløpBuilder(jan2020)
                 .medBeløp("555555", "EUR", "N", barn1)
@@ -61,9 +65,11 @@ class TilpassUtenlandskePeriodebeløpTilKompetanserTest {
                 .medKompetanse("SSSSSS", barn1, annenForeldersAktivitetsland = "S")
                 .byggKompetanser()
 
+        // Act
         val faktiskeUtenlandskePeriodebeløp =
             tilpassUtenlandskePeriodebeløpTilKompetanser(forrigeUtenlandskePeriodebeløp, gjeldendeKompetanser)
 
+        // Assert
         val forventedeUtenlandskePeriodebeløp =
             UtenlandskPeriodebeløpBuilder(jan2020)
                 .medBeløp("------", null, "S", barn1)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpServiceTest.kt
@@ -49,6 +49,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `skal tilpasse utenlandsk periodebeløp til endrede kompetanser`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).førsteDagIInneværendeMåned())
@@ -68,9 +69,11 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
         every { kompetanseRepository.findByBehandlingId(behandlingId.id) } returns kompetanser
 
+        // Act
         tilpassUtenlandskePeriodebeløpTilKompetanserService
             .tilpassUtenlandskPeriodebeløpTilKompetanser(behandlingId)
 
+        // Assert
         val faktiskeUtenlandskePeriodebeløp = utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId)
 
         val forventedeUtenlandskePeriodebeløp =
@@ -83,6 +86,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Slette et utenlandskPeriodebeløp-skjema skal resultere i et skjema uten innhold, men som fortsatt har utbetalingsland`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).førsteDagIInneværendeMåned())
@@ -93,8 +97,10 @@ internal class UtenlandskPeriodebeløpServiceTest {
                 .lagreTil(utenlandskPeriodebeløpRepository)
                 .single()
 
+        // Act
         utenlandskPeriodebeløpService.slettUtenlandskPeriodebeløp(lagretUtenlandskPeriodebeløp.id)
 
+        // Assert
         val faktiskUtenlandskPeriodebeløp =
             utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId).single()
 
@@ -110,6 +116,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kunne lukke åpen utenlandskPeriodebeløp-skjema ved å sende inn identisk skjema med satt tom-dato`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).førsteDagIInneværendeMåned())
@@ -127,8 +134,11 @@ internal class UtenlandskPeriodebeløpServiceTest {
                 .medIntervall(Intervall.UKENTLIG)
                 .bygg()
                 .first()
+
+        // Act
         utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(behandlingId, oppdatertUtenlandskPeriodebeløp)
 
+        // Assert
         // Forventer en liste på 2 elementer hvor det første dekker 2 mnd og det andre dekker fra mnd 3 og til uendelig (null). Det siste elementet skal ha beløp, valutakode og intervall satt til null, mens utbetalingsland skal være "SE".
         val faktiskUtenlandskPeriodebeløp = utenlandskPeriodebeløpService.hentUtenlandskePeriodebeløp(behandlingId)
 
@@ -144,6 +154,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kaste funksjonell feil dersom fom ikke er satt`() {
+        // Act & Assert
         val feilmelding =
             assertThrows<FunksjonellFeil> {
                 utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
@@ -162,6 +173,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kaste funksjonell feil dersom det forsøkes å settes fom fra og med 1 januar 2026 med valutakode BGN`() {
+        // Act & Assert
         val feilmelding =
             assertThrows<FunksjonellFeil> {
                 utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(
@@ -180,6 +192,7 @@ internal class UtenlandskPeriodebeløpServiceTest {
 
     @Test
     fun `Skal kaste funksjonell feil dersom det forsøkes å settes tom fra og med 1 januar 2026 med valutakode BGN`() {
+        // Act & Assert
         val feilmelding =
             assertThrows<FunksjonellFeil> {
                 utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskePeriodebeløpUtfyltTest.kt
@@ -11,6 +11,7 @@ import java.math.BigDecimal
 class UtenlandskePeriodebeløpUtfyltTest {
     @Test
     fun `Skal sette UtfyltStatus til OK når alle felter er utfylt`() {
+        // Arrange
         val utenlandskPeriodebeløp =
             lagUtenlandskPeriodebeløp(
                 beløp = BigDecimal.valueOf(500),
@@ -18,39 +19,50 @@ class UtenlandskePeriodebeløpUtfyltTest {
                 intervall = Intervall.MÅNEDLIG,
             )
 
+        // Act
         val restUtenlandskPeriodebeløp = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.OK, restUtenlandskPeriodebeløp.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til UFULLSTENDIG når ett eller to felter er utfylt`() {
+        // Arrange
         var utenlandskPeriodebeløp =
             lagUtenlandskPeriodebeløp(
                 beløp = BigDecimal.valueOf(500),
             )
 
+        // Act
         var restUtenlandskPeriodebeløp = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.UFULLSTENDIG, restUtenlandskPeriodebeløp.status)
 
+        // Arrange
         utenlandskPeriodebeløp =
             lagUtenlandskPeriodebeløp(
                 beløp = BigDecimal.valueOf(500),
                 valutakode = "NOK",
             )
 
+        // Act
         restUtenlandskPeriodebeløp = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.UFULLSTENDIG, restUtenlandskPeriodebeløp.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til IKKE_UTFYLT når ingen felter er utfylt`() {
+        // Arrange
         val utenlandskPeriodebeløp = lagUtenlandskPeriodebeløp()
 
+        // Act
         val restUtenlandskPeriodebeløp = utenlandskPeriodebeløp.tilUtenlandskPeriodebeløpDto()
 
+        // Assert
         assertEquals(UtfyltStatus.IKKE_UTFYLT, restUtenlandskPeriodebeløp.status)
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/TilpassValutakursTilUtenlandskePeridebeløpTest.kt
@@ -22,6 +22,7 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
 
     @Test
     fun `test tilpasning av valutakurser mot kompleks endring av utenlandsk valutabeløp`() {
+        // Arrange
         val gjeldendeValutakurser =
             ValutakursBuilder(jan2020)
                 .medKurs("--3456789-----", "EUR", barn1, barn2)
@@ -42,9 +43,11 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .medKurs("      -    ", "DKK", barn1, barn3)
                 .bygg()
 
+        // Act
         val faktiskeValutakurser =
             tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp)
 
+        // Assert
         assertThat(faktiskeValutakurser)
             .containsAll(forventedeValutakurser)
             .hasSize(forventedeValutakurser.size)
@@ -52,6 +55,7 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
 
     @Test
     fun `test at endret valuta i utenlandsk periodebeløp fører til endring i valutakurs`() {
+        // Arrange
         val gjeldendeValutakurser =
             ValutakursBuilder(jan2020)
                 .medKurs("333333", "EUR", barn1)
@@ -67,9 +71,11 @@ class TilpassValutakursTilUtenlandskePeridebeløpTest {
                 .medKurs("$$$$$$", "DKK", barn1)
                 .bygg()
 
+        // Act
         val faktiskeValutakurser =
             tilpassValutakurserTilUtenlandskePeriodebeløp(gjeldendeValutakurser, utenlandskePeriodebeløp)
 
+        // Assert
         assertThat(faktiskeValutakurser)
             .containsAll(forventedeValutakurser)
             .hasSize(forventedeValutakurser.size)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursControllerTest.kt
@@ -51,8 +51,11 @@ class ValutakursControllerTest {
 
     @Test
     fun `Test at valutakurs hentes fra ECB dersom dato og valuta er satt`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
         val valuta = "SEK"
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
@@ -65,7 +68,10 @@ class ValutakursControllerTest {
 
     @Test
     fun `Test at valutakurs ikke hentes fra ECB dersom dato ikke er satt`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
@@ -78,7 +84,10 @@ class ValutakursControllerTest {
 
     @Test
     fun `Test at valutakurs ikke hentes fra ECB dersom valuta ikke er satt`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
@@ -91,7 +100,10 @@ class ValutakursControllerTest {
 
     @Test
     fun `Test at valutakurs ikke hentes fra ECB dersom ISK og før 1 feb 2018`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2018, 1, 31)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,
@@ -104,7 +116,10 @@ class ValutakursControllerTest {
 
     @Test
     fun `Test at valutakurs hentes fra ECB dersom ISK og etter 1 feb 2018`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2018, 2, 1)
+
+        // Act & Assert
         assertThrows<MockKException> {
             valutakursController.oppdaterValutakurs(
                 1,

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursServiceTest.kt
@@ -48,6 +48,7 @@ internal class ValutakursServiceTest {
 
     @Test
     fun `skal tilpasse utenlandsk periodebeløp til endrede kompetanser`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val barn1 = tilfeldigPerson(personType = PersonType.BARN, fødselsdato = jan(2020).førsteDagIInneværendeMåned())
@@ -65,8 +66,10 @@ internal class ValutakursServiceTest {
 
         every { utenlandskPeriodebeløpRepository.findByBehandlingId(behandlingId.id) } returns utenlandskePeriodebeløp
 
+        // Act
         tilpassValutakurserTilUtenlandskePeriodebeløpService.tilpassValutakursTilUtenlandskPeriodebeløp(behandlingId)
 
+        // Assert
         val faktiskeValutakurser = valutakursService.hentValutakurser(behandlingId)
 
         val forventedeValutakurser =
@@ -81,6 +84,7 @@ internal class ValutakursServiceTest {
 
     @Test
     fun `slette et valutakurs-skjema skal resultere i et skjema uten innhold, men som fortsatt har valutakoden`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
 
         val lagretValutakurs =
@@ -98,8 +102,10 @@ internal class ValutakursServiceTest {
                     ).medBehandlingId(behandlingId),
                 ).single()
 
+        // Act
         valutakursService.slettValutakurs(lagretValutakurs.id)
 
+        // Assert
         val faktiskValutakurs = valutakursService.hentValutakurser(behandlingId).single()
 
         assertEquals("EUR", faktiskValutakurs.valutakode)
@@ -113,6 +119,7 @@ internal class ValutakursServiceTest {
 
     @Test
     fun `skal kunne lukke åpen valutakurs ved å sende inn identisk skjema med til-og-med-dato`() {
+        // Arrange
         val behandlingId = BehandlingId(10L)
         val barn1 = tilfeldigPerson(personType = PersonType.BARN)
 
@@ -121,10 +128,12 @@ internal class ValutakursServiceTest {
             .medKurs("4>", "EUR", barn1)
             .lagreTil(valutakursRepository)
 
+        // Act
         // Endrer kun til-og-med dato fra uendelig (null) til en gitt dato
         val oppdatertKompetanse = valutakurs(jan(2020), "444", "EUR", barn1)
         valutakursService.oppdaterValutakurs(behandlingId, oppdatertKompetanse)
 
+        // Assert
         // Forventer skjema uten innhold (MEN MED VALUTAKODE) fra oppdatert dato og fremover
         val forventedeValutakurser =
             ValutakursBuilder(jan(2020), behandlingId)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceTest.kt
@@ -77,6 +77,7 @@ class FagsakServiceTest {
     inner class HentEllerOpprettFagsak {
         @Test
         fun `Skal returnere eksisterende fagsak når forespurt personIdent eller aktørId har fagsak i db`() {
+            // Arrange
             val fødselsnummer = randomFnr()
             val aktør = randomAktør(fødselsnummer)
             val fagsak = lagFagsak(aktør)
@@ -93,6 +94,7 @@ class FagsakServiceTest {
             every { personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(any()) } returns lagPersonopplysningGrunnlag()
             every { behandlingRepository.finnBehandlinger(fagsak.id) } returns emptyList()
 
+            // Act & Assert
             var minimalFagsak =
                 fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
 
@@ -108,6 +110,7 @@ class FagsakServiceTest {
 
         @Test
         fun `Skal returnere eksisterende fagsak med behandlinger når forespurt personIdent eller aktørId har fagsak i db`() {
+            // Arrange
             val fødselsnummer = randomFnr()
             val aktør = randomAktør(fødselsnummer)
             val fagsak = lagFagsak(aktør)
@@ -128,6 +131,7 @@ class FagsakServiceTest {
             every { behandlingRepository.finnBehandlinger(fagsak.id) } returns listOf(behandling)
             every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mockk(relaxed = true)
 
+            // Act & Assert
             var minimalFagsak =
                 fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
 
@@ -145,6 +149,7 @@ class FagsakServiceTest {
 
         @Test
         fun `Skal returnere ny fagsak når forespurt personIdent eller aktørId ikke har fagsak i db`() {
+            // Arrange
             val fødselsnummer = randomFnr()
             val aktør = randomAktør(fødselsnummer)
             val fagsak = lagFagsak(aktør)
@@ -157,6 +162,7 @@ class FagsakServiceTest {
             every { taskService.save(any()) } returns mockk()
             every { behandlingRepository.finnBehandlinger(fagsak.id) } returns emptyList()
 
+            // Act & Assert
             var minimalFagsak =
                 fagsakService.hentEllerOpprettFagsak(FagsakRequestDto(personIdent = null, aktørId = aktør.aktørId))
 
@@ -172,6 +178,7 @@ class FagsakServiceTest {
 
         @Test
         fun `Skal kaste Feil dersom verken personident eller aktørId er satt i FagsakRequestDto`() {
+            // Act & Assert
             val feil =
                 assertThrows<Feil> {
                     fagsakService.hentEllerOpprettFagsak(
@@ -197,6 +204,7 @@ class FagsakServiceTest {
     inner class HentMinimalFagsak {
         @Test
         fun `Skal returnere fagsak med tilhørende behandlinger når forespurt fagsakId finnes i db`() {
+            // Arrange
             val søker = randomAktør()
             val fagsak = lagFagsak(søker)
 
@@ -216,8 +224,11 @@ class FagsakServiceTest {
             every { vedtakRepository.findByBehandlingAndAktivOptional(any()) } returns mockk(relaxed = true)
             every { personopplysningGrunnlagRepository.finnSøkerOgBarnAktørerTilFagsak(any()) } returns setOf(PersonEnkel(PersonType.SØKER, søker, LocalDate.of(2000, 1, 1), null, Målform.NB))
             every { pdlKlient.hentAdressebeskyttelseBolk(any()) } returns mapOf(Pair(søker.aktørId, PdlAdressebeskyttelsePerson(listOf(Adressebeskyttelse(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG)))))
+
+            // Act
             val fagsakResponse = fagsakService.hentMinimalFagsak(fagsak.id)
 
+            // Assert
             assertEquals(fagsak.id, fagsakResponse.id)
             assertEquals(2, fagsakResponse.behandlinger.size)
             assertThat(fagsakResponse.finnesStrengtFortroligPersonIFagsak).isTrue()
@@ -225,8 +236,10 @@ class FagsakServiceTest {
 
         @Test
         fun `Skal kaste FunksjonellFeil dersom fagsak med fagsakId ikke finnes i db`() {
+            // Arrange
             every { fagsakRepository.finnFagsak(any()) } returns null
 
+            // Act & Assert
             val funksjonellFeil = assertThrows<FunksjonellFeil> { fagsakService.hentMinimalFagsak(404L) }
 
             assertEquals("Finner ikke fagsak med id 404", funksjonellFeil.message)
@@ -237,18 +250,23 @@ class FagsakServiceTest {
     inner class HentFagsak {
         @Test
         fun `Skal returnere fagsak når det finnes en fagsak med forespurt fagsakId i db`() {
+            // Arrange
             val fagsak = lagFagsak(randomAktør())
             every { fagsakRepository.finnFagsak(any()) } returns fagsak
 
+            // Act
             val hentetFagsak = fagsakService.hentFagsak(fagsak.id)
 
+            // Assert
             assertEquals(fagsak.id, hentetFagsak.id)
         }
 
         @Test
         fun `Skal kaste Funksjonell feil dersom fagsak med fagsakId ikke finnes i db`() {
+            // Arrange
             every { fagsakRepository.finnFagsak(any()) } returns null
 
+            // Act & Assert
             val funksjonellFeil = assertThrows<FunksjonellFeil> { fagsakService.hentFagsak(404L) }
 
             assertEquals("Finner ikke fagsak med id 404", funksjonellFeil.message)
@@ -259,25 +277,30 @@ class FagsakServiceTest {
     inner class HentFagsakForPeson {
         @Test
         fun `Skal returnere fagsak dersom fagsak tilknyttet aktør med forespurt personident finnes i db`() {
+            // Arrange
             val aktør = randomAktør()
             val fagsak = lagFagsak(aktør)
 
             every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
             every { fagsakRepository.finnFagsakForAktør(any()) } returns fagsak
 
+            // Act
             val fagsakForPerson = fagsakService.hentFagsakForPerson(aktør)
 
+            // Assert
             assertEquals(fagsak.id, fagsakForPerson.id)
             assertEquals(fagsak.aktør, fagsakForPerson.aktør)
         }
 
         @Test
         fun `Skal kaste Feil dersom fagsak tilknyttet aktør med forespurt personident ikke finnes i db`() {
+            // Arrange
             val aktør = randomAktør()
 
             every { personidentService.hentOgLagreAktør(any(), any()) } returns aktør
             every { fagsakRepository.finnFagsakForAktør(any()) } returns null
 
+            // Act & Assert
             val feil = assertThrows<Feil> { fagsakService.hentFagsakForPerson(aktør) }
 
             assertEquals("Fant ikke fagsak på person", feil.message)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIEndretUtbetalingAndelUtilTest.kt
@@ -26,6 +26,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
     inner class UtledEndringstidspunktForEndretUtbetalingAndelTest {
         @Test
         fun `Skal utlede riktig endringstidspunkt når årsak er endret`() {
+            // Arrange
             val barn = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
@@ -39,17 +40,20 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
             val nåværendeEndretAndel = forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)
 
+            // Act
             val endringstidspunkt =
                 EndringIEndretUtbetalingAndelUtil.utledEndringstidspunktForEndretUtbetalingAndel(
                     forrigeEndretAndeler = listOf(forrigeEndretAndel),
                     nåværendeEndretAndeler = listOf(nåværendeEndretAndel),
                 )
 
+            // Assert
             assertThat(jan22).isEqualTo(endringstidspunkt)
         }
 
         @Test
         fun `Endring av prosent skal ikke trigge at endringstidspunktet blir endret`() {
+            // Arrange
             val barn = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
@@ -63,17 +67,20 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
             val nåværendeEndretAndel = forrigeEndretAndel.copy(prosent = BigDecimal(100))
 
+            // Act
             val endringstidspunkt =
                 EndringIEndretUtbetalingAndelUtil.utledEndringstidspunktForEndretUtbetalingAndel(
                     forrigeEndretAndeler = listOf(forrigeEndretAndel),
                     nåværendeEndretAndeler = listOf(nåværendeEndretAndel),
                 )
 
+            // Assert
             assertNull(endringstidspunkt)
         }
 
         @Test
         fun `Skal utlede riktig endringstidspunkt når det har vært endring på årsak på et av to barn`() {
+            // Arrange
             val barn1 = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val barn2 = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
 
@@ -97,6 +104,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     årsak = Årsak.ETTERBETALING_3MND,
                 )
 
+            // Act
             val endringstidspunkt =
                 EndringIEndretUtbetalingAndelUtil.utledEndringstidspunktForEndretUtbetalingAndel(
                     forrigeEndretAndeler = listOf(forrigeEndretAndelBarn1, forrigeEndretAndelBarn2),
@@ -106,6 +114,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                             forrigeEndretAndelBarn2.copy(årsak = Årsak.ALLEREDE_UTBETALT),
                         ),
                 )
+            // Assert
             assertThat(jan22).isEqualTo(endringstidspunkt)
         }
     }
@@ -114,6 +123,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
     inner class LagEndringIEndretUbetalingAndelPerPersonTidslinje {
         @Test
         fun `Skal ha endret periode hvis årsak er endret`() {
+            // Arrange
             val barn = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
@@ -127,6 +137,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
             val nåværendeEndretAndel = forrigeEndretAndel.copy(årsak = Årsak.ALLEREDE_UTBETALT)
 
+            // Act
             val perioderMedEndring =
                 EndringIEndretUtbetalingAndelUtil
                     .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -135,6 +146,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(jan22.førsteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().fom)
             assertThat(aug22.sisteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().tom)
@@ -142,6 +154,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         @Test
         fun `Skal ikke ha noen endrede perioder hvis kun prosent er endret`() {
+            // Arrange
             val barn = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
@@ -155,6 +168,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
             val nåværendeEndretAndel = forrigeEndretAndel.copy(prosent = BigDecimal(100))
 
+            // Act
             val perioderMedEndring =
                 EndringIEndretUtbetalingAndelUtil
                     .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -163,11 +177,13 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertTrue(perioderMedEndring.isEmpty())
         }
 
         @Test
         fun `Skal returnere endret periode hvis et av to barn har endring på årsak`() {
+            // Arrange
             val barn1 = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val barn2 = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
 
@@ -191,6 +207,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     årsak = Årsak.ETTERBETALING_3MND,
                 )
 
+            // Act
             val perioderMedEndring =
                 listOf(barn1, barn2)
                     .map {
@@ -201,6 +218,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     }.flatMap { it.tilPerioder() }
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(jan22.førsteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().fom)
             assertThat(aug22.sisteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().tom)
@@ -208,6 +226,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         @Test
         fun `Skal noen endrede perioder hvis eneste endring er at perioden blir lenger`() {
+            // Arrange
             val barn = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val forrigeEndretAndel =
                 lagEndretUtbetalingAndel(
@@ -221,6 +240,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
             val nåværendeEndretAndel = forrigeEndretAndel.copy(tom = des22)
 
+            // Act
             val perioderMedEndring =
                 EndringIEndretUtbetalingAndelUtil
                     .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -229,6 +249,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(sep22.førsteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().fom)
             assertThat(des22.sisteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().tom)
@@ -236,6 +257,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
 
         @Test
         fun `Skal ha endrede perioder hvis endringsperiode oppstår i nåværende behandling`() {
+            // Arrange
             val barn = lagPerson(aktør = randomAktør(), personType = PersonType.BARN)
             val nåværendeEndretAndel =
                 lagEndretUtbetalingAndel(
@@ -247,6 +269,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     årsak = Årsak.ALLEREDE_UTBETALT,
                 )
 
+            // Act
             val perioderMedEndring =
                 EndringIEndretUtbetalingAndelUtil
                     .lagEndringIEndretUbetalingAndelPerPersonTidslinje(
@@ -255,6 +278,7 @@ class EndringIEndretUtbetalingAndelUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(jan22.førsteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().fom)
             assertThat(aug22.sisteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().tom)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIKompetanseUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIKompetanseUtilTest.kt
@@ -23,6 +23,7 @@ class EndringIKompetanseUtilTest {
     inner class UtledEndringstidspunktForEndretUtbetalingAndelTest {
         @Test
         fun `Skal ikke returnere noe endringstidspunkt hvis ingen ting har endret seg siden sist`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -41,17 +42,20 @@ class EndringIKompetanseUtilTest {
 
             val nåværendeKompetanse = forrigeKompetanse.copy().apply { behandlingId = nåværendeBehandling.id }
 
+            // Act
             val endringstidspunkt =
                 EndringIKompetanseUtil.utledEndringstidspunktForKompetanse(
                     nåværendeKompetanser = listOf(nåværendeKompetanse),
                     forrigeKompetanser = listOf(forrigeKompetanse),
                 )
 
+            // Assert
             Assertions.assertNull(endringstidspunkt)
         }
 
         @Test
         fun `Skal returnere riktig endringstidspunkt når søkers aktivitetsland endrer seg`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -71,6 +75,7 @@ class EndringIKompetanseUtilTest {
             val nåværendeKompetanse =
                 forrigeKompetanse.copy(søkersAktivitetsland = "DK").apply { behandlingId = nåværendeBehandling.id }
 
+            // Act
             val endringstidspunkt =
                 EndringIKompetanseUtil.utledEndringstidspunktForKompetanse(
                     nåværendeKompetanser =
@@ -80,11 +85,13 @@ class EndringIKompetanseUtilTest {
                     forrigeKompetanser = listOf(forrigeKompetanse),
                 )
 
+            // Assert
             assertThat(jan22).isEqualTo(endringstidspunkt)
         }
 
         @Test
         fun `Endringtidspunkt skal ikke endre på seg når det settes ekstra kompetanseperiode`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -106,6 +113,7 @@ class EndringIKompetanseUtilTest {
                     .copy(fom = YearMonth.now().minusMonths(10))
                     .apply { behandlingId = nåværendeBehandling.id }
 
+            // Act
             val endringstidspunkt =
                 EndringIKompetanseUtil.utledEndringstidspunktForKompetanse(
                     nåværendeKompetanser =
@@ -115,11 +123,13 @@ class EndringIKompetanseUtilTest {
                     forrigeKompetanser = listOf(forrigeKompetanse),
                 )
 
+            // Assert
             Assertions.assertNull(endringstidspunkt)
         }
 
         @Test
         fun `Endringstidspunkt skal ikke endre på seg når man fyller ut kompetanse som tidligere ikke var utfylt (pga migrering+ evt autovedtak)`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -150,6 +160,7 @@ class EndringIKompetanseUtilTest {
                     tom = null,
                 )
 
+            // Act
             val endringstidspunkt =
                 EndringIKompetanseUtil.utledEndringstidspunktForKompetanse(
                     nåværendeKompetanser =
@@ -159,6 +170,7 @@ class EndringIKompetanseUtilTest {
                     forrigeKompetanser = listOf(forrigeKompetanse),
                 )
 
+            // Assert
             Assertions.assertNull(endringstidspunkt)
         }
     }
@@ -167,6 +179,7 @@ class EndringIKompetanseUtilTest {
     inner class LagEndringIKompetanseForPersonTidslinjeTest {
         @Test
         fun `Skal ikke returnere noen endrede perioder når ingenting endrer seg`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -185,6 +198,7 @@ class EndringIKompetanseUtilTest {
 
             val nåværendeKompetanse = forrigeKompetanse.copy().apply { behandlingId = nåværendeBehandling.id }
 
+            // Act
             val perioderMedEndring =
                 EndringIKompetanseUtil
                     .lagEndringIKompetanseForPersonTidslinje(
@@ -193,11 +207,13 @@ class EndringIKompetanseUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
 
         @Test
         fun `Skal returnere endret periode når søkers aktivitetsland endrer seg`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -217,6 +233,7 @@ class EndringIKompetanseUtilTest {
             val nåværendeKompetanse =
                 forrigeKompetanse.copy(søkersAktivitetsland = "DK").apply { behandlingId = nåværendeBehandling.id }
 
+            // Act
             val perioderMedEndring =
                 EndringIKompetanseUtil
                     .lagEndringIKompetanseForPersonTidslinje(
@@ -228,6 +245,7 @@ class EndringIKompetanseUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(jan22.førsteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().fom)
             assertThat(mai22.sisteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().tom)
@@ -235,6 +253,7 @@ class EndringIKompetanseUtilTest {
 
         @Test
         fun `Skal ikke lage endret periode når det kun blir lagt på en ekstra kompetanseperiode`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -256,6 +275,7 @@ class EndringIKompetanseUtilTest {
                     .copy(fom = YearMonth.now().minusMonths(10))
                     .apply { behandlingId = nåværendeBehandling.id }
 
+            // Act
             val perioderMedEndring =
                 EndringIKompetanseUtil
                     .lagEndringIKompetanseForPersonTidslinje(
@@ -267,11 +287,13 @@ class EndringIKompetanseUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
 
         @Test
         fun `Skal ikke lage endret periode når forrige kompetanse ikke er utfylt (pga migrering+ evt autovedtak)`() {
+            // Arrange
             val forrigeBehandling = lagBehandling()
             val nåværendeBehandling = lagBehandling()
             val forrigeKompetanse =
@@ -302,6 +324,7 @@ class EndringIKompetanseUtilTest {
                     tom = null,
                 )
 
+            // Act
             val perioderMedEndring =
                 EndringIKompetanseUtil
                     .lagEndringIKompetanseForPersonTidslinje(
@@ -313,6 +336,7 @@ class EndringIKompetanseUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIUtbetalingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIUtbetalingUtilTest.kt
@@ -22,6 +22,7 @@ class EndringIUtbetalingUtilTest {
     inner class UtledEndringstidspunktForUtbetalingsbeløpTest {
         @Test
         fun `Skal returnere riktig endringstidspunkt når ny andel med beløp større enn 0 er lagt til`() {
+            // Arrange
             val barn1Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
             val barn2Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
 
@@ -56,17 +57,20 @@ class EndringIUtbetalingUtilTest {
                     ),
                 )
 
+            // Act
             val endringstidspunkt =
                 EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                     nåværendeAndeler = nåværendeAndeler,
                     forrigeAndeler = forrigeAndeler,
                 )
 
+            // Assert
             assertThat(sep22).isEqualTo(endringstidspunkt)
         }
 
         @Test
         fun `Endringstidspunktet skal ikke settes hvis andelene er helt like forrige behandling og nå`() {
+            // Arrange
             val barn1Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
             val barn2Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
 
@@ -86,17 +90,20 @@ class EndringIUtbetalingUtilTest {
                     ),
                 )
 
+            // Act
             val endringstidspunkt =
                 EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                     nåværendeAndeler = andeler,
                     forrigeAndeler = andeler,
                 )
 
+            // Assert
             Assertions.assertNull(endringstidspunkt)
         }
 
         @Test
         fun `Riktig endringstidspunkt skal settes dersom det er fjernet andel som har beløp større enn 0`() {
+            // Arrange
             val barn1Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
             val barn2Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
 
@@ -115,17 +122,20 @@ class EndringIUtbetalingUtilTest {
                     aktør = barn2Aktør,
                 )
 
+            // Act
             val endringstidspunkt =
                 EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                     nåværendeAndeler = listOf(andelBarn2),
                     forrigeAndeler = listOf(andelBarn2, andelBarn1),
                 )
 
+            // Assert
             assertThat(jan22).isEqualTo(endringstidspunkt)
         }
 
         @Test
         fun `Endringstidspunkt skal ikke settes dersom andel med 0 i beløp er fjernet`() {
+            // Arrange
             val barn1Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
             val barn2Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
 
@@ -144,12 +154,14 @@ class EndringIUtbetalingUtilTest {
                     aktør = barn2Aktør,
                 )
 
+            // Act
             val endringstidspunkt =
                 EndringIUtbetalingUtil.utledEndringstidspunktForUtbetalingsbeløp(
                     nåværendeAndeler = listOf(andelBarn2),
                     forrigeAndeler = listOf(andelBarn2, andelBarn1),
                 )
 
+            // Assert
             Assertions.assertNull(endringstidspunkt)
         }
     }
@@ -158,6 +170,7 @@ class EndringIUtbetalingUtilTest {
     inner class LagEndringIUtbetalingTidslinjeTest {
         @Test
         fun `Skal returnere periode med endring når ny andel med beløp større enn 0 er lagt til`() {
+            // Arrange
             val barn1Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
             val barn2Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
 
@@ -192,6 +205,7 @@ class EndringIUtbetalingUtilTest {
                     ),
                 )
 
+            // Act
             val perioderMedEndring =
                 EndringIUtbetalingUtil
                     .lagEndringIUtbetalingTidslinje(
@@ -200,6 +214,7 @@ class EndringIUtbetalingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(sep22).isEqualTo(perioderMedEndring.single().fom?.tilYearMonth())
             assertThat(des22).isEqualTo(perioderMedEndring.single().tom?.tilYearMonth())
@@ -207,6 +222,7 @@ class EndringIUtbetalingUtilTest {
 
         @Test
         fun `Skal ikke gi noen perioder med endring hvis andelene er helt like forrige behandling og nå`() {
+            // Arrange
             val barn1Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
             val barn2Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
 
@@ -257,6 +273,7 @@ class EndringIUtbetalingUtilTest {
                     aktør = barn2Aktør,
                 )
 
+            // Act
             val perioderMedEndring =
                 EndringIUtbetalingUtil
                     .lagEndringIUtbetalingTidslinje(
@@ -265,6 +282,7 @@ class EndringIUtbetalingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(jan22).isEqualTo(perioderMedEndring.single().fom?.tilYearMonth())
             assertThat(aug22).isEqualTo(perioderMedEndring.single().tom?.tilYearMonth())
@@ -272,6 +290,7 @@ class EndringIUtbetalingUtilTest {
 
         @Test
         fun `Skal ikke returnere periode med endring hvis andel med 0 i beløp er fjernet`() {
+            // Arrange
             val barn1Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
             val barn2Aktør = lagPerson(aktør = randomAktør(), personType = PersonType.BARN).aktør
 
@@ -290,6 +309,7 @@ class EndringIUtbetalingUtilTest {
                     aktør = barn2Aktør,
                 )
 
+            // Act
             val perioderMedEndring =
                 EndringIUtbetalingUtil
                     .lagEndringIUtbetalingTidslinje(
@@ -298,6 +318,7 @@ class EndringIUtbetalingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/forrigebehandling/EndringIVilkårsvurderingUtilTest.kt
@@ -28,6 +28,7 @@ class EndringIVilkårsvurderingUtilTest {
     inner class UtledEndringstidspunktForVilkårsvurderingTest {
         @Test
         fun `Endringstidspunkt skal ikke bli satt dersom vilkårresultatene er helt like`() {
+            // Arrange
             val fødselsdato = LocalDate.of(2015, 1, 1)
             val vilkårResultater =
                 setOf(
@@ -63,17 +64,20 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val endringstidspunkt =
                 EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
                     nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør)),
                     forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(vilkårResultater, aktør)),
                 )
 
+            // Assert
             Assertions.assertNull(endringstidspunkt)
         }
 
         @Test
         fun `Skal returnere riktig endringstidspunkt dersom det har vært endringer i regelverk`() {
+            // Arrange
             val fødselsdato = jan22.førsteDagIInneværendeMåned()
             val nåværendeVilkårResultat =
                 setOf(
@@ -113,17 +117,20 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val endringstidspunkt =
                 EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
                     nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
                     forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
                 )
 
+            // Assert
             assertThat(jan22).isEqualTo(endringstidspunkt)
         }
 
         @Test
         fun `Skal ikke sette endringstidspunkt dersom det bare har blitt opphørt vilkårsvurdering`() {
+            // Arrange
             val fødselsdato = LocalDate.of(2015, 1, 1)
             val nåværendeVilkårResultat =
                 setOf(
@@ -163,12 +170,14 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val endringstidspunkt =
                 EndringIVilkårsvurderingUtil.utledEndringstidspunktForVilkårsvurdering(
                     nåværendePersonResultat = setOf(lagPersonResultatFraVilkårResultater(nåværendeVilkårResultat, aktør)),
                     forrigePersonResultat = setOf(lagPersonResultatFraVilkårResultater(forrigeVilkårResultat, aktør)),
                 )
 
+            // Assert
             Assertions.assertNull(endringstidspunkt)
         }
     }
@@ -177,6 +186,7 @@ class EndringIVilkårsvurderingUtilTest {
     inner class LagEndringIVilkårsvurderingTidslinjeTest {
         @Test
         fun `Endring i vilkårsvurdering - skal ikke lage periode med endring dersom vilkårresultatene er helt like`() {
+            // Arrange
             val fødselsdato = LocalDate.of(2015, 1, 1)
             val vilkårResultater =
                 setOf(
@@ -212,6 +222,7 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val perioderMedEndring =
                 EndringIVilkårsvurderingUtil
                     .lagEndringIVilkårsvurderingTidslinje(
@@ -220,11 +231,13 @@ class EndringIVilkårsvurderingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
 
         @Test
         fun `Endring i vilkårsvurdering - skal returnere periode med endring dersom det har vært endringer i regelverk`() {
+            // Arrange
             val fødselsdato = jan22.førsteDagIInneværendeMåned()
             val nåværendeVilkårResultat =
                 setOf(
@@ -264,6 +277,7 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val perioderMedEndring =
                 EndringIVilkårsvurderingUtil
                     .lagEndringIVilkårsvurderingTidslinje(
@@ -272,6 +286,7 @@ class EndringIVilkårsvurderingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             assertThat(1).isEqualTo(perioderMedEndring.size)
             assertThat(fødselsdato).isEqualTo(perioderMedEndring.single().fom)
             assertThat(mai22.sisteDagIInneværendeMåned()).isEqualTo(perioderMedEndring.single().tom)
@@ -279,6 +294,7 @@ class EndringIVilkårsvurderingUtilTest {
 
         @Test
         fun `Endring i vilkårsvurdering - skal ikke lage periode med endring hvis det kun er opphørt`() {
+            // Arrange
             val fødselsdato = LocalDate.of(2015, 1, 1)
             val nåværendeVilkårResultat =
                 setOf(
@@ -318,6 +334,7 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val perioderMedEndring =
                 EndringIVilkårsvurderingUtil
                     .lagEndringIVilkårsvurderingTidslinje(
@@ -326,11 +343,13 @@ class EndringIVilkårsvurderingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
 
         @Test
         fun `Endring i vilkårsvurdering - skal ikke lage periode med endring hvis det er barnets alder som er endret`() {
+            // Arrange
             val nåværendeVilkårResultat =
                 setOf(
                     VilkårResultat(
@@ -374,6 +393,7 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val perioderMedEndring =
                 EndringIVilkårsvurderingUtil
                     .lagEndringIVilkårsvurderingTidslinje(
@@ -382,11 +402,13 @@ class EndringIVilkårsvurderingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
 
         @Test
         fun `Endring i vilkårsvurdering - skal ikke lage periode med endring hvis eneste endring er å sette obligatoriske utdypende vilkårsvurderinger`() {
+            // Arrange
             val fødselsdato = LocalDate.of(2015, 1, 1)
             val forrigeVilkårResultat =
                 setOf(
@@ -423,6 +445,7 @@ class EndringIVilkårsvurderingUtilTest {
 
             val aktør = randomAktør()
 
+            // Act
             val perioderMedEndring =
                 EndringIVilkårsvurderingUtil
                     .lagEndringIVilkårsvurderingTidslinje(
@@ -431,6 +454,7 @@ class EndringIVilkårsvurderingUtilTest {
                     ).tilPerioder()
                     .filter { it.verdi == true }
 
+            // Assert
             Assertions.assertTrue(perioderMedEndring.isEmpty())
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingServiceTest.kt
@@ -19,15 +19,18 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `finnAktivtKorrigeringPåBehandling skal hente aktivt korrigering fra repository hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
 
+        // Act
         every { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id) } returns korrigertEtterbetaling
 
         val hentetKorrigertEtterbetaling =
             korrigertEtterbetalingService.finnAktivtKorrigeringPåBehandling(behandling.id)
                 ?: fail("etterbetaling korrigering ikke hentet riktig")
 
+        // Assert
         assertThat(hentetKorrigertEtterbetaling.behandling.id, Is(behandling.id))
         assertThat(hentetKorrigertEtterbetaling.aktiv, Is(true))
 
@@ -36,9 +39,11 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `finnAlleKorrigeringerPåBehandling skal hente alle korrigering fra repository hvis de finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
 
+        // Act
         every { korrigertEtterbetalingRepository.finnAlleKorrigeringerPåBehandling(behandling.id) } returns
             listOf(
                 korrigertEtterbetaling,
@@ -48,6 +53,7 @@ internal class KorrigertEtterbetalingServiceTest {
         val hentetKorrigertEtterbetaling =
             korrigertEtterbetalingService.finnAlleKorrigeringerPåBehandling(behandling.id)
 
+        // Assert
         assertThat(hentetKorrigertEtterbetaling.size, Is(2))
 
         verify(exactly = 1) { korrigertEtterbetalingRepository.finnAlleKorrigeringerPåBehandling(behandling.id) }
@@ -55,9 +61,11 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `lagreKorrigertEtterbetaling skal lagre korrigering på behandling og logg på dette`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
 
+        // Act
         every { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id) } returns null
         every { korrigertEtterbetalingRepository.save(korrigertEtterbetaling) } returns korrigertEtterbetaling
         every { loggService.opprettKorrigertEtterbetalingLogg(behandling, any()) } returns Unit
@@ -65,6 +73,7 @@ internal class KorrigertEtterbetalingServiceTest {
         val lagretKorrigertEtterbetaling =
             korrigertEtterbetalingService.lagreKorrigertEtterbetaling(korrigertEtterbetaling)
 
+        // Assert
         assertThat(lagretKorrigertEtterbetaling.behandling.id, Is(behandling.id))
 
         verify(exactly = 1) { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id) }
@@ -79,10 +88,12 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `lagreKorrigertEtterbetaling skal sette og lagre forrige korrigering til inaktivt hvis det finnes tidligere korrigering`() {
+        // Arrange
         val behandling = lagBehandling()
         val forrigeKorrigering = mockk<KorrigertEtterbetaling>(relaxed = true)
         val korrigertEtterbetaling = lagKorrigertEtterbetaling(behandling)
 
+        // Act
         every { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(any()) } returns forrigeKorrigering
         every { korrigertEtterbetalingRepository.saveAndFlush(forrigeKorrigering) } returns korrigertEtterbetaling
         every { korrigertEtterbetalingRepository.save(korrigertEtterbetaling) } returns korrigertEtterbetaling
@@ -90,6 +101,7 @@ internal class KorrigertEtterbetalingServiceTest {
 
         korrigertEtterbetalingService.lagreKorrigertEtterbetaling(korrigertEtterbetaling)
 
+        // Assert
         verify(exactly = 1) { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(any()) }
         verify(exactly = 1) { forrigeKorrigering setProperty "aktiv" value false }
         verify(exactly = 1) { korrigertEtterbetalingRepository.saveAndFlush(forrigeKorrigering) }
@@ -98,14 +110,17 @@ internal class KorrigertEtterbetalingServiceTest {
 
     @Test
     fun `settKorrigeringPåBehandlingTilInaktiv skal sette korrigering til inaktivt hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertEtterbetaling = mockk<KorrigertEtterbetaling>(relaxed = true)
 
+        // Act
         every { korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(any()) } returns korrigertEtterbetaling
         every { loggService.opprettKorrigertEtterbetalingLogg(any(), any()) } returns Unit
 
         korrigertEtterbetalingService.settKorrigeringPåBehandlingTilInaktiv(behandling)
 
+        // Assert
         verify(exactly = 1) { korrigertEtterbetaling setProperty "aktiv" value false }
         verify(exactly = 1) {
             loggService.opprettKorrigertEtterbetalingLogg(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelServiceTest.kt
@@ -308,6 +308,7 @@ class OvergangsordningAndelServiceTest {
 
     @Test
     fun `kopierOvergangsordningAndelFraForrigeBehandling - skal kopiere over overgangsordningandeler fra forrige behandling og lagre disse på ny`() {
+        // Arrange
         val gammelBehandling = lagBehandling()
         val nyBehandling = lagBehandling()
 
@@ -320,8 +321,10 @@ class OvergangsordningAndelServiceTest {
                 OvergangsordningAndel(id = 2, behandlingId = gammelBehandling.id),
             )
 
+        // Act
         val nyeOvergangsordningAndeler = overgangsordningAndelService.kopierOvergangsordningAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
 
+        // Assert
         assertThat(nyeOvergangsordningAndeler).allSatisfy {
             assertThat(it.behandlingId).isEqualTo(nyBehandling.id)
             assertThat(it.antallTimer).isEqualTo(BigDecimal.ZERO)
@@ -339,6 +342,7 @@ class OvergangsordningAndelServiceTest {
     inner class KopierOvergangsordningAndelFraForrigeBehandling {
         @Test
         fun `skal bruke personer fra inneværende behandling ved kopiering`() {
+            // Arrange
             val gammelBehandling = lagBehandling()
             val nyBehandling = lagBehandling()
             val aktør = randomAktør()
@@ -352,14 +356,17 @@ class OvergangsordningAndelServiceTest {
                 listOf(OvergangsordningAndel(id = 0, behandlingId = gammelBehandling.id, person = gammelPerson))
             every { overgangsordningAndelRepository.save(any()) } returnsArgument 0
 
+            // Act
             val nyeOvergangsordningAndeler = overgangsordningAndelService.kopierOvergangsordningAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
 
+            // Assert
             assertThat(nyeOvergangsordningAndeler).hasSize(1)
             assertThat(nyeOvergangsordningAndeler.single().person?.id).isEqualTo(2L)
         }
 
         @Test
         fun `skal ikke kopiere andel hvis personen ikke finnes i inneværende behandling`() {
+            // Arrange
             val gammelBehandling = lagBehandling()
             val nyBehandling = lagBehandling()
 
@@ -372,8 +379,10 @@ class OvergangsordningAndelServiceTest {
             every { overgangsordningAndelRepository.hentOvergangsordningAndelerForBehandling(gammelBehandling.id) } returns
                 listOf(OvergangsordningAndel(id = 0, behandlingId = gammelBehandling.id, person = gammelPerson))
 
+            // Act
             val nyeOvergangsordningAndeler = overgangsordningAndelService.kopierOvergangsordningAndelFraForrigeBehandling(nyBehandling, gammelBehandling)
 
+            // Assert
             assertThat(nyeOvergangsordningAndeler).isEmpty()
             verify(exactly = 0) { overgangsordningAndelRepository.save(any()) }
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidatorTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/overgangsordning/OvergangsordningAndelValidatorTest.kt
@@ -32,6 +32,7 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerOvergangsordningAndeler() {
+        // Arrange
         val overgangsordningAndel =
             OvergangsordningAndel(
                 behandlingId = 1,
@@ -63,6 +64,7 @@ class OvergangsordningAndelValidatorTest {
                 },
             )
 
+        // Act & Assert
         assertDoesNotThrow {
             OvergangsordningAndelValidator.validerOvergangsordningAndeler(
                 overgangsordningAndeler = listOf(overgangsordningAndel),
@@ -76,6 +78,7 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerIngenEndringIOrdinæreAndelerTilkjentYtelse() {
+        // Arrange
         val nåværendeAndeler =
             setOf(
                 lagAndelTilkjentYtelse(
@@ -96,6 +99,7 @@ class OvergangsordningAndelValidatorTest {
                 ),
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             OvergangsordningAndelValidator.validerIngenEndringIOrdinæreAndelerTilkjentYtelse(
                 andelerNåværendeBehandling = nåværendeAndeler,
@@ -107,8 +111,10 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerAndelerErIPeriodenBarnetEr20Til23Måneder() {
+        // Arrange
         val andeler = listOf(andel)
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             OvergangsordningAndelValidator.validerAndelerErIPeriodenBarnetEr20Til23Måneder(andeler)
         }
@@ -116,8 +122,10 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerAtAlleOpprettedeOvergangsordningAndelerErGyldigUtfylt() {
+        // Arrange
         val andeler = listOf(OvergangsordningAndel(behandlingId = 1))
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             OvergangsordningAndelValidator.validerAtAlleOpprettedeOvergangsordningAndelerErGyldigUtfylt(andeler)
         }
@@ -125,6 +133,7 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerAtOvergangsordningAndelerIkkeOverlapperMedOrdinæreAndeler() {
+        // Arrange
         val andelerTilkjentYtelse =
             setOf(
                 lagAndelTilkjentYtelse(
@@ -141,6 +150,7 @@ class OvergangsordningAndelValidatorTest {
                 ),
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             OvergangsordningAndelValidator.validerAtOvergangsordningAndelerIkkeOverlapperMedOrdinæreAndeler(andelerTilkjentYtelse)
         }
@@ -148,6 +158,7 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerAtBarnehagevilkårErOppfyltForAlleOvergangsordningPerioder() {
+        // Arrange
         val barnehageVilkår =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNEHAGEPLASS,
@@ -157,6 +168,7 @@ class OvergangsordningAndelValidatorTest {
 
         val barnehagevilkårPerAktør = mapOf(aktør to listOf(barnehageVilkår))
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             OvergangsordningAndelValidator.validerAtBarnehagevilkårErOppfyltForAlleOvergangsordningPerioder(listOf(andel), barnehagevilkårPerAktør)
         }
@@ -164,6 +176,7 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerAtBarnehagevilkårMedTomLikNullErOppfyltForAlleOvergangsordningPerioder() {
+        // Arrange
         val barnehageVilkår =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNEHAGEPLASS,
@@ -173,6 +186,7 @@ class OvergangsordningAndelValidatorTest {
 
         val barnehagevilkårPerAktør = mapOf(aktør to listOf(barnehageVilkår))
 
+        // Act & Assert
         assertDoesNotThrow {
             OvergangsordningAndelValidator.validerAtBarnehagevilkårErOppfyltForAlleOvergangsordningPerioder(listOf(andel), barnehagevilkårPerAktør)
         }
@@ -180,6 +194,7 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerIngenOverlappMedEksisterendeOvergangsordningAndeler() {
+        // Arrange
         val eksisterendeAndeler =
             listOf(
                 OvergangsordningAndel(
@@ -190,6 +205,7 @@ class OvergangsordningAndelValidatorTest {
                 ).tilUtfyltOvergangsordningAndel(),
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             OvergangsordningAndelValidator.validerIngenOverlappMedEksisterendeOvergangsordningAndeler(andel, eksisterendeAndeler)
         }
@@ -197,6 +213,7 @@ class OvergangsordningAndelValidatorTest {
 
     @Test
     fun validerAtBarnehagevilkårErOppfyltIOvergangsordningAndelPeriode() {
+        // Arrange
         val barnehageVilkår =
             lagVilkårResultat(
                 vilkårType = Vilkår.BARNEHAGEPLASS,
@@ -204,6 +221,7 @@ class OvergangsordningAndelValidatorTest {
                 periodeTom = LocalDate.now().minusMonths(1),
             )
 
+        // Act & Assert
         assertThrows<FunksjonellFeil> {
             OvergangsordningAndelValidator.validerAtBarnehagevilkårErOppfyltIOvergangsordningAndelPeriode(andel, listOf(barnehageVilkår))
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/HåndterNyIdentServiceTest.kt
@@ -304,6 +304,7 @@ internal class HåndterNyIdentServiceTest {
 
         @Test
         fun `Skal legge til ny ident på aktør som finnes i systemet`() {
+            // Arrange
             val personIdentSomFinnes = randomFnr()
             val personIdentSomSkalLeggesTil = randomFnr()
             val historiskIdent = randomFnr()
@@ -363,8 +364,10 @@ internal class HåndterNyIdentServiceTest {
                 null
             }
 
+            // Act
             val aktør = håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomSkalLeggesTil))
 
+            // Assert
             assertThat(aktør?.personidenter?.size).isEqualTo(2)
             assertThat(personIdentSomSkalLeggesTil).isEqualTo(aktør!!.aktivFødselsnummer())
             assertThat(
@@ -385,6 +388,7 @@ internal class HåndterNyIdentServiceTest {
 
         @Test
         fun `Skal kaste feil når vi prøver legge til ny ident på aktør som finnes i systemet og som har endret fødselsdato`() {
+            // Arrange
             val personIdentSomFinnes = randomFnr()
             val personIdentSomSkalLeggesTil = randomFnr()
             val historiskIdent = randomFnr()
@@ -437,6 +441,7 @@ internal class HåndterNyIdentServiceTest {
                 null
             }
 
+            // Act & Assert
             val exception =
                 assertThrows<Feil> {
                     håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomSkalLeggesTil))
@@ -447,6 +452,7 @@ internal class HåndterNyIdentServiceTest {
 
         @Test
         fun `Skal ikke legge til ny ident på aktør som allerede har denne identen registert i systemet`() {
+            // Arrange
             val personIdentSomFinnes = randomFnr()
             val aktørIdSomFinnes = randomAktør(personIdentSomFinnes)
 
@@ -464,8 +470,10 @@ internal class HåndterNyIdentServiceTest {
                 ).personidenter.first()
             }
 
+            // Act
             val aktør = håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(personIdentSomFinnes))
 
+            // Assert
             assertThat(aktørIdSomFinnes.aktørId).isEqualTo(aktør?.aktørId)
             assertThat(aktør?.personidenter?.size).isEqualTo(1)
             assertThat(personIdentSomFinnes).isEqualTo(aktør?.personidenter?.single()?.fødselsnummer)
@@ -475,6 +483,7 @@ internal class HåndterNyIdentServiceTest {
 
         @Test
         fun `Hendelse på en ident hvor gammel ident1 er merget med ny ident2 skal ikke kaste feil når bruker har alt bruker ny ident`() {
+            // Arrange
             val fnrIdent1 = randomFnr()
             val aktørIdent1 = randomAktør(fnrIdent1)
             val aktivFnrIdent2 = randomFnr()
@@ -496,7 +505,10 @@ internal class HåndterNyIdentServiceTest {
                 null
             }
 
+            // Act
             val aktør = håndterNyIdentService.håndterNyIdent(nyIdent = PersonIdent(aktivFnrIdent2))
+
+            // Assert
             assertThat(aktivAktørIdent2.aktørId).isEqualTo(aktør?.aktørId)
             assertThat(aktør?.personidenter?.size).isEqualTo(1)
             assertThat(aktivFnrIdent2).isEqualTo(aktør?.personidenter?.single()?.fødselsnummer)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdentHendelseTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/IdentHendelseTaskTest.kt
@@ -15,14 +15,17 @@ internal class IdentHendelseTaskTest {
 
     @Test
     fun `Task skal kalle videre på håndtering av ny ident`() {
+        // Arrange
         val nyPersonIdent = PersonIdent("123")
         val task = IdentHendelseTask.opprettTask(nyPersonIdent)
         assertEquals(nyPersonIdent, jsonMapper.readValue(task.payload, PersonIdent::class.java))
         assertEquals("123", task.metadata["nyPersonIdent"])
         assertEquals("IdentHendelseTask", task.type)
 
+        // Act
         identHendelseTask.doTask(task)
 
+        // Assert
         val slot = slot<PersonIdent>()
         verify(exactly = 1) { håndterNyIdentService.håndterNyIdent(capture(slot)) }
         assertEquals(nyPersonIdent, slot.captured)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/PersonidentServiceTest.kt
@@ -31,27 +31,36 @@ class PersonidentServiceTest {
 
     @Test
     fun `hentOgLagreAktør - skal hente personident fra personidentRepository dersom personident finnes i db`() {
+        // Arrange
         val personnummer = randomFnr()
         val personIdent = Personident(personnummer, randomAktør(personnummer))
         every { personidentRepository.findByFødselsnummerOrNull(personnummer) } returns personIdent
 
+        // Act
         val hentetAktør = personidentService.hentOgLagreAktør(personnummer, true)
+
+        // Assert
         assertNotNull(hentetAktør)
     }
 
     @Test
     fun `hentOgLagreAktør - skal hente aktør fra aktørRepository dersom aktørId finnes i db`() {
+        // Arrange
         val fødselsnummer = randomFnr()
         val aktør = randomAktør(fødselsnummer)
         every { personidentRepository.findByFødselsnummerOrNull(aktør.aktørId) } returns null
         every { aktørRepository.findByAktørId(aktør.aktørId) } returns aktør
 
+        // Act
         val hentetAktør = personidentService.hentOgLagreAktør(aktør.aktørId, true)
+
+        // Assert
         assertNotNull(hentetAktør)
     }
 
     @Test
     fun `hentOgLagreAktør - skal hente personident fra personidentRepository dersom aktivt fødselsnummer fra PDL finnes i db`() {
+        // Arrange
         val fødselsnummer = randomFnr()
 
         val pdlFødselsnummer = randomFnr()
@@ -63,13 +72,16 @@ class PersonidentServiceTest {
         every { aktørRepository.findByAktørId(fødselsnummer) } returns null
         every { pdlKlient.hentIdenter(any(), false) } returns listOf(pdlIdent)
 
+        // Act
         val hentetAktør = personidentService.hentOgLagreAktør(fødselsnummer, true)
 
+        // Assert
         assertEquals(personident.aktør, hentetAktør)
     }
 
     @Test
     fun `hentOgLagreAktør - skal hente aktør fra aktørRepository og opprette ny personident dersom aktiv aktørId fra PDL finnes i db`() {
+        // Arrange
         val fødselsnummer = randomFnr()
 
         val pdlFødselsnummer = randomFnr()
@@ -87,8 +99,10 @@ class PersonidentServiceTest {
         every { aktørRepository.saveAndFlush(pdlAktørMedPersonIdent) } returns pdlAktørMedPersonIdent
         every { pdlKlient.hentIdenter(any(), false) } returns listOf(personIdentPDL, aktørIdentPDL)
 
+        // Act
         val hentetAktør = personidentService.hentOgLagreAktør(fødselsnummer, true)
 
+        // Assert
         // Validerer at aktør lagres før og etter at personIdent er lagt til. Noe greier med index issues.
         verify(exactly = 2) {
             aktørRepository.saveAndFlush(
@@ -101,6 +115,7 @@ class PersonidentServiceTest {
 
     @Test
     fun `hentOgLagreAktør - skal opprette aktør og personident med aktørId og personident fra PDL dersom verken aktørId eller fødselsnummer fra PDL finnes i db fra før`() {
+        // Arrange
         val fødselsnummer = randomFnr()
 
         val pdlFødselsnummer = randomFnr()
@@ -117,8 +132,10 @@ class PersonidentServiceTest {
         every { pdlKlient.hentIdenter(any(), false) } returns listOf(personIdentPDL, aktørIdentPDL)
         every { aktørRepository.saveAndFlush(pdlAktørMedPersonIdent) } returns pdlAktørMedPersonIdent
 
+        // Act
         val hentetAktør = personidentService.hentOgLagreAktør(fødselsnummer, true)
 
+        // Assert
         verify(exactly = 1) { aktørRepository.saveAndFlush(pdlAktørMedPersonIdent) }
 
         assertEquals(pdlAktørMedPersonIdent, hentetAktør)
@@ -126,17 +143,21 @@ class PersonidentServiceTest {
 
     @Test
     fun `hentAktør - skal hente aktør dersom aktør har en aktiv personident`() {
+        // Arrange
         val fødselsnummer = randomFnr()
         val personIdent = Personident(fødselsnummer, randomAktør(fødselsnummer), aktiv = true)
         every { personidentRepository.findByFødselsnummerOrNull(fødselsnummer) } returns personIdent
 
+        // Act
         val hentetAktør = personidentService.hentAktør(fødselsnummer)
 
+        // Assert
         assertEquals(fødselsnummer, hentetAktør.personidenter.first { it.aktiv }.fødselsnummer)
     }
 
     @Test
     fun `hentAktør - skal kaste Feil dersom aktør ikke har en aktiv personident`() {
+        // Arrange
         val fødselsnummer = randomFnr()
         val aktør = Aktør(randomAktørId())
         val personIdent = Personident(fødselsnummer, aktør, aktiv = false)
@@ -144,6 +165,7 @@ class PersonidentServiceTest {
 
         every { personidentRepository.findByFødselsnummerOrNull(fødselsnummer) } returns personIdent
 
+        // Act & Assert
         val feil = assertThrows<Feil> { personidentService.hentAktør(fødselsnummer) }
 
         assertEquals("Fant ikke aktiv ident for aktør", feil.message)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/statsborgerskap/StatsborgerskapServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/personopplysninggrunnlag/statsborgerskap/StatsborgerskapServiceTest.kt
@@ -35,21 +35,27 @@ class StatsborgerskapServiceTest {
 
     @Test
     fun `hentLand skal hente returnere landNavn gitt landKode`() {
+        // Arrange
         every { integrasjonKlient.hentLand("NOR") } returns "Norge"
 
+        // Act
         val landNavn = statsborgerskapService.hentLand("NOR")
 
+        // Assert
         assertEquals(landNavn, "Norge")
     }
 
     @Test
     fun `hentStatsborgerskapMedMedlemskap skal hente statsborgerskap for en nordisk statsborger`() {
+        // Arrange
         val statsborgerskap = lagStatsborgerskap("SWE")
         val statsborgerskapereMedMedlemskap =
             statsborgerskapService.hentStatsborgerskapMedMedlemskap(
                 statsborgerskap,
                 lagPersonopplysningGrunnlag(111L, randomFnr()).søker,
             )
+
+        // Assert
         assertTrue { statsborgerskapereMedMedlemskap.isNotEmpty() }
         assertEquals(1, statsborgerskapereMedMedlemskap.size)
 
@@ -60,19 +66,24 @@ class StatsborgerskapServiceTest {
 
     @Test
     fun `hentStatsborgerskapMedMedlemskap skal hente statsborgerskap for en eøs statsborger`() {
+        // Arrange
         val statsborgerskap = lagStatsborgerskap("POL")
+
+        // Act
         val statsborgerskapMedMedlemskap =
             statsborgerskapService.hentStatsborgerskapMedMedlemskap(
                 statsborgerskap,
                 lagPersonopplysningGrunnlag(111L, randomFnr()).søker,
             )
 
+        // Assert
         assertEquals(Medlemskap.EØS, statsborgerskapMedMedlemskap.last().medlemskap)
         assertEquals("POL", statsborgerskapMedMedlemskap.last().landkode)
     }
 
     @Test
     fun `hentStatsborgerskapMedMedlemskap skal evaluere britiske statsborgere med ukjent periode som tredjelandsborgere`() {
+        // Arrange
         val statsborgerStorbritanniaUtenPeriode =
             Statsborgerskap(
                 "GBR",
@@ -81,11 +92,14 @@ class StatsborgerskapServiceTest {
                 bekreftelsesdato = null,
             )
 
+        // Act
         val grStatsborgerskapUtenPeriode =
             statsborgerskapService.hentStatsborgerskapMedMedlemskap(
                 statsborgerskap = statsborgerStorbritanniaUtenPeriode,
                 person = lagPerson(aktør = randomAktør()),
             )
+
+        // Assert
         assertEquals(1, grStatsborgerskapUtenPeriode.size)
         assertEquals(Medlemskap.TREDJELANDSBORGER, grStatsborgerskapUtenPeriode.single().medlemskap)
         assertTrue(grStatsborgerskapUtenPeriode.single().gjeldendeNå())
@@ -93,6 +107,7 @@ class StatsborgerskapServiceTest {
 
     @Test
     fun `hentStatsborgerskapMedMedlemskap skal evaluere britiske statsborgere etter brexit som tredjelandsborgere`() {
+        // Arrange
         val statsborgerStorbritanniaMedPeriodeEtterBrexit =
             Statsborgerskap(
                 "GBR",
@@ -100,11 +115,15 @@ class StatsborgerskapServiceTest {
                 gyldigTilOgMed = LocalDate.now(),
                 bekreftelsesdato = null,
             )
+
+        // Act
         val grStatsborgerskapEtterBrexit =
             statsborgerskapService.hentStatsborgerskapMedMedlemskap(
                 statsborgerskap = statsborgerStorbritanniaMedPeriodeEtterBrexit,
                 person = lagPerson(aktør = randomAktør()),
             )
+
+        // Assert
         assertEquals(1, grStatsborgerskapEtterBrexit.size)
         assertEquals(Medlemskap.TREDJELANDSBORGER, grStatsborgerskapEtterBrexit.single().medlemskap)
         assertTrue(grStatsborgerskapEtterBrexit.single().gjeldendeNå())
@@ -112,6 +131,7 @@ class StatsborgerskapServiceTest {
 
     @Test
     fun `hentStatsborgerskapMedMedlemskap skal evaluere britiske statsborgere under Brexit som først EØS, nå tredjelandsborgere`() {
+        // Arrange
         val datoFørBrexit = LocalDate.of(1989, 3, 1)
         val datoEtterBrexit = LocalDate.of(2020, 5, 1)
 
@@ -122,11 +142,15 @@ class StatsborgerskapServiceTest {
                 gyldigTilOgMed = datoEtterBrexit,
                 bekreftelsesdato = null,
             )
+
+        // Act
         val grStatsborgerskapUnderBrexit =
             statsborgerskapService.hentStatsborgerskapMedMedlemskap(
                 statsborgerskap = statsborgerStorbritanniaMedPeriodeUnderBrexit,
                 person = lagPerson(aktør = randomAktør()),
             )
+
+        // Assert
         assertEquals(2, grStatsborgerskapUnderBrexit.size)
         assertEquals(datoFørBrexit, grStatsborgerskapUnderBrexit.first().gyldigPeriode?.fom)
         assertEquals(LocalDate.of(2009, Month.DECEMBER, 31), grStatsborgerskapUnderBrexit.first().gyldigPeriode?.tom)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/tilbakekreving/TilbakekrevingServiceTest.kt
@@ -141,14 +141,18 @@ internal class TilbakekrevingServiceTest {
 
     @Test
     fun `hentForhåndsvisningTilbakekrevingVarselBrev henter forhåndvisning av varselbrev med feilutbetalte perioder`() {
+        // Arrange
         every {
             tilbakekrevingKlient.hentForhåndsvisningTilbakekrevingVarselbrev(capture(forhåndsvisVarselbrevRequestSlot))
         } returns ByteArray(10)
 
+        // Act
         tilbakekrevingService.hentForhåndsvisningTilbakekrevingVarselBrev(
             behandling.id,
             ForhåndsvisTilbakekrevingVarselbrevDto("fritekst"),
         )
+
+        // Assert
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) }
         verify(exactly = 1) { arbeidsfordelingService.hentArbeidsfordelingPåBehandling(behandling.id) }
@@ -179,12 +183,15 @@ internal class TilbakekrevingServiceTest {
 
     @Test
     fun `sendOpprettTilbakekrevingRequest sender OpprettTilbakekreving request med varsel`() {
+        // Arrange
         val requestSlot = slot<OpprettTilbakekrevingRequest>()
         every { tilbakekrevingRepository.findByBehandlingId(behandling.id) } returns
             lagTilbakekreving(Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL, "test")
 
+        // Act
         tilbakekrevingService.sendOpprettTilbakekrevingRequest(behandling)
 
+        // Assert
         verify(exactly = 1) { tilbakekrevingKlient.opprettTilbakekrevingBehandling(capture(requestSlot)) }
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) }
@@ -223,12 +230,15 @@ internal class TilbakekrevingServiceTest {
 
     @Test
     fun `sendOpprettTilbakekrevingRequest sender OpprettTilbakekreving request uten varsel`() {
+        // Arrange
         val requestSlot = slot<OpprettTilbakekrevingRequest>()
         every { tilbakekrevingRepository.findByBehandlingId(behandling.id) } returns
             lagTilbakekreving(Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_UTEN_VARSEL)
 
+        // Act
         tilbakekrevingService.sendOpprettTilbakekrevingRequest(behandling)
 
+        // Assert
         verify(exactly = 1) { tilbakekrevingKlient.opprettTilbakekrevingBehandling(capture(requestSlot)) }
         verify(exactly = 1) { vedtakRepository.findByBehandlingAndAktivOptional(behandling.id) }
         verify(exactly = 1) { personopplysningGrunnlagService.hentAktivPersonopplysningGrunnlagThrows(behandling.id) }
@@ -261,9 +271,11 @@ internal class TilbakekrevingServiceTest {
 
     @Test
     fun `opprettTilbakekrevingsbehandlingManuelt skal ikke opprette når kanBehandlingOpprettesManuelt returnerer med false respons`() {
+        // Arrange
         every { tilbakekrevingKlient.kanTilbakekrevingsbehandlingOpprettesManuelt(behandling.fagsak.id) } returns
             KanBehandlingOpprettesManueltRespons(kanBehandlingOpprettes = false, melding = "feilmelding")
 
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 tilbakekrevingService.opprettTilbakekrevingsbehandlingManuelt(behandling.fagsak.id)
@@ -274,6 +286,7 @@ internal class TilbakekrevingServiceTest {
 
     @Test
     fun `opprettTilbakekrevingsbehandlingManuelt skal ikke opprette når kanBehandlingOpprettesManuelt ikke returnerer referanse`() {
+        // Arrange
         every { tilbakekrevingKlient.kanTilbakekrevingsbehandlingOpprettesManuelt(behandling.fagsak.id) } returns
             KanBehandlingOpprettesManueltRespons(
                 kanBehandlingOpprettes = true,
@@ -281,6 +294,7 @@ internal class TilbakekrevingServiceTest {
                 kravgrunnlagsreferanse = null,
             )
 
+        // Act & Assert
         val exception =
             assertThrows<Feil> {
                 tilbakekrevingService.opprettTilbakekrevingsbehandlingManuelt(behandling.fagsak.id)
@@ -293,6 +307,7 @@ internal class TilbakekrevingServiceTest {
 
     @Test
     fun `opprettTilbakekrevingsbehandlingManuelt skal ikke opprette når kanBehandlingOpprettesManuelt returnerer med feil referanse`() {
+        // Arrange
         val kravgrunnlagsreferanse = "123"
         every { tilbakekrevingKlient.kanTilbakekrevingsbehandlingOpprettesManuelt(behandling.fagsak.id) } returns
             KanBehandlingOpprettesManueltRespons(
@@ -302,6 +317,7 @@ internal class TilbakekrevingServiceTest {
             )
         every { vedtakRepository.findByBehandlingAndAktivOptional(kravgrunnlagsreferanse.toLong()) } returns null
 
+        // Act & Assert
         val exception =
             assertThrows<FunksjonellFeil> {
                 tilbakekrevingService.opprettTilbakekrevingsbehandlingManuelt(behandling.fagsak.id)
@@ -321,6 +337,7 @@ internal class TilbakekrevingServiceTest {
 
     @Test
     fun `opprettTilbakekrevingsbehandlingManuelt skal opprette tilbakekrevingsbehandling`() {
+        // Arrange
         val requestSlot = slot<OpprettManueltTilbakekrevingRequest>()
         every { tilbakekrevingKlient.kanTilbakekrevingsbehandlingOpprettesManuelt(behandling.fagsak.id) } returns
             KanBehandlingOpprettesManueltRespons(
@@ -330,8 +347,10 @@ internal class TilbakekrevingServiceTest {
             )
         every { tilbakekrevingKlient.opprettTilbakekrevingsbehandlingManuelt(any()) } returns ""
 
+        // Act
         tilbakekrevingService.opprettTilbakekrevingsbehandlingManuelt(behandling.fagsak.id)
 
+        // Assert
         verify(exactly = 1) { tilbakekrevingKlient.opprettTilbakekrevingsbehandlingManuelt(capture(requestSlot)) }
 
         val request = requestSlot.captured

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/TotrinnskontrollServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/TotrinnskontrollServiceTest.kt
@@ -21,54 +21,68 @@ class TotrinnskontrollServiceTest {
 
     @Test
     fun `finnAktivForBehandling skal returnere null dersom det ikke finnes aktiv totrinnskontroll for behandling`() {
+        // Arrange
         every { totrinnskontrollRepository.findByBehandlingAndAktiv(404) } returns null
 
+        // Act
         val totrinnskontroll = totrinnskontrollService.finnAktivForBehandling(404)
 
+        // Assert
         assertThat(totrinnskontroll, Is(nullValue()))
     }
 
     @Test
     fun `finnAktivForBehandling skal returnere totrinnskontroll dersom det finnes aktiv for behandling`() {
+        // Arrange
         val mocketTotrinnskontroll = mockk<Totrinnskontroll>()
         every { totrinnskontrollRepository.findByBehandlingAndAktiv(200) } returns mocketTotrinnskontroll
 
+        // Act
         val totrinnskontroll = totrinnskontrollService.finnAktivForBehandling(200)
 
+        // Assert
         assertThat(totrinnskontroll, Is(notNullValue()))
         assertThat(totrinnskontroll, Is(mocketTotrinnskontroll))
     }
 
     @Test
     fun `hentAktivForBehandling skal kaste feil dersom det ikke eksisterer aktiv totrinnskontroll for behandling`() {
+        // Arrange
         every { totrinnskontrollRepository.findByBehandlingAndAktiv(404) } returns null
 
+        // Act & Assert
         val feil =
             assertThrows<Feil> {
                 totrinnskontrollService.hentAktivForBehandling(404)
             }
 
+        // Assert
         assertThat(feil.message, Is("Fant ikke aktiv totrinnskontroll for behandling 404"))
     }
 
     @Test
     fun `hentAktivForBehandling skal returnere totrinnskontroll dersom det finnes aktiv for behandling`() {
+        // Arrange
         val mocketTotrinnskontroll = mockk<Totrinnskontroll>()
         every { totrinnskontrollRepository.findByBehandlingAndAktiv(200) } returns mocketTotrinnskontroll
 
+        // Act
         val totrinnskontroll = totrinnskontrollService.hentAktivForBehandling(200)
 
+        // Assert
         assertThat(totrinnskontroll, Is(notNullValue()))
         assertThat(totrinnskontroll, Is(mocketTotrinnskontroll))
     }
 
     @Test
     fun `besluttTotrinnskontroll skal kaste funksjonell feil hvis totrinnskontroll er ugyldig`() {
+        // Arrange
         val mocketTotrinnskontroll = mockk<Totrinnskontroll>(relaxed = true)
 
         every { mocketTotrinnskontroll.erUgyldig() } returns true
         every { totrinnskontrollRepository.findByBehandlingAndAktiv(200) } returns mocketTotrinnskontroll
 
+        // Act & Assert
         val funksjonellFeil =
             assertThrows<FunksjonellFeil> {
                 totrinnskontrollService.besluttTotrinnskontroll(
@@ -79,6 +93,7 @@ class TotrinnskontrollServiceTest {
                 )
             }
 
+        // Assert
         assertThat(
             funksjonellFeil.message,
             Is("Samme saksbehandler kan ikke foreslå og beslutte iverksetting på samme vedtak"),
@@ -88,12 +103,14 @@ class TotrinnskontrollServiceTest {
 
     @Test
     fun `besluttTotrinnskontroll skal oppdatere behandling status til iverksetter vedtak hvis beslutning er godkjent`() {
+        // Arrange
         val mocketTotrinnskontroll = mockk<Totrinnskontroll>(relaxed = true)
 
         every { mocketTotrinnskontroll.erUgyldig() } returns false
         every { totrinnskontrollRepository.findByBehandlingAndAktiv(200) } returns mocketTotrinnskontroll
         every { totrinnskontrollRepository.save(mocketTotrinnskontroll) } returns mocketTotrinnskontroll
 
+        // Act
         totrinnskontrollService.besluttTotrinnskontroll(
             200,
             "beslutter",
@@ -101,6 +118,7 @@ class TotrinnskontrollServiceTest {
             Beslutning.GODKJENT,
         )
 
+        // Assert
         verify(exactly = 1) { mocketTotrinnskontroll.erUgyldig() }
         verify(exactly = 1) { totrinnskontrollRepository.findByBehandlingAndAktiv(200) }
         verify(exactly = 1) { totrinnskontrollRepository.save(mocketTotrinnskontroll) }
@@ -108,6 +126,7 @@ class TotrinnskontrollServiceTest {
 
     @Test
     fun `lagreOgDeaktiverGammel skal lagre ny totrinnskontroll`() {
+        // Arrange
         val mocketNyTotrinnskontroll = mockk<Totrinnskontroll>(relaxed = true)
         val mocketEksisterendeTotrinnskontroll = mockk<Totrinnskontroll>(relaxed = true)
 
@@ -118,8 +137,10 @@ class TotrinnskontrollServiceTest {
         every { totrinnskontrollRepository.saveAndFlush(mocketEksisterendeTotrinnskontroll) } returns mocketEksisterendeTotrinnskontroll
         every { mocketEksisterendeTotrinnskontroll.id } returns 200
 
+        // Act
         val totrinnskontroll = totrinnskontrollService.lagreOgDeaktiverGammel(mocketNyTotrinnskontroll)
 
+        // Assert
         assertThat(totrinnskontroll, Is(notNullValue()))
         assertThat(totrinnskontroll, Is(mocketNyTotrinnskontroll))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/TotrinnskontrollTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/domene/TotrinnskontrollTest.kt
@@ -14,6 +14,7 @@ class TotrinnskontrollTest {
     inner class ErUgyldigTest {
         @Test
         fun `Skal returnere false dersom det er samme navn på saksbehandler og beslutter men annen ID`() {
+            // Arrange
             val kontroll =
                 Totrinnskontroll(
                     behandling = behandling,
@@ -23,11 +24,14 @@ class TotrinnskontrollTest {
                     beslutter = "NAV-Bruker",
                     beslutterId = "X123Beslutter",
                 )
+
+            // Act & Assert
             assertFalse(kontroll.erUgyldig())
         }
 
         @Test
         fun `Skal returnere false dersom det er samme person som beslutter men det er system brukeren`() {
+            // Arrange
             val kontroll =
                 Totrinnskontroll(
                     behandling = behandling,
@@ -38,11 +42,13 @@ class TotrinnskontrollTest {
                     beslutterId = "VL",
                 )
 
+            // Act & Assert
             assertFalse(kontroll.erUgyldig())
         }
 
         @Test
         fun `Skal returnere false dersom det er forskjellige brukere som har fattet vedtak og besluttet`() {
+            // Arrange
             val kontroll =
                 Totrinnskontroll(
                     behandling = behandling,
@@ -53,11 +59,13 @@ class TotrinnskontrollTest {
                     beslutterId = "ID2",
                 )
 
+            // Act & Assert
             assertFalse(kontroll.erUgyldig())
         }
 
         @Test
         fun `Skal returnere true dersom id'ne er det samme selvom navn er annerledes på saksbehandler og beslutter`() {
+            // Arrange
             val kontroll =
                 Totrinnskontroll(
                     behandling = behandling,
@@ -68,6 +76,7 @@ class TotrinnskontrollTest {
                     beslutterId = "samme-id",
                 )
 
+            // Act & Assert
             assertTrue(kontroll.erUgyldig())
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/korrigertvedtak/KorrigertVedtakServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/korrigertvedtak/KorrigertVedtakServiceTest.kt
@@ -20,15 +20,18 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `finnAktivtKorrigertVedtakPåBehandling skal hente aktivt korrigert vedtak fra repository hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertVedtak = lagKorrigertVedtak(behandling)
 
         every { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id) } returns korrigertVedtak
 
+        // Act
         val hentetKorrigertVedtak =
             korrigertVedtakService.finnAktivtKorrigertVedtakPåBehandling(behandling.id)
                 ?: fail("korrigert vedtak ikke hentet riktig")
 
+        // Assert
         assertThat(hentetKorrigertVedtak.behandling.id, Is(behandling.id))
         assertThat(hentetKorrigertVedtak.aktiv, Is(true))
 
@@ -37,6 +40,7 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `lagreKorrigertVedtak skal lagre korrigert vedtak på behandling og logg på dette`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertVedtak = lagKorrigertVedtak(behandling)
 
@@ -44,9 +48,11 @@ internal class KorrigertVedtakServiceTest {
         every { korrigertVedtakRepository.save(korrigertVedtak) } returns korrigertVedtak
         every { loggService.opprettKorrigertVedtakLogg(behandling, any()) } returns Unit
 
+        // Act
         val lagretKorrigertVedtak =
             korrigertVedtakService.lagreKorrigertVedtakOgDeaktiverGamle(korrigertVedtak)
 
+        // Assert
         assertThat(lagretKorrigertVedtak.behandling.id, Is(behandling.id))
 
         verify(exactly = 1) { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id) }
@@ -61,6 +67,7 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `lagreKorrigertVedtak skal sette og lagre forrige korrigert vedtak til inaktivt hvis det finnes tidligere korrigering`() {
+        // Arrange
         val behandling = lagBehandling()
         val forrigeKorrigering = mockk<KorrigertVedtak>(relaxed = true)
         val korrigertVedtak = lagKorrigertVedtak(behandling, vedtaksdato = LocalDate.now().minusDays(3))
@@ -70,8 +77,10 @@ internal class KorrigertVedtakServiceTest {
         every { korrigertVedtakRepository.save(korrigertVedtak) } returns korrigertVedtak
         every { loggService.opprettKorrigertVedtakLogg(any(), any()) } returns Unit
 
+        // Act
         korrigertVedtakService.lagreKorrigertVedtakOgDeaktiverGamle(korrigertVedtak)
 
+        // Assert
         verify(exactly = 1) { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(any()) }
         verify(exactly = 1) { forrigeKorrigering setProperty "aktiv" value false }
         verify(exactly = 1) { korrigertVedtakRepository.saveAndFlush(forrigeKorrigering) }
@@ -80,14 +89,17 @@ internal class KorrigertVedtakServiceTest {
 
     @Test
     fun `settKorrigertVedtakPåBehandlingTilInaktiv skal sette korrigert vedtak til inaktivt hvis det finnes`() {
+        // Arrange
         val behandling = lagBehandling()
         val korrigertVedtak = mockk<KorrigertVedtak>(relaxed = true)
 
         every { korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(any()) } returns korrigertVedtak
         every { loggService.opprettKorrigertVedtakLogg(any(), any()) } returns Unit
 
+        // Act
         korrigertVedtakService.settKorrigertVedtakPåBehandlingTilInaktiv(behandling)
 
+        // Assert
         verify(exactly = 1) { korrigertVedtak setProperty "aktiv" value false }
         verify(exactly = 1) {
             loggService.opprettKorrigertVedtakLogg(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/SikkerhetContextTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/SikkerhetContextTest.kt
@@ -49,12 +49,16 @@ class SikkerhetContextTest {
     inner class ErSystemKontekstTest {
         @Test
         fun `returnerer false når NAVident er en saksbehandler-ident`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")))
+
+            // Act & Assert
             assertThat(erSystemKontekst()).isFalse()
         }
 
         @Test
         fun `returnerer true når det ikke finnes noe token (fallback til systemforkortelse)`() {
+            // Act & Assert
             assertThat(erSystemKontekst()).isTrue()
         }
     }
@@ -63,6 +67,7 @@ class SikkerhetContextTest {
     inner class ErMaskinTilMaskinTokenTest {
         @Test
         fun `returnerer true når oid er lik sub og roles inneholder access_as_application`() {
+            // Arrange
             val appId = "appId"
             settSikkerhetscontext(
                 lagJwt(
@@ -73,11 +78,14 @@ class SikkerhetContextTest {
                     ),
                 ),
             )
+
+            // Act & Assert
             assertThat(erMaskinTilMaskinToken()).isTrue()
         }
 
         @Test
         fun `returnerer false når oid er ulik sub`() {
+            // Arrange
             settSikkerhetscontext(
                 lagJwt(
                     mapOf(
@@ -87,11 +95,14 @@ class SikkerhetContextTest {
                     ),
                 ),
             )
+
+            // Act & Assert
             assertThat(erMaskinTilMaskinToken()).isFalse()
         }
 
         @Test
         fun `returnerer false når oid er lik sub men rollen mangler`() {
+            // Arrange
             val appId = "appId"
             settSikkerhetscontext(
                 lagJwt(
@@ -102,11 +113,14 @@ class SikkerhetContextTest {
                     ),
                 ),
             )
+
+            // Act & Assert
             assertThat(erMaskinTilMaskinToken()).isFalse()
         }
 
         @Test
         fun `returnerer false når det ikke finnes noe token`() {
+            // Act & Assert
             assertThat(erMaskinTilMaskinToken()).isFalse()
         }
     }
@@ -115,13 +129,19 @@ class SikkerhetContextTest {
     inner class HentSaksbehandlerTest {
         @Test
         fun `returnerer NAVident-claim fra token`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")))
+
+            // Act & Assert
             assertThat(hentSaksbehandler()).isEqualTo("Z999999")
         }
 
         @Test
         fun `returnerer systemforkortelse når NAVident-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentSaksbehandler()).isEqualTo(SikkerhetContext.SYSTEM_FORKORTELSE)
         }
     }
@@ -130,13 +150,19 @@ class SikkerhetContextTest {
     inner class HentSaksbehandlerEpostTest {
         @Test
         fun `returnerer preferred_username-claim fra token`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("preferred_username" to "fornavn.etternavn@nav.no")))
+
+            // Act & Assert
             assertThat(hentSaksbehandlerEpost()).isEqualTo("fornavn.etternavn@nav.no")
         }
 
         @Test
         fun `returnerer systemforkortelse når preferred_username-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentSaksbehandlerEpost()).isEqualTo(SikkerhetContext.SYSTEM_FORKORTELSE)
         }
     }
@@ -145,13 +171,19 @@ class SikkerhetContextTest {
     inner class HentSaksbehandlerNavnTest {
         @Test
         fun `returnerer name-claim fra token`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("name" to "Etternavn, Fornavn")))
+
+            // Act & Assert
             assertThat(hentSaksbehandlerNavn()).isEqualTo("Etternavn, Fornavn")
         }
 
         @Test
         fun `returnerer systemnavn når name-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentSaksbehandlerNavn()).isEqualTo(SikkerhetContext.SYSTEM_NAVN)
         }
     }
@@ -160,14 +192,20 @@ class SikkerhetContextTest {
     inner class HentGrupperTest {
         @Test
         fun `returnerer groups-claim som liste`() {
+            // Arrange
             val grupper = listOf("gruppe-a", "gruppe-b")
             settSikkerhetscontext(lagJwt(mapOf("groups" to grupper)))
+
+            // Act & Assert
             assertThat(hentGrupper()).containsExactlyElementsOf(grupper)
         }
 
         @Test
         fun `returnerer tom liste når groups-claim mangler`() {
+            // Arrange
             settSikkerhetscontext(lagJwt())
+
+            // Act & Assert
             assertThat(hentGrupper()).isEmpty()
         }
     }
@@ -176,13 +214,19 @@ class SikkerhetContextTest {
     inner class HarRolleTest {
         @Test
         fun `returnerer true når bruker har den angitte rollen`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(), roller = listOf(Rolle.SAKSBEHANDLER))
+
+            // Act & Assert
             assertThat(harRolle(Rolle.SAKSBEHANDLER)).isTrue()
         }
 
         @Test
         fun `returnerer false når bruker mangler den angitte rollen`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(), roller = listOf(Rolle.VEILEDER))
+
+            // Act & Assert
             assertThat(harRolle(Rolle.SAKSBEHANDLER)).isFalse()
         }
     }
@@ -193,36 +237,52 @@ class SikkerhetContextTest {
         inner class Enkeltroller {
             @Test
             fun `returnerer SYSTEM ved systemkontekst uten token`() {
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.SYSTEM)
             }
 
             @Test
             fun `returnerer BESLUTTER ved kun BESLUTTER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.BESLUTTER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.BESLUTTER)
             }
 
             @Test
             fun `returnerer SAKSBEHANDLER ved kun SAKSBEHANDLER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.SAKSBEHANDLER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.SAKSBEHANDLER)
             }
 
             @Test
             fun `returnerer FORVALTER ved kun FORVALTER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.FORVALTER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.FORVALTER)
             }
 
             @Test
             fun `returnerer VEILEDER ved kun VEILEDER-rolle`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.VEILEDER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.VEILEDER)
             }
 
             @Test
             fun `returnerer UKJENT uten noen roller`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), emptyList())
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.UKJENT)
             }
         }
@@ -231,25 +291,34 @@ class SikkerhetContextTest {
         inner class Rekkefølgetester {
             @Test
             fun `BESLUTTER returneres før alle lavere roller når bruker har alle roller`() {
+                // Arrange
                 settSikkerhetscontext(
                     lagJwt(mapOf("NAVident" to "Z999999")),
                     listOf(Rolle.BESLUTTER, Rolle.SAKSBEHANDLER, Rolle.FORVALTER, Rolle.VEILEDER),
                 )
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.BESLUTTER)
             }
 
             @Test
             fun `SAKSBEHANDLER returneres før FORVALTER og VEILEDER`() {
+                // Arrange
                 settSikkerhetscontext(
                     lagJwt(mapOf("NAVident" to "Z999999")),
                     listOf(Rolle.SAKSBEHANDLER, Rolle.FORVALTER, Rolle.VEILEDER),
                 )
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.SAKSBEHANDLER)
             }
 
             @Test
             fun `FORVALTER returneres før VEILEDER`() {
+                // Arrange
                 settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.FORVALTER, Rolle.VEILEDER))
+
+                // Act & Assert
                 assertThat(hentHøyesteRolletilgangForInnloggetBruker()).isEqualTo(BehandlerRolle.FORVALTER)
             }
         }
@@ -259,24 +328,34 @@ class SikkerhetContextTest {
     inner class HentRolletilgangFraSikkerhetscontextTest {
         @Test
         fun `returnerer SYSTEM ved systemkontekst uavhengig av lavesteSikkerhetsnivå`() {
+            // Act & Assert
             assertThat(hentRolletilgangFraSikkerhetscontext(BehandlerRolle.SAKSBEHANDLER)).isEqualTo(BehandlerRolle.SYSTEM)
         }
 
         @Test
         fun `returnerer UKJENT når lavesteSikkerhetsnivå er null og bruker ikke er system`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.SAKSBEHANDLER))
+
+            // Act & Assert
             assertThat(hentRolletilgangFraSikkerhetscontext(null)).isEqualTo(BehandlerRolle.UKJENT)
         }
 
         @Test
         fun `returnerer lavesteSikkerhetsnivå når bruker har tilstrekkelig nivå`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.BESLUTTER))
+
+            // Act & Assert
             assertThat(hentRolletilgangFraSikkerhetscontext(BehandlerRolle.SAKSBEHANDLER)).isEqualTo(BehandlerRolle.SAKSBEHANDLER)
         }
 
         @Test
         fun `returnerer UKJENT når bruker ikke har tilstrekkelig nivå`() {
+            // Arrange
             settSikkerhetscontext(lagJwt(mapOf("NAVident" to "Z999999")), listOf(Rolle.VEILEDER))
+
+            // Act & Assert
             assertThat(hentRolletilgangFraSikkerhetscontext(BehandlerRolle.SAKSBEHANDLER)).isEqualTo(BehandlerRolle.UKJENT)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/sikkerhet/TilgangServiceTest.kt
@@ -97,8 +97,10 @@ class TilgangServiceTest {
     internal fun `skal kaste RolleTilgangskontrollFeil dersom saksbehandler eller veileder forsøker å gjøre handling som krever BESLUTTER-rolle`(
         behandlerRolle: BehandlerRolle,
     ) {
+        // Arrange
         mockBrukerContext(groups = listOf(behandlerRolle.name))
 
+        // Act & Assert
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
                 tilgangService.validerTilgangTilHandling(BehandlerRolle.BESLUTTER, defaultHandling)
@@ -111,8 +113,10 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal kaste RolleTilgangskontrollFeil dersom veileder forsøker å gjøre handling som krever SAKSBEHANDLER-rolle`() {
+        // Arrange
         mockBrukerContext(groups = listOf(BehandlerRolle.VEILEDER.name))
 
+        // Act & Assert
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
                 tilgangService.validerTilgangTilHandling(BehandlerRolle.SAKSBEHANDLER, defaultHandling)
@@ -125,8 +129,10 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal kaste RolleTilgangskontrollFeil dersom bruker verken er veileder saksbehandler eller beslutter`() {
+        // Arrange
         mockBrukerContext(groups = emptyList())
 
+        // Act & Assert
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
                 tilgangService.validerTilgangTilHandling(BehandlerRolle.VEILEDER, defaultHandling)
@@ -139,7 +145,10 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal ikke kaste RolleTilgangskontrollFeil dersom beslutter beslutter forsøker å gjøre handling som krever BESLUTTER-rolle`() {
+        // Arrange
         mockBrukerContext(groups = listOf(BehandlerRolle.BESLUTTER.name))
+
+        // Act & Assert
         tilgangService.validerTilgangTilHandling(BehandlerRolle.BESLUTTER, "")
     }
 
@@ -148,7 +157,10 @@ class TilgangServiceTest {
     internal fun `skal ikke kaste RolleTilgangskontrollFeil dersom saksbehandler eller beslutter forsøker å gjøre handling som krever SAKSBEHANDLER-rolle`(
         behandlerRolle: BehandlerRolle,
     ) {
+        // Arrange
         mockBrukerContext(groups = listOf(behandlerRolle.name))
+
+        // Act & Assert
         tilgangService.validerTilgangTilHandling(BehandlerRolle.SAKSBEHANDLER, "")
     }
 
@@ -157,12 +169,16 @@ class TilgangServiceTest {
     internal fun `skal ikke kaste RolleTilgangskontrollFeil dersom saksbehandler beslutter eller veileder forsøker å gjøre handling som krever VEILEDER-rolle`(
         behandlerRolle: BehandlerRolle,
     ) {
+        // Arrange
         mockBrukerContext(groups = listOf(behandlerRolle.name))
+
+        // Act & Assert
         tilgangService.validerTilgangTilHandling(BehandlerRolle.VEILEDER, "")
     }
 
     @Test
     internal fun `skal kaste RolleTilgangskontrollFeil dersom saksbehandler ikke har tilgang til person`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), false, "Bruker mangler rolle 'TEST_ROLLE'"),
@@ -170,6 +186,7 @@ class TilgangServiceTest {
 
         val personIdenter = listOf(aktør.aktivFødselsnummer())
 
+        // Act & Assert
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
                 tilgangService.validerTilgangTilHandlingOgPersoner(
@@ -187,11 +204,13 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal ikke feile når saksbehandler har tilgang til person`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
             )
 
+        // Act & Assert
         tilgangService.validerTilgangTilHandlingOgPersoner(
             listOf(aktør.aktivFødselsnummer()),
             AuditLoggerEvent.ACCESS,
@@ -202,11 +221,13 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal kaste RolleTilgangskontrollFeil dersom saksbehandler ikke har tilgang til behandling`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), false, "Bruker mangler rolle 'TEST_ROLLE'"),
             )
 
+        // Act & Assert
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
                 tilgangService.validerTilgangTilHandlingOgFagsakForBehandling(
@@ -228,11 +249,13 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal ikke feile når saksbehandler har tilgang til behandling`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
             )
 
+        // Act & Assert
         tilgangService.validerTilgangTilHandlingOgFagsakForBehandling(
             behandling.id,
             AuditLoggerEvent.ACCESS,
@@ -243,6 +266,7 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilPersoner - hvis samme saksbehandler kaller skal den ha cachet resultatet`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
@@ -251,6 +275,7 @@ class TilgangServiceTest {
         mockBrukerContext("A", groups = listOf(BehandlerRolle.SAKSBEHANDLER.name))
         val ident = "12345678910"
 
+        // Act
         tilgangService.validerTilgangTilHandlingOgPersoner(
             listOf(ident),
             AuditLoggerEvent.ACCESS,
@@ -263,6 +288,7 @@ class TilgangServiceTest {
             BehandlerRolle.SAKSBEHANDLER,
             "",
         )
+        // Assert
         verify(exactly = 1) {
             mockIntegrasjonService.sjekkTilgangTilPersoner(any())
         }
@@ -270,6 +296,7 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilPersoner - hvis to ulike saksbehandler kaller skal den sjekke tilgang på nytt`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
@@ -280,6 +307,7 @@ class TilgangServiceTest {
         mockBrukerContext("A", roller)
         val ident = "12345678910"
 
+        // Act
         tilgangService.validerTilgangTilHandlingOgPersoner(
             listOf(ident),
             AuditLoggerEvent.ACCESS,
@@ -294,6 +322,7 @@ class TilgangServiceTest {
             "",
         )
 
+        // Assert
         verify(exactly = 2) {
             mockIntegrasjonService.sjekkTilgangTilPersoner(any())
         }
@@ -301,6 +330,7 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilBehandling - hvis samme saksbehandler kaller skal den ha cachet resultatet`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
@@ -308,6 +338,7 @@ class TilgangServiceTest {
 
         mockBrukerContext("A", listOf(BehandlerRolle.SAKSBEHANDLER.name))
 
+        // Act
         tilgangService.validerTilgangTilHandlingOgFagsakForBehandling(
             behandling.id,
             AuditLoggerEvent.ACCESS,
@@ -321,6 +352,7 @@ class TilgangServiceTest {
             "",
         )
 
+        // Assert
         verify(exactly = 1) {
             mockIntegrasjonService.sjekkTilgangTilPersoner(any())
         }
@@ -328,6 +360,7 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilBehandling - hvis to ulike saksbehandler kaller skal den sjekke tilgang på nytt`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
@@ -336,6 +369,7 @@ class TilgangServiceTest {
         val roller = listOf(BehandlerRolle.SAKSBEHANDLER.name)
 
         mockBrukerContext("A", roller)
+        // Act
         tilgangService.validerTilgangTilHandlingOgFagsakForBehandling(
             behandling.id,
             AuditLoggerEvent.ACCESS,
@@ -350,6 +384,7 @@ class TilgangServiceTest {
             "",
         )
 
+        // Assert
         verify(exactly = 2) {
             mockIntegrasjonService.sjekkTilgangTilPersoner(any())
         }
@@ -357,11 +392,13 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal kaste RolleTilgangskontrollFeil dersom saksbehandler ikke har tilgang til fagsak`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), false, "Bruker mangler rolle 'TEST_ROLLE'"),
             )
 
+        // Act & Assert
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
                 tilgangService.validerTilgangTilHandlingOgFagsak(
@@ -380,11 +417,13 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal ikke feile når saksbehandler har tilgang til fagsak`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
             )
 
+        // Act & Assert
         tilgangService.validerTilgangTilHandlingOgFagsak(
             fagsak.id,
             AuditLoggerEvent.ACCESS,
@@ -395,18 +434,23 @@ class TilgangServiceTest {
 
     @Test
     internal fun `skal ikke feile når fagsak ikke eksisterer`() {
+        // Arrange
         every { mockFagsakRepository.finnFagsak(fagsak.id) } returns null
+
+        // Act
         tilgangService.validerTilgangTilHandlingOgFagsak(
             fagsak.id,
             AuditLoggerEvent.ACCESS,
             BehandlerRolle.SAKSBEHANDLER,
             "hente behandling",
         )
+        // Assert
         verify(exactly = 0) { mockBehandlingRepository.finnBehandlinger(fagsak.id) }
     }
 
     @Test
     internal fun `validerTilgangTilFagsak - hvis samme saksbehandler kaller skal den ha cachet resultatet`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
@@ -414,6 +458,7 @@ class TilgangServiceTest {
 
         mockBrukerContext("A", listOf(BehandlerRolle.SAKSBEHANDLER.name))
 
+        // Act
         tilgangService.validerTilgangTilHandlingOgFagsak(
             fagsak.id,
             AuditLoggerEvent.ACCESS,
@@ -427,6 +472,7 @@ class TilgangServiceTest {
             "",
         )
 
+        // Assert
         verify(exactly = 1) {
             mockIntegrasjonService.sjekkTilgangTilPersoner(any())
         }
@@ -434,6 +480,7 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilFagsak - hvis to ulike saksbehandlere kaller skal den sjekke tilgang på nytt`() {
+        // Arrange
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
                 Tilgang(aktør.aktivFødselsnummer(), true),
@@ -442,6 +489,7 @@ class TilgangServiceTest {
         val roller = listOf(BehandlerRolle.SAKSBEHANDLER.name)
 
         mockBrukerContext("A", roller)
+        // Act
         tilgangService.validerTilgangTilHandlingOgFagsak(
             fagsak.id,
             AuditLoggerEvent.ACCESS,
@@ -456,6 +504,7 @@ class TilgangServiceTest {
             "",
         )
 
+        // Assert
         verify(exactly = 2) {
             mockIntegrasjonService.sjekkTilgangTilPersoner(any())
         }
@@ -463,6 +512,7 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilFagsakForPerson - skal kaste RolleTilgangskontrollFeil dersom saksbehandler ikke har tilgang til fagsak`() {
+        // Arrange
         val aktør = randomAktør("12345678910")
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
@@ -471,6 +521,7 @@ class TilgangServiceTest {
         every { personidentService.hentOgLagreAktør("12345678910", any()) } returns aktør
         every { mockFagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
 
+        // Act & Assert
         val rolleTilgangskontrollFeil =
             assertThrows<RolleTilgangskontrollFeil> {
                 tilgangService.validerTilgangTilHandlingOgFagsakForPerson(
@@ -489,6 +540,7 @@ class TilgangServiceTest {
 
     @Test
     internal fun `validerTilgangTilFagsakForPerson - skal ikke feile når saksbehandler har tilgang til fagsak`() {
+        // Arrange
         val aktør = randomAktør("12345678910")
         every { mockIntegrasjonService.sjekkTilgangTilPersoner(any()) } returns
             listOf(
@@ -497,6 +549,7 @@ class TilgangServiceTest {
         every { personidentService.hentOgLagreAktør("12345678910", any()) } returns aktør
         every { mockFagsakRepository.finnFagsakForAktør(aktør) } returns fagsak
 
+        // Act & Assert
         tilgangService.validerTilgangTilHandlingOgFagsakForPerson(
             "12345678910",
             AuditLoggerEvent.ACCESS,
@@ -507,6 +560,7 @@ class TilgangServiceTest {
 
     @Test
     fun `validerTilgangTilFagsak - skal kaste feil dersom søker eller et eller flere av barna har diskresjonskode og saksbehandler mangler tilgang`() {
+        // Arrange
         every { mockBehandlingRepository.finnBehandlinger(fagsak.id) }.returns(listOf(behandling))
         every { mockPersonopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id) }.returns(
             PersonopplysningGrunnlag(
@@ -575,6 +629,7 @@ class TilgangServiceTest {
                 Tilgang("12345678910", false),
             )
 
+        // Act & Assert
         assertThrows<RolleTilgangskontrollFeil> {
             tilgangService.validerTilgangTilHandlingOgFagsak(
                 fagsak.id,

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/AInntektControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/AInntektControllerTest.kt
@@ -40,6 +40,7 @@ class AInntektControllerTest : OppslagSpringRunnerTest() {
             header("Authorization", "Bearer $token")
             contentType(ContentType.JSON)
             body(jsonMapper.writeValueAsString(PersonIdent(ident)))
+            // Act & Assert
         } When {
             post(apiUrl)
         } Then {
@@ -65,6 +66,7 @@ class AInntektControllerTest : OppslagSpringRunnerTest() {
             header("Authorization", "Bearer $token")
             contentType(ContentType.JSON)
             body(jsonMapper.writeValueAsString(PersonIdent(ident)))
+            // Act & Assert
         } When {
             post(apiUrl)
         } Then {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/BehandlingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/BehandlingControllerTest.kt
@@ -48,6 +48,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentBehandling - skal returnere 401 dersom brukeren ikke har token for å hente behandling`() {
+        // Act & Assert
         When {
             get("$behandlingControllerUrl/401")
         } Then {
@@ -61,6 +62,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
         Given {
             header("Authorization", "Bearer $token")
+            // Act & Assert
         } When {
             get("$behandlingControllerUrl/403")
         } Then {
@@ -74,6 +76,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
         Given {
             header("Authorization", "Bearer $token")
+            // Act & Assert
         } When {
             get("$behandlingControllerUrl/${behandling.id}")
         } Then {
@@ -91,6 +94,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
             header("Authorization", "Bearer $token")
             contentType(ContentType.JSON)
             body(jsonMapper.writeValueAsString(EndreBehandlendeEnhetDto("enhet", "")))
+            // Act & Assert
         } When {
             put("$behandlingControllerUrl/${behandling.id}/enhet")
         } Then {
@@ -108,6 +112,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
             header("Authorization", "Bearer $token")
             contentType(ContentType.JSON)
             body(jsonMapper.writeValueAsString(EndreBehandlendeEnhetDto("50", "nybegrunnelse")))
+            // Act & Assert
         } When {
             put("$behandlingControllerUrl/${behandling.id}/enhet")
         } Then {
@@ -134,6 +139,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
                     ),
                 ),
             )
+            // Act & Assert
         } When {
             post(behandlingControllerUrl)
         } Then {
@@ -155,6 +161,7 @@ class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
         Given {
             header("Authorization", "Bearer $token")
+            // Act & Assert
         } When {
             get("$behandlingControllerUrl/fagsak/${fagsak.id}")
         } Then {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/OvergangsordningAndelControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/OvergangsordningAndelControllerTest.kt
@@ -96,6 +96,7 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
                 header("Authorization", "Bearer $token")
                 contentType(ContentType.JSON)
                 body(ugyldigOvergangsordningAndelDto)
+                // Act & Assert
             } When {
                 put("$overgangsordningAndelControllerUrl/${behandling.id}/${overgangsordningAndel.id}")
             } Then {
@@ -146,6 +147,7 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
                 header("Authorization", "Bearer $token")
                 contentType(ContentType.JSON)
                 body(jsonMapper.writeValueAsString(overgangsordningAndelDto))
+                // Act & Assert
             } When {
                 put("$overgangsordningAndelControllerUrl/${behandling.id}/${gamleOvergangsordningAndeler.first().id}")
             } Then {
@@ -181,6 +183,7 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
 
             Given {
                 header("Authorization", "Bearer $token")
+                // Act & Assert
             } When {
                 delete("$overgangsordningAndelControllerUrl/${behandling.id}/${overgangsordningAndel.id}")
             } Then {
@@ -202,6 +205,7 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
 
             Given {
                 header("Authorization", "Bearer $token")
+                // Act & Assert
             } When {
                 post("$overgangsordningAndelControllerUrl/${behandling.id}")
             } Then {
@@ -215,6 +219,7 @@ class OvergangsordningAndelControllerTest : OppslagSpringRunnerTest() {
         fun `skal opprette tom OvergangsordningAndel`() {
             Given {
                 header("Authorization", "Bearer $token")
+                // Act & Assert
             } When {
                 post("$overgangsordningAndelControllerUrl/${behandling.id}")
             } Then {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/TilbakekrevingControllerTest.kt
@@ -35,6 +35,7 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentTilbakekrevingsbehandlinger - skal returnere 401 unauthorized dersom brukeren ikke har token for å hente behandling`() {
+        // Act & Assert
         When {
             get("$controllerUrl/fagsak/123456")
         } Then {
@@ -49,6 +50,7 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
 
         Given {
             header("Authorization", "Bearer $token")
+            // Act & Assert
         } When {
             get("$controllerUrl/fagsak/123456")
         } Then {
@@ -76,6 +78,7 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
 
         Given {
             header("Authorization", "Bearer $token")
+            // Act & Assert
         } When {
             get("$controllerUrl/fagsak/123456")
         } Then {
@@ -96,6 +99,7 @@ class TilbakekrevingControllerTest : OppslagSpringRunnerTest() {
 
         Given {
             header("Authorization", "Bearer $token")
+            // Act & Assert
         } When {
             get("$controllerUrl/fagsak/123456")
         } Then {

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/api/VilkårsvurderingControllerTest.kt
@@ -83,6 +83,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `endreVilkår - skal returnere endrede vilkår`() {
+        // Arrange
         val bosattIRiketVilkår =
             vilkårsvurderingService
                 .hentAktivVilkårsvurderingForBehandling(behandling.id)
@@ -118,6 +119,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             }
             """.trimIndent()
 
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -135,6 +137,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `endreVilkår - skal endre vilkår og tilbakefører behandling til vilkårsvurdering`() {
+        // Arrange
         val behandlingForOppdatering = behandlingRepository.hentAktivBehandling(behandling.id)
         behandlingForOppdatering.behandlingStegTilstand.clear()
         behandlingForOppdatering.behandlingStegTilstand.addAll(
@@ -202,6 +205,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             }
             """.trimIndent()
 
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -216,6 +220,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             statusCode(HttpStatus.OK.value())
         }
 
+        // Assert
         assertTrue { vedtaksperiodeRepository.finnVedtaksperioderForVedtak(vedtak.id).isEmpty() }
 
         val oppdatertBehandling = behandlingRepository.hentAktivBehandling(behandlingForOppdatering.id)
@@ -235,6 +240,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettNyttVilkår - skal kaste feil dersom det eksisterer uvurdert vilkår av samme type`() {
+        // Arrange
         val request =
             """
             {
@@ -244,6 +250,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             }
             """.trimIndent()
 
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -262,6 +269,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettNyttVilkår - skal opprette nytt vilkår dersom det ikke eksisterer uvurdert vilkår av samme type på person`() {
+        // Arrange
         val request =
             """
             {
@@ -271,6 +279,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             }
             """.trimIndent()
 
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -288,6 +297,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `opprettNyttVilkår - skal opprette nytt vilkår og tilbakefører behandling til vilkårsvurdering steg`() {
+        // Arrange
         val behandlingForOppdatering = behandlingRepository.hentAktivBehandling(behandling.id)
         behandlingForOppdatering.behandlingStegTilstand.clear()
         behandlingForOppdatering.behandlingStegTilstand.addAll(
@@ -328,6 +338,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             }
             """.trimIndent()
 
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -342,6 +353,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             )
         }
 
+        // Assert
         assertTrue { vedtaksperiodeRepository.finnVedtaksperioderForVedtak(vedtak.id).isEmpty() }
 
         val oppdatertBehandling = behandlingRepository.hentAktivBehandling(behandlingForOppdatering.id)
@@ -361,6 +373,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `slettVilkår - skal kaste feil dersom det forsøkes å slette vilkår som ikke eksisterer`() {
+        // Arrange
         val ikkeEksisterendeVilkårId = 404
 
         val request =
@@ -368,6 +381,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             ${søker.aktivFødselsnummer()}
             """.trimIndent()
 
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -383,6 +397,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `slettVilkår - skal lage nytt initiell vilkår av samme type dersom det bare finnes en ved sletting`() {
+        // Arrange
         val bosattIRiketVilkår =
             vilkårsvurderingService
                 .hentAktivVilkårsvurderingForBehandling(behandling.id)
@@ -398,6 +413,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
             ${søker.aktivFødselsnummer()}
             """.trimIndent()
 
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -415,6 +431,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `endreAnnenVurdering - skal kaste feil dersom annen vurdering ikke finnes`() {
+        // Arrange
         val token = lokalTestToken(behandlerRolle = BehandlerRolle.SAKSBEHANDLER)
         val request =
             """
@@ -426,6 +443,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
               
             }
             """.trimIndent()
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)
@@ -440,6 +458,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `endreAnnenVurdering - skal oppdatere eksisterende annen vurdering`() {
+        // Arrange
         val token = lokalTestToken(behandlerRolle = BehandlerRolle.SAKSBEHANDLER)
         val personResultat =
             vilkårsvurderingService
@@ -463,6 +482,7 @@ class VilkårsvurderingControllerTest : OppslagSpringRunnerTest() {
                 "begrunnelse": "Begrunnelse"
             }
             """.trimIndent()
+        // Act
         Given {
             header("Authorization", "Bearer $token")
             body(request)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/ecb/ECBIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/ecb/ECBIntegrationTest.kt
@@ -49,6 +49,7 @@ class ECBIntegrationTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `Skal teste at valutakurs hentes fra cache dersom valutakursen allerede er hentet fra ECB`() {
+        // Arrange
         val valutakursDato = LocalDate.of(2022, 7, 20)
         val ecbExchangeRatesData =
             createECBResponse(
@@ -64,6 +65,7 @@ class ECBIntegrationTest : OppslagSpringRunnerTest() {
             )
         } returns ecbExchangeRatesData.toExchangeRates()
 
+        // Act & Assert
         ecbService.hentValutakurs("EUR", valutakursDato)
         val valutakurs = ecbValutakursCacheRepository.findByValutakodeAndValutakursdato("EUR", valutakursDato)
         assertEquals(valutakurs!!.kurs, BigDecimal.valueOf(9.4567))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/adopsjon/AdopsjonRepositoryTest.kt
@@ -21,6 +21,7 @@ class AdopsjonRepositoryTest(
 
     @Test
     fun `skal kaste feil hvis det forsøkes å lagre to adopsjoner på samme aktør i samme behandling `() {
+        // Arrange
         val adopsjon =
             Adopsjon(
                 aktør = barn,
@@ -37,6 +38,7 @@ class AdopsjonRepositoryTest(
 
         adopsjonRepository.saveAndFlush(adopsjon)
 
+        // Act & Assert
         assertThrows<DataIntegrityViolationException> {
             adopsjonRepository.saveAndFlush(adopsjon2)
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/domene/BehandlingRepositoryTest.kt
@@ -27,53 +27,68 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentBehandling - skal finne behandling med behandlingsId`() {
+        // Act
         val hentetBehandling = behandlingRepository.hentBehandling(behandling.id)
 
+        // Assert
         assertEquals(behandling.id, hentetBehandling.id)
     }
 
     @Test
     fun `hentAktivBehandling - skal finne behandling med behandlingsId som er aktiv`() {
+        // Act
         val aktivBehandling = behandlingRepository.hentAktivBehandling(behandling.id)
 
+        // Assert
         assertTrue(aktivBehandling.aktiv)
     }
 
     @Test
     fun `finnBehandlinger - skal finne behandlinger tilknyttet fagsakId`() {
+        // Act
         val behandlinger = behandlingRepository.finnBehandlinger(fagsak.id)
 
+        // Assert
         assertEquals(1, behandlinger.size)
     }
 
     @Test
     fun `finnBehandlinger - skal returnere tom liste dersom det ikke finnes behandlinger tilknyttet fagsakId`() {
+        // Act
         val behandlinger = behandlingRepository.finnBehandlinger(404L)
 
+        // Assert
         assertEquals(0, behandlinger.size)
     }
 
     @Test
     fun `findByFagsakAndAktiv - skal finne aktiv behandling tilknyttet fagsakId`() {
+        // Act
         val behandling = behandlingRepository.findByFagsakAndAktiv(fagsak.id)
 
+        // Assert
         assertNotNull(behandling)
         assertEquals(fagsak.id, behandling?.fagsak?.id)
     }
 
     @Test
     fun `findByFagsakAndAktiv - skal returnere null dersom det ikke finnes en aktiv behandling tilknyttet fagsakId`() {
+        // Arrange
         behandlingRepository.saveAndFlush(behandling.also { it.aktiv = false })
 
+        // Act
         val behandling = behandlingRepository.findByFagsakAndAktiv(fagsak.id)
 
+        // Assert
         assertNull(behandling)
     }
 
     @Test
     fun `findByFagsakAndAktivAndOpen - skal finne aktiv og åpen behandling tilknyttet fagsakId`() {
+        // Act
         val behandling = behandlingRepository.findByFagsakAndAktivAndOpen(fagsak.id)
 
+        // Assert
         assertNotNull(behandling)
         assertEquals(fagsak.id, behandling?.fagsak?.id)
         assertTrue(behandling!!.aktiv)
@@ -82,53 +97,75 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `findByFagsakAndAktivAndOpen - skal returnere null dersom aktiv behandling tilknyttet fagsakId er avsluttet`() {
+        // Arrange
         behandlingRepository.saveAndFlush(behandling.also { it.status = BehandlingStatus.AVSLUTTET })
 
+        // Act
         val behandling = behandlingRepository.findByFagsakAndAktivAndOpen(fagsak.id)
 
+        // Assert
         assertNull(behandling)
     }
 
     @Test
     fun `findByFagsakAndAktivAndOpen - skal returnere null dersom åpen behandling tilknyttet fagsakId ikke er aktiv`() {
+        // Arrange
         behandlingRepository.saveAndFlush(behandling.also { it.aktiv = false })
 
+        // Act
         val behandling = behandlingRepository.findByFagsakAndAktivAndOpen(fagsak.id)
 
+        // Assert
         assertNull(behandling)
     }
 
     @Test
     fun `finnIverksatteBehandlinger - skal returnere alle behandlinger som har tilkjentytelse med utbetalingsoppdrag i fagsak`() {
+        // Arrange
         lagTilkjentYtelse("utbetalingsoppdrag")
 
+        // Act
         val behandlinger = behandlingRepository.finnIverksatteBehandlinger(fagsak.id)
 
+        // Assert
         assertThat(behandlinger.size, Is(1))
         assertThat(behandlinger.single().id, Is(behandling.id))
     }
 
     @Test
     fun `finnIverksatteBehandlinger - skal returnere tom liste dersom det ikke er noen behandliner som har tilkjentytelse med utbetalingsoppdrag i fagsak`() {
+        // Arrange
         lagTilkjentYtelse(null)
 
+        // Act
         val behandlinger = behandlingRepository.finnIverksatteBehandlinger(fagsak.id)
 
+        // Assert
         assertThat(behandlinger.size, Is(0))
     }
 
     @Test
     fun `finnBehandlingerSomHolderPåÅIverksettes - skal returnere alle behandlinger som har status 'IVERKSETTER_VEDTAK'`() {
+        // Arrange
         behandlingRepository.saveAndFlush(behandling.also { it.status = BehandlingStatus.IVERKSETTER_VEDTAK })
+
+        // Act
         val behandlinger = behandlingRepository.finnBehandlingerSomHolderPåÅIverksettes(fagsak.id)
+
+        // Assert
         assertThat(behandlinger.size, Is(1))
         assertThat(behandlinger.single().id, Is(behandling.id))
     }
 
     @Test
     fun `finnBehandlingerSomHolderPåÅIverksettes - skal returnere tom liste dersom status er ulik 'IVERKSETTER_VEDTAK'`() {
+        // Arrange
         behandlingRepository.saveAndFlush(behandling.also { it.status = BehandlingStatus.UTREDES })
+
+        // Act
         val behandlinger = behandlingRepository.finnBehandlingerSomHolderPåÅIverksettes(fagsak.id)
+
+        // Assert
         assertThat(behandlinger.size, Is(0))
     }
 
@@ -140,6 +177,7 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     fun `finnBehandlingerSentTilGodkjenning - skal returnere alle behandlinger som står på steget BESLUTTE_VEDTAK og har status 'KLAR' eller 'VENTER'`(
         behandlingStegStatus: BehandlingStegStatus,
     ) {
+        // Arrange
         behandling.behandlingStegTilstand.add(
             BehandlingStegTilstand(
                 behandling = behandling,
@@ -148,7 +186,11 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
             ),
         )
         behandlingRepository.saveAndFlush(behandling)
+
+        // Act
         val behandlinger = behandlingRepository.finnBehandlingerSendtTilGodkjenning(fagsak.id)
+
+        // Assert
         assertThat(behandlinger.size, Is(1))
         assertThat(behandlinger.single().id, Is(behandling.id))
     }
@@ -162,6 +204,7 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     fun `finnBehandlingerSentTilGodkjenning - skal returnere tom liste når behandling står på steget BESLUTTE_VEDTAK og har status som ikke er 'KLAR' eller 'VENTER'`(
         behandlingStegStatus: BehandlingStegStatus,
     ) {
+        // Arrange
         behandling.behandlingStegTilstand.add(
             BehandlingStegTilstand(
                 behandling = behandling,
@@ -170,7 +213,11 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
             ),
         )
         behandlingRepository.saveAndFlush(behandling)
+
+        // Act
         val behandlinger = behandlingRepository.finnBehandlingerSendtTilGodkjenning(fagsak.id)
+
+        // Assert
         assertThat(behandlinger.size, Is(0))
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrerPersonGrunnlagStegTest.kt
@@ -42,8 +42,10 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre REGISTRERE_PERSONGRUNNLAG steg for FGB`() {
+        // Arrange
         assertDoesNotThrow { registrerPersonGrunnlagSteg.utførSteg(behandling.id) }
 
+        // Assert
         val personopplysningGrunnlag =
             personopplysningGrunnlagRepository.findByBehandlingAndAktiv(behandling.id).shouldNotBeNull()
         assertEquals(1, personopplysningGrunnlag.personer.size)
@@ -60,6 +62,7 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre REGISTRERE_PERSONGRUNNLAG steg for Revurdering med opprettet årsak søknad`() {
+        // Arrange
         val barnAktør = lagreAktør(randomAktør())
 
         val gammelPersonopplysningGrunnlag =
@@ -70,6 +73,8 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
                 barnasIdenter = listOf(barnAktør.aktivFødselsnummer()),
                 barnAktør = listOf(barnAktør),
             )
+
+        // Act
         personopplysningGrunnlagRepository.save(gammelPersonopplysningGrunnlag)
 
         lagreBehandling(
@@ -87,6 +92,8 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
                     opprettetÅrsak = BehandlingÅrsak.SØKNAD,
                 ),
             )
+
+        // Assert
         assertDoesNotThrow { registrerPersonGrunnlagSteg.utførSteg(revurdering.id) }
 
         val personopplysningGrunnlag =
@@ -106,6 +113,7 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre REGISTRERE_PERSONGRUNNLAG steg for Revurdering med opprettet årsak ÅRLIG_KONTROLL`() {
+        // Arrange
         val barnAktør = lagreAktør(randomAktør())
 
         val gammelPersonopplysningGrunnlag =
@@ -116,6 +124,8 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
                 barnasIdenter = listOf(randomFnr()),
                 barnAktør = listOf(barnAktør),
             )
+
+        // Act
         personopplysningGrunnlagRepository.save(gammelPersonopplysningGrunnlag)
         vilkårsvurderingService.opprettVilkårsvurdering(behandling, null)
 
@@ -134,6 +144,8 @@ class RegistrerPersonGrunnlagStegTest : OppslagSpringRunnerTest() {
                     opprettetÅrsak = BehandlingÅrsak.ÅRLIG_KONTROLL,
                 ),
             )
+
+        // Assert
         assertDoesNotThrow { registrerPersonGrunnlagSteg.utførSteg(revurdering.id) }
 
         val personopplysningGrunnlag =

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/RegistrereSøknadStegTest.kt
@@ -60,6 +60,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg - skal opprette SøknadGrunnlag og oppdatere personopplysningsgrunnlag for FGB`() {
+        // Arrange
         val søknadDto =
             SøknadDto(
                 søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
@@ -75,6 +76,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
         val personopplysningGrunnlagFørSteg = personopplysningGrunnlagRepository.hentByBehandlingAndAktiv(behandling.id)
         assertEquals(1, personopplysningGrunnlagFørSteg.personer.size)
 
+        // Act
         registrereSøknadSteg.utførSteg(
             behandling.id,
             RegistrerSøknadDto(
@@ -83,6 +85,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
             ),
         )
 
+        // Assert
         // Valider at lagret søknad stemmer med innsendt søknad
         val søknadGrunnlag = søknadGrunnlagRepository.finnAktiv(behandling.id)
         assertNotNull(søknadGrunnlag)
@@ -117,6 +120,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg - skal deaktivere eksisterende SøknadGrunnlag dersom det finnes fra før av og deretter opprette et nytt`() {
+        // Arrange
         val søknadDto =
             SøknadDto(
                 søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
@@ -127,6 +131,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
                 endringAvOpplysningerBegrunnelse = "",
             )
 
+        // Act
         registrereSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto, true))
 
         val søknadDto2 =
@@ -142,6 +147,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
         registrereSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto2, true))
 
+        // Assert
         val søknadsGrunnlag = søknadGrunnlagRepository.hentAlle(behandling.id)
         val aktivtSøknadsGrunnlag = søknadsGrunnlag.singleOrNull { it.aktiv }
 
@@ -152,6 +158,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg - skal ikke utføre noen endringer dersom det allerede finnes en identisk søknad`() {
+        // Arrange
         val søknadDto =
             SøknadDto(
                 søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = søker.aktivFødselsnummer()),
@@ -164,6 +171,7 @@ class RegistrereSøknadStegTest : OppslagSpringRunnerTest() {
 
         søknadGrunnlagRepository.saveAndFlush(søknadDto.tilSøknadGrunnlag(behandling.id))
 
+        // Act
         registrereSøknadSteg.utførSteg(behandling.id, RegistrerSøknadDto(søknadDto, false))
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/StegServiceTest.kt
@@ -118,9 +118,13 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre REGISTRER_PERSONGRUNNLAG og sette neste steg til REGISTRER_SØKNAD for FGB`() {
+        // Arrange
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
+
+        // Act & Assert
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
 
+        // Assert
         behandling = behandlingRepository.hentBehandling(behandling.id)
         assertEquals(2, behandling.behandlingStegTilstand.size)
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, UTFØRT)
@@ -129,6 +133,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre REGISTRER_PERSONGRUNNLAG og sette neste steg til VILKÅRSVURDERING for revurdering`() {
+        // Arrange
         lagreBehandling(
             behandling.also {
                 it.aktiv = false
@@ -145,8 +150,11 @@ class StegServiceTest : OppslagSpringRunnerTest() {
             )
         lagreArbeidsfordeling(lagArbeidsfordelingPåBehandling(behandlingId = revurderingBehandling.id))
         assertBehandlingHarSteg(revurderingBehandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
+
+        // Act & Assert
         assertDoesNotThrow { stegService.utførSteg(revurderingBehandling.id, REGISTRERE_PERSONGRUNNLAG) }
 
+        // Assert
         revurderingBehandling = behandlingRepository.hentBehandling(revurderingBehandling.id)
         assertEquals(2, revurderingBehandling.behandlingStegTilstand.size)
         assertBehandlingHarSteg(revurderingBehandling, REGISTRERE_PERSONGRUNNLAG, UTFØRT)
@@ -155,10 +163,14 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal tilbakeføre behandlingsresultat når REGISTRERE_SØKNAD utføres på nytt for FGB`() {
+        // Arrange
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
         val vedtak = Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now())
+
+        // Act
         vedtakRepository.saveAndFlush(vedtak)
 
+        // Assert
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_SØKNAD, lagRegistrerSøknadDto()) }
         assertDoesNotThrow { stegService.utførSteg(behandling.id, VILKÅRSVURDERING) }
@@ -181,8 +193,13 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal gjenoppta REGISTRERE_SØKNAD når steget er på vent for FGB`() {
+        // Arrange
         assertBehandlingHarSteg(behandling, REGISTRERE_PERSONGRUNNLAG, KLAR)
+
+        // Act & Assert
         assertDoesNotThrow { stegService.utførSteg(behandling.id, REGISTRERE_PERSONGRUNNLAG) }
+
+        // Assert
         behandling = behandlingRepository.hentBehandling(behandling.id)
 
         stegService.settBehandlingstegPåVent(behandling, LocalDate.now().plusMonths(2), VenteÅrsak.AVVENTER_BEHANDLING)
@@ -201,6 +218,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal ikke utføre IVERKSETT_MOT_OPPDRAG steg av beslutter`() {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.leggTilNesteSteg(IVERKSETT_MOT_OPPDRAG)
         lagreBehandling(behandling)
@@ -208,7 +226,10 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         mockkObject(SikkerhetContext)
         every { SikkerhetContext.erSystemKontekst() } returns false
 
+        // Act & Assert
         val exception = assertThrows<RuntimeException> { stegService.utførSteg(behandling.id, IVERKSETT_MOT_OPPDRAG) }
+
+        // Assert
         assertEquals(
             "Steget ${IVERKSETT_MOT_OPPDRAG.name} kan ikke behandles for behandling ${behandling.id}",
             exception.message,
@@ -217,6 +238,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal ikke utføre REGISTRERE_SØKNAD for behandling med årsak SATSENDRING`() {
+        // Arrange
         lagreBehandling(
             behandling.also {
                 it.aktiv = false
@@ -236,7 +258,10 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         lagreBehandling(revurderingBehandling)
 
         val exception =
+
+            // Act & Assert
             assertThrows<RuntimeException> {
+                // Assert
                 stegService.utførSteg(
                     revurderingBehandling.id,
                     REGISTRERE_SØKNAD,
@@ -252,11 +277,15 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal ikke utføre SATSENDRING steg før REGISTRERE_PERSONGRUNNLAG er utført`() {
+        // Arrange
         behandling.leggTilNesteSteg(REGISTRERE_SØKNAD)
         lagreBehandling(behandling)
 
         val exception =
+
+            // Act & Assert
             assertThrows<RuntimeException> {
+                // Assert
                 stegService.utførSteg(
                     behandling.id,
                     REGISTRERE_SØKNAD,
@@ -273,6 +302,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal videresende behandling fra BESLUTTE_VEDTAK til IVERKSETT_MOT_OPPDRAG steg når SB godkjenner`() {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, VEDTAK, UTFØRT))
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, BESLUTTE_VEDTAK, KLAR))
@@ -280,6 +310,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         behandling.status = BehandlingStatus.FATTER_VEDTAK
         lagreBehandling(behandling)
         val vedtak = Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now())
+
+        // Act
         vedtakRepository.saveAndFlush(vedtak)
 
         søknadGrunnlagService.lagreOgDeaktiverGammel(
@@ -317,6 +349,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         val beslutteVedtakDto = BesluttVedtakDto(beslutning = Beslutning.GODKJENT, begrunnelse = "Godkjent")
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling = behandling)
 
+        // Assert
         assertDoesNotThrow { stegService.utførSteg(behandling.id, BESLUTTE_VEDTAK, beslutteVedtakDto) }
 
         val oppdatertBehandling = behandlingRepository.hentBehandling(behandling.id)
@@ -331,6 +364,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @ParameterizedTest
     @EnumSource(value = BehandlingSteg::class, names = ["BESLUTTE_VEDTAK", "IVERKSETT_MOT_OPPDRAG", "JOURNALFØR_VEDTAKSBREV", "AVSLUTT_BEHANDLING"])
     fun `utførSteg skal kaste feil dersom vi forsøker å utføre et allerede utført steg fra og med BESLUTTE_VEDTAK-steget`(behandlingSteg: BehandlingSteg) {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, behandlingSteg, UTFØRT))
 
@@ -342,7 +376,10 @@ class StegServiceTest : OppslagSpringRunnerTest() {
             every { SikkerhetContext.erSystemKontekst() } returns true
         }
 
+        // Act & Assert
         val alleredeUtførtStegFeil = assertThrows<Feil> { stegService.utførSteg(behandling.id, behandlingSteg, null) }
+
+        // Assert
         assertTrue(alleredeUtførtStegFeil.message!!.contains("allerede utført"))
         unmockkObject(SikkerhetContext)
     }
@@ -350,6 +387,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @ParameterizedTest
     @EnumSource(BehandlingSteg::class)
     fun `utførSteg skal kaste feil dersom vi forsøker å utføre et steg i en avsluttet behandling`(behandlingSteg: BehandlingSteg) {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
 
         BehandlingSteg.entries.forEach {
@@ -366,13 +404,17 @@ class StegServiceTest : OppslagSpringRunnerTest() {
             every { SikkerhetContext.erSystemKontekst() } returns true
         }
 
+        // Act & Assert
         val behandlingAvsluttetFeil = assertThrows<Feil> { stegService.utførSteg(behandling.id, behandlingSteg, null) }
+
+        // Assert
         assertTrue(behandlingAvsluttetFeil.message!!.contains("avsluttet behandling"))
         unmockkObject(SikkerhetContext)
     }
 
     @Test
     fun `utførSteg skal tilbakeføre behandling fra BESLUTTE_VEDTAK til VEDTAK steg når SB underkjenner vedtaket`() {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, VEDTAK, UTFØRT))
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, BESLUTTE_VEDTAK, KLAR))
@@ -381,8 +423,11 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         lagreBehandling(behandling)
 
         val beslutteVedtakDto = BesluttVedtakDto(beslutning = Beslutning.UNDERKJENT, begrunnelse = "Underkjent")
+
+        // Act
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling = behandling)
 
+        // Assert
         assertDoesNotThrow { stegService.utførSteg(behandling.id, BESLUTTE_VEDTAK, beslutteVedtakDto) }
 
         val oppdatertBehandling = behandlingRepository.hentBehandling(behandling.id)
@@ -394,6 +439,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
     @Test
     @Transactional
     fun `utførStegEtterIverksettelseAutomatisk skal utføre AVSLUTT_BEHANDLING steg automatisk`() {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, UTFØRT))
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, AVSLUTT_BEHANDLING, KLAR))
@@ -406,9 +452,12 @@ class StegServiceTest : OppslagSpringRunnerTest() {
                 kalkulertUtbetalingsbeløp = 1000,
                 behandling = behandling,
             )
+
+        // Act
         andelTilkjentYtelseRepository.saveAndFlush(andelTilkjentYtelse)
         val lagretBehandling = lagreBehandling(behandling)
 
+        // Assert
         assertDoesNotThrow { stegService.utførStegEtterIverksettelseAutomatisk(lagretBehandling.id) }
         assertNotNull(
             taskService.lagredeTasker.find {
@@ -423,13 +472,17 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførStegEtterIverksettelseAutomatisk skal opprette task for å utføre JOURNALFØR_VEDTAKSBREV steg automatisk`() {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT))
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
         lagreBehandling(behandling)
+
+        // Act
         vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now()))
 
+        // Assert
         assertDoesNotThrow { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) }
 
         assertNotNull(
@@ -441,11 +494,14 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførStegEtterIverksettelseAutomatisk skal opprette tilbakekreving task for revurdering`() {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT))
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
         lagreBehandling(behandling)
+
+        // Act
         vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now()))
         tilbakekrevingRepository.save(
             Tilbakekreving(
@@ -456,6 +512,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
             ),
         )
 
+        // Assert
         assertDoesNotThrow { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) }
         assertNotNull(
             taskService.lagredeTasker.find {
@@ -471,11 +528,14 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførStegEtterIverksettelseAutomatisk skal ikke opprette tilbakekreving task for revurdering med valg IGNORER_TILBAKEKREVING`() {
+        // Arrange
         behandling.behandlingStegTilstand.clear()
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, IVERKSETT_MOT_OPPDRAG, UTFØRT))
         behandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(behandling, JOURNALFØR_VEDTAKSBREV, KLAR))
         behandling.status = BehandlingStatus.IVERKSETTER_VEDTAK
         lagreBehandling(behandling)
+
+        // Act
         vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, vedtaksdato = LocalDateTime.now()))
         tilbakekrevingRepository.save(
             Tilbakekreving(
@@ -486,6 +546,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
             ),
         )
 
+        // Assert
         assertDoesNotThrow { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) }
         assertNotNull(
             taskService.lagredeTasker.find {
@@ -496,6 +557,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre TEKNISK_ENDRING behandling som ikke iverksetter og ikke sender brev til bruker`() {
+        // Arrange
         val aktør = lagreAktør(aktør = randomAktør())
         val fagsak = lagreFagsak(lagFagsak(aktør = aktør, status = FagsakStatus.LØPENDE))
         val tekniskEndringBehandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING, type = BehandlingType.TEKNISK_ENDRING))
@@ -507,11 +569,14 @@ class StegServiceTest : OppslagSpringRunnerTest() {
         tekniskEndringBehandling.behandlingStegTilstand.clear()
         tekniskEndringBehandling.behandlingStegTilstand.add(lagBehandlingStegTilstand(tekniskEndringBehandling, BESLUTTE_VEDTAK, KLAR))
         lagreBehandling(tekniskEndringBehandling)
+
+        // Act
         vedtakRepository.saveAndFlush(Vedtak(behandling = tekniskEndringBehandling, vedtaksdato = LocalDateTime.now()))
 
         val beslutteVedtakDto = BesluttVedtakDto(beslutning = Beslutning.GODKJENT, begrunnelse = "Godkjent")
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling = tekniskEndringBehandling)
 
+        // Assert
         assertDoesNotThrow { stegService.utførSteg(tekniskEndringBehandling.id, BESLUTTE_VEDTAK, beslutteVedtakDto) }
 
         val oppdatertBehandling = behandlingRepository.hentBehandling(tekniskEndringBehandling.id)
@@ -521,6 +586,7 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `utførSteg skal utføre TEKNISK_ENDRING behandling som iverksetter`() {
+        // Arrange
         val aktør = lagreAktør(aktør = randomAktør())
         val fagsak = lagreFagsak(lagFagsak(aktør = aktør, status = FagsakStatus.LØPENDE))
         val tekniskEndringBehandling = lagreBehandling(lagBehandling(fagsak = fagsak, opprettetÅrsak = BehandlingÅrsak.TEKNISK_ENDRING, type = BehandlingType.TEKNISK_ENDRING))
@@ -533,6 +599,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
                 kalkulertUtbetalingsbeløp = 1000,
                 behandling = tekniskEndringBehandling,
             )
+
+        // Act
         andelTilkjentYtelseRepository.saveAndFlush(andelTilkjentYtelse)
 
         tekniskEndringBehandling.resultat = Behandlingsresultat.ENDRET_UTBETALING
@@ -544,6 +612,8 @@ class StegServiceTest : OppslagSpringRunnerTest() {
 
         val beslutteVedtakDto = BesluttVedtakDto(beslutning = Beslutning.GODKJENT, begrunnelse = "Godkjent")
         totrinnskontrollService.opprettTotrinnskontrollMedSaksbehandler(behandling = tekniskEndringBehandling)
+
+        // Assert
         assertDoesNotThrow { stegService.utførSteg(tekniskEndringBehandling.id, BESLUTTE_VEDTAK, beslutteVedtakDto) }
 
         val oppdatertBehandling = behandlingRepository.hentBehandling(tekniskEndringBehandling.id)

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/domene/SøknadGrunnlagRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/registrersøknad/domene/SøknadGrunnlagRepositoryTest.kt
@@ -28,11 +28,14 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentAktiv - skal hente aktiv SøknadGrunnlag tilknyttet behandlingId`() {
+        // Arrange
         val barn = lagreAktør(randomAktør())
         val søknadDto = lagreSøknadGrunnlag(behandling.id, listOf(barn), true)
 
+        // Act
         val søknadGrunnlag = søknadGrunnlagRepository.finnAktiv(behandling.id)
 
+        // Assert
         assertNotNull(søknadGrunnlag)
         assertThat(søknadGrunnlag!!.behandlingId, Is(behandling.id))
         assertThat(søknadGrunnlag.søknad, Is(søknadDto.tilSøknadGrunnlag(behandling.id).søknad))
@@ -40,18 +43,24 @@ class SøknadGrunnlagRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentAktiv - skal returnere null dersom det ikke finnes et SøknadsGrunnlag tilknyttet behandlingId`() {
+        // Act
         val søknadGrunnlag = søknadGrunnlagRepository.finnAktiv(404L)
 
+        // Assert
         assertNull(søknadGrunnlag)
     }
 
     @Test
     fun `hentAlle - skal returnere alle SøknadsGrunnlag tilknyttet behandlingId`() {
+        // Arrange
         lagreSøknadGrunnlag(behandling.id, listOf(randomAktør()))
         lagreSøknadGrunnlag(behandling.id, listOf(randomAktør()))
         lagreSøknadGrunnlag(behandling.id, listOf(randomAktør()), true)
 
+        // Act
         val søknadsGrunnlag = søknadGrunnlagRepository.hentAlle(behandling.id)
+
+        // Assert
         assertEquals(3, søknadsGrunnlag.size)
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/domene/VedtakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vedtak/domene/VedtakRepositoryTest.kt
@@ -23,27 +23,38 @@ internal class VedtakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentVedtak - skal kaste EmptyResultDataAccessException hvis det ikke finnes noen vedtak med id`() {
+        // Arrange
         val feil =
+
+            // Act & Assert
             assertThrows<EmptyResultDataAccessException> { vedtakRepository.hentVedtak(404) }
 
+        // Assert
         assertThat(feil.message, Is("Result must not be null"))
     }
 
     @Test
     fun `hentVedtak - skal returnere vedtak hvis vedtak med id finnes`() {
+        // Arrange
         val vedtak = vedtakRepository.saveAndFlush(Vedtak(behandling = behandling, aktiv = false))
 
         val hentetVedtak = vedtakRepository.hentVedtak(vedtak.id)
 
+        // Assert
         assertThat(vedtak.id, Is(hentetVedtak.id))
     }
 
     @Test
     fun `findByBehandlingAndAktiv - skal kaste EmptyResultDataAccessException hvis det ikke finnes aktiv vedtak for behandling`() {
+        // Arrange
         val vedtak = Vedtak(behandling = behandling, aktiv = false)
+
+        // Act
         vedtakRepository.saveAndFlush(vedtak)
 
         val feil =
+
+            // Assert
             assertThrows<EmptyResultDataAccessException> { vedtakRepository.findByBehandlingAndAktiv(behandling.id) }
 
         assertThat(feil.message, Is("Result must not be null"))
@@ -51,50 +62,67 @@ internal class VedtakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `findByBehandlingAndAktiv - skal returnere vedtak hvis det finnes aktiv vedtak for behandling`() {
+        // Arrange
         val vedtak = Vedtak(behandling = behandling, aktiv = true)
+
+        // Act
         vedtakRepository.saveAndFlush(vedtak)
 
         val hentetVedtak = vedtakRepository.findByBehandlingAndAktiv(behandling.id)
 
+        // Assert
         assertThat(hentetVedtak.behandling, Is(behandling))
     }
 
     @Test
     fun `findByBehandlingAndAktivOptional - skal returnere null hvis det ikke finnes aktiv vedtak for behandling`() {
+        // Arrange
         val vedtak = Vedtak(behandling = behandling, aktiv = false)
+
+        // Act
         vedtakRepository.saveAndFlush(vedtak)
 
         val hentetVedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandling.id)
 
+        // Assert
         assertThat(hentetVedtak, Is(nullValue()))
     }
 
     @Test
     fun `findByBehandlingAndAktivOptional - skal returnere vedtak hvis det finnes aktiv vedtak for behandling`() {
+        // Arrange
         val vedtak = Vedtak(behandling = behandling, aktiv = true)
+
+        // Act
         vedtakRepository.saveAndFlush(vedtak)
 
         val hentetVedtak = vedtakRepository.findByBehandlingAndAktivOptional(behandling.id)!!
 
+        // Assert
         assertThat(hentetVedtak.behandling, Is(behandling))
     }
 
     @Test
     fun `finnVedtakForBehandling - skal returnere tom liste hvis det ikke finnes noen vedtak for behandling`() {
+        // Arrange
         val hentetVedtaker = vedtakRepository.finnVedtakForBehandling(behandling.id)
 
+        // Assert
         assertThat(hentetVedtaker.size, Is(0))
     }
 
     @Test
     fun `finnVedtakForBehandling - skal returnere liste med alle vedtak hvis det finnes for behandling`() {
+        // Arrange
         val vedtak1 = Vedtak(behandling = behandling, aktiv = false)
         val vedtak2 = Vedtak(behandling = behandling, aktiv = true)
 
+        // Act
         vedtakRepository.saveAllAndFlush(listOf(vedtak1, vedtak2))
 
         val hentetVedtaker = vedtakRepository.finnVedtakForBehandling(behandling.id)
 
+        // Assert
         assertThat(hentetVedtaker.size, Is(2))
         assertThat(hentetVedtaker.map { it.aktiv }, containsInAnyOrder(false, true))
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårsvurderingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/vilkårsvurdering/domene/VilkårsvurderingRepositoryTest.kt
@@ -21,17 +21,22 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `finnAktivForBehandling - skal returnere aktiv vilkårsvurdering for behandling`() {
+        // Arrange
         opprettVilkårsvurdering(aktør = søker, behandling = behandling, resultat = Resultat.IKKE_VURDERT)
 
+        // Act
         val hentetVilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(behandling.id).shouldNotBeNull()
 
+        // Assert
         assertEquals(behandling.id, hentetVilkårsvurdering.behandling.id)
     }
 
     @Test
     fun `finnAktivForBehandling - skal returnere null dersom vilkårsvurdering for behandling ikke finnes`() {
+        // Act
         val hentetVilkårsvurdering = vilkårsvurderingRepository.finnAktivForBehandling(404L)
 
+        // Assert
         assertNull(hentetVilkårsvurdering)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs.valutakurs/ValutakursRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs.valutakurs/ValutakursRepositoryTest.kt
@@ -23,6 +23,7 @@ class ValutakursRepositoryTest(
 ) : OppslagSpringRunnerTest() {
     @Test
     fun `Skal lagre flere valutakurser med gjenbruk av flere aktører`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
         val barn2 = aktørIdRepository.save(randomAktør())
@@ -30,6 +31,7 @@ class ValutakursRepositoryTest(
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))
 
+        // Act
         val valutakurs =
             valutakursRepository.save(
                 lagValutakurs(
@@ -44,11 +46,13 @@ class ValutakursRepositoryTest(
                 ).also { it.behandlingId = behandling.id },
             )
 
+        // Assert
         assertEquals(valutakurs.barnAktører, valutakurs2.barnAktører)
     }
 
     @Test
     fun `Skal lagre skjema-feltene`() {
+        // Arrange
         val søker = aktørIdRepository.save(randomAktør())
         val barn1 = aktørIdRepository.save(randomAktør())
 
@@ -68,9 +72,11 @@ class ValutakursRepositoryTest(
                 ),
             )
 
+        // Act
         val hentedeValutakurser =
             valutakursRepository.findByBehandlingId(behandlingId = behandling.id)
 
+        // Assert
         assertEquals(1, hentedeValutakurser.size)
         assertEquals(valutakurs, hentedeValutakurser.first())
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs.valutakurs/ValutakursUtfyltTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs.valutakurs/ValutakursUtfyltTest.kt
@@ -11,44 +11,56 @@ import java.time.LocalDate
 class ValutakursUtfyltTest {
     @Test
     fun `Skal sette UtfyltStatus til OK når alle felter er utfylt`() {
+        // Arrange
         val valutakurs =
             lagValutakurs(
                 valutakursdato = LocalDate.now(),
                 kurs = BigDecimal.valueOf(10),
             )
 
+        // Act
         val restValutakurs = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.OK, restValutakurs.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til UFULLSTENDIG når ett felt er utfylt`() {
+        // Arrange
         var valutakurs =
             lagValutakurs(
                 valutakursdato = LocalDate.now(),
             )
 
+        // Act
         var restValutakurs = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.UFULLSTENDIG, restValutakurs.status)
 
+        // Arrange
         valutakurs =
             lagValutakurs(
                 kurs = BigDecimal.valueOf(10),
             )
 
+        // Act
         restValutakurs = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.UFULLSTENDIG, restValutakurs.status)
     }
 
     @Test
     fun `Skal sette UtfyltStatus til IKKE_UTFYLT når ingen felter er utfylt`() {
+        // Arrange
         val valutakurs = lagValutakurs()
 
+        // Act
         val restValutakurs = valutakurs.tilValutakursDto()
 
+        // Assert
         Assertions.assertEquals(UtfyltStatus.IKKE_UTFYLT, restValutakurs.status)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpControllerTest.kt
@@ -40,6 +40,7 @@ class UtenlandskPeriodebeløpControllerTest {
 
     @Test
     fun `Skal kaste feil dersom validering av input feiler`() {
+        // Act & Assert
         val exception =
             assertThrows<ConstraintViolationException> {
                 utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(
@@ -48,6 +49,7 @@ class UtenlandskPeriodebeløpControllerTest {
                 )
             }
 
+        // Assert
         val forventedeFelterMedFeil = listOf("beløp")
         val faktiskeFelterMedFeil =
             exception.constraintViolations.map { constraintViolation ->
@@ -62,15 +64,18 @@ class UtenlandskPeriodebeløpControllerTest {
 
     @Test
     fun `Skal ikke kaste feil dersom validering av input går bra`() {
+        // Arrange
         every { utenlandskPeriodebeløpRepository.getReferenceById(any()) } returns UtenlandskPeriodebeløp.NULL
         every { utenlandskPeriodebeløpService.oppdaterUtenlandskPeriodebeløp(any(), any()) } just runs
 
+        // Act
         val response =
             utenlandskPeriodebeløpController.oppdaterUtenlandskPeriodebeløp(
                 1,
                 UtenlandskPeriodebeløpDto(1, null, null, emptyList(), beløp = 1.0.toBigDecimal(), null, null, null),
             )
 
+        // Assert
         assertEquals(HttpStatus.OK, response.statusCode)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/utenlandskperiodebeløp/UtenlandskPeriodebeløpRepositoryTest.kt
@@ -23,6 +23,7 @@ class UtenlandskPeriodebeløpRepositoryTest(
 ) : OppslagSpringRunnerTest() {
     @Test
     fun `Skal lagre flere utenlandske periodebeløp med gjenbruk av flere aktører`() {
+        // Arrange
         val søker = aktørRepository.save(randomAktør())
         val barn1 = aktørRepository.save(randomAktør())
         val barn2 = aktørRepository.save(randomAktør())
@@ -30,6 +31,7 @@ class UtenlandskPeriodebeløpRepositoryTest(
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))
 
+        // Act
         val utenlandskPeriodebeløp =
             utenlandskPeriodebeløpRepository.save(
                 lagUtenlandskPeriodebeløp(
@@ -44,17 +46,20 @@ class UtenlandskPeriodebeløpRepositoryTest(
                 ).also { it.behandlingId = behandling.id },
             )
 
+        // Assert
         assertEquals(utenlandskPeriodebeløp.barnAktører, utenlandskPeriodebeløp2.barnAktører)
     }
 
     @Test
     fun `Skal lagre skjema-feltene`() {
+        // Arrange
         val søker = aktørRepository.save(randomAktør())
         val barn1 = aktørRepository.save(randomAktør())
 
         val fagsak = fagsakRepository.save(Fagsak(aktør = søker))
         val behandling = behandlingRepository.save(lagBehandling(fagsak))
 
+        // Act
         val utenlandskPeriodebeløp =
             utenlandskPeriodebeløpRepository.save(
                 lagUtenlandskPeriodebeløp(
@@ -68,6 +73,7 @@ class UtenlandskPeriodebeløpRepositoryTest(
                 ),
             )
 
+        // Assert
         val hentedeUtenlandskePeriodebeløp =
             utenlandskPeriodebeløpRepository.findByBehandlingId(behandlingId = behandling.id)
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceIntegrasjonTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/FagsakServiceIntegrasjonTest.kt
@@ -47,6 +47,7 @@ class FagsakServiceIntegrasjonTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `ikke oppdater status på fagsaker som er løpende og har løpende utbetalinger`() {
+        // Arrange
         val søker = randomAktør(randomFnr())
 
         opprettSøkerFagsakOgBehandling(søker, fagsakStatus = FagsakStatus.LØPENDE)
@@ -64,7 +65,10 @@ class FagsakServiceIntegrasjonTest : OppslagSpringRunnerTest() {
 
         Assertions.assertTrue(løpendeFagsaker.any { it.id == søkersFagsak.id })
 
+        // Act
         fagsakService.finnOgAvsluttFagsakerSomSkalAvsluttes()
+
+        // Assert
         val løpendeFagsaker2 = fagsakRepository.finnLøpendeFagsaker()
 
         Assertions.assertTrue(løpendeFagsaker2.any { it.id == søkersFagsak.id })
@@ -72,6 +76,7 @@ class FagsakServiceIntegrasjonTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `skal sette status til avsluttet hvis ingen løpende utbetalinger`() {
+        // Arrange
         val søker = randomAktør(randomFnr())
 
         opprettSøkerFagsakOgBehandling(søker, fagsakStatus = FagsakStatus.LØPENDE)
@@ -89,7 +94,10 @@ class FagsakServiceIntegrasjonTest : OppslagSpringRunnerTest() {
         tilkjentYtelse.stønadTom = LocalDate.now().minusMonths(1).toYearMonth()
         tilkjentYtelseRepository.saveAndFlush(tilkjentYtelse)
 
+        // Act
         fagsakService.finnOgAvsluttFagsakerSomSkalAvsluttes()
+
+        // Assert
         val løpendeFagsaker = fagsakRepository.finnLøpendeFagsaker()
 
         Assertions.assertFalse(løpendeFagsaker.any { it.id == søkersFagsak.id })
@@ -97,18 +105,22 @@ class FagsakServiceIntegrasjonTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `Skal kun hente løpende fagsak for søker`() {
+        // Arrange
         val søker = randomAktør(randomFnr())
 
         opprettSøkerFagsakOgBehandling(søker, fagsakStatus = FagsakStatus.LØPENDE)
         opprettPersonopplysningGrunnlagOgPersonForBehandling(behandling.id)
 
+        // Act
         val fagsakerMedSøkerSomDeltaker = fagsakService.finnAlleFagsakerHvorAktørErSøkerEllerMottarLøpendeKontantstøtte(søker)
 
+        // Assert
         assertEquals(1, fagsakerMedSøkerSomDeltaker.size)
     }
 
     @Test
     fun `Skal hente fagsak hvor barn har løpende andel`() {
+        // Arrange
         val søker = randomAktør(randomFnr())
 
         opprettSøkerFagsakOgBehandling(søker, fagsakStatus = FagsakStatus.LØPENDE)
@@ -122,8 +134,10 @@ class FagsakServiceIntegrasjonTest : OppslagSpringRunnerTest() {
 
         lagreBehandling(behandling.apply { status = BehandlingStatus.AVSLUTTET })
 
+        // Act
         val fagsakDerBarnharLøpendeAndel = fagsakService.finnAlleFagsakerHvorAktørErSøkerEllerMottarLøpendeKontantstøtte(barn)
 
+        // Assert
         assertEquals(1, fagsakDerBarnharLøpendeAndel.size)
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/fagsak/domene/FagsakRepositoryTest.kt
@@ -20,31 +20,47 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `finnFagsak skal returnere fagsak dersom det eksisterer en fagsak med id`() {
+        // Arrange (data er opprettet av @BeforeEach)
+
+        // Act
         val hentetFagsak = fagsakRepository.finnFagsak(fagsak.id)!!
 
+        // Assert
         assertThat(hentetFagsak.id, Is(fagsak.id))
         assertThat(hentetFagsak.aktør, Is(fagsak.aktør))
     }
 
     @Test
     fun `finnFagsak skal returnere null dersom det ikke eksisterer en fagsak med id`() {
+        // Arrange
+
+        // Act
         val ikkeEksisterendeFagsak = fagsakRepository.finnFagsak(404)
 
+        // Assert
         assertThat(ikkeEksisterendeFagsak, Is(nullValue()))
     }
 
     @Test
     fun `finnFagsakForAktør skal returnere null dersom det ikke finnes fagsak for aktør`() {
+        // Arrange
         val randomAktør = randomAktør()
+
+        // Act
         val ikkeEksisterendeFagsak = fagsakRepository.finnFagsakForAktør(randomAktør)
 
+        // Assert
         assertThat(ikkeEksisterendeFagsak, Is(nullValue()))
     }
 
     @Test
     fun `finnFagsakForAktør skal returnere fagsak dersom det finnes fagsak for aktør`() {
+        // Arrange (data er opprettet av @BeforeEach)
+
+        // Act
         val hentetFagsak = fagsakRepository.finnFagsakForAktør(søker)!!
 
+        // Assert
         assertThat(hentetFagsak.id, Is(fagsak.id))
         assertThat(hentetFagsak.aktør, Is(fagsak.aktør))
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/korrigertetterbetaling/KorrigertEtterbetalingRepositoryTest.kt
@@ -22,6 +22,7 @@ class KorrigertEtterbetalingRepositoryTest(
 
     @Test
     fun `finnAktivtKorrigeringPåBehandling skal returnere null dersom det ikke eksisterer en aktiv etterbetaling korrigering på behandling`() {
+        // Arrange
         val inaktivKorrigertEtterbetaling =
             KorrigertEtterbetaling(
                 årsak = KorrigertEtterbetalingÅrsak.REFUSJON_FRA_ANDRE_MYNDIGHETER,
@@ -33,14 +34,17 @@ class KorrigertEtterbetalingRepositoryTest(
 
         korrigertEtterbetalingRepository.saveAndFlush(inaktivKorrigertEtterbetaling)
 
+        // Act
         val ikkeEksisterendeKorrigertEtterbetaling =
             korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id)
 
+        // Assert
         assertThat(ikkeEksisterendeKorrigertEtterbetaling, Is(nullValue()))
     }
 
     @Test
     fun `finnAktivtKorrigeringPåBehandling skal returnere aktiv korrigering på behandling dersom det finnes`() {
+        // Arrange
         val aktivKorrigertEtterbetaling =
             KorrigertEtterbetaling(
                 årsak = KorrigertEtterbetalingÅrsak.REFUSJON_FRA_ANDRE_MYNDIGHETER,
@@ -52,15 +56,18 @@ class KorrigertEtterbetalingRepositoryTest(
 
         korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling)
 
+        // Act
         val eksisterendeKorrigertEtterbetaling =
             korrigertEtterbetalingRepository.finnAktivtKorrigeringPåBehandling(behandling.id)!!
 
+        // Assert
         assertThat(eksisterendeKorrigertEtterbetaling.begrunnelse, Is("Test på aktiv korrigering"))
         assertThat(eksisterendeKorrigertEtterbetaling.beløp, Is(1000))
     }
 
     @Test
     fun `Det skal kastes DataIntegrityViolationException dersom det forsøkes å lagre aktivt korrigering når det allerede finnes en`() {
+        // Arrange
         val aktivKorrigertEtterbetaling =
             KorrigertEtterbetaling(
                 årsak = KorrigertEtterbetalingÅrsak.REFUSJON_FRA_ANDRE_MYNDIGHETER,
@@ -81,6 +88,7 @@ class KorrigertEtterbetalingRepositoryTest(
 
         korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling)
 
+        // Act & Assert
         assertThrows<DataIntegrityViolationException> {
             korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling2)
         }
@@ -88,6 +96,7 @@ class KorrigertEtterbetalingRepositoryTest(
 
     @Test
     fun `hentAlleKorrigeringPåBehandling skal returnere alle KorrigertEtterbetaling på behandling`() {
+        // Arrange
         val aktivKorrigertEtterbetaling =
             KorrigertEtterbetaling(
                 årsak = KorrigertEtterbetalingÅrsak.REFUSJON_FRA_ANDRE_MYNDIGHETER,
@@ -109,9 +118,11 @@ class KorrigertEtterbetalingRepositoryTest(
         korrigertEtterbetalingRepository.saveAndFlush(aktivKorrigertEtterbetaling)
         korrigertEtterbetalingRepository.saveAndFlush(inaktivKorrigertEtterbetaling)
 
+        // Act
         val eksisterendeKorrigertEtterbetaling =
             korrigertEtterbetalingRepository.finnAlleKorrigeringerPåBehandling(behandling.id)
 
+        // Assert
         assertThat(eksisterendeKorrigertEtterbetaling.size, Is(2))
         assertThat(eksisterendeKorrigertEtterbetaling.map { it.begrunnelse }, containsInAnyOrder("1", "2"))
     }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/korrigertvedtak/KorrigertVedtakRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/korrigertvedtak/KorrigertVedtakRepositoryTest.kt
@@ -22,6 +22,7 @@ class KorrigertVedtakRepositoryTest(
 
     @Test
     fun `finnAktivtKorrigertVedtakPåBehandling skal returnere null dersom det ikke eksisterer en aktiv korrigering av vedtak på behandling`() {
+        // Arrange
         val inaktivKorrigertVedtak =
             KorrigertVedtak(
                 vedtaksdato = LocalDate.now().minusDays(6),
@@ -32,14 +33,17 @@ class KorrigertVedtakRepositoryTest(
 
         korrigertVedtakRepository.saveAndFlush(inaktivKorrigertVedtak)
 
+        // Act
         val ikkeEksisterendeKorrigertVedtak =
             korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id)
 
+        // Assert
         Assertions.assertNull(ikkeEksisterendeKorrigertVedtak, "Skal ikke finnes aktiv korrigert vedtak på behandling")
     }
 
     @Test
     fun `finnAktivtKorrigertVedtakPåBehandling skal returnere aktiv korrigert vedtak når det eksisterer en aktiv korrigering av vedtak på behandling`() {
+        // Arrange
         val aktivKorrigertVedtak =
             KorrigertVedtak(
                 vedtaksdato = LocalDate.now().minusDays(6),
@@ -50,9 +54,11 @@ class KorrigertVedtakRepositoryTest(
 
         korrigertVedtakRepository.saveAndFlush(aktivKorrigertVedtak)
 
+        // Act
         val eksisterendeKorrigertVedtak =
             korrigertVedtakRepository.finnAktivtKorrigertVedtakPåBehandling(behandling.id)
 
+        // Assert
         Assertions.assertNotNull(
             eksisterendeKorrigertVedtak,
             "Skal finnes aktiv korrigert vedtak på behandling",
@@ -61,6 +67,7 @@ class KorrigertVedtakRepositoryTest(
 
     @Test
     fun `Det skal kastes DataIntegrityViolationException dersom det forsøkes å lagre aktivt korrigert vedtak når det allerede finnes en`() {
+        // Arrange
         val aktivKorrigertVedtak1 =
             KorrigertVedtak(
                 begrunnelse = "Test på aktiv korrigering",
@@ -79,6 +86,7 @@ class KorrigertVedtakRepositoryTest(
 
         korrigertVedtakRepository.saveAndFlush(aktivKorrigertVedtak1)
 
+        // Act & Assert
         assertThrows<DataIntegrityViolationException> {
             korrigertVedtakRepository.saveAndFlush(aktivKorrigertVedtak2)
         }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/domene/LoggRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/logg/domene/LoggRepositoryTest.kt
@@ -21,6 +21,7 @@ internal class LoggRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentLoggForBehandling - skal returnere logg som er lagret for behandling`() {
+        // Arrange
         val logg =
             Logg(
                 behandlingId = behandling.id,
@@ -31,8 +32,10 @@ internal class LoggRepositoryTest : OppslagSpringRunnerTest() {
 
         loggRepository.saveAndFlush(logg)
 
+        // Act
         val hentetLogg = loggRepository.hentLoggForBehandling(behandling.id)
 
+        // Assert
         assertThat(hentetLogg.size, Is(1))
         assertThat(hentetLogg.single().behandlingId, Is(behandling.id))
         assertThat(hentetLogg.single().type, Is(LoggType.BEHANDLING_OPPRETTET))

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/AktørRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/AktørRepositoryTest.kt
@@ -23,19 +23,25 @@ class AktørRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `findByAktørId - skal returnere Aktør dersom aktør med bestemt aktørId finnes i db`() {
+        // Arrange
         val aktør = opprettAktør()
 
+        // Act
         val hentetAktør = aktørRepository.findByAktørId(aktør.aktørId)
 
+        // Assert
         assertNotNull(hentetAktør)
     }
 
     @Test
     fun `findByAktørId - skal returnere null dersom aktør med bestemt aktørId ikke finnes i db`() {
+        // Arrange
         val aktørId = randomAktørId()
 
+        // Act
         val hentetAktør = aktørRepository.findByAktørId(aktørId)
 
+        // Assert
         assertNull(hentetAktør)
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/personident/domene/PersonidentRepositoryTest.kt
@@ -22,27 +22,37 @@ class PersonidentRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `hentAlleIdenterForAktørid - skal hente liste over alle personidenter tilknyttet aktørId`() {
+        // Arrange (data er opprettet av @BeforeEach)
+
+        // Act
         val hentedePersonidenter = personidentRepository.hentAlleIdenterForAktørid(søker.aktørId)
 
+        // Assert
         assertEquals(1, hentedePersonidenter.size)
     }
 
     @Test
     fun `findByFødselsnummerOrNull - skal hente personident med bestemt fødselsnummer dersom det finnes i db`() {
+        // Arrange
         val aktivFødselsnummer = søker.aktivFødselsnummer()
 
+        // Act
         val personident = personidentRepository.findByFødselsnummerOrNull(aktivFødselsnummer)
 
+        // Assert
         assertNotNull(personident)
         assertEquals(aktivFødselsnummer, personident!!.fødselsnummer)
     }
 
     @Test
     fun `findByFødselsnummerOrNull - skal returnere null dersom det ikke finnes en personident med bestemt fødselsnummer i db`() {
+        // Arrange
         val fødselsnummer = randomFnr()
 
+        // Act
         val personident = personidentRepository.findByFødselsnummerOrNull(fødselsnummer)
 
+        // Assert
         assertNull(personident)
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/TotrinnskontrollRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/totrinnskontroll/TotrinnskontrollRepositoryTest.kt
@@ -22,25 +22,31 @@ class TotrinnskontrollRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `findByBehandlingAndAktiv - skal returnere null dersom det ikke finnes noe aktiv totrinnskontroll for behandling`() {
+        // Arrange
         val totrinnskontroll =
             Totrinnskontroll(behandling = behandling, aktiv = false, saksbehandler = "test", saksbehandlerId = "testId")
 
         totrinnskontrollRepository.saveAndFlush(totrinnskontroll)
 
+        // Act
         val hentetTotrinnskontroll = totrinnskontrollRepository.findByBehandlingAndAktiv(behandling.id)
 
+        // Assert
         assertThat(hentetTotrinnskontroll, Is(nullValue()))
     }
 
     @Test
     fun `findByBehandlingAndAktiv - skal returnere totrinnskontroll dersom det finnes aktiv en for behandling`() {
+        // Arrange
         val totrinnskontroll =
             Totrinnskontroll(behandling = behandling, aktiv = true, saksbehandler = "test", saksbehandlerId = "testId")
 
         totrinnskontrollRepository.saveAndFlush(totrinnskontroll)
 
+        // Act
         val hentetTotrinnskontroll = totrinnskontrollRepository.findByBehandlingAndAktiv(behandling.id).shouldNotBeNull()
 
+        // Assert
         assertThat(hentetTotrinnskontroll.behandling, Is(behandling))
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtak/refusjonEøs/RefusjonEøsServiceTest.kt
@@ -23,6 +23,7 @@ class RefusjonEøsServiceTest(
 
     @Test
     fun kanLagreEndreOgSlette() {
+        // Arrange
         val refusjonEøs =
             RefusjonEøsDto(
                 id = 0,
@@ -33,14 +34,17 @@ class RefusjonEøsServiceTest(
                 refusjonAvklart = true,
             )
 
+        // Act
         val id = refusjonEøsService.leggTilRefusjonEøsPeriode(refusjonEøs = refusjonEøs, behandlingId = behandling.id)
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it[0].id).isEqualTo(id) }
             .also { Assertions.assertThat(it[0].fom).isEqualTo("2020-01-01") }
             .also { Assertions.assertThat(it[0].tom).isEqualTo("2021-05-31") }
 
+        // Act
         refusjonEøsService.oppdaterRefusjonEøsPeriode(
             refusjonEøs =
                 RefusjonEøsDto(
@@ -54,6 +58,7 @@ class RefusjonEøsServiceTest(
             id = id,
         )
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it[0].id).isEqualTo(id) }
@@ -62,6 +67,7 @@ class RefusjonEøsServiceTest(
             .also { Assertions.assertThat(it[0].land).isEqualTo("NL") }
             .also { Assertions.assertThat(it[0].refusjonAvklart).isEqualTo(false) }
 
+        // Arrange
         val refusjonEøs2 =
             RefusjonEøsDto(
                 id = 0,
@@ -72,15 +78,19 @@ class RefusjonEøsServiceTest(
                 refusjonAvklart = false,
             )
 
+        // Act
         val id2 = refusjonEøsService.leggTilRefusjonEøsPeriode(refusjonEøs = refusjonEøs2, behandlingId = behandling.id)
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it.size).isEqualTo(2) }
             .also { Assertions.assertThat(it[0].id).isEqualTo(id2) }
 
+        // Act
         refusjonEøsService.fjernRefusjonEøsPeriode(id = id, behandlingId = behandling.id)
 
+        // Assert
         refusjonEøsService
             .hentRefusjonEøsPerioder(behandlingId = behandling.id)
             .also { Assertions.assertThat(it.size).isEqualTo(1) }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtaksperiode/domene/VedtaksperiodeRepositoryTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/kjerne/vedtaksperiode/domene/VedtaksperiodeRepositoryTest.kt
@@ -25,38 +25,49 @@ class VedtaksperiodeRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `finnVedtaksperiode skal returnere null dersom det ikke finnes noen vedtaksperiode med lik id`() {
+        // Act
         val vedtaksperiode = vedtaksperiodeRepository.finnVedtaksperiode(404)
 
+        // Assert
         assertThat(vedtaksperiode, Is(nullValue()))
     }
 
     @Test
     fun `finnVedtaksperiode skal returnere vedtaksperiode dersom det finnes vedtaksperiode med lik id`() {
+        // Arrange
         val lagretVedtaksperiode = opprettOgLagVedtaksperiode()
 
+        // Act
         val vedtaksperiode = vedtaksperiodeRepository.finnVedtaksperiode(lagretVedtaksperiode.id)!!
 
+        // Assert
         assertThat(lagretVedtaksperiode.id, Is(vedtaksperiode.id))
     }
 
     @Test
     @Transactional
     fun `slettVedtaksperioderFor skal slette vedtakperioder for en gitt vedtak`() {
+        // Arrange
         val vedtaksperiodeId = opprettOgLagVedtaksperiode().id
 
+        // Act
         vedtaksperiodeRepository.slettVedtaksperioderForVedtak(vedtak)
 
         val vedtaksperiode = vedtaksperiodeRepository.finnVedtaksperiode(vedtaksperiodeId)
 
+        // Assert
         assertThat(vedtaksperiode, Is(nullValue()))
     }
 
     @Test
     fun `finnVedtaksperioderForVedtak skal returnere vedtaksperioder for en gitt vedtak`() {
+        // Arrange
         opprettOgLagVedtaksperiode()
 
+        // Act
         val vedtaksperioderForVedtak = vedtaksperiodeRepository.finnVedtaksperioderForVedtak(vedtak.id)
 
+        // Assert
         assertThat(vedtaksperioderForVedtak.size, Is(1))
     }
 


### PR DESCRIPTION
### 📮 Favro: NAV-30008

### 💰 Hva skal gjøres, og hvorfor?

Legger til `// Arrange`, `// Act` og `// Assert`-kommentarer i testene våre, slik at hele
testsuiten følger samme konvensjon som vi allerede har innført i familie-ba-sak
(se navikt/familie-ba-sak#6398).

Før: 137 av 261 testfiler fulgte konvensjonen.
Etter: **247 av 261 (94,6 %)**.

**116 filer endret, 1712 innsettinger, 0 slettinger.**

Endringene er rene kommentar-innsettinger. Ingen testlogikk er endret, ingen linjer er
fjernet, og ingen tester er lagt til eller flyttet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

Diffen er stor, men mekanisk — den kan med fordel leses med `?w=1` eller bare stikkprøves.
Si ifra hvis det er filer hvor Act-steget er plassert feil.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.