### PR TITLE
legg til toggle for å iverksette oppdrag fra familie-oppdrag-backend

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -17,4 +17,5 @@ enum class FeatureToggle(
 
     // NAV-30011
     OPPDRAG_MIGRERING_HENT_SIMULERING_GCP("familie-baks-sak.oppdrag-migrering-hent-simulering-gcp"),
+    OPPDRAG_MIGRERING_IVERKSETT_OPPDRAG_GCP("familie-ba-og-ks-sak.oppdrag-migrering-iverksett-oppdrag-gcp"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragBackendKlient.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragBackendKlient.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ks.sak.integrasjon.oppdrag
 
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient.Companion.RETRY_BACKOFF_5000MS
@@ -20,6 +22,22 @@ class OppdragBackendKlient(
     private val familieOppdragBackendUri: String,
     @Qualifier("oppdragBackendRestClient") private val restClient: RestClient,
 ) {
+    fun iverksettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag): String {
+        val uri = URI.create("$familieOppdragBackendUri/oppdrag")
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag-backend",
+            uri = uri,
+            formål = "Iverksetter mot oppdrag",
+        ) {
+            restClient
+                .post()
+                .uri(uri)
+                .body(utbetalingsoppdrag)
+                .retrieve()
+                .body()!!
+        }
+    }
+
     @Retryable(
         value = [Exception::class],
         maxAttempts = 3,
@@ -37,6 +55,22 @@ class OppdragBackendKlient(
                 .post()
                 .uri(uri)
                 .body(utbetalingsoppdrag)
+                .retrieve()
+                .body()!!
+        }
+    }
+
+    fun hentStatus(oppdragId: OppdragId): OppdragStatus {
+        val uri = URI.create("$familieOppdragBackendUri/status")
+        return kallEksternTjenesteRessurs(
+            tjeneste = "familie-oppdrag-backend",
+            uri = uri,
+            formål = "Henter oppdragstatus fra oppdrag",
+        ) {
+            restClient
+                .post()
+                .uri(uri)
+                .body(oppdragId)
                 .retrieve()
                 .body()!!
         }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsoppdragService.kt
@@ -8,6 +8,9 @@ import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.util.toYearMonth
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragBackendKlient
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -30,11 +33,13 @@ import java.time.LocalDate
 @Service
 class UtbetalingsoppdragService(
     private val oppdragKlient: OppdragKlient,
+    private val oppdragBackendKlient: OppdragBackendKlient,
     private val tilkjentYtelseValideringService: TilkjentYtelseValideringService,
     private val utbetalingsoppdragGenerator: UtbetalingsoppdragGenerator,
     private val behandlingService: BehandlingService,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+    private val featureToggleService: FeatureToggleService,
 ) {
     private val sammeOppdragSendtKonflikt = Metrics.counter("familie.ks.sak.samme.oppdrag.sendt.konflikt")
 
@@ -65,7 +70,11 @@ class UtbetalingsoppdragService(
             return
         }
         try {
-            oppdragKlient.iverksettOppdrag(utbetalingsoppdrag)
+            if (featureToggleService.isEnabled(FeatureToggle.OPPDRAG_MIGRERING_IVERKSETT_OPPDRAG_GCP)) {
+                oppdragBackendKlient.iverksettOppdrag(utbetalingsoppdrag)
+            } else {
+                oppdragKlient.iverksettOppdrag(utbetalingsoppdrag)
+            }
         } catch (exception: Exception) {
             if (exception is RestClientResponseException &&
                 exception.statusCode == HttpStatus.CONFLICT

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/HentStatusFraOppdragTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/HentStatusFraOppdragTask.kt
@@ -5,6 +5,9 @@ import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragBackendKlient
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.FAGSYSTEM
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -40,9 +43,11 @@ import java.util.Properties
 )
 class HentStatusFraOppdragTask(
     private val oppdragKlient: OppdragKlient,
+    private val oppdragBackendKlient: OppdragBackendKlient,
     private val taskService: TaskRepositoryWrapper,
     private val stegService: StegService,
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+    private val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val statusFraOppdragDto = jsonMapper.readValue(task.payload, HentStatusFraOppdragDto::class.java)
@@ -75,7 +80,11 @@ class HentStatusFraOppdragTask(
         behandlingId: BehandlingId,
     ): OppdragStatus =
         if (tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(behandlingId.id).skalIverksettesMotOppdrag()) {
-            oppdragKlient.hentStatus(oppdragId)
+            if (featureToggleService.isEnabled(FeatureToggle.OPPDRAG_MIGRERING_IVERKSETT_OPPDRAG_GCP)) {
+                oppdragBackendKlient.hentStatus(oppdragId)
+            } else {
+                oppdragKlient.hentStatus(oppdragId)
+            }
         } else {
             OppdragStatus.KVITTERT_OK
         }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/ØkonomiTestConfig.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/config/ØkonomiTestConfig.kt
@@ -61,6 +61,12 @@ class ØkonomiTestConfig {
         fun clearOppdragBackendMocks(oppdragBackendKlient: OppdragBackendKlient) {
             clearMocks(oppdragBackendKlient)
 
+            val iverksettRespons = "Mocksvar fra Økonomi-klient"
+            every { oppdragBackendKlient.iverksettOppdrag(any()) } returns iverksettRespons
+
+            val hentStatusRespons = OppdragStatus.KVITTERT_OK
+            every { oppdragBackendKlient.hentStatus(any()) } returns hentStatusRespons
+
             every { oppdragBackendKlient.hentSimulering(any()) } returns DetaljertSimuleringResultat(simuleringMottakerMock)
         }
     }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragBackendKlientTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/oppdrag/OppdragBackendKlientTest.kt
@@ -16,16 +16,16 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import org.hamcrest.CoreMatchers.`is` as Is
 
-internal class OppdragKlientTest {
+internal class OppdragBackendKlientTest {
     private val restClient: RestClient = RestClient.builder().build()
-    private lateinit var oppdragKlient: OppdragKlient
+    private lateinit var oppdragBackendKlient: OppdragBackendKlient
     private lateinit var wiremockServerItem: WireMockServer
 
     @BeforeEach
     fun beforeEach() {
         wiremockServerItem = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
         wiremockServerItem.start()
-        oppdragKlient = OppdragKlient(wiremockServerItem.baseUrl(), restClient)
+        oppdragBackendKlient = OppdragBackendKlient(wiremockServerItem.baseUrl(), restClient)
     }
 
     @Test
@@ -39,7 +39,7 @@ internal class OppdragKlientTest {
 
         // Act
         val simulering =
-            oppdragKlient.hentSimulering(
+            oppdragBackendKlient.hentSimulering(
                 Utbetalingsoppdrag(
                     kodeEndring = Utbetalingsoppdrag.KodeEndring.NY,
                     fagSystem = "KS",
@@ -79,7 +79,7 @@ internal class OppdragKlientTest {
         )
 
         // Act
-        val oppdragStatus = oppdragKlient.hentStatus(OppdragId("KS", "12345678910", "1"))
+        val oppdragStatus = oppdragBackendKlient.hentStatus(OppdragId("KS", "12345678910", "1"))
 
         // Assert
         assertThat(oppdragStatus, Is(OppdragStatus.KVITTERT_OK))

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/økonomi/utbetalingsoppdrag/UtbetalingsperiodeServiceTest.kt
@@ -8,11 +8,14 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.lagAndelTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagInitiellTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagVedtak
 import no.nav.familie.ks.sak.data.tilfeldigPerson
+import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragBackendKlient
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.behandling.domene.Behandling
@@ -24,33 +27,43 @@ import no.nav.familie.ks.sak.kjerne.beregning.domene.TilkjentYtelseRepository
 import no.nav.familie.ks.sak.kjerne.beregning.domene.YtelseType
 import no.nav.familie.ks.sak.kjerne.beregning.domene.filtrerAndelerSomSkalSendesTilOppdrag
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.YearMonth
 
 internal class UtbetalingsperiodeServiceTest {
     private val oppdragKlient = mockk<OppdragKlient>()
+    private val oppdragBackendKlient = mockk<OppdragBackendKlient>()
     private val tilkjentYtelseValideringService = mockk<TilkjentYtelseValideringService>()
     private val behandlingService = mockk<BehandlingService>()
     private val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
     private val andelTilkjentYtelseRepository = mockk<AndelTilkjentYtelseRepository>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val utbetalingsoppdragGenerator = UtbetalingsoppdragGenerator()
     private val utbetalingsoppdragService =
         UtbetalingsoppdragService(
             oppdragKlient = oppdragKlient,
+            oppdragBackendKlient = oppdragBackendKlient,
             tilkjentYtelseValideringService = tilkjentYtelseValideringService,
             utbetalingsoppdragGenerator = utbetalingsoppdragGenerator,
             behandlingService = behandlingService,
             tilkjentYtelseRepository = tilkjentYtelseRepository,
             andelTilkjentYtelseRepository = andelTilkjentYtelseRepository,
+            featureToggleService = featureToggleService,
         )
+
+    @BeforeEach
+    fun setUp() {
+        every { featureToggleService.isEnabled(FeatureToggle.OPPDRAG_MIGRERING_IVERKSETT_OPPDRAG_GCP) } returns true
+    }
 
     @Test
     fun `oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett - skal ikke iverksette mot oppdrag hvis det ikke finnes utbetalingsperioder`() {
         // Arrange
         every { tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(any()) } just runs
-        every { oppdragKlient.iverksettOppdrag(any()) } returns ""
+        every { oppdragBackendKlient.iverksettOppdrag(any()) } returns ""
 
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
@@ -71,14 +84,14 @@ internal class UtbetalingsperiodeServiceTest {
         )
 
         // Assert
-        verify(exactly = 0) { oppdragKlient.iverksettOppdrag(any()) }
+        verify(exactly = 0) { oppdragBackendKlient.iverksettOppdrag(any()) }
     }
 
     @Test
     fun `oppdaterTilkjentYtelseMedUtbetalingsoppdragOgIverksett - skal iverksette mot oppdrag hvis det finnes utbetalingsperioder`() {
         // Arrange
         every { tilkjentYtelseValideringService.validerIngenAndelerTilkjentYtelseMedSammeOffsetIBehandling(any()) } just runs
-        every { oppdragKlient.iverksettOppdrag(any()) } returns ""
+        every { oppdragBackendKlient.iverksettOppdrag(any()) } returns ""
 
         val vedtak = lagVedtak()
         val tilkjentYtelse = lagInitiellTilkjentYtelse(vedtak.behandling)
@@ -122,7 +135,7 @@ internal class UtbetalingsperiodeServiceTest {
         )
 
         // Assert
-        verify(exactly = 1) { oppdragKlient.iverksettOppdrag(any()) }
+        verify(exactly = 1) { oppdragBackendKlient.iverksettOppdrag(any()) }
     }
 
     @Test

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/HentStatusFraOppdragTaskTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/behandling/steg/iverksettmotoppdrag/HentStatusFraOppdragTaskTest.kt
@@ -10,9 +10,12 @@ import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.lagBehandling
 import no.nav.familie.ks.sak.data.lagTilkjentYtelse
 import no.nav.familie.ks.sak.data.lagUtbetalingsperiode
+import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragBackendKlient
 import no.nav.familie.ks.sak.integrasjon.oppdrag.OppdragKlient
 import no.nav.familie.ks.sak.integrasjon.økonomi.utbetalingsoppdrag.FAGSYSTEM
 import no.nav.familie.ks.sak.kjerne.behandling.domene.BehandlingÅrsak
@@ -32,16 +35,20 @@ import java.util.UUID
 
 internal class HentStatusFraOppdragTaskTest {
     private val oppdragKlient = mockk<OppdragKlient>()
+    private val oppdragBackendKlient = mockk<OppdragBackendKlient>()
     private val taskService = mockk<TaskRepositoryWrapper>()
     private val stegService = mockk<StegService>()
     private val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val hentStatusFraOppdragTask =
         HentStatusFraOppdragTask(
             oppdragKlient = oppdragKlient,
+            oppdragBackendKlient = oppdragBackendKlient,
             taskService = taskService,
             stegService = stegService,
             tilkjentYtelseRepository = tilkjentYtelseRepository,
+            featureToggleService = featureToggleService,
         )
 
     private val behandling = lagBehandling(opprettetÅrsak = BehandlingÅrsak.SØKNAD)
@@ -49,6 +56,8 @@ internal class HentStatusFraOppdragTaskTest {
     @BeforeEach
     fun setup() {
         every { taskService.save(any()) } returns mockk()
+
+        every { featureToggleService.isEnabled(FeatureToggle.OPPDRAG_MIGRERING_IVERKSETT_OPPDRAG_GCP) } returns true
 
         // utbetalingsoppdrag med periode
         every { tilkjentYtelseRepository.hentTilkjentYtelseForBehandling(any()) } returns
@@ -70,7 +79,7 @@ internal class HentStatusFraOppdragTaskTest {
     @Test
     fun `doTask skal kaste feil når oppdrag returnerer med status LAGT_PÅ_KØ`() {
         // Arrange
-        every { oppdragKlient.hentStatus(any()) } returns OppdragStatus.LAGT_PÅ_KØ
+        every { oppdragBackendKlient.hentStatus(any()) } returns OppdragStatus.LAGT_PÅ_KØ
 
         // Act & Assert
         val exception = assertThrows<RekjørSenereException> { hentStatusFraOppdragTask.doTask(lagTask()) }
@@ -81,7 +90,7 @@ internal class HentStatusFraOppdragTaskTest {
     @Test
     fun `doTask skal sette task til manuell oppfølging når oppdrag returnerer med KVITTERT_TEKNISK_FEIL`() {
         // Arrange
-        every { oppdragKlient.hentStatus(any()) } returns OppdragStatus.KVITTERT_TEKNISK_FEIL
+        every { oppdragBackendKlient.hentStatus(any()) } returns OppdragStatus.KVITTERT_TEKNISK_FEIL
         val taskSlot = slot<Task>()
 
         // Act
@@ -95,7 +104,7 @@ internal class HentStatusFraOppdragTaskTest {
     @Test
     fun `doTask skal utføre task når oppdrag returnerer med KVITTERT_OK`() {
         // Arrange
-        every { oppdragKlient.hentStatus(any()) } returns OppdragStatus.KVITTERT_OK
+        every { oppdragBackendKlient.hentStatus(any()) } returns OppdragStatus.KVITTERT_OK
         every { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) } just runs
 
         // Act & Assert
@@ -125,7 +134,7 @@ internal class HentStatusFraOppdragTaskTest {
         // Act & Assert
         assertDoesNotThrow { hentStatusFraOppdragTask.doTask(lagTask()) }
         verify(exactly = 1) { stegService.utførStegEtterIverksettelseAutomatisk(behandling.id) }
-        verify(exactly = 0) { oppdragKlient.hentStatus(any()) }
+        verify(exactly = 0) { oppdragBackendKlient.hentStatus(any()) }
     }
 
     private fun lagTask() =


### PR DESCRIPTION
### 📮 Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29077

### 💰 Hva skal gjøres, og hvorfor?
Trenger å enkelt kunne toggle for å bruke familie-oppdrag-backend i stedet for familie-oppdrag for iverksettelse av oppdrag

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
