### PR TITLE
NAV-26710: Hente valutakurser fra Norges Bank

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -106,6 +106,7 @@ spec:
         - host: familie-oppdrag.dev-fss-pub.nais.io
         - host: data-api.ecb.europa.eu
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
+        - host: data.norges-bank.no
   replicas:
     min: 2
     max: 2

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -112,6 +112,7 @@ spec:
         - host: data-api.ecb.europa.eu
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
         - host: graph.microsoft.com
+        - host: data.norges-bank.no
           ports:
             - port: 443
           # Sanity IPs https://www.sanity.io/docs/api-cdn#5fa01dfe1285 (Fjernes når feilen er rettet av platform teamet https://nav-it.slack.com/archives/C5KUST8N6/p1719994144462539)

--- a/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/api/ForvaltningController.kt
@@ -26,8 +26,11 @@ import no.nav.familie.ks.sak.common.util.Periode
 import no.nav.familie.ks.sak.config.BehandlerRolle
 import no.nav.familie.ks.sak.config.SpringProfile
 import no.nav.familie.ks.sak.config.TaskRepositoryWrapper
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.integrasjon.ecb.ECBService
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonKlient
+import no.nav.familie.ks.sak.integrasjon.norgesbank.NorgesBankService
 import no.nav.familie.ks.sak.integrasjon.oppdrag.AvstemmingKlient
 import no.nav.familie.ks.sak.internal.TestVerktøyService
 import no.nav.familie.ks.sak.kjerne.autovedtak.AutovedtakService
