### PR TITLE
NAV-30037 Lagre manueltRegistrert på barn i søknaden

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/BehandlingStegDto.kt
@@ -57,6 +57,7 @@ data class BarnMedOpplysningerDto(
     val navn: String = "",
     val fødselsdato: LocalDate? = null,
     val inkludertISøknaden: Boolean = true,
+    val manueltRegistrert: Boolean = false,
     val erFolkeregistrert: Boolean = true,
 ) : BehandlingStegDto() {
     val personnummer: String? = if (ident == "") null else ident

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/BarnMedOpplysningerDtoTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/dto/BarnMedOpplysningerDtoTest.kt
@@ -1,0 +1,52 @@
+package no.nav.familie.ks.sak.api.dto
+
+import no.nav.familie.ks.sak.api.mapper.SøknadGrunnlagMapper.tilSøknadDto
+import no.nav.familie.ks.sak.kjerne.behandling.steg.registrersøknad.domene.SøknadGrunnlag
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BarnMedOpplysningerDtoTest {
+    @Test
+    fun `skal beholde manueltRegistrert når søknaden lagres ned og hentes opp igjen`() {
+        // Arrange
+        val søknadDto =
+            SøknadDto(
+                søkerMedOpplysninger = SøkerMedOpplysningerDto(ident = "12345678910"),
+                barnaMedOpplysninger =
+                    listOf(
+                        BarnMedOpplysningerDto(ident = "01011012345", manueltRegistrert = true),
+                        BarnMedOpplysningerDto(ident = "02022012345"),
+                    ),
+                endringAvOpplysningerBegrunnelse = "",
+            )
+
+        // Act
+        val lagretSøknadDto = søknadDto.tilSøknadGrunnlag(behandlingId = 1L).tilSøknadDto()
+
+        // Assert
+        assertThat(lagretSøknadDto.barnaMedOpplysninger.single { it.ident == "01011012345" }.manueltRegistrert).isTrue()
+        assertThat(lagretSøknadDto.barnaMedOpplysninger.single { it.ident == "02022012345" }.manueltRegistrert).isFalse()
+    }
+
+    @Test
+    fun `skal defaulte manueltRegistrert til false for allerede lagrede søknader uten feltet`() {
+        // Arrange
+        val søknadUtenManueltRegistrert =
+            """
+            {
+              "søkerMedOpplysninger": { "ident": "12345678910", "målform": "NB" },
+              "barnaMedOpplysninger": [
+                { "ident": "01011012345", "navn": "Barn", "inkludertISøknaden": true, "erFolkeregistrert": true }
+              ],
+              "endringAvOpplysningerBegrunnelse": ""
+            }
+            """.trimIndent()
+        val søknadGrunnlag = SøknadGrunnlag(behandlingId = 1L, søknad = søknadUtenManueltRegistrert)
+
+        // Act
+        val søknadDto = søknadGrunnlag.tilSøknadDto()
+
+        // Assert
+        assertThat(søknadDto.barnaMedOpplysninger.single().manueltRegistrert).isFalse()
+    }
+}


### PR DESCRIPTION
### 📮 Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-30037

### 💰 Hva skal gjøres, og hvorfor?
Fikser bug hvor saksbehandler ikke kunne slette manuelt lagt til barn i `ks-sak-frontend` etter at søknaden var lagret ned.

Frontend sender `manueltRegistrert` når et barn legges til manuelt, men feltet fantes ikke i `BarnMedOpplysningerDto`. Siden søknaden lagres som JSON av `SøknadDto` (`tilSøknadGrunnlag()`), ble feltet forkastet ved serialisering. Når man gikk videre til vilkårsvurderingen og deretter tilbake til "registrer søknad", kom barnet tilbake uten `manueltRegistrert`, og slette-knappen forsvant.

Løsningen er å utvide `BarnMedOpplysningerDto` med `manueltRegistrert`, med default `false` slik at allerede lagrede søknader ikke påvirkes.

Ingen endringer i frontend er nødvendig – `manueltRegistrert` finnes allerede i `typer/søknad.ts`. Dette er ikke et problem i ba-sak, hvor feltet allerede ligger på DTO-en.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Plassering av feltet er lagt etter `inkludertISøknaden` for å speile `BarnMedOpplysninger` i `familie-ba-sak`.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_