### PR TITLE
NAV-30081 Vis deployet branch og versjon i preprod

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -123,6 +123,10 @@ spec:
       value: preprod
     - name: JDK_JAVA_OPTIONS
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+    - name: APP_VERSION
+      value: "{{ VERSION }}"
+    - name: APP_BRANCH
+      value: "{{ BRANCH }}"
   kafka:
     pool: nav-dev
   observability:

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/PreprodController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/PreprodController.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.ks.sak.api
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.ks.sak.api.dto.VersjonsinfoDto
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Profile("!prod")
+@RestController
+@RequestMapping("/api/preprod")
+class PreprodController(
+    @Value("\${APP_BRANCH:ukjent}") private val branch: String,
+    @Value("\${APP_VERSION:ukjent}") private val versjon: String,
+) {
+    @GetMapping("/versjonsinfo")
+    fun hentVersjonsinfo(): ResponseEntity<Ressurs<VersjonsinfoDto>> = ResponseEntity.ok(Ressurs.success(VersjonsinfoDto(branch = branch, versjon = versjon)))
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VersjonsinfoDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/dto/VersjonsinfoDto.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.ks.sak.api.dto
+
+data class VersjonsinfoDto(
+    val branch: String,
+    val versjon: String,
+)

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/PreprodControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/api/PreprodControllerTest.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ks.sak.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PreprodControllerTest {
+    @Test
+    fun `skal returnere deployet branch og versjon`() {
+        // Arrange
+        val preprodController = PreprodController(branch = "NAV-30081_min_branch", versjon = "familie-ks-sak:abc123")
+
+        // Act
+        val respons = preprodController.hentVersjonsinfo()
+
+        // Assert
+        assertThat(respons.body?.data?.branch).isEqualTo("NAV-30081_min_branch")
+        assertThat(respons.body?.data?.versjon).isEqualTo("familie-ks-sak:abc123")
+    }
+}


### PR DESCRIPTION
### 📮 Favro: NAV-30081

### 💰 Hva skal gjøres, og hvorfor?
Viser hvilken branch som er deployet i preprod, slik at testere kan verifisere at riktig branch faktisk er deployet før de tester. Samme løsning som allerede er innført i `familie-ba-sak`.

- `.nais/app-dev.yaml`: eksponerer `APP_VERSION` og `APP_BRANCH` fra nais-variablene `{{ VERSION }}` og `{{ BRANCH }}`.
- `PreprodController`: ny kontroller med endepunktet `GET /api/preprod/versjonsinfo` som returnerer branch og versjon. Kontrolleren er annotert med `@Profile("!prod")`, så endepunktet finnes ikke i prod. Verdiene defaulter til `ukjent` lokalt.
- `VersjonsinfoDto`: nytt DTO med feltene `branch` og `versjon`.
- `PreprodControllerTest`: enhetstest av endepunktet.
- `{{ VERSION }}` og `{{ BRANCH }}` settes allerede av den delte deploy-actionen i `familie-baks-gha-workflows`, så det er ikke nødvendig med endringer i workflowene.