### PR TITLE
 Ta i bruk tilgangsmaskinen (foreløpig bare skygging)

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -82,6 +82,9 @@ spec:
           cluster: dev-gcp
         - application: familie-integrasjoner
           cluster: dev-fss
+        - application: populasjonstilgangskontroll
+          namespace: tilgangsmaskin
+          cluster: dev-gcp
         - application: familie-ks-infotrygd
           cluster: dev-fss
         - application: familie-ef-sak

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -83,6 +83,9 @@ spec:
           cluster: prod-gcp
         - application: familie-integrasjoner
           cluster: prod-fss
+        - application: populasjonstilgangskontroll
+          namespace: tilgangsmaskin
+          cluster: prod-gcp
         - application: familie-ks-infotrygd
           cluster: prod-fss
         - application: familie-ef-sak

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- Nav Familie-->
         <prosessering.version>2.20260622101837_623782e</prosessering.version>
         <felles-kontrakter.version>4.0_20260622103258_a3e0997</felles-kontrakter.version>
-        <felles.version>4.20260622095330_affbfcf</felles.version>
+        <felles.version>4.20260807140555_998c828</felles.version>
         <eksterne-kontrakter-bisys.version>2.0_20260623154817_f726581</eksterne-kontrakter-bisys.version>
         <familie.kontrakter.stønadsstatistikk>2.0_20260623154817_f726581</familie.kontrakter.stønadsstatistikk>
         <familie.kontrakter.saksstatistikk>2.0_20260623154817_f726581</familie.kontrakter.saksstatistikk>
@@ -270,6 +270,10 @@
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>token-klient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>tilgangsmaskin-klient</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/ApplicationConfig.kt
@@ -4,6 +4,7 @@ import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
 import no.nav.familie.log.interceptor.ConsumerIdClientInterceptor
 import no.nav.familie.sikkerhet.context.FamilieFellesSpringSecurityKonfigurasjon
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinKlientConfig
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
@@ -20,7 +21,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @ComponentScan(
     "no.nav.familie.prosessering",
     "no.nav.familie.unleash",
-    "no.nav.familie.felles.tokenklient",
+    "no.nav.familie.felles.tokenklient.entraid",
     ApplicationConfig.PAKKENAVN,
 )
 @EnableRetry