@@ -91,6 +94,8 @@ class ForvaltningController(
     private val barnehagelisteVarslingService: BarnehagelisteVarslingService,
     private val avstemmingKlient: AvstemmingKlient,
     private val fagsakStatusScheduler: FagsakStatusScheduler,
+    private val norgesBankService: NorgesBankService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     private val logger = LoggerFactory.getLogger(ForvaltningController::class.java)
 
@@ -275,7 +280,13 @@ class ForvaltningController(
             minimumBehandlerRolle = BehandlerRolle.FORVALTER,
             handling = "hentValutakurs",
         )
-        return ResponseEntity.ok(ecbService.hentValutakurs(valuta, dato))
+        val valutakurs =
+            if (featureToggleService.isEnabled(FeatureToggle.HENT_VALUTAKURS_FRA_NORGESBANK)) {
+                norgesBankService.hentValutakurs(valuta, dato)
+            } else {
+                ecbService.hentValutakurs(valuta, dato)
+            }
+        return ResponseEntity.ok(valutakurs)
     }
 
     @GetMapping(path = ["/behandling/{behandlingId}/begrunnelsetest"])

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -22,4 +22,7 @@ enum class FeatureToggle(
     // NAV-30112
     FAGSAKLÅSING_SCHEDULER("familie-ks-sak.fagsaklaasing-scheduler"),
     KAN_LÅSE_FAGSAK("familie-ks-sak.kan-laase-fagsak"),
+
+    // NAV-26710
+    HENT_VALUTAKURS_FRA_NORGESBANK("familie-baks-sak.hent-valutakurs-fra-norgesbank"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankScheduler.kt
@@ -17,7 +17,7 @@ class NorgesBankScheduler(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(NorgesBankScheduler::class.java)
 
-    @Scheduled(cron = "0 0 0 8 * MON-FRI")
+    @Scheduled(cron = "0 0 0 * * MON-FRI")
     fun dagligSjekkOmValutakursklientFungerer() {
         if (LeaderClient.isLeader() == true) {
             val førsteMandagIForrigeMåned =

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankScheduler.kt
@@ -1,0 +1,50 @@
+package no.nav.familie.ks.sak.integrasjon.norgesbank
+
+import no.nav.familie.leader.LeaderClient
+import no.nav.familie.valutakurs.NorgesBankValutakursRestKlient
+import no.nav.familie.valutakurs.domene.norgesbank.Frekvens
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+@Component
+class NorgesBankScheduler(
+    private val norgesBankValutakursRestKlient: NorgesBankValutakursRestKlient,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(NorgesBankScheduler::class.java)
+
+    @Scheduled(cron = "0 0 0 8 * MON-FRI")
+    fun dagligSjekkOmValutakursklientFungerer() {
+        if (LeaderClient.isLeader() == true) {
+            val førsteMandagIForrigeMåned =
+                LocalDate
+                    .now()
+                    .minusMonths(1)
+                    .withDayOfMonth(1)
+                    .with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
+
+            try {
+                norgesBankValutakursRestKlient.hentValutakurs(
+                    frekvens = Frekvens.VIRKEDAG,
+                    valuta = "SEK",
+                    kursDato = førsteMandagIForrigeMåned,
+                )
+            } catch (e: Exception) {
+                logger.error(
+                    """Den daglige selftesten mot Norges Bank feilet med verdier SEK og $førsteMandagIForrigeMåned. 
+                    |- Sjekk om Norges Bank er nede. 
+                    |- Sjekk om API har endret seg. 
+                    |
+                    |Se README i https://github.com/navikt/familie-felles/tree/main/valutakurs-klient for å kjøre integrasjonstest mot Norges Bank og for linker til dokumentasjonen til Norges Bank
+                    |
+                    """.trimMargin(),
+                    e,
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankService.kt
@@ -1,0 +1,51 @@
+package no.nav.familie.ks.sak.integrasjon.norgesbank
+
+import no.nav.familie.ks.sak.common.util.saner
+import no.nav.familie.ks.sak.integrasjon.ecb.domene.ECBValutakursCache
+import no.nav.familie.ks.sak.integrasjon.ecb.domene.ECBValutakursCacheRepository
+import no.nav.familie.valutakurs.NorgesBankValutakursRestKlient
+import no.nav.familie.valutakurs.domene.norgesbank.Frekvens
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Import
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Service
+@Import(NorgesBankValutakursRestKlient::class)
+class NorgesBankService(
+    private val norgesBankValutakursRestKlient: NorgesBankValutakursRestKlient,
+    private val ecbValutakursCacheRepository: ECBValutakursCacheRepository,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(NorgesBankService::class.java)
+
+    /**
+     * @param utenlandskValuta valutaen vi skal hente kurs for
+     * @param kursDato datoen vi skal hente kurs for
+     * @return Henter valutakurs for utenlandskValuta -> NOK.
+     */
+    fun hentValutakurs(
+        utenlandskValuta: String,
+        kursDato: LocalDate,
+    ): BigDecimal {
+        val valutakurs =
+            ecbValutakursCacheRepository.findByValutakodeAndValutakursdato(utenlandskValuta, kursDato)
+        if (valutakurs == null) {
+            logger.info("Henter valutakurs for ${utenlandskValuta.saner()} på $kursDato")
+            val valutakurs =
+                norgesBankValutakursRestKlient.hentValutakurs(Frekvens.VIRKEDAG, utenlandskValuta, kursDato)
+            val lagretValutakurs =
+                ecbValutakursCacheRepository.save(
+                    ECBValutakursCache(
+                        kurs = valutakurs.kurs,
+                        valutakode = valutakurs.valuta,
+                        valutakursdato = valutakurs.kursDato,
+                    ),
+                )
+            return lagretValutakurs.kurs
+        }
+        logger.info("Valutakurs ble hentet fra cache for ${utenlandskValuta.saner()} på $kursDato")
+        return valutakurs.kurs
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursController.kt
@@ -6,7 +6,10 @@ import no.nav.familie.ks.sak.api.dto.ValutakursDto
 import no.nav.familie.ks.sak.api.dto.tilValutakurs
 import no.nav.familie.ks.sak.common.BehandlingId
 import no.nav.familie.ks.sak.config.BehandlerRolle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.integrasjon.ecb.ECBService
+import no.nav.familie.ks.sak.integrasjon.norgesbank.NorgesBankService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.eøs.valutakurs.domene.Valutakurs
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
@@ -32,6 +35,8 @@ class ValutakursController(
     private val personidentService: PersonidentService,
     private val behandlingService: BehandlingService,
     private val ecbService: ECBService,
+    private val norgesBankService: NorgesBankService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     @PutMapping(path = ["{behandlingId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun oppdaterValutakurs(
@@ -50,7 +55,7 @@ class ValutakursController(
             if (skalManueltSetteValutakurs(valutakursDto)) {
                 valutakursDto.tilValutakurs(barnAktører)
             } else {
-                oppdaterValutakursMedKursFraECB(valutakursDto, valutakursDto.tilValutakurs(barnAktører = barnAktører))
+                oppdaterValutakurs(valutakursDto, valutakursDto.tilValutakurs(barnAktører = barnAktører))
             }
 
         valutakursService.oppdaterValutakurs(BehandlingId(behandlingId), valutaKurs)
@@ -74,19 +79,30 @@ class ValutakursController(
         return ResponseEntity.ok(Ressurs.success(behandlingService.lagBehandlingRespons(behandlingId = behandlingId)))
     }
 
-    private fun oppdaterValutakursMedKursFraECB(
+    private fun oppdaterValutakurs(
         restValutakurs: ValutakursDto,
         valutakurs: Valutakurs,
-    ) = if (valutakursErEndret(restValutakurs, valutakursService.hentValutakurs(restValutakurs.id))) {
-        valutakurs.copy(
-            kurs =
-                ecbService.hentValutakurs(
-                    restValutakurs.valutakode!!,
-                    restValutakurs.valutakursdato!!,
-                ),
-        )
-    } else {
-        valutakurs
+    ): Valutakurs {
+        val skalHenteValutakursFraNorgesBank =
+            featureToggleService.isEnabled(FeatureToggle.HENT_VALUTAKURS_FRA_NORGESBANK, false)
+        return if (valutakursErEndret(restValutakurs, valutakursService.hentValutakurs(restValutakurs.id))) {
+            valutakurs.copy(
+                kurs =
+                    if (skalHenteValutakursFraNorgesBank) {
+                        norgesBankService.hentValutakurs(
+                            restValutakurs.valutakode!!,
+                            restValutakurs.valutakursdato!!,
+                        )
+                    } else {
+                        ecbService.hentValutakurs(
+                            restValutakurs.valutakode!!,
+                            restValutakurs.valutakursdato!!,
+                        )
+                    },
+            )
+        } else {
+            valutakurs
+        }
     }
 
     /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -119,6 +119,7 @@ FAMILIE_OPPDRAG_API_URL: http://familie-oppdrag/api
 FAMILIE_OPPDRAG_BACKEND_API_URL: http://familie-oppdrag-backend/api
 SANITY_FAMILIE_API_URL: https://xsrv1mh6.apicdn.sanity.io/v2021-06-07/data/query/ba-brev
 ECB_API_URL: https://data-api.ecb.europa.eu/service/data/EXR/
+NORGES_BANK_API_URL: https://data.norges-bank.no/api/data/EXR/
 
 # Swagger
 AUTHORIZATION_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/authorize

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceTest.kt
@@ -1,0 +1,88 @@
+package no.nav.familie.ks.sak.integrasjon.norgesbank
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ks.sak.integrasjon.ecb.domene.ECBValutakursCache
+import no.nav.familie.ks.sak.integrasjon.ecb.domene.ECBValutakursCacheRepository
+import no.nav.familie.valutakurs.NorgesBankValutakursRestKlient
+import no.nav.familie.valutakurs.domene.Valutakurs
+import no.nav.familie.valutakurs.domene.norgesbank.Frekvens
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class NorgesBankServiceTest {
+    private val norgesBankValutakursRestKlient = mockk<NorgesBankValutakursRestKlient>()
+    private val ecbValutakursCacheRepository = mockk<ECBValutakursCacheRepository>()
+
+    private val norgesBankService = NorgesBankService(norgesBankValutakursRestKlient, ecbValutakursCacheRepository)
+
+    @Test
+    fun `hentValutakurs skal hente valutakurs fra Norges Bank og lagre den i cache dersom den ikke finnes i cache fra før`() {
+        // Arrange
+        val utenlandskValuta = "SEK"
+        val kursDato = LocalDate.of(2023, 5, 15)
+        val kurs = BigDecimal.valueOf(0.95)
+
+        every {
+            ecbValutakursCacheRepository.findByValutakodeAndValutakursdato(
+                utenlandskValuta,
+                kursDato,
+            )
+        } returns null
+        every {
+            norgesBankValutakursRestKlient.hentValutakurs(Frekvens.VIRKEDAG, utenlandskValuta, kursDato)
+        } returns Valutakurs(valuta = utenlandskValuta, kurs = kurs, kursDato = kursDato)
+        every { ecbValutakursCacheRepository.save(any()) } answers { firstArg() }
+
+        // Act
+        val hentetValutakurs = norgesBankService.hentValutakurs(utenlandskValuta, kursDato)
+
+        // Assert
+        assertEquals(kurs, hentetValutakurs)
+        verify(exactly = 1) {
+            norgesBankValutakursRestKlient.hentValutakurs(
+                Frekvens.VIRKEDAG,
+                utenlandskValuta,
+                kursDato,
+            )
+        }
+        verify(exactly = 1) {
+            ecbValutakursCacheRepository.save(
+                ECBValutakursCache(
+                    kurs = kurs,
+                    valutakode = utenlandskValuta,
+                    valutakursdato = kursDato,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `hentValutakurs skal returnere valutakurs fra cache dersom den finnes fra før uten å kalle Norges Bank`() {
+        // Arrange
+        val utenlandskValuta = "SEK"
+        val kursDato = LocalDate.of(2023, 5, 15)
+        val kurs = BigDecimal.valueOf(0.95)
+        val cachetValutakurs =
+            ECBValutakursCache(
+                kurs = kurs,
+                valutakode = utenlandskValuta,
+                valutakursdato = kursDato,
+            )
+
+        every {
+            ecbValutakursCacheRepository.findByValutakodeAndValutakursdato(utenlandskValuta, kursDato)
+        } returns cachetValutakurs
+
+        // Act
+        val hentetValutakurs = norgesBankService.hentValutakurs(utenlandskValuta, kursDato)
+
+        // Assert
+        assertEquals(kurs, hentetValutakurs)
+        verify(exactly = 0) { norgesBankValutakursRestKlient.hentValutakurs(any(), any(), any()) }
+        verify(exactly = 0) { ecbValutakursCacheRepository.save(any()) }
+    }
+}

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursControllerTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/kjerne/eøs/valutakurs/ValutakursControllerTest.kt
@@ -8,8 +8,11 @@ import io.mockk.verify
 import no.nav.familie.ks.sak.api.dto.UtfyltStatus
 import no.nav.familie.ks.sak.api.dto.ValutakursDto
 import no.nav.familie.ks.sak.api.dto.tilValutakurs
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
 import no.nav.familie.ks.sak.data.tilfeldigPerson
 import no.nav.familie.ks.sak.integrasjon.ecb.ECBService
+import no.nav.familie.ks.sak.integrasjon.norgesbank.NorgesBankService
 import no.nav.familie.ks.sak.kjerne.behandling.BehandlingService
 import no.nav.familie.ks.sak.kjerne.personident.PersonidentService
 import no.nav.familie.ks.sak.sikkerhet.TilgangService
@@ -25,7 +28,9 @@ class ValutakursControllerTest {
     private val personidentService = mockk<PersonidentService>()
     private val behandlingService = mockk<BehandlingService>()
     private val ecbService = mockk<ECBService>()
+    private val norgesBankService = mockk<NorgesBankService>()
     private val tilgangService = mockk<TilgangService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val valutakursController =
         ValutakursController(
@@ -34,6 +39,8 @@ class ValutakursControllerTest {
             personidentService = personidentService,
             behandlingService = behandlingService,
             ecbService = ecbService,
+            norgesBankService = norgesBankService,
+            featureToggleService = featureToggleService,
         )
 
     private val barnId = tilfeldigPerson()
@@ -45,12 +52,13 @@ class ValutakursControllerTest {
     fun setup() {
         every { personidentService.hentAktør(any()) } returns barnId.aktør
         every { valutakursService.hentValutakurs(any()) } returns restValutakurs.tilValutakurs(listOf(barnId.aktør))
-        every { ecbService.hentValutakurs(any(), any()) } returns BigDecimal.valueOf(0.95)
+        every { norgesBankService.hentValutakurs(any(), any()) } returns BigDecimal.valueOf(0.95)
+        every { featureToggleService.isEnabled(FeatureToggle.HENT_VALUTAKURS_FRA_NORGESBANK, false) } returns true
         justRun { tilgangService.validerTilgangTilHandlingOgFagsakForBehandling(any(), any(), any(), any()) }
     }
 
     @Test
-    fun `Test at valutakurs hentes fra ECB dersom dato og valuta er satt`() {
+    fun `Test at valutakurs hentes fra Norges Bank dersom dato og valuta er satt`() {
         // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
         val valuta = "SEK"
@@ -62,12 +70,12 @@ class ValutakursControllerTest {
                 restValutakurs.copy(valutakursdato = valutakursDato, valutakode = valuta),
             )
         }
-        verify(exactly = 1) { ecbService.hentValutakurs("SEK", valutakursDato) }
+        verify(exactly = 1) { norgesBankService.hentValutakurs("SEK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
-    fun `Test at valutakurs ikke hentes fra ECB dersom dato ikke er satt`() {
+    fun `Test at valutakurs ikke hentes fra Norges Bank dersom dato ikke er satt`() {
         // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
 
@@ -78,12 +86,12 @@ class ValutakursControllerTest {
                 restValutakurs.copy(valutakode = "SEK"),
             )
         }
-        verify(exactly = 0) { ecbService.hentValutakurs("SEK", valutakursDato) }
+        verify(exactly = 0) { norgesBankService.hentValutakurs("SEK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
-    fun `Test at valutakurs ikke hentes fra ECB dersom valuta ikke er satt`() {
+    fun `Test at valutakurs ikke hentes fra NorgesBank dersom valuta ikke er satt`() {
         // Arrange
         val valutakursDato = LocalDate.of(2022, 1, 1)
 
@@ -94,12 +102,12 @@ class ValutakursControllerTest {
                 restValutakurs.copy(valutakursdato = valutakursDato),
             )
         }
-        verify(exactly = 0) { ecbService.hentValutakurs("SEK", valutakursDato) }
+        verify(exactly = 0) { norgesBankService.hentValutakurs("SEK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
-    fun `Test at valutakurs ikke hentes fra ECB dersom ISK og før 1 feb 2018`() {
+    fun `Test at valutakurs ikke hentes fra Norges Bank dersom ISK og før 1 feb 2018`() {
         // Arrange
         val valutakursDato = LocalDate.of(2018, 1, 31)
 
@@ -110,12 +118,12 @@ class ValutakursControllerTest {
                 restValutakurs.copy(valutakursdato = valutakursDato, valutakode = "ISK"),
             )
         }
-        verify(exactly = 0) { ecbService.hentValutakurs("ISK", valutakursDato) }
+        verify(exactly = 0) { norgesBankService.hentValutakurs("ISK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 
     @Test
-    fun `Test at valutakurs hentes fra ECB dersom ISK og etter 1 feb 2018`() {
+    fun `Test at valutakurs hentes fra Norges Bank dersom ISK og etter 1 feb 2018`() {
         // Arrange
         val valutakursDato = LocalDate.of(2018, 2, 1)
 
@@ -126,7 +134,7 @@ class ValutakursControllerTest {
                 restValutakurs.copy(valutakursdato = valutakursDato, valutakode = "ISK"),
             )
         }
-        verify(exactly = 1) { ecbService.hentValutakurs("ISK", valutakursDato) }
+        verify(exactly = 1) { norgesBankService.hentValutakurs("ISK", valutakursDato) }
         verify(exactly = 1) { valutakursService.oppdaterValutakurs(any(), any()) }
     }
 }

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceIntegrationTest.kt
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.time.LocalDate
 
-class NorgesBankServiceTest : OppslagSpringRunnerTest() {
+class NorgesBankServiceIntegrationTest : OppslagSpringRunnerTest() {
     private val norgesBankValutakursRestKlient = mockk<NorgesBankValutakursRestKlient>()
 
     @Autowired

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceIntegrationTest.kt
@@ -17,25 +17,22 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.time.LocalDate
 
-class NorgesBankServiceIntegrationTest : OppslagSpringRunnerTest() {
+class NorgesBankServiceIntegrationTest(
+    @Autowired
+    private val ecbValutakursCacheRepository: ECBValutakursCacheRepository,
+    @Autowired
+    private val databaseCleanupService: DatabaseCleanupService,
+) : OppslagSpringRunnerTest() {
     private val norgesBankValutakursRestKlient = mockk<NorgesBankValutakursRestKlient>()
 
-    @Autowired
-    private lateinit var ecbValutakursCacheRepository: ECBValutakursCacheRepository
-
-    @Autowired
-    private lateinit var databaseCleanupService: DatabaseCleanupService
-
-    @Autowired
-    private lateinit var norgesBankService: NorgesBankService
+    private val norgesBankService: NorgesBankService =
+        NorgesBankService(
+            norgesBankValutakursRestKlient = norgesBankValutakursRestKlient,
+            ecbValutakursCacheRepository = ecbValutakursCacheRepository,
+        )
 
     @BeforeEach
     fun setUp() {
-        norgesBankService =
-            NorgesBankService(
-                norgesBankValutakursRestKlient = norgesBankValutakursRestKlient,
-                ecbValutakursCacheRepository = ecbValutakursCacheRepository,
-            )
         databaseCleanupService.truncate()
     }
 

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceIntegrationTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceIntegrationTest.kt
@@ -1,0 +1,77 @@
+package no.nav.familie.ks.sak.no.nav.familie.ks.sak.integrasjon.norgesbank
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ks.sak.OppslagSpringRunnerTest
+import no.nav.familie.ks.sak.config.DatabaseCleanupService
+import no.nav.familie.ks.sak.integrasjon.ecb.domene.ECBValutakursCacheRepository
+import no.nav.familie.ks.sak.integrasjon.norgesbank.NorgesBankService
+import no.nav.familie.valutakurs.NorgesBankValutakursRestKlient
+import no.nav.familie.valutakurs.domene.Valutakurs
+import no.nav.familie.valutakurs.domene.norgesbank.Frekvens
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class NorgesBankServiceIntegrationTest : OppslagSpringRunnerTest() {
+    private val norgesBankValutakursRestKlient = mockk<NorgesBankValutakursRestKlient>()
+
+    @Autowired
+    private lateinit var ecbValutakursCacheRepository: ECBValutakursCacheRepository
+
+    @Autowired
+    private lateinit var databaseCleanupService: DatabaseCleanupService
+
+    @Autowired
+    private lateinit var norgesBankService: NorgesBankService
+
+    @BeforeEach
+    fun setUp() {
+        norgesBankService =
+            NorgesBankService(
+                norgesBankValutakursRestKlient = norgesBankValutakursRestKlient,
+                ecbValutakursCacheRepository = ecbValutakursCacheRepository,
+            )
+        databaseCleanupService.truncate()
+    }
+
+    @Test
+    fun `Skal teste at valutakurs hentes fra cache dersom valutakursen allerede er hentet fra NorgesBank`() {
+        // Arrange
+        val kursDato = LocalDate.of(2026, 7, 31)
+        val valuta = "SEK"
+        val kurs = BigDecimal.valueOf(0.9960)
+        every {
+            norgesBankValutakursRestKlient.hentValutakurs(
+                Frekvens.VIRKEDAG,
+                valuta,
+                kursDato,
+            )
+        } returns
+            Valutakurs(
+                valuta = valuta,
+                kurs = kurs,
+                kursDato = kursDato,
+            )
+
+        // Act & Assert
+        norgesBankService.hentValutakurs(valuta, kursDato)
+        val valutakurs = ecbValutakursCacheRepository.findByValutakodeAndValutakursdato(valuta, kursDato)
+        assertThat(valutakurs!!.kurs).isEqualTo(kurs)
+        assertThat(valutakurs.valutakode).isEqualTo(valuta)
+        assertThat(valutakurs.valutakursdato).isEqualTo(kursDato)
+
+        norgesBankService.hentValutakurs(valuta, kursDato)
+        verify(exactly = 1) {
+            norgesBankValutakursRestKlient.hentValutakurs(
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceTest.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/integrasjon/norgesbank/NorgesBankServiceTest.kt
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.time.LocalDate
 
-class NorgesBankServiceIntegrationTest : OppslagSpringRunnerTest() {
+class NorgesBankServiceTest : OppslagSpringRunnerTest() {
     private val norgesBankValutakursRestKlient = mockk<NorgesBankValutakursRestKlient>()
 
     @Autowired


### PR DESCRIPTION
### 📮 Favro: [NAV-26710](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26710)

### 💰 Hva skal gjøres, og hvorfor?
Vi har hentet valutakurser fra Norges Bank og ECB parallellt siden desember 2025. I den forbindelse har vi logget ut eventuelle differanser i valutakursen fra de 2 kildene. Ingen signifikante forskjeller er oppdaget.

Den største forskjellen mellom de to kildene er at vi fra ECB er nødt til å gjøre beregninger for å finne kursen `utenlandskValuta -> NOK` selv, mens fra Norges Bank får vi denne kursen direkte. Norges Bank opererer med en presisjon på 4 desimaler på alle valutakurser, mens vi opererer med inntil 10 desimaler. Dette fører til at vi kan få en forskjell på inntil 0.00005+- fra de to kildene. Feilen vil først ha noe å si dersom det utenlandske beløpet er veldig stort. I EØS er det kun valutaen HUF (Ungarske forint) som kan gjøre utslag her, hvor 85000 HUF tilsvarer ca 2500 kr og et avvik på 0.00005 vil tilsvare ca 2 kr.

Vi tar også vare på alle hentede valutakurser i tabellen `ECBValuakursCache` (burde kanskje omdøpes etterhvert). Dette betyr at vi aldri vil hente kurs fra Norges Bank dersom vi allerede har hentet den forespurte kursen tidligere. Altså burde det ikke oppstå feilutbetalinger / etterbetalinger bakover i tid på grunn av overgang til Norges Bank.

Hva er gjort:
* Legger til `NorgesBankService` for henting av valutakurs fra Norges Bank
* Tar NorgesBankService i bruk alle steder vi tidligere har brukt `ECBService` (Bak toggle)
* Legger til FeatureToggle - `HENT_VALUTAKURS_FRA_NORGESBANK`.  (Toggelen er kanskje litt unødvendig)

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.
