### PR TITLE
Slett feature toggle familie-ks-sak.hent-arbeidsfordeling-med-beh

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -7,10 +7,7 @@ enum class FeatureToggle(
     TEKNISK_VEDLIKEHOLD_HENLEGGELSE("familie-ks-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring"),
     TEKNISK_ENDRING("familie-ks-sak.behandling.teknisk-endring"),
     KAN_OPPRETTE_OG_ENDRE_SAMMENSATTE_KONTROLLSAKER("familie-ks-sak.kan-opprette-og-endre-sammensatte-kontrollsaker"),
-
-    // Ikke operasjonelle
     SKAL_HÅNDTERE_FALSK_IDENTITET("familie-ks-sak.skal-handtere-falsk-identitet"),
-    HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE("familie-ks-sak.hent-arbeidsfordeling-med-behandlingstype"),
 
     // NAV-29382
     HENT_VEDTAKSBREV_FRA_JOARK("familie-ks-sak.hent-vedtaksbrev-fra-joark"),

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlient.kt
@@ -31,8 +31,6 @@ import no.nav.familie.kontrakter.felles.saksbehandler.SaksbehandlerGrupper
 import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.familie.ks.sak.api.dto.ManuellAdresseInfo
 import no.nav.familie.ks.sak.api.dto.OppdaterJournalpostRequestDto
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.domene.Arbeidsfordelingsenhet
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjeneste
 import no.nav.familie.ks.sak.integrasjon.kallEksternTjenesteRessurs
@@ -55,7 +53,6 @@ import java.net.URI
 class IntegrasjonKlient(
     @Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: URI,
     @Qualifier("integrasjonerRestClient") private val restClient: RestClient,
-    private val featureToggleService: FeatureToggleService,
 ) {
     val tilgangPersonUri =
         UriComponentsBuilder
@@ -317,13 +314,8 @@ class IntegrasjonKlient(
             UriComponentsBuilder
                 .fromUri(integrasjonUri)
                 .pathSegment("arbeidsfordeling", "enhet", Tema.KON.name)
-                .let {
-                    if (featureToggleService.isEnabled(FeatureToggle.HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE)) {
-                        it.queryParam("behandlingstype", behandlingstype)
-                    } else {
-                        it
-                    }
-                }.build()
+                .queryParam("behandlingstype", behandlingstype)
+                .build()
                 .encode()
                 .toUri()
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevService.kt
@@ -100,30 +100,21 @@ class BrevService(
         fagsakId: Long,
         manueltBrevDto: ManueltBrevDto,
     ): ManueltBrevDto {
+        val enheterSomNavIdentHarTilgangTil = integrasjonKlient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(SikkerhetContext.hentSaksbehandler()))
         val arbeidsfordelingsenhet =
-            if (featureToggleService.isEnabled(FeatureToggle.HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE)) {
-                val enheterSomNavIdentHarTilgangTil = integrasjonKlient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(NavIdent(SikkerhetContext.hentSaksbehandler()))
-                if (enheterSomNavIdentHarTilgangTil.size == 1) {
-                    Arbeidsfordelingsenhet(
-                        enhetId = enheterSomNavIdentHarTilgangTil.first().enhetsnummer,
-                        enhetNavn = enheterSomNavIdentHarTilgangTil.first().enhetsnavn,
-                    )
-                } else {
-                    val sisteVedtatteBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId)
-
-                    arbeidsfordelingService
-                        .hentArbeidsfordelingsenhetPåIdenter(
-                            søkerIdent = manueltBrevDto.mottakerIdent,
-                            barnIdenter = manueltBrevDto.barnIBrev,
-                            behandlingstype = sisteVedtatteBehandling?.kategori?.tilOppgavebehandlingType(),
-                        )
-                }
+            if (enheterSomNavIdentHarTilgangTil.size == 1) {
+                Arbeidsfordelingsenhet(
+                    enhetId = enheterSomNavIdentHarTilgangTil.first().enhetsnummer,
+                    enhetNavn = enheterSomNavIdentHarTilgangTil.first().enhetsnavn,
+                )
             } else {
+                val sisteVedtatteBehandling = behandlingService.hentSisteBehandlingSomErVedtatt(fagsakId)
+
                 arbeidsfordelingService
                     .hentArbeidsfordelingsenhetPåIdenter(
                         søkerIdent = manueltBrevDto.mottakerIdent,
                         barnIdenter = manueltBrevDto.barnIBrev,
-                        behandlingstype = null,
+                        behandlingstype = sisteVedtatteBehandling?.kategori?.tilOppgavebehandlingType(),
                     )
             }
         return manueltBrevDto.copy(

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonKlientTest.kt
@@ -8,7 +8,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import no.nav.familie.kontrakter.felles.BrukerIdType
@@ -26,8 +25,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.ks.sak.api.dto.JournalpostBrukerDto
 import no.nav.familie.ks.sak.api.dto.OppdaterJournalpostRequestDto
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle.HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.randomFnr
 import no.nav.familie.ks.sak.integrasjon.lagAvsenderMottaker
 import no.nav.familie.ks.sak.integrasjon.lagJournalpost
@@ -44,13 +41,12 @@ internal class IntegrasjonKlientTest {
     private val restClient: RestClient = RestClient.builder().build()
     private lateinit var integrasjonKlient: IntegrasjonKlient
     private lateinit var wiremockServerItem: WireMockServer
-    private val featureToggleService = mockk<FeatureToggleService>()
 
     @BeforeEach
     fun initClass() {
         wiremockServerItem = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
         wiremockServerItem.start()
-        integrasjonKlient = IntegrasjonKlient(URI.create(wiremockServerItem.baseUrl()), restClient, featureToggleService)
+        integrasjonKlient = IntegrasjonKlient(URI.create(wiremockServerItem.baseUrl()), restClient)
     }
 
     @AfterEach
@@ -78,28 +74,8 @@ internal class IntegrasjonKlientTest {
     }
 
     @Test
-    fun `hentBehandlendeEnhet skal hente enhet fra familie-integrasjon uten behandlingstype`() {
-        // Arrange
-        every { featureToggleService.isEnabled(HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE) } returns false
-        wiremockServerItem.stubFor(
-            WireMock
-                .post(urlEqualTo("/arbeidsfordeling/enhet/KON"))
-                .willReturn(okJson(readFile("hentBehandlendeEnhetEnkelResponse.json"))),
-        )
-
-        // Act
-        val behandlendeEnheter = integrasjonKlient.hentBehandlendeEnheter("testident")
-
-        // Assert
-        assertThat(behandlendeEnheter).hasSize(2)
-        assertThat(behandlendeEnheter.map { it.enhetId }).containsExactlyInAnyOrder("enhetId1", "enhetId2")
-        assertThat(behandlendeEnheter.map { it.enhetNavn }).containsExactlyInAnyOrder("enhetNavn1", "enhetNavn2")
-    }
-
-    @Test
     fun `hentBehandlendeEnhet skal hente enhet fra familie-integrasjon med behandlingstype`() {
         // Arrange
-        every { featureToggleService.isEnabled(HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE) } returns true
         wiremockServerItem.stubFor(
             WireMock
                 .post(urlEqualTo("/arbeidsfordeling/enhet/KON?behandlingstype=E%C3%98S"))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/brev/BrevServiceTest.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ks.sak.api.dto.FullmektigEllerVerge
 import no.nav.familie.ks.sak.api.dto.ManueltBrevDto
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
-import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle.HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle.HENT_VEDTAKSBREV_FRA_JOARK
 import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.lagArbeidsfordelingPåBehandling
@@ -351,40 +350,8 @@ class BrevServiceTest {
 
     @Nested
     inner class LeggTilEnhet {
-        @BeforeEach
-        fun setup() {
-            every { featureToggleService.isEnabled(HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE) } returns true
-        }
-
         @Test
-        fun `skal hente arbeidsfordeling uten behandlingstype når feature toggle er av`() {
-            // Arrange
-            val arbeidsfordelingsenhet =
-                Arbeidsfordelingsenhet(
-                    enhetId = OSLO.enhetsnummer,
-                    enhetNavn = OSLO.enhetsnavn,
-                )
-
-            every { featureToggleService.isEnabled(HENT_ARBEIDSFORDELING_MED_BEHANDLINGSTYPE) } returns false
-            every { arbeidsfordelingService.hentArbeidsfordelingsenhetPåIdenter(any(), any(), any()) } returns arbeidsfordelingsenhet
-
-            // Act
-            val oppdatertManueltBrevDto = brevService.leggTilEnhet(fagsak.id, manueltBrevDto)
-
-            // Assert
-            assertThat(oppdatertManueltBrevDto.enhet?.enhetId).isEqualTo(OSLO.enhetsnummer)
-            assertThat(oppdatertManueltBrevDto.enhet?.enhetNavn).isEqualTo(OSLO.enhetsnavn)
-            verify(exactly = 1) {
-                arbeidsfordelingService.hentArbeidsfordelingsenhetPåIdenter(
-                    søkerIdent = søker.aktivFødselsnummer(),
-                    barnIdenter = any(),
-                    behandlingstype = null,
-                )
-            }
-        }
-
-        @Test
-        fun `skal legge til saksbehandlers enhet når feature toggle er på og NavIdent har tilgang til kun én enhet`() {
+        fun `skal legge til saksbehandlers enhet når NavIdent har tilgang til kun én enhet`() {
             // Arrange
             every { integrasjonKlient.hentBehandlendeEnheterSomNavIdentHarTilgangTil(any()) } returns listOf(OSLO)
 
@@ -399,7 +366,7 @@ class BrevServiceTest {
         }
 
         @Test
-        fun `skal hente arbeidsfordeling med behandlingstype når feature toggle er på og NavIdent har tilgang til flere enheter`() {
+        fun `skal hente arbeidsfordeling med behandlingstype når NavIdent har tilgang til flere enheter`() {
             // Arrange
             val behandling = lagBehandling(fagsak, opprettetÅrsak = BehandlingÅrsak.SØKNAD)
             val arbeidsfordelingsenhet =
@@ -429,7 +396,7 @@ class BrevServiceTest {
         }
 
         @Test
-        fun `skal håndtere ingen siste vedtatte behandling når feature toggle er på og NavIdent har tilgang til flere enheter`() {
+        fun `skal håndtere ingen siste vedtatte behandling når NavIdent har tilgang til flere enheter`() {
             // Arrange
             val barn1Ident = "12345678910"
             val barn2Ident = "10987654321"

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/fake/FakeIntegrasjonKlient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/fake/FakeIntegrasjonKlient.kt
@@ -40,7 +40,7 @@ import java.net.URI
 import java.time.LocalDate
 import java.util.UUID
 
-class FakeIntegrasjonKlient : IntegrasjonKlient(URI("integrasjoner-url"), mockk(relaxed = true), mockk(relaxed = true)) {
+class FakeIntegrasjonKlient : IntegrasjonKlient(URI("integrasjoner-url"), mockk(relaxed = true)) {
     private val egenansatt = mutableSetOf<String>()
     private val behandlendeEnhetForIdent = mutableMapOf<String, List<Arbeidsfordelingsenhet>>()
     private val journalførteDokumenter = mutableListOf<ArkiverDokumentRequest>()


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?

Toggelen er skrudd på i prod. Fjerner if/else og beholder atferden
der behandlingstype alltid sendes med i arbeidsfordelingsoppslaget.


behandlingstype sendes nå alltid med i arbeidsfordelingsoppslaget. if/else-grenen som utelot behandlingstype er slettet.
Berørte filer:
- FeatureToggle.kt — enum-oppføring fjernet
- IntegrasjonKlient.kt — behandlingstype query param sendes alltid med; FeatureToggleService-avhengighet fjernet
- BrevService.kt — if/else-togglesjekk fjernet; ny logikk alltid aktiv
- Tester oppdatert tilsvarende — test for gammel adferd (uten behandlingstype) fjernet


Husk å arkiver:
https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-sak.hent-arbeidsfordeling-med-behandlingstype

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