@@ -29,6 +30,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @Import(
     ConsumerIdClientInterceptor::class,
     FamilieFellesSpringSecurityKonfigurasjon::class,
+    TilgangsmaskinKlientConfig::class,
 )
 class ApplicationConfig {
     @Bean

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/RestClientConfig.kt
@@ -4,6 +4,7 @@ import no.nav.familie.felles.tokenklient.entraid.EntraIDRestClientFactory
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.log.interceptor.ConsumerIdClientInterceptor
 import no.nav.familie.log.interceptor.MdcValuesPropagatingClientInterceptor
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinKlientConfig
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -86,6 +87,24 @@ class RestClientConfig(
     fun pdlRestClient(
         @Value("\${PDL_SCOPE}") scope: String,
     ): RestClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(scope)
+
+    @Bean(TilgangsmaskinKlientConfig.TILGANGSMASKIN_OBO_REST_CLIENT)
+    fun tilgangsmaskinOboRestClient(
+        @Value("\${TILGANGSMASKIN_SCOPE}") scope: String,
+    ): RestClient {
+        val requestFactory =
+            SimpleClientHttpRequestFactory().apply {
+                setConnectTimeout(Duration.ofSeconds(2))
+                setReadTimeout(Duration.ofSeconds(5))
+            }
+        return entraIDRestClientFactory
+            .lagOboRestKlient(scope) {
+                SikkerhetContext.hentJwt()?.tokenValue
+                    ?: throw IllegalStateException("Kall mot Tilgangsmaskinen krever OBO-token, men fant ingen JWT i konteksten")
+            }.mutate()
+            .requestFactory(requestFactory)
+            .build()
+    }
 
     @Bean("utenAuthRestClient")
     fun utenAuthRestClient(): RestClient =

--- a/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/config/featureToggle/FeatureToggle.kt
@@ -22,4 +22,7 @@ enum class FeatureToggle(
     // NAV-30112
     FAGSAKLÅSING_SCHEDULER("familie-ks-sak.fagsaklaasing-scheduler"),
     KAN_LÅSE_FAGSAK("familie-ks-sak.kan-laase-fagsak"),
+
+    // NAV-27897
+    SKAL_SKYGGEKJØRE_TILGANGSMASKINEN("familie-ks-sak.skal-skyggekjore-tilgangsmaskinen"),
 }

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.familie.ks.sak.api.dto.PersonInfoDto
 import no.nav.familie.ks.sak.integrasjon.pdl.PdlKlient
 import no.nav.familie.ks.sak.integrasjon.pdl.tilAdressebeskyttelse
+import no.nav.familie.ks.sak.integrasjon.tilgangsmaskin.TilgangsmaskinSkyggeService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
 import org.springframework.stereotype.Service
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service
 class IntegrasjonService(
     private val integrasjonKlient: IntegrasjonKlient,
     private val pdlKlient: PdlKlient,
+    private val tilgangsmaskinSkyggeService: TilgangsmaskinSkyggeService,
 ) {
     fun sjekkTilgangTilPerson(personIdent: String): Tilgang = sjekkTilgangTilPersoner(listOf(personIdent)).single()
 
@@ -21,7 +23,9 @@ class IntegrasjonService(
         if (SikkerhetContext.erSystemKontekst()) {
             personIdenter.map { Tilgang(personIdent = it, harTilgang = true, begrunnelse = null) }
         } else {
-            integrasjonKlient.sjekkTilgangTilPersoner(personIdenter)
+            integrasjonKlient.sjekkTilgangTilPersoner(personIdenter).also { tilganger ->
+                tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(personIdenter, tilganger)
+            }
         }
 
     fun hentMaskertPersonInfoVedManglendeTilgang(aktør: Aktør): PersonInfoDto? {

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerService.kt
@@ -4,6 +4,8 @@ import com.neovisionaries.i18n.CountryCode
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.Statsborgerskap
+import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
+import no.nav.familie.ks.sak.common.exception.Feil
 import no.nav.familie.ks.sak.common.exception.FunksjonellFeil
 import no.nav.familie.ks.sak.common.exception.PdlPersonKanIkkeBehandlesIFagsystem
 import no.nav.familie.ks.sak.config.PersonInfoQuery
@@ -49,13 +51,15 @@ class PersonopplysningerService(
     private fun PersonInfo.medRelasjonerOgEgenAnsattInfo(aktør: Aktør): PersonInfo {
         val relasjonsidenter = this.forelderBarnRelasjoner.map { it.aktør.aktivFødselsnummer() }
         val egenAnsattPerIdent = integrasjonService.sjekkErEgenAnsattBulk(setOf(aktør.aktivFødselsnummer()) + relasjonsidenter)
+        val tilgangPerRelasjonsident = hentTilgangPerIdent(relasjonsidenter)
 
         val identerMedAdressebeskyttelse = mutableSetOf<Pair<Aktør, FORELDERBARNRELASJONROLLE>>()
         val forelderBarnRelasjonerMedAdressebeskyttelseGradering =
             forelderBarnRelasjoner
                 .mapNotNull { forelderBarnRelasjon ->
                     val harTilgang =
-                        integrasjonService.sjekkTilgangTilPerson(forelderBarnRelasjon.aktør.aktivFødselsnummer()).harTilgang
+                        tilgangPerRelasjonsident[forelderBarnRelasjon.aktør.aktivFødselsnummer()]?.harTilgang
+                            ?: throw Feil("Mangler tilgangssvar for relasjon fra familie-integrasjoner")
 
                     if (harTilgang) {
                         try {
@@ -100,6 +104,13 @@ class PersonopplysningerService(
             erEgenAnsatt = egenAnsattPerIdent.getOrDefault(aktør.aktivFødselsnummer(), null),
         )
     }
+
+    private fun hentTilgangPerIdent(personIdenter: List<String>): Map<String, Tilgang> =
+        if (personIdenter.isEmpty()) {
+            emptyMap()
+        } else {
+            integrasjonService.sjekkTilgangTilPersoner(personIdenter).associateBy { it.personIdent }
+        }
 
     fun hentAdressebeskyttelseSomSystembruker(aktør: Aktør): ADRESSEBESKYTTELSEGRADERING = pdlKlient.hentAdressebeskyttelse(aktør).tilAdressebeskyttelse()
 

--- a/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilgangsmaskin/TilgangsmaskinSkyggeService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/tilgangsmaskin/TilgangsmaskinSkyggeService.kt
@@ -1,0 +1,126 @@
+package no.nav.familie.ks.sak.integrasjon.tilgangsmaskin
+
+import io.micrometer.core.instrument.Metrics
+import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ks.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.tilgangsmaskin.Avvisningskode
+import no.nav.familie.tilgangsmaskin.Regeltype
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinException
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinKlient
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinResultat
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+
+/**
+ * Skyggekjøring av Tilgangsmaskinen (NAV-27897): sammenligner dagens tilgangsbeslutning fra
+ * familie-integrasjoner med hva Tilgangsmaskinen ville svart, og logger divergenser.
+ * Påvirker aldri selve tilgangsbeslutningen.
+ */
+@Service
+class TilgangsmaskinSkyggeService(
+    private val tilgangsmaskinKlient: TilgangsmaskinKlient,
+    private val featureToggleService: FeatureToggleService,
+) {
+    private val sammenlignetTeller = Metrics.counter("familie.ks.sak.tilgangsmaskin.skygge.sammenlignet")
+    private val manglendeSvarTeller = Metrics.counter("familie.ks.sak.tilgangsmaskin.skygge.manglende.svar")
+
+    fun skyggeSjekkTilgangTilPersoner(
+        personIdenter: List<String>,
+        tilgangerFraIntegrasjoner: List<Tilgang>,
+    ) {
+        try {
+            // Bulk-endepunktet krever OBO-token, og systemkontekst har uansett blanke tilganger i dag.
+            if (SikkerhetContext.erSystemKontekst()) return
+            if (!featureToggleService.isEnabled(FeatureToggle.SKAL_SKYGGEKJØRE_TILGANGSMASKINEN)) return
+
+            val (manglendeSvar, resultaterFraTilgangsmaskinen) =
+                tilgangsmaskinKlient
+                    .sjekkTilgangTilPersoner(personIdenter.toSet(), Regeltype.KJERNE_REGELTYPE)
+                    .partition { it.erManglendeSvar() }
+            if (manglendeSvar.isNotEmpty()) {
+                manglendeSvarTeller.increment(manglendeSvar.size.toDouble())
+                logger.warn(
+                    "Tilgangsmaskin-skygge: fikk ikke svar for ${manglendeSvar.size} av " +
+                        "${manglendeSvar.size + resultaterFraTilgangsmaskinen.size} identer, disse sammenlignes ikke.",
+                )
+            }
+            sammenlignetTeller.increment(resultaterFraTilgangsmaskinen.size.toDouble())
+
+            val tilgangerPerIdent = tilgangerFraIntegrasjoner.associateBy { it.personIdent }
+            val divergenser =
+                resultaterFraTilgangsmaskinen.mapNotNull { nyttResultat ->
+                    val gammelTilgang = tilgangerPerIdent[nyttResultat.personIdent] ?: return@mapNotNull null
+                    if (gammelTilgang.harTilgang != nyttResultat.harTilgang) gammelTilgang to nyttResultat else null
+                }
+            if (divergenser.isEmpty()) {
+                logger.info("Tilgangsmaskin-skygge: sammenlignet ${resultaterFraTilgangsmaskinen.size} identer, ingen divergens.")
+                return
+            }
+
+            divergenser.forEach { (gammelTilgang, nyttResultat) -> loggDivergens(gammelTilgang, nyttResultat) }
+
+            val avvisningskoder = divergenser.mapNotNull { (_, nyttResultat) -> nyttResultat.avvisningskode }.groupingBy { it }.eachCount()
+            val traceIder = divergenser.mapNotNull { (_, nyttResultat) -> nyttResultat.traceId }
+
+            logger.warn(
+                "Tilgangsmaskin-skygge: ${divergenser.size} av ${resultaterFraTilgangsmaskinen.size} identer divergerte. " +
+                    "Avvisningskoder=$avvisningskoder, traceIder=$traceIder. Se securelogs for detaljer.",
+            )
+        } catch (exception: Exception) {
+            // Skyggingen skal aldri påvirke den gjeldende tilgangskontrollen.
+            val httpStatus = (exception as? TilgangsmaskinException)?.httpStatus
+            Metrics
+                .counter(
+                    "familie.ks.sak.tilgangsmaskin.skygge.feilet",
+                    "feiltype",
+                    exception.javaClass.simpleName,
+                    "httpStatus",
+                    httpStatus?.toString() ?: "INGEN",
+                ).increment()
+            logger.warn("Tilgangsmaskin-skygge feilet: ${exception.javaClass.simpleName}${httpStatus?.let { " (HTTP $it)" } ?: ""}")
+            secureLogger.warn("Tilgangsmaskin-skygge feilet", exception)
+        }
+    }
+
+    private fun TilgangsmaskinResultat.erManglendeSvar(): Boolean =
+        !harTilgang &&
+            httpStatus == HttpStatus.INTERNAL_SERVER_ERROR.value() &&
+            avvisningskode == Avvisningskode.UKJENT
+
+    private fun loggDivergens(
+        gammelTilgang: Tilgang,
+        nyttResultat: TilgangsmaskinResultat,
+    ) {
+        val retning = if (nyttResultat.harTilgang) Divergensretning.NY_MILDERE else Divergensretning.NY_STRENGERE
+        Metrics
+            .counter(
+                "familie.ks.sak.tilgangsmaskin.skygge.divergens",
+                "retning",
+                retning.tag,
+                "avvisningskode",
+                nyttResultat.avvisningskode?.name ?: "INGEN",
+            ).increment()
+        secureLogger.warn(
+            "Tilgangsmaskin-skygge divergens (${retning.tag}) for ident ${nyttResultat.personIdent}: " +
+                "integrasjoner harTilgang=${gammelTilgang.harTilgang} (begrunnelse=${gammelTilgang.begrunnelse}), " +
+                "tilgangsmaskinen harTilgang=${nyttResultat.harTilgang} (avvisningskode=${nyttResultat.avvisningskode}, " +
+                "begrunnelse=${nyttResultat.begrunnelse}, kanOverstyres=${nyttResultat.kanOverstyres}, " +
+                "httpStatus=${nyttResultat.httpStatus}, traceId=${nyttResultat.traceId})",
+        )
+    }
+
+    private enum class Divergensretning(
+        val tag: String,
+    ) {
+        NY_MILDERE("ny-mildere"),
+        NY_STRENGERE("ny-strengere"),
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(TilgangsmaskinSkyggeService::class.java)
+        private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    }
+}

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -25,6 +25,8 @@ FAMILIE_KLAGE_SCOPE: api://dev-gcp.teamfamilie.familie-klage/.default
 FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.dev-fss-pub.nais.io/api
 FAMILIE_INTEGRASJONER_SCOPE: api://dev-fss.teamfamilie.familie-integrasjoner/.default
 
+TILGANGSMASKIN_SCOPE: api://dev-gcp.tilgangsmaskin.populasjonstilgangskontroll/.default
+
 FAMILIE_KS_INFOTRYGD_SCOPE: api://dev-fss.teamfamilie.familie-ks-infotrygd/.default
 FAMILIE_OPPDRAG_SCOPE: api://dev-fss.teamfamilie.familie-oppdrag/.default
 FAMILIE_OPPDRAG_BACKEND_SCOPE: api://dev-gcp.teamfamilie.familie-oppdrag-backend/.default

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -28,6 +28,8 @@ FAMILIE_EF_SAK_API_URL_SCOPE: api://prod-gcp.teamfamilie.familie-ef-sak/.default
 FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.prod-fss-pub.nais.io/api
 FAMILIE_INTEGRASJONER_SCOPE: api://prod-fss.teamfamilie.familie-integrasjoner/.default
 
+TILGANGSMASKIN_SCOPE: api://prod-gcp.tilgangsmaskin.populasjonstilgangskontroll/.default
+
 
 FAMILIE_KS_INFOTRYGD_SCOPE: api://prod-fss.teamfamilie.familie-ks-infotrygd/.default
 FAMILIE_KS_INFOTRYGD_API_URL: https://familie-ks-infotrygd.prod-fss-pub.nais.io/api

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -115,6 +115,7 @@ TILBAKEKREVING_REQUEST_TOPIC: tilbake.privat-tbk-hentfagsystemsbehandling
 TILBAKEKREVING_RESPONSE_TOPIC: tilbake.privat-tbk-hentfagsystemsbehandling-svar
 PDL_URL: http://pdl-api.default
 FAMILIE_INTEGRASJONER_API_URL: http://familie-integrasjoner/api
+TILGANGSMASKIN_API_URL: http://populasjonstilgangskontroll.tilgangsmaskin
 FAMILIE_OPPDRAG_API_URL: http://familie-oppdrag/api
 FAMILIE_OPPDRAG_BACKEND_API_URL: http://familie-oppdrag-backend/api
 SANITY_FAMILIE_API_URL: https://xsrv1mh6.apicdn.sanity.io/v2021-06-07/data/query/ba-brev

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonServiceTest.kt
@@ -10,16 +10,41 @@ import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
 import no.nav.familie.ks.sak.data.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.ks.sak.data.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.ks.sak.integrasjon.pdl.PdlKlient
+import no.nav.familie.ks.sak.integrasjon.tilgangsmaskin.TilgangsmaskinSkyggeService
 import no.nav.familie.ks.sak.kjerne.personident.Aktør
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.hamcrest.CoreMatchers.`is` as Is
 
 internal class IntegrasjonServiceTest {
     private val integrasjonKlient = mockk<IntegrasjonKlient>()
     private val pdlKlient = mockk<PdlKlient>()
-    private val integrasjonService = IntegrasjonService(integrasjonKlient, pdlKlient)
+    private val tilgangsmaskinSkyggeService = mockk<TilgangsmaskinSkyggeService>(relaxed = true)
+    private val integrasjonService = IntegrasjonService(integrasjonKlient, pdlKlient, tilgangsmaskinSkyggeService)
+
+    @AfterEach
+    fun tearDown() {
+        clearBrukerContext()
+    }
+
+    @Test
+    fun `sjekkTilgangTilPersoner skal skyggekjøre Tilgangsmaskinen med resultatet fra integrasjoner i saksbehandlerkontekst`() {
+        // Arrange
+        val personIdenter = listOf("1234567891234")
+        val tilganger = listOf(Tilgang("1234567891234", true))
+
+        every { integrasjonKlient.sjekkTilgangTilPersoner(personIdenter) } returns tilganger
+
+        mockBrukerContext()
+
+        // Act
+        integrasjonService.sjekkTilgangTilPersoner(personIdenter)
+
+        // Assert
+        verify(exactly = 1) { tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(personIdenter, tilganger) }
+    }
 
     @Test
     fun `hentMaskertPersonInfoVedManglendeTilgang skal returnere maskert personinfo hvis SB ikke har tilgang til aktør`() {
@@ -47,7 +72,6 @@ internal class IntegrasjonServiceTest {
             maskertPersonInfo.adressebeskyttelseGradering,
             Is(ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND),
         )
-        clearBrukerContext()
     }
 
     @Test
@@ -69,8 +93,6 @@ internal class IntegrasjonServiceTest {
         verify(exactly = 1) { integrasjonKlient.sjekkTilgangTilPersoner(listOf(aktørFnr)) }
 
         assertThat(maskertPersonInfo, Is(nullValue()))
-
-        clearBrukerContext()
     }
 
     @Test
@@ -114,8 +136,6 @@ internal class IntegrasjonServiceTest {
 
         assertThat(tilgang.all { it.harTilgang }, Is(true))
         assertThat(tilgang.all { it.begrunnelse == "test" }, Is(true))
-
-        clearBrukerContext()
     }
 
     @Test
@@ -132,7 +152,5 @@ internal class IntegrasjonServiceTest {
         verify(exactly = 0) { integrasjonKlient.sjekkTilgangTilPersoner(listeMedIdenter) }
 
         assertThat(tilgang.all { it.harTilgang }, Is(true))
-
-        clearBrukerContext()
     }
 }

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/pdl/PersonopplysningerServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.sak.integrasjon.pdl
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.kontrakter.felles.personopplysning.ForelderBarnRelasjon
 import no.nav.familie.kontrakter.felles.personopplysning.KJOENN
@@ -77,7 +78,7 @@ class PersonopplysningerServiceTest {
 
             every { pdlKlient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
             every { personidentService.hentAktør(barnIdent.fødselsnummer) } returns barnAktør
-            every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
+            every { integrasjonService.sjekkTilgangTilPersoner(listOf(barnAktør.aktivFødselsnummer())) } returns listOf(Tilgang(barnAktør.aktivFødselsnummer(), true))
             every { pdlKlient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
             every { pdlKlient.hentAdressebeskyttelse(any()) } returns emptyList()
 
@@ -91,6 +92,65 @@ class PersonopplysningerServiceTest {
 
             assertThat(barnRelasjon.navn).isEqualTo("Fornavn Etternavn")
             assertThat(barnRelasjon.aktør).isEqualTo(barnAktør)
+        }
+
+        @Test
+        fun `Skal sjekke tilgang til alle relasjoner i ett kall og maskere relasjoner saksbehandler ikke har tilgang til`() {
+            // Arrange
+            val aktør = randomAktør()
+            val barnMedTilgangAktør = randomAktør()
+            val barnUtenTilgangAktør = randomAktør()
+            val fødselsdato = LocalDate.of(2000, 2, 2)
+
+            val pdlPersonData =
+                PdlPersonData(
+                    forelderBarnRelasjon =
+                        listOf(
+                            ForelderBarnRelasjon(
+                                relatertPersonsIdent = barnMedTilgangAktør.aktivFødselsnummer(),
+                                relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
+                            ),
+                            ForelderBarnRelasjon(
+                                relatertPersonsIdent = barnUtenTilgangAktør.aktivFødselsnummer(),
+                                relatertPersonsRolle = FORELDERBARNRELASJONROLLE.BARN,
+                            ),
+                        ),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
+
+            val pdlRelasjonData =
+                PdlPersonData(
+                    navn = listOf(PdlNavn("Fornavn", null, "Etternavn")),
+                    folkeregisteridentifikator = emptyList(),
+                    foedselsdato = listOf(PdlFødselsDato(fødselsdato.toString())),
+                    bostedsadresse = emptyList(),
+                )
+
+            every { pdlKlient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
+            every { personidentService.hentAktør(barnMedTilgangAktør.aktivFødselsnummer()) } returns barnMedTilgangAktør
+            every { personidentService.hentAktør(barnUtenTilgangAktør.aktivFødselsnummer()) } returns barnUtenTilgangAktør
+            every {
+                integrasjonService.sjekkTilgangTilPersoner(
+                    listOf(barnMedTilgangAktør.aktivFødselsnummer(), barnUtenTilgangAktør.aktivFødselsnummer()),
+                )
+            } returns
+                listOf(
+                    Tilgang(barnMedTilgangAktør.aktivFødselsnummer(), true),
+                    Tilgang(barnUtenTilgangAktør.aktivFødselsnummer(), false),
+                )
+            every { pdlKlient.hentPerson(barnMedTilgangAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
+            every { pdlKlient.hentAdressebeskyttelse(barnUtenTilgangAktør) } returns emptyList()
+
+            // Act
+            val personInfo = personopplysningerService.hentPersonInfoMedRelasjonerOgRegisterinformasjon(aktør)
+
+            // Assert
+            verify(exactly = 1) { integrasjonService.sjekkTilgangTilPersoner(any()) }
+            verify(exactly = 0) { integrasjonService.sjekkTilgangTilPerson(any()) }
+            assertThat(personInfo.forelderBarnRelasjoner.map { it.aktør }).containsExactly(barnMedTilgangAktør)
+            assertThat(personInfo.forelderBarnRelasjonerMaskert.map { it.relasjonsrolle }).containsExactly(FORELDERBARNRELASJONROLLE.BARN)
         }
 
         @Test
@@ -125,7 +185,7 @@ class PersonopplysningerServiceTest {
 
             every { pdlKlient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
             every { personidentService.hentAktør(barnIdent.fødselsnummer) } throws PdlPersonKanIkkeBehandlesIFagsystem(PdlPersonKanIkkeBehandlesIFagSystemÅrsak.MANGLER_FØDSELSDATO)
-            every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnIdent.fødselsnummer, true)
+            every { integrasjonService.sjekkTilgangTilPersoner(listOf(barnAktør.aktivFødselsnummer())) } returns listOf(Tilgang(barnAktør.aktivFødselsnummer(), true))
             every { pdlKlient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
             every { pdlKlient.hentAdressebeskyttelse(any()) } returns emptyList()
 
@@ -167,7 +227,7 @@ class PersonopplysningerServiceTest {
 
             every { pdlKlient.hentPerson(aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns pdlPersonData
             every { personidentService.hentAktør(barnAktør.aktivFødselsnummer()) } returns barnAktør
-            every { integrasjonService.sjekkTilgangTilPerson(barnAktør.aktivFødselsnummer()) } returns Tilgang(barnAktør.aktivFødselsnummer(), true)
+            every { integrasjonService.sjekkTilgangTilPersoner(listOf(barnAktør.aktivFødselsnummer())) } returns listOf(Tilgang(barnAktør.aktivFødselsnummer(), true))
             every { pdlKlient.hentPerson(barnAktør, PersonInfoQuery.ENKEL) } returns pdlRelasjonData
             every { pdlKlient.hentAdressebeskyttelse(any()) } returns emptyList()
 
@@ -210,7 +270,7 @@ class PersonopplysningerServiceTest {
 
         every { pdlKlient.hentPerson(person.aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns søkerPersonInfoData
         every { pdlKlient.hentPerson(barn.aktør, PersonInfoQuery.ENKEL) } returns barnPersonInfoData
-        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang(personIdent = barn.aktør.aktivFødselsnummer(), harTilgang = true)
+        every { integrasjonService.sjekkTilgangTilPersoner(any()) } returns listOf(Tilgang(personIdent = barn.aktør.aktivFødselsnummer(), harTilgang = true))
 
         every { integrasjonService.sjekkErEgenAnsattBulk(any()) } returns emptyMap()
 
@@ -259,7 +319,7 @@ class PersonopplysningerServiceTest {
 
         every { pdlKlient.hentPerson(søker.aktør, PersonInfoQuery.MED_RELASJONER_OG_REGISTERINFORMASJON) } returns søkerPersonInfoData
         every { pdlKlient.hentPerson(barn.aktør, PersonInfoQuery.ENKEL) } returns barnPersonInfoData
-        every { integrasjonService.sjekkTilgangTilPerson(any()) } returns Tilgang(personIdent = barn.aktør.aktivFødselsnummer(), harTilgang = true)
+        every { integrasjonService.sjekkTilgangTilPersoner(any()) } returns listOf(Tilgang(personIdent = barn.aktør.aktivFødselsnummer(), harTilgang = true))
 
         every { integrasjonService.sjekkErEgenAnsattBulk(any()) } returns emptyMap()
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/tilgangsmaskin/TilgangsmaskinSkyggeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/tilgangsmaskin/TilgangsmaskinSkyggeServiceTest.kt
@@ -144,9 +144,8 @@ class TilgangsmaskinSkyggeServiceTest {
     }
 
     @Test
-    fun `skal logge oppsummering på debug-nivå uten personident når det ikke er divergens`() {
+    fun `skal logge oppsummering uten personident når det ikke er divergens`() {
         // Arrange
-        åpenLogg.level = Level.DEBUG
         every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
             listOf(TilgangsmaskinResultat(personIdent = PERSONIDENT, harTilgang = true, httpStatus = 204))
 

--- a/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/tilgangsmaskin/TilgangsmaskinSkyggeServiceTest.kt
+++ b/src/test/enhetstester/kotlin/no/nav/familie/ks/sak/integrasjon/tilgangsmaskin/TilgangsmaskinSkyggeServiceTest.kt
@@ -1,0 +1,292 @@
+package no.nav.familie.ks.sak.integrasjon.tilgangsmaskin
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.kontrakter.felles.tilgangskontroll.Tilgang
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggle
+import no.nav.familie.ks.sak.config.featureToggle.FeatureToggleService
+import no.nav.familie.ks.sak.data.BrukerContextUtil.clearBrukerContext
+import no.nav.familie.ks.sak.data.BrukerContextUtil.mockBrukerContext
+import no.nav.familie.tilgangsmaskin.Avvisningskode
+import no.nav.familie.tilgangsmaskin.Regeltype
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinException
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinKlient
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinResultat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.slf4j.LoggerFactory
+
+class TilgangsmaskinSkyggeServiceTest {
+    private val tilgangsmaskinKlient = mockk<TilgangsmaskinKlient>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val tilgangsmaskinSkyggeService = TilgangsmaskinSkyggeService(tilgangsmaskinKlient, featureToggleService)
+
+    private val åpenLogg = LoggerFactory.getLogger(TilgangsmaskinSkyggeService::class.java) as Logger
+    private val listAppender = ListAppender<ILoggingEvent>()
+    private var opprinneligLoggnivå: Level? = null
+
+    private val meterRegistry = SimpleMeterRegistry()
+
+    @BeforeEach
+    fun setUp() {
+        mockBrukerContext()
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SKYGGEKJØRE_TILGANGSMASKINEN) } returns true
+        opprinneligLoggnivå = åpenLogg.level
+        listAppender.start()
+        åpenLogg.addAppender(listAppender)
+        Metrics.addRegistry(meterRegistry)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Metrics.removeRegistry(meterRegistry)
+        meterRegistry.close()
+        åpenLogg.detachAppender(listAppender)
+        åpenLogg.level = opprinneligLoggnivå
+        listAppender.stop()
+        clearBrukerContext()
+    }
+
+    @Test
+    fun `skal ikke kalle Tilgangsmaskinen når toggelen er av`() {
+        // Arrange
+        every { featureToggleService.isEnabled(FeatureToggle.SKAL_SKYGGEKJØRE_TILGANGSMASKINEN) } returns false
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+
+        // Assert
+        verify(exactly = 0) { tilgangsmaskinKlient.sjekkTilgangTilPersoner(any(), any()) }
+    }
+
+    @Test
+    fun `skal ikke kalle Tilgangsmaskinen i systemkontekst`() {
+        // Arrange
+        clearBrukerContext()
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+
+        // Assert
+        verify(exactly = 0) { tilgangsmaskinKlient.sjekkTilgangTilPersoner(any(), any()) }
+    }
+
+    @Test
+    fun `skal kalle Tilgangsmaskinen med identene som unikt sett og kjerneregeltypen`() {
+        // Arrange
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
+            listOf(TilgangsmaskinResultat(personIdent = PERSONIDENT, harTilgang = true, httpStatus = 204))
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(
+            listOf(PERSONIDENT, PERSONIDENT),
+            listOf(Tilgang(PERSONIDENT, true)),
+        )
+
+        // Assert
+        verify(exactly = 1) { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) }
+    }
+
+    @Test
+    fun `skal ikke feile når Tilgangsmaskinen divergerer fra integrasjoner`() {
+        // Arrange
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
+            listOf(
+                TilgangsmaskinResultat(
+                    personIdent = PERSONIDENT,
+                    harTilgang = false,
+                    httpStatus = 403,
+                    avvisningskode = Avvisningskode.AVVIST_SKJERMING,
+                    begrunnelse = "Bruker er skjermet",
+                    traceId = "en-trace-id",
+                ),
+            )
+
+        // Act & Assert
+        assertDoesNotThrow {
+            tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+        }
+    }
+
+    @Test
+    fun `divergenslogg i åpen logg skal aldri inneholde personidenten`() {
+        // Arrange
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
+            listOf(
+                TilgangsmaskinResultat(
+                    personIdent = PERSONIDENT,
+                    harTilgang = false,
+                    httpStatus = 403,
+                    avvisningskode = Avvisningskode.AVVIST_SKJERMING,
+                    begrunnelse = "Bruker er skjermet",
+                    traceId = "en-trace-id",
+                ),
+            )
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+
+        // Assert
+        val meldinger = listAppender.list.map { it.formattedMessage }
+        assertThat(meldinger).isNotEmpty
+        assertThat(meldinger).noneMatch { it.contains(PERSONIDENT) }
+        assertThat(meldinger.single()).contains("AVVIST_SKJERMING", "en-trace-id")
+    }
+
+    @Test
+    fun `skal logge oppsummering på debug-nivå uten personident når det ikke er divergens`() {
+        // Arrange
+        åpenLogg.level = Level.DEBUG
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
+            listOf(TilgangsmaskinResultat(personIdent = PERSONIDENT, harTilgang = true, httpStatus = 204))
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+
+        // Assert
+        val meldinger = listAppender.list.map { it.formattedMessage }
+        assertThat(meldinger.single()).contains("ingen divergens")
+        assertThat(meldinger.single()).doesNotContain(PERSONIDENT)
+    }
+
+    @Test
+    fun `skal ikke telle manglende svar fra Tilgangsmaskinen som divergens, men varsle med kun antall`() {
+        // Arrange
+        // Klienten fyller inn dette syntetiske avslaget for identer Tilgangsmaskinen ikke svarte for.
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
+            listOf(
+                TilgangsmaskinResultat(
+                    personIdent = PERSONIDENT,
+                    harTilgang = false,
+                    httpStatus = 500,
+                    avvisningskode = Avvisningskode.UKJENT,
+                    begrunnelse = "Fikk ikke svar fra Tilgangsmaskinen for personen",
+                ),
+            )
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+
+        // Assert
+        val advarsler = listAppender.list.filter { it.level == Level.WARN }.map { it.formattedMessage }
+        assertThat(advarsler.single()).contains("fikk ikke svar for 1 av 1 identer")
+        assertThat(advarsler.single()).doesNotContain(PERSONIDENT, "divergerte")
+        assertThat(tellerVerdi("familie.ks.sak.tilgangsmaskin.skygge.manglende.svar")).isEqualTo(1.0)
+        assertThat(tellerVerdi("familie.ks.sak.tilgangsmaskin.skygge.sammenlignet")).isEqualTo(0.0)
+        assertThat(meterRegistry.find("familie.ks.sak.tilgangsmaskin.skygge.divergens").counters().sumOf { it.count() }).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `skal telle divergens som ny-strengere med avvisningskode når Tilgangsmaskinen avviser`() {
+        // Arrange
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
+            listOf(
+                TilgangsmaskinResultat(
+                    personIdent = PERSONIDENT,
+                    harTilgang = false,
+                    httpStatus = 403,
+                    avvisningskode = Avvisningskode.AVVIST_SKJERMING,
+                ),
+            )
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+
+        // Assert
+        assertThat(tellerVerdi("familie.ks.sak.tilgangsmaskin.skygge.sammenlignet")).isEqualTo(1.0)
+        assertThat(
+            tellerVerdi(
+                "familie.ks.sak.tilgangsmaskin.skygge.divergens",
+                "retning",
+                "ny-strengere",
+                "avvisningskode",
+                "AVVIST_SKJERMING",
+            ),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `skal telle divergens som ny-mildere uten avvisningskode når Tilgangsmaskinen gir tilgang`() {
+        // Arrange
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(setOf(PERSONIDENT), Regeltype.KJERNE_REGELTYPE) } returns
+            listOf(TilgangsmaskinResultat(personIdent = PERSONIDENT, harTilgang = true, httpStatus = 204))
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, false)))
+
+        // Assert
+        assertThat(
+            tellerVerdi(
+                "familie.ks.sak.tilgangsmaskin.skygge.divergens",
+                "retning",
+                "ny-mildere",
+                "avvisningskode",
+                "INGEN",
+            ),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `skal svelge unntak fra Tilgangsmaskinen slik at tilgangskontrollen ikke påvirkes`() {
+        // Arrange
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(any(), any()) } throws
+            TilgangsmaskinException("Feil ved kall mot Tilgangsmaskinen: HTTP 500", httpStatus = 500)
+
+        // Act & Assert
+        assertDoesNotThrow {
+            tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+        }
+    }
+
+    @Test
+    fun `skal telle feil mot Tilgangsmaskinen med feiltype og httpStatus`() {
+        // Arrange
+        every { tilgangsmaskinKlient.sjekkTilgangTilPersoner(any(), any()) } throws
+            TilgangsmaskinException("Feil ved kall mot Tilgangsmaskinen: HTTP 503", httpStatus = 503)
+
+        // Act
+        tilgangsmaskinSkyggeService.skyggeSjekkTilgangTilPersoner(listOf(PERSONIDENT), listOf(Tilgang(PERSONIDENT, true)))
+
+        // Assert
+        assertThat(
+            tellerVerdi(
+                "familie.ks.sak.tilgangsmaskin.skygge.feilet",
+                "feiltype",
+                "TilgangsmaskinException",
+                "httpStatus",
+                "503",
+            ),
+        ).isEqualTo(1.0)
+        val advarsel =
+            listAppender.list
+                .filter { it.level == Level.WARN }
+                .map { it.formattedMessage }
+                .single()
+        assertThat(advarsel).contains("TilgangsmaskinException", "HTTP 503")
+        assertThat(advarsel).doesNotContain(PERSONIDENT)
+    }
+
+    private fun tellerVerdi(
+        navn: String,
+        vararg tags: String,
+    ): Double =
+        meterRegistry
+            .find(navn)
+            .tags(*tags)
+            .counter()
+            ?.count() ?: 0.0
+
+    companion object {
+        private const val PERSONIDENT = "1234567891234"
+    }
+}

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/config/FakeConfig.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/config/FakeConfig.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ks.sak.fake.FakePdlKlient
 import no.nav.familie.ks.sak.fake.FakePersonopplysningerService
 import no.nav.familie.ks.sak.fake.FakeTaskRepositoryWrapper
 import no.nav.familie.ks.sak.fake.FakeTilbakekrevingKlient
+import no.nav.familie.ks.sak.fake.FakeTilgangsmaskinKlient
 import no.nav.familie.ks.sak.integrasjon.familieintegrasjon.IntegrasjonService
 import no.nav.familie.ks.sak.integrasjon.pdl.PdlKlient
 import no.nav.familie.ks.sak.kjerne.arbeidsfordeling.domene.ArbeidsfordelingPåBehandlingRepository
@@ -39,6 +40,11 @@ class FakeConfig {
     @Primary
     @Profile("fake-integrasjon-klient")
     fun fakeIntegrasjonKlient(): FakeIntegrasjonKlient = FakeIntegrasjonKlient()
+
+    @Bean
+    @Primary
+    @Profile("integrasjonstest", "postgres")
+    fun fakeTilgangsmaskinKlient(): FakeTilgangsmaskinKlient = FakeTilgangsmaskinKlient()
 
     @Bean
     @Primary

--- a/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/fake/FakeTilgangsmaskinKlient.kt
+++ b/src/test/integrasjonstester/kotlin/no/nav/familie/ks/sak/fake/FakeTilgangsmaskinKlient.kt
@@ -1,0 +1,23 @@
+package no.nav.familie.ks.sak.fake
+
+import io.mockk.mockk
+import no.nav.familie.tilgangsmaskin.Regeltype
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinKlient
+import no.nav.familie.tilgangsmaskin.TilgangsmaskinResultat
+import java.net.URI
+
+class FakeTilgangsmaskinKlient : TilgangsmaskinKlient(URI("http://tilgangsmaskin-url"), mockk(relaxed = true)) {
+    override fun sjekkTilgangTilPersoner(
+        personIdenter: Set<String>,
+        regeltype: Regeltype,
+    ): List<TilgangsmaskinResultat> =
+        personIdenter
+            .filter { it.isNotBlank() }
+            .map { personIdent ->
+                TilgangsmaskinResultat(
+                    personIdent = personIdent,
+                    harTilgang = true,
+                    httpStatus = 204,
+                )
+            }
+}

--- a/src/test/resources/application-dev-postgres-preprod.yaml
+++ b/src/test/resources/application-dev-postgres-preprod.yaml
@@ -48,6 +48,8 @@ FAMILIE_KS_INFOTRYGD_SCOPE: api://dev-fss.teamfamilie.familie-ks-infotrygd/.defa
 
 FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.intern.dev.nav.no/api
 FAMILIE_INTEGRASJONER_SCOPE: api://dev-fss.teamfamilie.familie-integrasjoner/.default
+TILGANGSMASKIN_API_URL: https://tilgangsmaskin.intern.dev.nav.no
+TILGANGSMASKIN_SCOPE: api://dev-gcp.tilgangsmaskin.populasjonstilgangskontroll/.default
 PDL_URL: https://pdl-api.dev.intern.nav.no/
 PDL_SCOPE: api://dev-fss.pdl.pdl-api/.default
 FAMILIE_OPPDRAG_API_URL: https://familie-oppdrag.dev.intern.nav.no/api

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -51,6 +51,7 @@ NAIS_TOKEN_ENDPOINT: http://localhost/token
 NAIS_TOKEN_EXCHANGE_ENDPOINT: http://localhost/token/exchange
 
 FAMILIE_INTEGRASJONER_SCOPE: "dummy"
+TILGANGSMASKIN_SCOPE: "dummy"
 FAMILIE_KLAGE_SCOPE: "dummy"
 FAMILIE_TILBAKE_API_URL_SCOPE: "dummy"
 FAMILIE_KS_INFOTRYGD_SCOPE: "dummy"
@@ -63,6 +64,7 @@ FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087/api
 FAMILIE_OPPDRAG_BACKEND_API_URL: http://localhost:8087/api
 FAMILIE_INTEGRASJONER_API_URL: http://localhost:28085/api
+TILGANGSMASKIN_API_URL: http://localhost:28090
 FAMILIE_TILBAKE_API_URL: http://localhost:8030/api
 FAMILIE_KS_SAK_API_URL: http://localhost:8086/api
 

--- a/src/test/resources/application-postgres.yaml
+++ b/src/test/resources/application-postgres.yaml
@@ -43,6 +43,7 @@ NAIS_TOKEN_ENDPOINT: http://localhost/token
 NAIS_TOKEN_EXCHANGE_ENDPOINT: http://localhost/token/exchange
 
 FAMILIE_INTEGRASJONER_SCOPE: "dummy"
+TILGANGSMASKIN_SCOPE: "dummy"
 FAMILIE_KLAGE_SCOPE: "dummy"
 FAMILIE_TILBAKE_API_URL_SCOPE: "dummy"
 FAMILIE_KS_INFOTRYGD_SCOPE: "dummy"
@@ -55,6 +56,7 @@ FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087/api
 FAMILIE_OPPDRAG_BACKEND_API_URL: http://localhost:8087/api
 FAMILIE_INTEGRASJONER_API_URL: http://localhost:28085/api
+TILGANGSMASKIN_API_URL: http://localhost:28090
 FAMILIE_TILBAKE_API_URL: http://localhost:8030/api
 FAMILIE_KS_SAK_API_URL: http://localhost:8086/api
 


### PR DESCRIPTION
### 📮 Favro: Nav-27897

### 💰 Hva skal gjøres, og hvorfor?
Tilgangsmaskinen skal på sikt erstatte tilgangssjekken vi i dag gjør via familie-integrasjoner. Som første steg skyggekjører vi den: vi beholder dagens tilgangsstyring uendret, spør Tilgangsmaskinen om det samme, og logger/teller divergenser slik at vi kan vurdere om den er trygg å bytte til.

**Integrasjon**
- Tar i bruk `tilgangsmaskin-klient` fra familie-felles (bump av `felles.version` til `4.20260807140555_998c828`) og importerer `TilgangsmaskinKlientConfig`.

- Egen `tilgangsmaskinOboRestClient` i `RestClientConfig`: bulk-endepunktet krever OBO-token (maskin-til-maskin avvises), og siden skyggekallet ligger synkront i tilgangssjekken er tidsavbruddene satt stramt (2 s connect / 5 s read).

- Nais outbound-regel mot `populasjonstilgangskontroll` (namespace `tilgangsmaskin`) i dev og prod, samt `TILGANGSMASKIN_API_URL`/`TILGANGSMASKIN_SCOPE` i application-yaml-ene.

**Skyggekjøring**
- Ny `TilgangsmaskinSkyggeService`, kalt fra `IntegrasjonService.sjekkTilgangTilPersoner` i saksbehandlerkontekst (aldri i systemkontekst). Sammenligner `harTilgang` per ident mot Tilgangsmaskinen med `KJERNE_REGELTYPE`, styrt av ny toggle `SKAL_SKYGGEKJØRE_TILGANGSMASKINEN`. Alle feil svelges – skyggingen kan aldri påvirke selve tilgangsbeslutningen.
- Divergenser logges med ident kun i securelogs; åpen logg får antall, avvisningskoder og traceId-er. Identer Tilgangsmaskinen ikke svarer for (klientens syntetiske avslag) telles for seg og ikke som divergens.

**Annet**
- `PersonopplysningerService` sjekket tilgang per forelder-barn-relasjon; nå ett bulk-kall for alle relasjonene (halverer også antall skyggekall).

**Tester**
- `TilgangsmaskinSkyggeServiceTest` (toggle av, systemkontekst, unikt identsett, divergens, ident aldri i åpen logg, manglende svar, metrikk-tags, feiltelling, unntak svelges), oppdatert `IntegrasjonServiceTest` og `PersonopplysningerServiceTest` (bulk-sjekk av relasjoner), samt `FakeTilgangsmaskinKlient` for integrasjonstester.